### PR TITLE
feature(TestMapStats.svelte): Release Test Map redesign

### DIFF
--- a/argus/backend/assets/ReleaseDashboard/ReleaseDashboard.svelte
+++ b/argus/backend/assets/ReleaseDashboard/ReleaseDashboard.svelte
@@ -1,13 +1,8 @@
 <script>
     export let releaseData = {};
-    import { faGithub } from "@fortawesome/free-brands-svg-icons";
-    import { faBug } from "@fortawesome/free-solid-svg-icons";
-    import Fa from "svelte-fa";
-    import ChartStats from "../Stats/ChartStats.svelte";
     import ReleaseStats from "../Stats/ReleaseStats.svelte";
     import ReleaseActivity from "./ReleaseActivity.svelte";
     import GithubIssues from "../Github/GithubIssues.svelte";
-    import ReleaseGithubIssues from "./ReleaseGithubIssues.svelte";
     import TestPopoutSelector from "./TestPopoutSelector.svelte";
     import { sendMessage } from "../Stores/AlertStore";
     let clickedTests = {};
@@ -17,18 +12,19 @@
             sendMessage("info", `The test "${e.detail.name}" hasn't been run yet!"`);
             return;
         }
-
-        if (!clickedTests[e.detail.name]) {
-            clickedTests[e.detail.name] = e.detail;
+        let key = `${e.detail.group}/${e.detail.name}`;
+        if (!clickedTests[key]) {
+            clickedTests[key] = e.detail;
         } else {
-            delete clickedTests[e.detail.name];
+            delete clickedTests[key];
             clickedTests = clickedTests;
         }
     };
 
-    const handleDeleteRequest = function(ev) {
-        if (clickedTests[ev.detail.name]) {
-            delete clickedTests[ev.detail.name];
+    const handleDeleteRequest = function(e) {
+        let key = `${e.detail.group}/${e.detail.name}`;
+        if (clickedTests[key]) {
+            delete clickedTests[key];
             clickedTests = clickedTests;
         }
     };
@@ -44,9 +40,8 @@
         <div class="col-8">
             <ReleaseStats
                 releaseName={releaseData.release.name}
-                DisplayItem={ChartStats}
                 showTestMap={true}
-                horizontal={true}
+                horizontal={false}
                 bind:clickedTests={clickedTests}
                 on:testClick={handleTestClick}
             />

--- a/argus/backend/assets/ReleaseDashboard/TestPopoutSelector.svelte
+++ b/argus/backend/assets/ReleaseDashboard/TestPopoutSelector.svelte
@@ -34,9 +34,10 @@
         tests: {},
     };
     const dispatch = createEventDispatcher();
-    const handleTrashClick = function (name) {
+    const handleTrashClick = function (name, group) {
         dispatch("deleteRequest", {
             name: name,
+            group: group,
         });
     };
 
@@ -79,7 +80,7 @@
                             <button
                                 class="ms-1 btn btn-secondary btn-sm"
                                 title="Dismiss"
-                                on:click={() => handleTrashClick(test.name)}
+                                on:click={() => handleTrashClick(test.name, test.group)}
                                 ><Fa icon={faTimes} /></button
                             >
                         </div>

--- a/argus/backend/assets/Stats/ReleaseStats.svelte
+++ b/argus/backend/assets/Stats/ReleaseStats.svelte
@@ -33,7 +33,7 @@
 <div class="d-flex justify-content-center" class:flex-column={!horizontal} class:align-items-center={!horizontal}>
     {#if releaseStats?.total > 0}
         {#if showReleaseStats}
-            <div class="w-100">
+            <div class="w-100 mb-2">
                 <svelte:component this={DisplayItem} stats={releaseStats} />
             </div>
         {/if}

--- a/argus/backend/assets/WorkArea/AssigneeList.svelte
+++ b/argus/backend/assets/WorkArea/AssigneeList.svelte
@@ -28,8 +28,8 @@
 
 <style>
     .img-tiny {
-        height: 28px;
-        width: 28px;
+        height: 24px;
+        width: 24px;
         background-color: black;
         background-clip: border-box;
         background-repeat: no-repeat;
@@ -38,7 +38,7 @@
         image-rendering: crisp-edges;
         cursor: help;
         border-radius: 50%;
-        border: solid 1px rgb(122, 122, 122);
+        /* border: solid 1px rgb(122, 122, 122); */
     }
 
     .img-smaller {


### PR DESCRIPTION
This commits bring a new redesign to the release dashboard, focusing on
TestMapStats component, changing it from a heat-map like design to a
card design. Tests are now sorted by status, include the name and
current assignees icons.

[Trello](https://trello.com/c/rIE5y7qM/4853-redesign-release-dashboard)