### PR TITLE
improvement(TestPopoutSelector.svelte): Show assignees for tests

### DIFF
--- a/argus/backend/argus_service.py
+++ b/argus/backend/argus_service.py
@@ -87,7 +87,7 @@ class ArgusService:
             f"start_time, end_time, heartbeat FROM {TestRun.table_name()}"
         )
         self.run_by_release_stats_statement = self.database.prepare(
-            "SELECT id, name, group, release_name, status, start_time, build_job_url, "
+            "SELECT id, name, group, release_name, status, start_time, build_job_url, assignee, "
             f"end_time, investigation_status, heartbeat FROM {TestRun.table_name()} WHERE release_name = ?"
         )
         self.event_insert_statement = self.database.prepare(
@@ -337,6 +337,7 @@ class ArgusService:
                             "build_number": run["build_job_url"].rstrip("/").split("/")[-1],
                             "build_job_url": run["build_job_url"],
                             "start_time": run["start_time"],
+                            "assignee": run["assignee"],
                             "issues": [dict(i.items()) for i in release_issues if i.run_id == run["id"]],
                             "comments": [dict(i.items()) for i in release_comments if i.test_run_id == run["id"]],
                         }

--- a/argus/backend/assets/Stats/TestMapStats.svelte
+++ b/argus/backend/assets/Stats/TestMapStats.svelte
@@ -16,7 +16,7 @@
         TestInvestigationStatusStrings,
         TestStatus,
     } from "../Common/TestStatus";
-    import { assigneeStore, requestAssigneesForReleaseGroups } from "../Stores/AssigneeSubscriber";
+    import { assigneeStore, requestAssigneesForReleaseGroups, requestAssigneesForReleaseTests } from "../Stores/AssigneeSubscriber";
     import { userList } from "../Stores/UserlistSubscriber";
     import { getPicture } from "../Common/UserUtils";
     export let releaseName = "";
@@ -65,8 +65,18 @@
             }, {});
     };
 
+    const requestTestAssignees = function() {
+        console.log(stats);
+        Object.entries(stats.groups).map((entry) => {
+            let [groupName, groupStats] = entry;
+            let tests = Object.values(groupStats.tests).filter((test) => test.status != "unknown");
+            requestAssigneesForReleaseTests(releaseName, tests, groupName);
+        })
+    }
+
     onMount(() =>  {
         requestAssigneesForReleaseGroups(releaseName, Object.keys(stats.groups));
+        requestTestAssignees();
     });
 </script>
 

--- a/argus/backend/assets/WorkArea/AssigneeList.svelte
+++ b/argus/backend/assets/WorkArea/AssigneeList.svelte
@@ -1,6 +1,7 @@
 <script>
     import { userList } from "../Stores/UserlistSubscriber";
     export let assignees = [];
+    export let smallImage = false;
     let users = {};
     $: users = $userList;
 
@@ -13,10 +14,12 @@
     <div class="d-flex">
         {#each assignees as assignee}
             <div title={users[assignee].full_name} class="assignee-container">
-                <img
+                <div
                     src={getPicture(users[assignee].picture_id)}
                     class="img-tiny"
+                    class:img-smaller={smallImage}
                     alt="{users[assignee].full_name}"
+                    style="background-image: url({getPicture(users[assignee].picture_id)});"
                 />
             </div>
         {/each}
@@ -25,10 +28,22 @@
 
 <style>
     .img-tiny {
-        width: 24px;
+        height: 28px;
+        width: 28px;
+        background-color: black;
+        background-clip: border-box;
+        background-repeat: no-repeat;
+        background-position: center;
+        background-size: cover;
+        image-rendering: crisp-edges;
         cursor: help;
         border-radius: 50%;
         border: solid 1px rgb(122, 122, 122);
+    }
+
+    .img-smaller {
+        height: 20px;
+        width: 20px;
     }
 
     .assignee-container:not(:first-child) {


### PR DESCRIPTION
This commits adds assignees icons to selected tests in
TestPopoutSelector, much like assignee icons in the Work Area.

[Trello](https://trello.com/c/3ULVTqWG/4818-show-assignee-in-release-dasboard-when-clicked-on-run)
![image](https://user-images.githubusercontent.com/7761415/159567154-8b44ce2d-ff48-4cb0-bcd4-189eb170b73d.png)
