### PR TITLE
improvement(argus.frontend/TestRun.svelte): Improve card visibility

### DIFF
--- a/argus/backend/assets/TestRun/TestRun.svelte
+++ b/argus/backend/assets/TestRun/TestRun.svelte
@@ -317,7 +317,7 @@
     });
 </script>
 
-<div class="border rounded bg-white p-2">
+<div class="border rounded p-2 shadow-sm testrun-card mb-4">
     {#if test_run}
         <div class="row p-2">
             <div class="col-6">
@@ -528,7 +528,7 @@
             </div>
         </nav>
         <div
-            class="tab-content border-start border-end border-bottom"
+            class="tab-content border-start border-end border-bottom bg-white"
             id="nav-tabContent-{id}"
         >
             <div
@@ -676,5 +676,9 @@
         height: 32px;
         border-radius: 50%;
         object-fit: cover;
+    }
+
+    .testrun-card {
+        background-color: #fafafa;
     }
 </style>


### PR DESCRIPTION
This commit adjusts the background, margins and shadow of a TestRun
card. This should help with visibility and assist with distinguishing
individual test runs.

![image](https://user-images.githubusercontent.com/7761415/154849970-a0729adc-69f6-4bd5-b3ec-a00e2673c1ac.png)
[Trello](https://trello.com/c/Xr7Vl1JN/4661-test-runs-should-be-more-easily-distinguished)