### PR TITLE
feature(argus.backend): Profile Jobs tab v2

### DIFF
--- a/argus/backend/assets/Profile/JobsList.svelte
+++ b/argus/backend/assets/Profile/JobsList.svelte
@@ -1,0 +1,105 @@
+<script>
+    export let runs = [];
+    import Fa from "svelte-fa";
+    import { StatusBackgroundCSSClassMap } from "../Common/TestStatus";
+    import { faExternalLinkSquareAlt } from "@fortawesome/free-solid-svg-icons";
+    import TestRun from "../TestRun/TestRun.svelte";
+    import { timestampToISODate } from "../Common/DateUtils";
+    let filterString = "";
+
+    const filterJob = function (job) {
+        let jobName = `${job.build_job_name}#${getBuildNumber(
+            job.build_job_url
+        )}`;
+        if (filterString == "") {
+            return false;
+        }
+        try {
+            return !RegExp(filterString.toLowerCase()).test(
+                jobName.toLowerCase()
+            );
+        } catch (e) {
+            return true;
+        }
+    };
+
+    const getBuildNumber = function (url) {
+        return url
+            .trim()
+            .slice(0, url.length - 1)
+            .split("/")
+            .at(-1);
+    };
+
+    let clickedRuns = {};
+</script>
+
+{#if runs.length > 1}
+    <div class="row mb-2">
+        <input
+            class="form-control"
+            type="text"
+            placeholder="Filter by name"
+            on:keyup={(e) => {
+                filterString = e.target.value;
+                runs = runs;
+            }}
+        />
+    </div>
+{/if}
+{#each runs as run}
+    <div class="row" class:d-none={filterJob(run)}>
+        <div class="col border rounded mb-2">
+            <div class="d-flex align-items-center">
+                <div
+                    class="p-2 border rounded {StatusBackgroundCSSClassMap[
+                        run.status
+                    ]} text-light text-center"
+                    style="width: 156px"
+                >
+                    {run.status.toUpperCase()}
+                </div>
+                <h3 class="ms-2 p-2">
+                    <span class="text-muted">{run.build_job_name}#</span
+                    >{getBuildNumber(run.build_job_url)}
+                </h3>
+                <div class="ms-auto">
+                    <h6 class="text-muted">Started at</h6>
+                    <div>
+                        {timestampToISODate(run.start_time * 1000, true)}
+                    </div>
+                </div>
+                <div class="ms-2">
+                    <div class="btn-group">
+                        <button
+                            class="btn btn-sm btn-secondary"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#testRun_{run.id}"
+                            on:click={() => (clickedRuns[run.id] = true)}
+                            >Open</button
+                        >
+                        <a
+                            href="/test_run/{run.id}"
+                            class="btn btn-sm btn-secondary"
+                            ><Fa icon={faExternalLinkSquareAlt} /></a
+                        >
+                    </div>
+                </div>
+            </div>
+            <div class="collapse" id="testRun_{run.id}">
+                {#if clickedRuns[run.id]}
+                    <TestRun
+                        id={run.id}
+                        build_number={getBuildNumber(run.build_job_url)}
+                    />
+                {/if}
+            </div>
+        </div>
+    </div>
+{:else}
+    <div class="row">
+        <div class="col my-5">
+            <h1 class="text-muted text-center">Nothing to do!</h1>
+        </div>
+    </div>
+{/each}

--- a/argus/backend/assets/Profile/ProfileJobs.svelte
+++ b/argus/backend/assets/Profile/ProfileJobs.svelte
@@ -1,71 +1,30 @@
 <script>
-    import Fa from "svelte-fa";
-    import { StatusBackgroundCSSClassMap } from "../Common/TestStatus";
-    import { faExternalLinkSquareAlt } from "@fortawesome/free-solid-svg-icons";
-    import TestRun from "../TestRun/TestRun.svelte";
     export let runs = [];
-    const getBuildNumber = function (url) {
-        return url
-            .trim()
-            .slice(0, url.length - 1)
-            .split("/")
-            .at(-1);
+    import JobsList from "./JobsList.svelte";
+    const filterInvestigated = function (jobs) {
+        return jobs.filter(
+            (job) =>
+                job.investigation_status == "investigated" ||
+                job.status == "passed"
+        );
     };
-    let clickedRuns = {};
+
+    const filterNotInvestigated = function (jobs) {
+        return jobs.filter(
+            (job) =>
+                job.investigation_status == "not_investigated" &&
+                job.status != "passed"
+        );
+    };
 </script>
 
 <div class="container bg-white border rounded my-4 shadow-sm min-vh-100">
-    {#each runs as run}
-        <div class="row mb-3 p-4">
-            <div class="col border rounded">
-                <div class="d-flex p-2 align-items-center">
-                    <div
-                        class="me-2 p-2 border rounded {StatusBackgroundCSSClassMap[
-                            run.status
-                        ]} text-light"
-                    >
-                        {run.status.toUpperCase()}
-                    </div>
-                    <h3 class="me-4 p-2">
-                        <span class="text-muted">{run.build_job_name}#</span>{getBuildNumber(run.build_job_url)}
-                    </h3>
-                    <div class="me-4">
-                        <h6 class="text-muted">Started at</h6>
-                        <div>
-                            {new Date(run.start_time * 1000).toLocaleString(
-                                "en-CA"
-                            )}
-                        </div>
-                    </div>
-                    <div class="ms-auto">
-                        <div class="btn-group">
-                            <button
-                                class="btn btn-sm btn-secondary"
-                                data-bs-toggle="collapse"
-                                data-bs-target="#testRun_{run.id}"
-                                on:click={() => clickedRuns[run.id] = true}
-                                >Open</button
-                            >
-                            <a
-                                href="/test_run/{run.id}"
-                                class="btn btn-sm btn-secondary"
-                                ><Fa icon={faExternalLinkSquareAlt} /></a
-                            >
-                        </div>
-                    </div>
-                </div>
-                <div class="collapse" id="testRun_{run.id}">
-                    {#if clickedRuns[run.id]}
-                        <TestRun id={run.id} build_number={getBuildNumber(run.build_job_url)} />
-                    {/if}
-                </div>
-            </div>
-        </div>
-    {:else}
-        <div class="row">
-            <div class="col my-5">
-                <h1 class="text-muted text-center">Nothing to do!</h1>
-            </div>
-        </div>
-    {/each}
+    <div class="row justify-content-center border-bottom">
+        <h2 class="mt-2 display-6">Not Investigated</h2>
+        <JobsList runs={filterNotInvestigated(runs)}/>
+    </div>
+    <div class="row justify-content-center">
+        <h2 class="mt-2 display-6">Investigated</h2>
+        <JobsList runs={filterInvestigated(runs)}/>
+    </div>
 </div>


### PR DESCRIPTION
This commit revises the way assigned jobs are presented to the user
on the profile jobs page. First, the jobs are split into "Investigated"
and "Not Investigated" categories, with succesfully passed jobs
automatically being added to "Investigated" ones. Second, the jobs are
filtered server-side to only apply to current schedule + 1 week behind.
Lastly, a new "filter by name" control was added to simplify looking for
specific jobs
![image](https://user-images.githubusercontent.com/7761415/154852221-53c94a72-2632-4e90-8fe1-e30fc14b6613.png)
[Trello](https://trello.com/c/hRI4a2hR/4658-my-jobs-page)