### PR TITLE
fix(argus.db.testrun): Use new scheduled test naming format 

### DIFF
--- a/argus/db/testrun.py
+++ b/argus/db/testrun.py
@@ -551,8 +551,9 @@ class TestRun:
             connection=self.argus.CQL_ENGINE_CONNECTION_NAME
         )
 
+        scheduled_test_name = f"{self.group}/{self.run_info.details.name}"
         scheduled_tests = ArgusReleaseScheduleTest.filter(
-            release=self.release_name, name=self.run_info.details.name
+            release=self.release_name, name=scheduled_test_name
         ).all().using(
             connection=self.argus.CQL_ENGINE_CONNECTION_NAME
         )

--- a/tests/test_e2e_argus.py
+++ b/tests/test_e2e_argus.py
@@ -8,7 +8,7 @@ from argus.db.testrun import TestRun, TestRunInfo, TestRunWithHeartbeat
 from argus.db.db_types import TestInvestigationStatus
 from argus.db.interface import ArgusDatabase
 from argus.db.models import ArgusReleaseSchedule, ArgusReleaseScheduleAssignee, \
-    ArgusReleaseScheduleGroup
+    ArgusReleaseScheduleGroup, ArgusReleaseScheduleTest
 
 LOGGER = logging.getLogger(__name__)
 
@@ -86,7 +86,7 @@ class TestEndToEnd:
 
     @staticmethod
     @pytest.mark.docker_required
-    def test_auto_assign_run(completed_testrun: TestRunInfo, argus_database: ArgusDatabase):
+    def test_auto_assign_run_by_group(completed_testrun: TestRunInfo, argus_database: ArgusDatabase):
         group_assignee_user = uuid4()
 
         today = datetime.datetime.utcnow()
@@ -121,3 +121,41 @@ class TestEndToEnd:
         row = argus_database.fetch(table_name=TestRun.table_name(), run_id=test_id)
         rebuilt_testrun = TestRun.from_db_row(row)
         assert group_assignee_user == UUID(rebuilt_testrun.assignee)
+
+    @staticmethod
+    @pytest.mark.docker_required
+    def test_auto_assign_run_by_test_name(completed_testrun: TestRunInfo, argus_database: ArgusDatabase):
+        test_assignee_user = uuid4()
+
+        today = datetime.datetime.utcnow()
+        this_monday = today - datetime.timedelta(today.weekday() + 1)
+        next_week = this_monday + datetime.timedelta(8)
+
+        schedule = ArgusReleaseSchedule()
+        schedule.release = "4_5rc5"
+        schedule.period_start = this_monday
+        schedule.period_end = next_week
+        schedule.using(connection=argus_database.CQL_ENGINE_CONNECTION_NAME).save()
+
+        scheduled_test = ArgusReleaseScheduleTest()
+        scheduled_test.schedule_id = schedule.schedule_id
+        scheduled_test.release = "4_5rc5"
+        scheduled_test.name = "longevity-test/longevity-test-100gb-4h"
+        scheduled_test.using(connection=argus_database.CQL_ENGINE_CONNECTION_NAME).save()
+
+        scheduled_assignee = ArgusReleaseScheduleAssignee()
+        scheduled_assignee.schedule_id = schedule.schedule_id
+        scheduled_assignee.release = "4_5rc5"
+        scheduled_assignee.assignee = test_assignee_user
+        scheduled_assignee.using(connection=argus_database.CQL_ENGINE_CONNECTION_NAME).save()
+
+        TestRun.set_argus(argus_database)
+        test_id = uuid4()
+        test_run = TestRun(test_id=test_id, group="longevity-test", release_name="4_5rc5", assignee="",
+                           run_info=completed_testrun, investigation_status=TestInvestigationStatus.INVESTIGATED)
+        test_run.save()
+        assert test_assignee_user == UUID(test_run.assignee)
+
+        row = argus_database.fetch(table_name=TestRun.table_name(), run_id=test_id)
+        rebuilt_testrun = TestRun.from_db_row(row)
+        assert test_assignee_user == UUID(rebuilt_testrun.assignee)


### PR DESCRIPTION
Since https://github.com/scylladb/argus/commit/36d7e51d95e7f3ec94cb6d5739933eb279137228 it is possible to run
into a name collision between tests, so tests that were scheduled using
duty planning now use a convention of "group/test_name" to avoid such
collisions. This fix is addressing the auto-assignment logic of TestRun
to also use such convention when looking for valid schedules.

[Trello](https://trello.com/c/6eBrOJxy/4753-auto-assignment-doesnt-work-after-changes-to-release-planning)