### PR TITLE
fix(argus.db.testrun): Heartbeat only updates heartbeat

### DIFF
--- a/argus/db/testrun.py
+++ b/argus/db/testrun.py
@@ -624,8 +624,9 @@ class TestRunWithHeartbeat(TestRun):
             if self._shutdown_event.is_set():
                 break
             LOGGER.debug("Sending heartbeat...")
-            self.heartbeat = time.time()
-            self.save()
+            self.heartbeat = int(time.time())
+            self.argus.session.execute(f"UPDATE {TestRun.table_name()} SET heartbeat = ? WHERE id = ?",
+                                       parameters=(self.heartbeat, self.id,))
         LOGGER.debug("Heartbeat exit")
 
     def shutdown(self):


### PR DESCRIPTION
This replaces generic mechanism for updates with a manual query,
during heartbeat updates. Due to the fact that client application might
get stuck, but might update TestRun data in another part of the system,
the stuck heartbeat thread might override said data in this case.
This is now fixed

[Trello](https://trello.com/c/Bor1fUgt/4621-heartbeat-shoouldnt-override-the-data-when-test-is-stuck-and-we-moved-to-another-staged-in-jenkins-job)