### PR TITLE
feature(TestRuns.svelte): Viewport run indicator

### DIFF
--- a/argus/backend/assets/TestRun/TestRun.svelte
+++ b/argus/backend/assets/TestRun/TestRun.svelte
@@ -1,5 +1,5 @@
 <script>
-    import { onMount, onDestroy } from "svelte";
+    import { onMount, onDestroy, createEventDispatcher } from "svelte";
     import Fa from "svelte-fa";
     import {
         faTimes,
@@ -39,6 +39,7 @@
     import { sendMessage } from "../Stores/AlertStore";
     export let id = "";
     export let build_number = -1;
+    const dispatch = createEventDispatcher();
     let test_run = undefined;
     let heartbeatHuman = "";
     let newStatus = "";
@@ -187,7 +188,9 @@
 
     const handleAssign = async function (event) {
         let new_assignee = event.detail.value;
-        new_assignee = Object.values(userSelect).find(user => (user.value == new_assignee));
+        new_assignee = Object.values(userSelect).find(
+            (user) => user.value == new_assignee
+        );
         if (!new_assignee) {
             return;
         }
@@ -317,332 +320,371 @@
     });
 </script>
 
-<div class="border rounded p-2 shadow-sm testrun-card mb-4">
-    {#if test_run}
-        <div class="row p-2">
-            <div class="col-6">
-                <div class="mb-2">
-                <a
-                    class="link-dark"
-                    href="/test_run/{id}"
-                    target="_blank"
-                >
-                {test_run.build_job_name}#{build_number}
+<div class="border rounded shadow-sm testrun-card mb-4 top-bar">
+    <div class="d-flex px-2 py-2 mb-1 border-bottom bg-white ">
+        <div class="p-1">
+            {#if test_run}
+                <a class="link-dark" href="/test_run/{id}" target="_blank">
+                    {test_run.build_job_name}#{build_number}
                 </a>
-                </div>
-                <div class="d-flex align-items-center">
-                    <div class="dropdown">
-                        <button
-                            class="btn {StatusButtonCSSClassMap[
-                                test_run.status
-                            ]} text-light"
-                            type="button"
-                            title={timestampToISODate(
-                                test_run.end_time * 1000,
-                                true
-                            )}
-                            data-bs-toggle="dropdown"
-                        >
-                            {test_run.status.toUpperCase()}
-                            {#if InProgressStatuses.find((status) => status == test_run.status)}
-                                <span
-                                    class="spinner-border spinner-border-sm d-inline-block"
+            {/if}
+        </div>
+        <div class="ms-auto text-end">
+            <button class="btn btn-sm btn-outline-dark" title="Close" on:click={() => {
+                dispatch("closeRun", { id: id })
+            }}
+                ><Fa icon={faTimes} /></button
+            >
+        </div>
+    </div>
+    {#if test_run}
+        <div class="p-2">
+            <div class="row p-2">
+                <div class="col-6">
+                    <div class="d-flex align-items-center">
+                        <div class="dropdown">
+                            <button
+                                class="btn {StatusButtonCSSClassMap[
+                                    test_run.status
+                                ]} text-light"
+                                type="button"
+                                title={timestampToISODate(
+                                    test_run.end_time * 1000,
+                                    true
+                                )}
+                                data-bs-toggle="dropdown"
+                            >
+                                {test_run.status.toUpperCase()}
+                                {#if InProgressStatuses.find((status) => status == test_run.status)}
+                                    <span
+                                        class="spinner-border spinner-border-sm d-inline-block"
+                                    />
+                                {/if}
+                            </button>
+                            <ul class="dropdown-menu">
+                                {#each Object.keys(TestStatusChangeable) as status}
+                                    <li>
+                                        <button
+                                            class="dropdown-item"
+                                            disabled={disableButtons}
+                                            on:click={() => {
+                                                newStatus =
+                                                    status.toLowerCase();
+                                                handleStatus();
+                                            }}>{status}</button
+                                        >
+                                    </li>
+                                {/each}
+                            </ul>
+                        </div>
+                        <div class="dropdown ms-2">
+                            <button
+                                class="btn {InvestigationButtonCSSClassMap[
+                                    test_run.investigation_status
+                                ]} text-light"
+                                type="button"
+                                data-bs-toggle="dropdown"
+                            >
+                                <Fa
+                                    icon={investigationStatusIcon[
+                                        test_run.investigation_status
+                                    ]}
                                 />
