### PR TITLE
Build system release tracking

### DIFF
--- a/argus/backend/__init__.py
+++ b/argus/backend/__init__.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from flask import Flask
 from yaml import safe_load
 from argus.backend.db import ScyllaCluster
+from argus.backend.build_system_monitor import scan_jenkins_command
 from argus.backend import auth, main, api
 
 
@@ -16,6 +17,7 @@ def create_app(config=None) -> Flask:
     app.register_blueprint(auth.bp)
     app.register_blueprint(main.bp)
     app.register_blueprint(api.bp)
+    app.cli.add_command(scan_jenkins_command)
 
     @app.template_filter('from_timestamp')
     def from_timestamp_filter(timestamp: int):

--- a/argus/backend/api.py
+++ b/argus/backend/api.py
@@ -388,6 +388,7 @@ def run_stats():
         res["response"] = service.collect_stats(request_payload)
     except Exception as exc:
         LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Details: ", exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,

--- a/argus/backend/assets/Common/StateManagement.js
+++ b/argus/backend/assets/Common/StateManagement.js
@@ -1,0 +1,17 @@
+import { Base64 } from "js-base64";
+
+export const stateEncoder = function(rawState) {
+    let state = JSON.stringify(rawState);
+    let encodedState = Base64.encode(state, true);
+    return `state=${encodedState}`;
+};
+
+export const stateDecoder = function () {
+    let params = new URLSearchParams(document.location.search);
+    let state = params.get("state");
+    if (state) {
+        let decodedState = JSON.parse(Base64.decode(state));
+        return decodedState;
+    }
+    return {};
+}

--- a/argus/backend/assets/ReleaseDashboard/TestPopoutSelector.svelte
+++ b/argus/backend/assets/ReleaseDashboard/TestPopoutSelector.svelte
@@ -3,7 +3,7 @@
     import { StatusCSSClassMap } from "../Common/TestStatus";
     import { timestampToISODate } from "../Common/DateUtils";
     import { createEventDispatcher } from "svelte";
-    import { Base64 } from "js-base64";
+    import { stateEncoder } from "../Common/StateManagement";
     import {
         faCircle,
         faTimes,
@@ -12,22 +12,19 @@
         faHammer,
         faExternalLinkSquareAlt,
     } from "@fortawesome/free-solid-svg-icons";
-    import { faGithub } from "@fortawesome/free-brands-svg-icons"
+    import { faGithub } from "@fortawesome/free-brands-svg-icons";
     export let tests = [];
     export let releaseName = "";
