### PR TITLE
improvement(TestPopoutSelector.svelte): Sticky selector

### DIFF
--- a/argus/backend/assets/ReleaseDashboard/TestPopoutSelector.svelte
+++ b/argus/backend/assets/ReleaseDashboard/TestPopoutSelector.svelte
@@ -34,102 +34,114 @@
     };
 </script>
 
-{#if Object.values(tests).length > 0}
-    <div class="d-flex flex-column">
-        <ul class="list-group" style="height: 960px; overflow-y: scroll;">
-            {#each Object.values(tests) as test (test.name)}
-                <li class="list-group-item">
-                    <div class="d-flex align-items-center">
-                        <div class="d-flex flex-column">
-                            <span class="fw-bold">{test.name}</span>
+<div class="sticky">
+    {#if Object.values(tests).length > 0}
+        <div class="d-flex flex-column">
+            <ul class="list-group" style="height: 600px;overflow-y: scroll;">
+                {#each Object.values(tests) as test (test.name)}
+                    <li class="list-group-item">
+                        <div class="d-flex align-items-center">
+                            <div class="d-flex flex-column">
+                                <span class="fw-bold">{test.name}</span>
+                            </div>
+                            <button
+                                class="ms-auto btn btn-secondary btn-sm"
+                                data-bs-toggle="collapse"
+                                data-bs-target="#collapse-builds-{test.name}"
+                                title="Latest builds"
+                                ><Fa icon={faAngleDoubleDown} /></button
+                            >
+                            <button
+                                class="ms-1 btn btn-secondary btn-sm"
+                                title="Dismiss"
+                                on:click={() => handleTrashClick(test.name)}
+                                ><Fa icon={faTimes} /></button
+                            >
                         </div>
-                        <button
-                            class="ms-auto btn btn-secondary btn-sm"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapse-builds-{test.name}"
-                            title="Latest builds"
-                            ><Fa icon={faAngleDoubleDown} /></button
+                        <div
+                            class="collapse show"
+                            id="collapse-builds-{test.name}"
                         >
-                        <button
-                            class="ms-1 btn btn-secondary btn-sm"
-                            title="Dismiss"
-                            on:click={() => handleTrashClick(test.name)}
-                            ><Fa icon={faTimes} /></button
-                        >
-                    </div>
-                    <div class="collapse show" id="collapse-builds-{test.name}">
-                        <ul class="list-unstyled">
-                            {#each test.last_runs as run, idx}
-                                <li class="my-1" class:border-top={idx > 0}>
-                                    <div class="d-flex align-items-center">
-                                        <div
-                                            class="ms-2 {StatusCSSClassMap[
-                                                run.status
-                                            ]}"
-                                        >
-                                            <Fa icon={faCircle} />
-                                        </div>
-                                        <div class="ms-2">
-                                            <a
-                                                target="_blank"
-                                                href={run.build_job_url}
-                                                class="link-dark"
+                            <ul class="list-unstyled">
+                                {#each test.last_runs as run, idx}
+                                    <li class="my-1" class:border-top={idx > 0}>
+                                        <div class="d-flex align-items-center">
+                                            <div
+                                                class="ms-2 {StatusCSSClassMap[
+                                                    run.status
+                                                ]}"
                                             >
-                                                #{run.build_number}
-                                            </a>
-                                        </div>
-                                        <div
-                                            class="ms-auto text-muted small-text"
-                                        >
-                                            {timestampToISODate(
-                                                run.start_time * 1000
-                                            )}
-                                        </div>
-                                    </div>
-                                    <div>
-                                        <ul class="list-unstyled">
-                                            {#each run.issues as issue}
-                                                <li
-                                                    class="ms-3 d-flex align-items-center"
+                                                <Fa icon={faCircle} />
+                                            </div>
+                                            <div class="ms-2">
+                                                <a
+                                                    target="_blank"
+                                                    href={run.build_job_url}
+                                                    class="link-dark"
                                                 >
-                                                    <div class="ms-1">
-                                                        <Fa icon={faGithub} />
-                                                    </div>
-                                                    <div class="ms-1">
-                                                        <a
-                                                            target="_blank"
-                                                            href={issue.url}
-                                                        >
-                                                            {issue.title}
-                                                        </a>
-                                                    </div>
-                                                    <div
-                                                        class="ms-auto text-muted"
+                                                    #{run.build_number}
+                                                </a>
+                                            </div>
+                                            <div
+                                                class="ms-auto text-muted small-text"
+                                            >
+                                                {timestampToISODate(
+                                                    run.start_time * 1000
+                                                )}
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <ul class="list-unstyled">
+                                                {#each run.issues as issue}
+                                                    <li
+                                                        class="ms-3 d-flex align-items-center"
                                                     >
-                                                        {issue.owner}/{issue.repo}#{issue.issue_number}
-                                                    </div>
-                                                </li>
-                                            {/each}
-                                        </ul>
-                                    </div>
-                                </li>
-                            {/each}
-                        </ul>
-                    </div>
-                </li>
-            {/each}
-        </ul>
-        <a
-            href="/run_dashboard?{encodedState}"
-            class="btn btn-primary"
-            target="_blank"
-            >Investigate selected <Fa icon={faExternalLinkSquareAlt} /></a
-        >
-    </div>
-{/if}
+                                                        <div class="ms-1">
+                                                            <Fa
+                                                                icon={faGithub}
+                                                            />
+                                                        </div>
+                                                        <div class="ms-1">
+                                                            <a
+                                                                target="_blank"
+                                                                href={issue.url}
+                                                            >
+                                                                {issue.title}
+                                                            </a>
+                                                        </div>
+                                                        <div
+                                                            class="ms-auto text-muted"
+                                                        >
+                                                            {issue.owner}/{issue.repo}#{issue.issue_number}
+                                                        </div>
+                                                    </li>
+                                                {/each}
+                                            </ul>
+                                        </div>
+                                    </li>
+                                {/each}
+                            </ul>
+                        </div>
+                    </li>
+                {/each}
+            </ul>
+            <a
+                href="/run_dashboard?{encodedState}"
+                class="btn btn-primary"
+                target="_blank"
+                >Investigate selected <Fa icon={faExternalLinkSquareAlt} /></a
+            >
+        </div>
+    {/if}
+</div>
 
 <style>
     .small-text {
         font-size: 0.75em;
+    }
+
+    .sticky {
+        position: sticky;
+        top: 1em;
     }
 </style>


### PR DESCRIPTION
This changes the behaviour of TestPopoutSelector to be sticky once
scrolled down, allowing easier track of what's selected on the test map

[Trello](https://trello.com/c/VYdB1paH/4770-anchor-selected-runs-in-release-dashboard)

Demo:

https://user-images.githubusercontent.com/7761415/159343386-59ceb5da-ea38-4f69-b4d0-69b716f820a8.mp4


