### PR TITLE
fix(argus.db.testrun): Use prepared statements for heartbeat updates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ base_dir = os.path.dirname(os.path.realpath(__file__))
 
 setup(
     name='argus',
-    version='0.6.0',
+    version='0.6.1',
     packages=["argus.db", "argus.backend"],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
Previously, heartbeat thread used a concatenated statement to update
heartbeat value, this is changed now to a BoundStatement to bring it in
line with other parts of argus.db interface. This also corrects an issue
with marker used for placeholder value, since '?' is not understood as a
placeholder in a non-prepared statement