### PR TITLE
improvement(argus.backend): Show assignees for individual jobs

### DIFF
--- a/argus/backend/assets/ReleasePlanner/DutyPlanner.svelte
+++ b/argus/backend/assets/ReleasePlanner/DutyPlanner.svelte
@@ -202,7 +202,7 @@
             selectedGroups = [];
         }
         if (selectedGroups.findIndex(val => val.value == data.group.name) == -1) {
-            selectedGroups.push({ label: data.group.pretty_name, value: data.group.name });
+            selectedGroups.push({ label: data.group.pretty_name ?? data.group.name, value: data.group.name });
             selectedGroups = selectedGroups;
             handleGroupSelect({
                 detail: selectedGroups
@@ -251,7 +251,7 @@
         <div class="p-2 display-6">{releaseData.release.name}</div>
     </div>
     <div class="row">
-        {#if schedules.length > 0 && Object.values(users).length > 0}
+        {#if Object.values(users).length > 0}
             <ScheduleTable {releaseData} {users} {schedules} on:cellClick={handleCellClick} on:deleteSchedule={deleteSchedule} on:clearGroups={handleClearGroups}/>
         {/if}
     </div>

--- a/argus/backend/assets/ReleasePlanner/Schedule.svelte
+++ b/argus/backend/assets/ReleasePlanner/Schedule.svelte
@@ -61,7 +61,7 @@
                         <li class="list-group-item d-flex align-items-center">
                             <div>
                                 {releaseData.groups.find((val) => val.name == group)
-                                    .pretty_name}
+                                    .pretty_name ?? group}
                             </div>
                         </li>
                     {/each}

--- a/argus/backend/assets/ReleasePlanner/ScheduleTable.svelte
+++ b/argus/backend/assets/ReleasePlanner/ScheduleTable.svelte
@@ -125,7 +125,7 @@
             {#each groups as group (group.name)}
                 <tr>
                     <td
-                        >{group.pretty_name}</td
+                        >{group.pretty_name ?? group.name}</td
                     >
                     {#each dates as date}
                         <td

--- a/argus/backend/assets/Stores/AssigneeSubscriber.js
+++ b/argus/backend/assets/Stores/AssigneeSubscriber.js
@@ -61,6 +61,22 @@ export const requestAssigneesForReleaseGroups = function (release, groups) {
     }, 250);
 }
 
+export const requestAssigneesForReleaseTests = function (release, tests, group) {
+    tests = tests.map((test) => `${group}/${test.name}`);
+    assigneeRequests.update((value) => {
+        let releaseBody = value[release] ?? {};
+        let testSet = new Set([...(releaseBody.tests ?? []), ...tests]);
+        releaseBody.tests = Array.from(testSet.values());
+        value[release] = releaseBody;
+        return value;
+    });
+
+    setTimeout(() => {
+        fetchAssignees((value) => assigneeStore.update(() => value));
+    }, 250);
+}
+
+
 export const assigneeStore = writable({}, (set) => {
     setInterval(() => {
         fetchAssignees(set);

--- a/argus/backend/assets/WorkArea/RunGroup.svelte
+++ b/argus/backend/assets/WorkArea/RunGroup.svelte
@@ -2,6 +2,7 @@
     import { groupRequests, stats } from "../Stores/StatsSubscriber";
     import { StatusSortPriority } from "../Common/TestStatus";
     import { sendMessage } from "../Stores/AlertStore";
+    import { requestAssigneesForReleaseTests } from "../Stores/AssigneeSubscriber";
     import NumberStats from "../Stats/NumberStats.svelte";
     import AssigneeList from "./AssigneeList.svelte";
     import Test from "./Test.svelte";
@@ -93,6 +94,7 @@
                 tests = apiJson.response["tests"];
                 clickedGroups[group.name] = true;
                 sortTestsByStatus();
+                requestAssigneesForReleaseTests(release, tests, group.name);
                 testsReady = true;
             } else {
                 throw apiJson;

--- a/argus/backend/assets/WorkArea/Test.svelte
+++ b/argus/backend/assets/WorkArea/Test.svelte
@@ -3,6 +3,8 @@
     import { testRequests, stats } from "../Stores/StatsSubscriber";
     import { StatusBackgroundCSSClassMap } from "../Common/TestStatus.js";
     import { timestampToISODate } from "../Common/DateUtils";
+    import { assigneeStore } from "../Stores/AssigneeSubscriber";
+    import AssigneeList from "./AssigneeList.svelte";
     export let release = "";
     export let group = "";
     export let filtered = false;
@@ -17,6 +19,8 @@
     };
     export let lastStatus = "unknown";
     export let runs = {};
+    let assigneeList = [];
+    $: assigneeList = $assigneeStore?.[release]?.["tests"]?.[`${group}/${test.name}`] ?? [];
     const dispatch = createEventDispatcher();
 
     let startTime = 0;
@@ -67,7 +71,12 @@
                 {/if}
             </div>
             <div class="col-10 overflow-hidden">
-                <div>{test.pretty_name ?? test.name}</div>
+                <div class="d-flex">
+                    <div>{test.pretty_name ?? test.name}</div>
+                    <div class="ms-auto text-right">
+                        <AssigneeList assignees={assigneeList}/>
+                    </div>
+                </div>
                 {#if startTime > 1}
                 <div
                     class:text-muted={!runs[`${release}/${test.name}`]}


### PR DESCRIPTION
This commit adds display of assignees to invidual tests in line with
their respective schedules defined in Release Planner.

[Trello](https://trello.com/c/ELd1kWBJ/4771-assignees-not-shown-in-work-area-for-release-50)