### PR TITLE
fix(argus_service.py): Remove obsolete regex substituion

### DIFF
--- a/argus/backend/argus_service.py
+++ b/argus/backend/argus_service.py
@@ -449,7 +449,7 @@ class ArgusService:
         test_run = TestRun.from_id(test_id=UUID(test_run_id))
         release_name = test_run.release_name
         release = ArgusRelease.get(name=release_name)
-        test_name = re.sub(r"\-test$", "", test_run.run_info.details.name)
+        test_name = test_run.run_info.details.name
         test = [test for test in ArgusReleaseGroupTest.all() if test.release_id ==
                 release.id and test.name.startswith(test_name)]
         test = test[0]
@@ -488,7 +488,7 @@ class ArgusService:
         test_run = TestRun.from_id(test_id=UUID(test_run_id))
         release_name = test_run.release_name
         release = ArgusRelease.get(name=release_name)
-        test_name = re.sub(r"\-test$", "", test_run.run_info.details.name)
+        test_name = test_run.run_info.details.name
         test = [test for test in ArgusReleaseGroupTest.all() if test.release_id ==
                 release.id and test.name.startswith(test_name)]
         test = test[0]
@@ -611,7 +611,7 @@ class ArgusService:
             raise Exception("URL doesn't match Github schema")
 
         run = self.session.execute(self.runs_by_id_stmt, parameters=([UUID(run_id)],)).one()
-        test_name = re.sub(r"\-test$", "", run["name"])
+        test_name = run["name"]
         release = ArgusRelease.get(name=run["release_name"])
         test = ArgusReleaseGroupTest.filter(name=test_name).all()
         test = first(test, release.id, key=lambda val: val.release_id)


### PR DESCRIPTION
Removes obsolete substitution logic that was previously used
to strip test name of a suffix inside it.
[Trello](https://trello.com/c/UVrc1jUQ/4809-api-error-when-pasting-in-github-issue-link-in-dashboard-run-issues-tab)
Fixes #59 