-                            {/if}
-                        </button>
-                        <ul class="dropdown-menu">
-                            {#each Object.keys(TestStatusChangeable) as status}
-                                <li>
-                                    <button
-                                        class="dropdown-item"
-                                        disabled={disableButtons}
-                                        on:click={() => {
-                                            newStatus = status.toLowerCase();
-                                            handleStatus();
-                                        }}>{status}</button
-                                    >
-                                </li>
-                            {/each}
-                        </ul>
-                    </div>
-                    <div class="dropdown ms-2">
-                        <button
-                            class="btn {InvestigationButtonCSSClassMap[
-                                test_run.investigation_status
-                            ]} text-light"
-                            type="button"
-                            data-bs-toggle="dropdown"
-                        >
-                            <Fa
-                                icon={investigationStatusIcon[
+                                {TestInvestigationStatusStrings[
                                     test_run.investigation_status
                                 ]}
-                            />
-                            {TestInvestigationStatusStrings[
-                                test_run.investigation_status
-                            ]}
-                        </button>
-                        <ul class="dropdown-menu">
-                            {#each Object.entries(TestInvestigationStatus) as [key, status]}
-                                <li>
-                                    <button
-                                        class="dropdown-item"
-                                        disabled={disableButtons}
-                                        on:click={() => {
-                                            newInvestigationStatus = status;
-                                            handleInvestigationStatus();
-                                        }}
-                                        >{TestInvestigationStatusStrings[
-                                            status
-                                        ]}</button
-                                    >
-                                </li>
-                            {/each}
-                        </ul>
+                            </button>
+                            <ul class="dropdown-menu">
+                                {#each Object.entries(TestInvestigationStatus) as [key, status]}
+                                    <li>
+                                        <button
+                                            class="dropdown-item"
+                                            disabled={disableButtons}
+                                            on:click={() => {
+                                                newInvestigationStatus = status;
+                                                handleInvestigationStatus();
+                                            }}
+                                            >{TestInvestigationStatusStrings[
+                                                status
+                                            ]}</button
+                                        >
+                                    </li>
+                                {/each}
+                            </ul>
+                        </div>
                     </div>
                 </div>
+                <div class="col-6">
+                    <div class="row mb-2 text-sm justify-content-end">
+                        <div class="col-6">
+                            {#if Object.keys(userSelect).length > 1}
+                                <div class="text-muted text-sm text-end mb-2">
+                                    Assignee
+                                </div>
+                                <div class="border rounded">
+                                    <div class="d-flex align-items-center m-1">
+                                        {#if users[currentAssignee.id]}
+                                            <img
+                                                class="img-profile me-2"
+                                                src={getPicture(
+                                                    users[currentAssignee.id]
+                                                        ?.picture_id
+                                                )}
+                                                alt={users[currentAssignee.id]
+                                                    ?.username}
+                                            />
+                                        {/if}
+                                        <div class="flex-fill">
+                                            <Select
+                                                Item={User}
+                                                value={currentAssignee.value}
+                                                items={Object.values(
+                                                    userSelect
+                                                )}
+                                                hideEmptyState={true}
+                                                isClearable={false}
+                                                isSearchable={true}
+                                                on:select={handleAssign}
+                                            />
+                                        </div>
+                                    </div>
+                                </div>
+                            {/if}
+                        </div>
+                    </div>
+                    {#if InProgressStatuses.includes(test_run.status)}
+                        <div class="row text-end">
+                            <div
+                                class="col d-flex flex-column text-muted text-sm"
+                            >
+                                <div>Last heartbeat: {heartbeatHuman} ago</div>
+                                <div>Started: {startedAtHuman} ago</div>
+                            </div>
+                        </div>
+                    {/if}
+                </div>
             </div>
-            <div class="col-6">
-                <div class="row mb-2 text-sm justify-content-end">
-                    <div class="col-6">
-                        {#if Object.keys(userSelect).length > 1}
-                            <div class="text-muted text-sm text-end mb-2">Assignee</div>
-                            <div class="border rounded">
-                                <div class="d-flex align-items-center m-1">
-                                    {#if users[currentAssignee.id]}
-                                        <img
-                                            class="img-profile me-2"
-                                            src={getPicture(
-                                                users[currentAssignee.id]
-                                                    ?.picture_id
-                                            )}
-                                            alt={users[currentAssignee.id]
-                                                ?.username}
-                                        />
-                                    {/if}
-                                    <div class="flex-fill">
-                                        <Select
-                                            Item={User}
-                                            value={currentAssignee.value}
-                                            items={Object.values(userSelect)}
-                                            hideEmptyState={true}
-                                            isClearable={false}
-                                            isSearchable={true}
-                                            on:select={handleAssign}
-                                        />
+            <nav>
+                <div class="nav nav-tabs" id="nav-tab-{id}" role="tablist">
+                    <button
+                        class="nav-link active"
+                        id="nav-details-tab-{id}"
+                        data-bs-toggle="tab"
+                        data-bs-target="#nav-details-{id}"
+                        type="button"
+                        role="tab"
+                        ><i class="fas fa-info-circle" /> Details</button
+                    >
+                    <button
+                        class="nav-link"
+                        id="nav-screenshots-tab-{id}"
+                        data-bs-toggle="tab"
+                        data-bs-target="#nav-screenshots-{id}"
+                        type="button"
+                        role="tab"
+                        ><i class="fas fa-images" /> Screenshots</button
+                    >
+                    <button
+                        class="nav-link"
+                        id="nav-resources-tab-{id}"
+                        data-bs-toggle="tab"
+                        data-bs-target="#nav-resources-{id}"
+                        type="button"
+                        role="tab"><i class="fas fa-cloud" /> Resources</button
+                    >
+                    <button
+                        class="nav-link"
+                        id="nav-events-tab-{id}"
+                        data-bs-toggle="tab"
+                        data-bs-target="#nav-events-{id}"
+                        type="button"
+                        role="tab"
+                        ><i class="fas fa-rss-square" /> Events</button
+                    >
+                    <button
+                        class="nav-link"
+                        id="nav-nemesis-tab-{id}"
+                        data-bs-toggle="tab"
+                        data-bs-target="#nav-nemesis-{id}"
+                        type="button"
+                        role="tab"><i class="fas fa-spider" /> Nemesis</button
+                    >
+                    <button
+                        class="nav-link"
+                        id="nav-logs-tab-{id}"
+                        data-bs-toggle="tab"
+                        data-bs-target="#nav-logs-{id}"
+                        type="button"
+                        role="tab"><i class="fas fa-box" /> Logs</button
+                    >
+                    <button
+                        class="nav-link"
+                        id="nav-discuss-tab-{id}"
+                        data-bs-toggle="tab"
+                        data-bs-target="#nav-discuss-{id}"
+                        type="button"
+                        on:click={() => (commentsOpen = true)}
+                        role="tab"
+                        ><i class="fas fa-comments" /> Discussion</button
+                    >
+                    <button
+                        class="nav-link"
+                        id="nav-issues-tab-{id}"
+                        data-bs-toggle="tab"
+                        data-bs-target="#nav-issues-{id}"
+                        type="button"
+                        role="tab"
+                        on:click={() => (issuesOpen = true)}
+                        ><i class="fas fa-code-branch" /> Issues</button
+                    >
+                    <button
+                        class="nav-link"
+                        id="nav-activity-tab-{id}"
+                        data-bs-toggle="tab"
+                        data-bs-target="#nav-activity-{id}"
+                        type="button"
+                        on:click={() => (activityOpen = true)}
+                        role="tab"
+                        ><i class="fas fa-exclamation-triangle" /> Activity</button
+                    >
+                </div>
+            </nav>
+            <div
+                class="tab-content border-start border-end border-bottom bg-white"
+                id="nav-tabContent-{id}"
+            >
+                <div
+                    class="tab-pane fade show active"
+                    id="nav-details-{id}"
+                    role="tabpanel"
+                >
+                    <TestRunInfo {test_run} />
+                </div>
+                <div
+                    class="tab-pane fade"
+                    id="nav-screenshots-{id}"
+                    role="tabpanel"
+                >
+                    <Screenshots screenshots={test_run.screenshots} />
+                </div>
+                <div
+                    class="tab-pane fade"
+                    id="nav-resources-{id}"
+                    role="tabpanel"
+                >
+                    <div class="p-2">
+                        <ResourcesInfo
+                            resources={test_run.allocated_resources}
+                        />
+                    </div>
+                </div>
+                <div class="tab-pane fade" id="nav-events-{id}" role="tabpanel">
+                    <div class="accordion accordion-flush" id="accordionEvents">
+                        {#each test_run.events as event_container}
+                            <div class="accordion-item">
+                                <h2
+                                    class="accordion-header"
+                                    id="accordionHeadingEvents{event_container.severity}-{id}"
+                                >
+                                    <button
+                                        class="accordion-button collapsed"
+                                        type="button"
+                                        data-bs-toggle="collapse"
+                                        data-bs-target="#accordionBodyEvents{event_container.severity}-{id}"
+                                    >
+                                        {event_container.severity.toUpperCase()}
+                                        ({event_container.event_amount})
+                                    </button>
+                                </h2>
+                                <div
+                                    id="accordionBodyEvents{event_container.severity}-{id}"
+                                    class="accordion-collapse collapse"
+                                    data-bs-parent="#accordionEvents"
+                                >
+                                    <div class="accordion-body">
+                                        {#each event_container.last_events as event}
+                                            <pre
+                                                class="mb-1 p-1 border font-monospace">
+                                                {event}
+                                            </pre>
+                                        {/each}
                                     </div>
                                 </div>
                             </div>
-                        {/if}
+                        {:else}
+                            <div class="row">
+                                <div class="col text-center p-1 text-muted">
+                                    No events submitted yet.
+                                </div>
+                            </div>
+                        {/each}
                     </div>
                 </div>
-                {#if InProgressStatuses.includes(test_run.status)}
-                <div class="row text-end">
-                        <div class="col d-flex flex-column text-muted text-sm">
-                            <div>Last heartbeat: {heartbeatHuman} ago</div>
-                            <div>Started: {startedAtHuman} ago</div>
-                        </div>
-                </div>
-                {/if}
-            </div>
-        </div>
-        <nav>
-            <div class="nav nav-tabs" id="nav-tab-{id}" role="tablist">
-                <button
-                    class="nav-link active"
-                    id="nav-details-tab-{id}"
-                    data-bs-toggle="tab"
-                    data-bs-target="#nav-details-{id}"
-                    type="button"
-                    role="tab"><i class="fas fa-info-circle" /> Details</button
+                <div
+                    class="tab-pane fade"
+                    id="nav-nemesis-{id}"
+                    role="tabpanel"
                 >
-                <button
-                    class="nav-link"
-                    id="nav-screenshots-tab-{id}"
-                    data-bs-toggle="tab"
-                    data-bs-target="#nav-screenshots-{id}"
-                    type="button"
-                    role="tab"><i class="fas fa-images" /> Screenshots</button
-                >
-                <button
-                    class="nav-link"
-                    id="nav-resources-tab-{id}"
-                    data-bs-toggle="tab"
-                    data-bs-target="#nav-resources-{id}"
-                    type="button"
-                    role="tab"><i class="fas fa-cloud" /> Resources</button
-                >
-                <button
-                    class="nav-link"
-                    id="nav-events-tab-{id}"
-                    data-bs-toggle="tab"
-                    data-bs-target="#nav-events-{id}"
-                    type="button"
-                    role="tab"><i class="fas fa-rss-square" /> Events</button
-                >
-                <button
-                    class="nav-link"
-                    id="nav-nemesis-tab-{id}"
-                    data-bs-toggle="tab"
-                    data-bs-target="#nav-nemesis-{id}"
-                    type="button"
-                    role="tab"><i class="fas fa-spider" /> Nemesis</button
-                >
-                <button
-                    class="nav-link"
-                    id="nav-logs-tab-{id}"
-                    data-bs-toggle="tab"
-                    data-bs-target="#nav-logs-{id}"
-                    type="button"
-                    role="tab"><i class="fas fa-box" /> Logs</button
-                >
-                <button
-                    class="nav-link"
-                    id="nav-discuss-tab-{id}"
-                    data-bs-toggle="tab"
-                    data-bs-target="#nav-discuss-{id}"
-                    type="button"
-                    on:click={() => (commentsOpen = true)}
-                    role="tab"><i class="fas fa-comments" /> Discussion</button
-                >
-                <button
-                    class="nav-link"
-                    id="nav-issues-tab-{id}"
-                    data-bs-toggle="tab"
-                    data-bs-target="#nav-issues-{id}"
-                    type="button"
-                    role="tab"
-                    on:click={() => (issuesOpen = true)}
-                    ><i class="fas fa-code-branch" /> Issues</button
-                >
-                <button
-                    class="nav-link"
-                    id="nav-activity-tab-{id}"
-                    data-bs-toggle="tab"
-                    data-bs-target="#nav-activity-{id}"
-                    type="button"
-                    on:click={() => (activityOpen = true)}
-                    role="tab"
-                    ><i class="fas fa-exclamation-triangle" /> Activity</button
-                >
-            </div>
-        </nav>
-        <div
-            class="tab-content border-start border-end border-bottom bg-white"
-            id="nav-tabContent-{id}"
-        >
-            <div
-                class="tab-pane fade show active"
-                id="nav-details-{id}"
-                role="tabpanel"
-            >
-                <TestRunInfo {test_run} />
-            </div>
-            <div
-                class="tab-pane fade"
-                id="nav-screenshots-{id}"
-                role="tabpanel"
-            >
-                <Screenshots screenshots={test_run.screenshots} />
-            </div>
-            <div class="tab-pane fade" id="nav-resources-{id}" role="tabpanel">
-                <div class="p-2">
-                    <ResourcesInfo
+                    <NemesisTable
+                        nemesisCollection={test_run.nemesis_data}
                         resources={test_run.allocated_resources}
                     />
                 </div>
-            </div>
-            <div class="tab-pane fade" id="nav-events-{id}" role="tabpanel">
-                <div class="accordion accordion-flush" id="accordionEvents">
-                    {#each test_run.events as event_container}
-                        <div class="accordion-item">
-                            <h2
-                                class="accordion-header"
-                                id="accordionHeadingEvents{event_container.severity}-{id}"
-                            >
-                                <button
-                                    class="accordion-button collapsed"
-                                    type="button"
-                                    data-bs-toggle="collapse"
-                                    data-bs-target="#accordionBodyEvents{event_container.severity}-{id}"
-                                >
-                                    {event_container.severity.toUpperCase()} ({event_container.event_amount})
-                                </button>
-                            </h2>
-                            <div
-                                id="accordionBodyEvents{event_container.severity}-{id}"
-                                class="accordion-collapse collapse"
-                                data-bs-parent="#accordionEvents"
-                            >
-                                <div class="accordion-body">
-                                    {#each event_container.last_events as event}
-                                        <pre
-                                            class="mb-1 p-1 border font-monospace">
-                                            {event}
-                                        </pre>
-                                    {/each}
-                                </div>
-                            </div>
-                        </div>
+                <div class="tab-pane fade" id="nav-logs-{id}" role="tabpanel">
+                    {#if test_run.logs.length > 0}
+                        <table
+                            class="table table-bordered table-sm text-center"
+                        >
+                            <thead>
+                                <th>Log Type</th>
+                                <th>Log URL</th>
+                            </thead>
+                            <tbody>
+                                {#each test_run.logs as log}
+                                    <tr>
+                                        <td>{log[0]}</td>
+                                        <td
+                                            ><a
+                                                class="btn btn-primary"
+                                                href={log[1]}>Download</a
+                                            ></td
+                                        >
+                                    </tr>
+                                {/each}
+                            </tbody>
+                        </table>
                     {:else}
                         <div class="row">
                             <div class="col text-center p-1 text-muted">
-                                No events submitted yet.
+                                No logs.
                             </div>
                         </div>
-                    {/each}
+                    {/if}
                 </div>
-            </div>
-            <div class="tab-pane fade" id="nav-nemesis-{id}" role="tabpanel">
-                <NemesisTable
-                    nemesisCollection={test_run.nemesis_data}
-                    resources={test_run.allocated_resources}
-                />
-            </div>
-            <div class="tab-pane fade" id="nav-logs-{id}" role="tabpanel">
-                {#if test_run.logs.length > 0}
-                    <table class="table table-bordered table-sm text-center">
-                        <thead>
-                            <th>Log Type</th>
-                            <th>Log URL</th>
-                        </thead>
-                        <tbody>
-                            {#each test_run.logs as log}
-                                <tr>
-                                    <td>{log[0]}</td>
-                                    <td
-                                        ><a
-                                            class="btn btn-primary"
-                                            href={log[1]}>Download</a
-                                        ></td
-                                    >
-                                </tr>
-                            {/each}
-                        </tbody>
-                    </table>
-                {:else}
-                    <div class="row">
-                        <div class="col text-center p-1 text-muted">
-                            No logs.
-                        </div>
-                    </div>
-                {/if}
-            </div>
-            <div class="tab-pane fade" id="nav-discuss-{id}" role="tabpanel">
-                {#if commentsOpen}
-                    <TestRunComments {id} />
-                {/if}
-            </div>
-            <div class="tab-pane fade" id="nav-issues-{id}" role="tabpanel">
-                <IssueTemplate {test_run} />
-                {#if issuesOpen}
-                    <GithubIssues {id} />
-                {/if}
-            </div>
-            <div class="tab-pane fade" id="nav-activity-{id}" role="tabpanel">
-                {#if activityOpen}
-                    <ActivityTab {id} />
-                {/if}
+                <div
+                    class="tab-pane fade"
+                    id="nav-discuss-{id}"
+                    role="tabpanel"
+                >
+                    {#if commentsOpen}
+                        <TestRunComments {id} />
+                    {/if}
+                </div>
+                <div class="tab-pane fade" id="nav-issues-{id}" role="tabpanel">
+                    <IssueTemplate {test_run} />
+                    {#if issuesOpen}
+                        <GithubIssues {id} />
+                    {/if}
+                </div>
+                <div
+                    class="tab-pane fade"
+                    id="nav-activity-{id}"
+                    role="tabpanel"
+                >
+                    {#if activityOpen}
+                        <ActivityTab {id} />
+                    {/if}
+                </div>
             </div>
         </div>
     {:else}
@@ -679,6 +721,10 @@
     }
 
     .testrun-card {
-        background-color: #fafafa;
+        background-color: #ededed;
+    }
+
+    .top-bar {
+        overflow: hidden;
     }
 </style>

--- a/argus/backend/assets/TestRun/TestRunInfo.svelte
+++ b/argus/backend/assets/TestRun/TestRunInfo.svelte
@@ -148,19 +148,19 @@
                         target="_blank"
                         href="http://{locateGrafanaNode().instance_info
                             .public_ip}:3000/"
-                        class="btn btn-warning">Open Grafana</a
+                        class="btn btn-outline-warning">Open Grafana</a
                     >
                 {:else}
                     <a
                         href="https://jenkins.scylladb.com/view/QA/job/QA-tools/job/hydra-show-monitor/parambuild/?test_id={test_run.id}"
-                        class="btn btn-primary"
+                        class="btn btn-outline-primary"
                         target="_blank"
                         aria-current="page"
                         ><Fa icon={faSearch} /> Restore Monitoring Stack</a
                     >
                     <button
                         type="button"
-                        class="btn btn-success"
+                        class="btn btn-outline-success"
                         on:click={() => {
                             navigator.clipboard.writeText(
                                 cmd_hydraInvestigateShowMonitor
@@ -169,7 +169,7 @@
                     >
                     <button
                         type="button"
-                        class="btn btn-success"
+                        class="btn btn-outline-success"
                         on:click={() => {
                             navigator.clipboard.writeText(
                                 cmd_hydraInvestigateShowLogs
@@ -180,7 +180,7 @@
                 <a
                     target="_blank"
                     href="/dashboard/{test_run.release_name}"
-                    class="btn btn-info"
+                    class="btn btn-outline-success"
                     ><Fa icon={faBusinessTime} /> Release Dashboard</a
                 >
             </div>

--- a/argus/backend/assets/WorkArea/RunRelease.svelte
+++ b/argus/backend/assets/WorkArea/RunRelease.svelte
@@ -192,7 +192,4 @@
         margin-left: 2rem;
     }
 
-    .bg-white {
-        background-color: #fff;
-    }
 </style>

--- a/argus/backend/assets/WorkArea/WorkArea.svelte
+++ b/argus/backend/assets/WorkArea/WorkArea.svelte
@@ -81,7 +81,7 @@
 </script>
 <svelte:window on:popstate={() => { test_runs = stateDecoder() }}/>
 
-<div class="container-fluid bg-light">
+<div class="container-fluid bg-lighter">
     <div class="row p-4" id="dashboard-main">
         <div
             class="col-3 p-0 py-4 me-3 border rounded shadow-sm bg-white"
@@ -102,16 +102,13 @@
                 {/each}
             </div>
         </div>
-        <div class="col-8 p-2 border rounded shadow-sm bg-white">
+        <div class="col-8 p-2 border rounded shadow-sm bg-main">
             <TestRunsPanel bind:test_runs={test_runs} on:testRunRemove={onTestRunRemove} workAreaAttached={true}/>
         </div>
     </div>
 </div>
 
 <style>
-    .bg-white {
-        background-color: #fff;
-    }
 
     #run-sidebar {
         height: 960px;

--- a/argus/backend/assets/argus.css
+++ b/argus/backend/assets/argus.css
@@ -51,6 +51,10 @@ div#argusErrors {
     z-index: 999999;
 }
 
-.bg-white {
-    background-color: #fff;
+.bg-main {
+    background-color: #f9f9f9;
+}
+
+.bg-lighter {
+    background-color: #e5e5e5;
 }

--- a/argus/backend/templates/base.html.j2
+++ b/argus/backend/templates/base.html.j2
@@ -14,7 +14,7 @@
     <script src="/static/dist/globalAlert.bundle.js"></script>
     {% endblock javascripts %}
 </head>
-<body class="bg-light">
+<body class="bg-lighter">
     <div class="app d-flex flex-column min-vh-100">
         {% include "partials/nav_bar.html.j2" %}
         <div id="argusErrors">

--- a/argus/backend/templates/profile.html.j2
+++ b/argus/backend/templates/profile.html.j2
@@ -14,7 +14,7 @@ Profile
         </div>
     </div>
     {% endif %}
-    <div class="row border rounded bg-white my-3 shadow-sm">
+    <div class="row border rounded bg-main my-3 shadow-sm">
         <div class="col-2 border-end p-2">
             {% if g.user.picture_id %}
                 <img class="img-fluid" src="/storage/picture/{{g.user.picture_id}}" alt="">

--- a/argus/backend/templates/test_runs.html.j2
+++ b/argus/backend/templates/test_runs.html.j2
@@ -12,7 +12,7 @@ Test Runs
 {% block body %}
 <div class="container mt-3">
 <div class="row">
-    <div class="col border rounded shadow-sm bg-white" id="testRunsBreakout">
+    <div class="col border rounded shadow-sm bg-main" id="testRunsBreakout">
 
     </div>
 </div>


### PR DESCRIPTION
This commit adds a sticky indicator to a TestRuns accordion, which shows
when the header of said accordion moves outside the viewport. To reduce
visual clutter, the area also received slight color adjustment and
removal of most unneeded borders. Additionally, the build number buttons
now scroll towards open run instead of closing it, and closing was moved
onto the card itself as its own separate button.

[Trello](https://trello.com/c/450qC6kD/4660-anchor-test-run-info-title-and-builds-when-scrolling-down)
Demo:

https://user-images.githubusercontent.com/7761415/159334679-4a4c5cc8-a6b6-45a0-86c1-05df36de957f.mp4


