### PR TITLE
improvement(TestRunInfo.svelte): Show an SCT Runner field during runs

### DIFF
--- a/argus/backend/assets/TestRun/TestRunInfo.svelte
+++ b/argus/backend/assets/TestRun/TestRunInfo.svelte
@@ -116,7 +116,32 @@
         </div>
     </div>
     <div class="row">
-        <div class="col p-2">
+        <div class="col-6 p-2">
+            {#if InProgressStatuses.includes(test_run.status)}
+                <div class="mb-1">
+                    <div class="input-group">
+                        <span class="input-group-text fw-bold">SCT Runner</span>
+                        <input
+                            type="text"
+                            class="form-control user-select-all"
+                            disabled
+                            value="ssh -i ~/.ssh/scylla-qa-ec2 ubuntu@{test_run
+                                .sct_runner_host.public_ip}"
+                        />
+                        <button
+                            class="btn btn-success"
+                            type="button"
+                            on:click={() => {
+                                navigator.clipboard.writeText(
+                                    `ssh -i ~/.ssh/scylla-qa-ec2 ubuntu@${test_run.sct_runner_host.public_ip}`
+                                );
+                            }}
+                        >
+                            <Fa icon={faCopy} />
+                        </button>
+                    </div>
+                </div>
+            {/if}
             <div class="btn-group">
                 {#if InProgressStatuses.includes(test_run.status) && locateGrafanaNode()}
                     <a


### PR DESCRIPTION
This commit adds an ssh field to the run details, allowing quick ssh
connections to be established
[Trello](https://trello.com/c/nxl7gox6/4773-add-ssh-command-to-connect-to-the-sct-runner-in-details-tab)
![image](https://user-images.githubusercontent.com/7761415/159154732-3180a4ae-8f54-4d2a-a4c6-ed22c6ec1275.png)