-    let encodedState = "e30";
-    $: encodedState = Base64.encode(
-        JSON.stringify(
-            Object.values(tests).reduce((acc, val) => {
-                acc[`${releaseName}/${val.name}`] = {
-                    test: val.name,
-                    release: releaseName,
-                    runs: [],
-                };
-                return acc;
-            }, {})
-        ),
-        true
+    let encodedState = "state=e30";
+    $: encodedState = stateEncoder(
+        Object.values(tests).reduce((acc, val) => {
+            acc[`${releaseName}/${val.group}/${val.name}`] = {
+                test: val.name,
+                group: val.group,
+                release: releaseName,
+            };
+            return acc;
+        }, {})
     );
     const dispatch = createEventDispatcher();
     const handleTrashClick = function (name) {
@@ -75,35 +72,40 @@
                                         <div class="ms-2">
                                             <a
                                                 target="_blank"
-                                                href="{run.build_job_url}"
+                                                href={run.build_job_url}
                                                 class="link-dark"
                                             >
                                                 #{run.build_number}
                                             </a>
                                         </div>
-                                        <div class="ms-auto text-muted small-text">
+                                        <div
+                                            class="ms-auto text-muted small-text"
+                                        >
                                             {timestampToISODate(
                                                 run.start_time * 1000
                                             )}
                                         </div>
                                     </div>
-                                    <div
-                                    >
+                                    <div>
                                         <ul class="list-unstyled">
                                             {#each run.issues as issue}
-                                                <li class="ms-3 d-flex align-items-center">
+                                                <li
+                                                    class="ms-3 d-flex align-items-center"
+                                                >
                                                     <div class="ms-1">
                                                         <Fa icon={faGithub} />
                                                     </div>
                                                     <div class="ms-1">
                                                         <a
                                                             target="_blank"
-                                                            href="{issue.url}"
+                                                            href={issue.url}
                                                         >
                                                             {issue.title}
                                                         </a>
                                                     </div>
-                                                    <div class="ms-auto text-muted">
+                                                    <div
+                                                        class="ms-auto text-muted"
+                                                    >
                                                         {issue.owner}/{issue.repo}#{issue.issue_number}
                                                     </div>
                                                 </li>
@@ -118,7 +120,7 @@
             {/each}
         </ul>
         <a
-            href="/run_dashboard?state={encodedState}"
+            href="/run_dashboard?{encodedState}"
             class="btn btn-primary"
             target="_blank"
             >Investigate selected <Fa icon={faExternalLinkSquareAlt} /></a

--- a/argus/backend/assets/Stats/TestMapStats.svelte
+++ b/argus/backend/assets/Stats/TestMapStats.svelte
@@ -45,10 +45,11 @@
 
     const dispatch = createEventDispatcher();
 
-    const handleTestClick = function (name, test) {
+    const handleTestClick = function (name, test, group) {
         if (test.start_time == 0) return;
         dispatch("testClick", {
             name: name,
+            group: group,
             status: test.status,
             start_time: test.start_time,
             last_runs: test.last_runs,
@@ -87,10 +88,10 @@
             {/if}
         </h5>
         <div class="my-2 d-flex flex-wrap">
-            {#each Object.entries(filterTestsForGroup(groupName, stats.tests)) as [testName, test] (testName)}
+            {#each Object.entries(filterTestsForGroup(groupName, group.tests)) as [testName, test] (testName)}
                 <div
                     on:click={() => {
-                        handleTestClick(testName, test);
+                        handleTestClick(testName, test, groupName);
                     }}
                     class:status-block-active={test.start_time != 0}
                     class="d-inline-block border status-block {StatusBackgroundCSSClassMap[

--- a/argus/backend/assets/TestRun/TestRunInfo.svelte
+++ b/argus/backend/assets/TestRun/TestRunInfo.svelte
@@ -31,8 +31,16 @@
             <h5>Run Details</h5>
             <ul class="list-unstyled border-start ps-2">
                 <li>
+                    <span class="fw-bold">Release:</span>
+                    {test_run.release_name}
+                </li>
+                <li>
+                    <span class="fw-bold">Group:</span>
+                    {test_run.group}
+                </li>
+                <li>
                     <span class="fw-bold">Test:</span>
-                    {test_run.group}.{test_run.name}
+                    {test_run.name}
                 </li>
                 <li>
                     <span class="fw-bold">Id:</span>

--- a/argus/backend/assets/WorkArea/RunGroup.svelte
+++ b/argus/backend/assets/WorkArea/RunGroup.svelte
@@ -22,6 +22,7 @@
         failed: 0,
         total: -1,
         lastStatus: "unknown",
+        tests: {},
     };
     let groupStats = groupStatsTemplate;
     let tests = [];
@@ -61,7 +62,7 @@
         groupStats =
             val["releases"]?.[release]?.["groups"]?.[group.name] ??
             groupStatsTemplate;
-        testStatus = val["releases"]?.[release]?.["tests"];
+        testStatus = groupStats["tests"];
         sortTestsByStatus();
     });
 

--- a/argus/backend/assets/WorkArea/Test.svelte
+++ b/argus/backend/assets/WorkArea/Test.svelte
@@ -22,8 +22,8 @@
     let startTime = 0;
     let fetching = false;
     testRequests.update((val) => [...val, [release, group, test.name]]);
-    $: lastStatus = $stats?.["releases"]?.[release]?.["tests"]?.[test.name]["status"] ?? lastStatus;
-    $: startTime = $stats?.["releases"]?.[release]?.["tests"]?.[test.name]["start_time"] ?? startTime;
+    $: lastStatus = $stats?.["releases"]?.[release]?.["groups"]?.[group]?.["tests"]?.[test.name]["status"] ?? lastStatus;
+    $: startTime = $stats?.["releases"]?.[release]?.["groups"]?.[group]?.["tests"]?.[test.name]["start_time"] ?? startTime;
 
     const titleCase = function (string) {
         return string[0].toUpperCase() + string.slice(1).toLowerCase();
@@ -31,16 +31,17 @@
 
 
     const handleTestClick = function (e) {
-        if (runs[`${release}/${test.name}`]) {
-            dispatch("testRunRemove", { runId: `${release}/${test.name}`});
+        if (runs[`${release}/${group}/${test.name}`]) {
+            dispatch("testRunRemove", { runId: `${release}/${group}/${test.name}`});
             return;
         }
         if (fetching) return;
         fetching = true;
         dispatch("testRunRequest", {
-            uuid: `${release}/${test.name}`,
+            uuid: `${release}/${group}/${test.name}`,
             runs: [],
             test: test.name,
+            group: group,
             release: release
         });
         fetching = false;
@@ -49,8 +50,8 @@
 
 <li
     class:d-none={filtered}
-    class:active={runs[`${release}/${test.name}`]}
-    class:active-test-text={runs[`${release}/${test.name}`]}
+    class:active={runs[`${release}/${group}/${test.name}`]}
+    class:active-test-text={runs[`${release}/${group}/${test.name}`]}
     class="list-group-item argus-test"
     on:click={handleTestClick}
 >

--- a/argus/backend/assets/WorkArea/TestRuns.svelte
+++ b/argus/backend/assets/WorkArea/TestRuns.svelte
@@ -11,15 +11,16 @@
     export let removableRuns = false;
     const dispatch = createEventDispatcher();
     let clickedTestRuns = {};
-    let testInfo = data.test;
-    let runs = data.runs;
+    let testName = data.test;
+    let groupName = data.group
+    let runs = [];
     let noRuns = false;
     let updateCounter = 0;
     let releaseName = data.release;
-    let myId = `${releaseName}/${testInfo}`;
+    let myId = `${releaseName}/${groupName}/${testName}`;
 
     runStore.update((val) => {
-        val[myId] = [releaseName, testInfo]
+        val[myId] = [releaseName, testName, groupName]
         return val;
     });
 
@@ -77,7 +78,7 @@
                 ></span
             >
             {/if}
-            <div>{testInfo} ({releaseName})</div>
+            <div>{testName} ({releaseName}/{groupName})</div>
             {#if runs.length > 0}
             <div class="ms-auto flex-fill text-end">{timestampToISODate(runs[0].start_time * 1000)}</div>
             <div class="mx-2">#{runs[0].build_number}</div>

--- a/argus/backend/assets/WorkArea/TestRunsPanel.svelte
+++ b/argus/backend/assets/WorkArea/TestRunsPanel.svelte
@@ -1,10 +1,10 @@
 <script>
-    import { Base64 } from "js-base64";
+    import { stateEncoder } from "../Common/StateManagement";
     import TestRuns from "./TestRuns.svelte";
     export let test_runs = {};
     export let workAreaAttached = false;
     let serializedState = "";
-    $: serializedState = Base64.encode(JSON.stringify(test_runs), true);
+    $: serializedState = stateEncoder(test_runs);
     let filterStringRuns = "";
     const isFiltered = function(name = "", filterString = "") {
         if (filterString == "") {
@@ -15,7 +15,7 @@
 </script>
 
 {#if Object.keys(test_runs).length > 0}
-<div class="p-2 mb-1 text-end"><a href="/test_runs?state={serializedState}" class="btn btn-secondary btn-sm">Share</a></div>
+<div class="p-2 mb-1 text-end"><a href="/test_runs?{serializedState}" class="btn btn-secondary btn-sm">Share</a></div>
 <div class="p-2">
     <input class="form-control" type="text" placeholder="Filter runs" bind:value={filterStringRuns} on:input={() => { test_runs = test_runs }}>
 </div>

--- a/argus/backend/build_system_monitor.py
+++ b/argus/backend/build_system_monitor.py
@@ -1,0 +1,126 @@
+import logging
+from abc import ABC, abstractmethod
+import jenkins
+import click
+from flask import current_app
+from flask.cli import with_appcontext
+
+from argus.backend.db import ScyllaCluster
+from argus.db.models import ArgusRelease, ArgusReleaseGroup, ArgusReleaseGroupTest
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ArgusTestsMonitor(ABC):
+    def __init__(self) -> None:
+        self._cluster = ScyllaCluster.get()
+        self._existing_releases = list(ArgusRelease.all())
+        self._existing_groups = list(ArgusReleaseGroup.all())
+        self._existing_tests = list(ArgusReleaseGroupTest.all())
+
+    def create_release(self, release_name):
+        # pylint: disable=no-self-use
+        release = ArgusRelease()
+        release.name = release_name
+        release.save()
+
+        return release
+
+    def create_group(self, release: ArgusRelease, group_name: str, group_pretty_name: str | None = None):
+        # pylint: disable=no-self-use
+        group = ArgusReleaseGroup()
+        group.release_id = release.id
+        group.name = group_name.rstrip("-")
+        group.pretty_name = group_pretty_name
+        group.save()
+
+        return group
+
+    def create_test(self, release: ArgusRelease, group: ArgusReleaseGroup, test_name: str):
+        # pylint: disable=no-self-use
+        test = ArgusReleaseGroupTest()
+        test.name = test_name
+        test.group_id = group.id
+        test.release_id = release.id
+        test.save()
+
+        return test
+
+    @abstractmethod
+    def collect(self):
+        raise NotImplementedError()
+
+
+class JenkinsMonitor(ArgusTestsMonitor):
+    def __init__(self) -> None:
+        super().__init__()
+        self._jenkins = jenkins.Jenkins(url=current_app.config["JENKINS_URL"],
+                                        username=current_app.config["JENKINS_USER"],
+                                        password=current_app.config["JENKINS_API_TOKEN"])
+        self._monitored_releases = current_app.config["JENKINS_MONITORED_RELEASES"]
+
+    def collect(self):
+        click.echo("Collecting new tests from jenkins")
+        all_jobs = self._jenkins.get_all_jobs(folder_depth=4)
+        all_monitored_folders = [
+            job for job in all_jobs if job["name"] in self._monitored_releases]
+        for release in all_monitored_folders:
+            LOGGER.info("Processing release %s", release["name"])
+            try:
+                saved_release = ArgusRelease.get(name=release["name"])
+            except ArgusRelease.DoesNotExist:
+                LOGGER.warning(
+                    "Release %s does not exist, creating...", release["name"])
+                saved_release = self.create_release(release["name"])
+                self._existing_releases.append(saved_release)
+
+            groups = self.collect_groups_for_release(release["jobs"])
+            for group in groups:
+                LOGGER.info("Processing group %s for release %s",
+                            group["name"], saved_release.name)
+                try:
+                    group_name = group["name"].rstrip("-")
+                    saved_groups = [g for g in self._existing_groups if g.release_id ==
+                                    saved_release.id and g.name == group_name]
+                    saved_group = saved_groups[0]
+                except IndexError:
+                    LOGGER.warning(
+                        "Group %s for release %s doesn't exist, creating...", group_name, saved_release.name)
+                    saved_group = self.create_group(saved_release, group_name)
+                    self._existing_groups.append(saved_group)
+                tests = self.collect_tests_from_group(group)
+                for test in tests:
+                    LOGGER.info("Processing test %s for release %s and group %s",
+                                test["name"], saved_group.name, saved_release.name)
+                    saved_test = None
+                    for t in self._existing_tests:  # pylint: disable=invalid-name
+                        if t.release_id == saved_release.id and t.group_id == saved_group.id and t.name == test["name"]:
+                            saved_test = t
+                            break
+                    if not saved_test:
+                        LOGGER.warning("Test %s for release %s (group %s) doesn't exist, creating...",
+                                       test["name"], saved_release.name, saved_group.name)
+                        saved_test = self.create_test(
+                            saved_release, saved_group, test["name"])
+                        self._existing_tests.append(saved_test)
+
+    def collect_groups_for_release(self, jobs):
+        # pylint: disable=no-self-use
+        groups = [folder for folder in jobs if "Folder" in folder["_class"]]
+        groups = [group for group in groups if "releng" not in group["name"]]
+
+        return groups
+
+    def collect_tests_from_group(self, group):
+        # pylint: disable=no-self-use
+        tests = [test for test in group["jobs"]
+                 if "WorkflowJob" in test["_class"]]
+        return tests
+
+
+@click.command('scan-jenkins')
+@with_appcontext
+def scan_jenkins_command():
+    monitor = JenkinsMonitor()
+    monitor.collect()
+    click.echo("Done.")

--- a/argus/db/models.py
+++ b/argus/db/models.py
@@ -57,6 +57,7 @@ class UserOauthToken(Model):
 
 
 class ArgusRelease(Model):
+    __table_name__ = "argus_release_v2"
     id = columns.UUID(primary_key=True, default=uuid4)
     name = columns.Text(index=True, required=True)
     pretty_name = columns.Text()
@@ -66,17 +67,26 @@ class ArgusRelease(Model):
     picture_id = columns.UUID()
     enabled = columns.Boolean(default=lambda: True)
 
+    def __eq__(self, other):
+        return self.name == other.name
+
 
 class ArgusReleaseGroup(Model):
+    __table_name__ = "argus_group_v2"
     id = columns.UUID(primary_key=True, default=uuid4)
     release_id = columns.UUID(required=True, index=True)
     name = columns.Text(required=True, index=True)
     pretty_name = columns.Text()
     description = columns.Text()
     assignee = columns.List(value_type=columns.UUID)
+    enabled = columns.Boolean(default=lambda: True)
+
+    def __eq__(self, other):
+        return self.name == other.name and self.release_id == other.release_id
 
 
 class ArgusReleaseGroupTest(Model):
+    __table_name__ = "argus_test_v2"
     id = columns.UUID(primary_key=True, default=uuid4)
     group_id = columns.UUID(required=True, index=True)
     release_id = columns.UUID(required=True, index=True)
@@ -84,6 +94,10 @@ class ArgusReleaseGroupTest(Model):
     pretty_name = columns.Text()
     description = columns.Text()
     assignee = columns.List(value_type=columns.UUID)
+    enabled = columns.Boolean(default=lambda: True)
+
+    def __eq__(self, other):
+        return self.name == other.name and self.group_id == other.group_id and self.release_id == other.release_id
 
 
 class ArgusPlannedTestsForRelease(Model):
@@ -144,14 +158,16 @@ class ArgusGithubIssue(Model):
 
 class ArgusReleaseSchedule(Model):
     release = columns.Text(primary_key=True, required=True)
-    schedule_id = columns.TimeUUID(primary_key=True, default=uuid1, clustering_order="DESC")
+    schedule_id = columns.TimeUUID(
+        primary_key=True, default=uuid1, clustering_order="DESC")
     period_start = columns.DateTime(required=True, default=datetime.utcnow)
     period_end = columns.DateTime(required=True)
 
 
 class ArgusReleaseScheduleAssignee(Model):
     assignee = columns.UUID(primary_key=True)
-    id = columns.TimeUUID(primary_key=True, default=uuid1, clustering_order="DESC")
+    id = columns.TimeUUID(primary_key=True, default=uuid1,
+                          clustering_order="DESC")
     schedule_id = columns.TimeUUID(required=True, index=True)
     release = columns.Text(required=True)
 
@@ -159,14 +175,16 @@ class ArgusReleaseScheduleAssignee(Model):
 class ArgusReleaseScheduleTest(Model):
     name = columns.Text(partition_key=True)
     release = columns.Text(partition_key=True)
-    id = columns.TimeUUID(primary_key=True, default=uuid1, clustering_order="DESC")
+    id = columns.TimeUUID(primary_key=True, default=uuid1,
+                          clustering_order="DESC")
     schedule_id = columns.TimeUUID(required=True, index=True)
 
 
 class ArgusReleaseScheduleGroup(Model):
     name = columns.Text(partition_key=True)
     release = columns.Text(partition_key=True)
-    id = columns.TimeUUID(primary_key=True, default=uuid1, clustering_order="DESC")
+    id = columns.TimeUUID(primary_key=True, default=uuid1,
+                          clustering_order="DESC")
     schedule_id = columns.TimeUUID(required=True, index=True)
 
 

--- a/argus/db/testrun.py
+++ b/argus/db/testrun.py
@@ -344,7 +344,7 @@ class TestRun:
         "id": (UUID, "partition"),
     }
     _USING_RUNINFO = TestRunInfo
-    _TABLE_NAME = "test_runs_v5"
+    _TABLE_NAME = "test_runs_v6"
     _IS_TABLE_INITIALIZED = False
     _ARGUS_DB_INTERFACE = None
 

--- a/requirements_web.txt
+++ b/requirements_web.txt
@@ -6,3 +6,4 @@ humanize==3.13.1
 python-magic==0.4.24
 requests==2.26.0
 uwsgi==2.0.20
+python-jenkins==1.7.0


### PR DESCRIPTION
This PR adds a build system monitor and a specific implementation
for Jenkins. The intention is to monitor Jenkins releases and update
Argus metadata tables when there are missing tests. It also reworks 
theway the stats for runs are gathered and displayed,
the group field is now used to collect runs by group, since tests can
now have the same name across different groups.

[Trello](https://trello.com/c/aDyI6n3Y/4257-add-group-and-test-name-to-all-test-yamls)
