### PR TITLE
improvement(argus.backend): Show manually assigned jobs on My Jobs page

### DIFF
--- a/argus/backend/argus_service.py
+++ b/argus/backend/argus_service.py
@@ -1065,8 +1065,13 @@ class ArgusService:
         runs = self.session.execute(self.jobs_by_assignee, parameters=(str(user.id),))
         schedules = self.get_schedules_for_user(user)
         valid_runs = []
+        today = datetime.datetime.now()
+        month_ago = today - datetime.timedelta(days=30)
         for run in runs:
             run_date = datetime.datetime.fromtimestamp(run["start_time"])
+            if user.id == UUID(run["assignee"]) and run_date >= month_ago:
+                valid_runs.append(run)
+                continue
             for schedule in schedules:
                 if not run["release_name"] == schedule["release"]:
                     continue


### PR DESCRIPTION
This commit adds a way to show manually (that is, assigned without a
schedule) assigned jobs that are at most 1 month old.

[Trello](https://trello.com/c/O7WHA32K/4761-verify-that-manual-assignments-show-up-on-my-jobs-page)