### PR TITLE
fix(TestMapStats.svelte): Display actual assignee if assigned

### DIFF
--- a/argus/backend/assets/Stats/TestMapStats.svelte
+++ b/argus/backend/assets/Stats/TestMapStats.svelte
@@ -90,10 +90,16 @@
         });
     };
 
-    const getAssigneesForTest = function (test, group) {
+    const getAssigneesForTest = function (test, group, last_runs) {
         let testAssignees = assigneeList.tests?.[`${group}/${test}`] ?? [];
         let groupAssignees = assigneeList.groups?.[group] ?? [];
-        return [...testAssignees, ...groupAssignees];
+        let allAssignees = [...testAssignees, ...groupAssignees];
+        let lastRun = last_runs?.[0];
+        if (lastRun?.assignee && allAssignees.findIndex(v => v == lastRun.assignee) == -1)
+        {
+            return [lastRun.assignee];
+        }
+        return allAssignees;
     };
 
     onMount(() => {
@@ -159,7 +165,8 @@
                                     smallImage={false}
                                     assignees={getAssigneesForTest(
                                         testName,
-                                        groupName
+                                        groupName,
+                                        test.last_runs ?? [],
                                     )}
                                 />
                             {/if}


### PR DESCRIPTION
This commit changes the behaiour of a test card to display last run's
assignee if it differs from people assigned to the test.

[Trello](https://trello.com/c/Dk2kTCBG/4864-show-test-run-assignee-on-test-card-if-it-differs-from-scheduled-assignee)
