### PR TITLE
fix(Schedule.svelte): Add a close button

### DIFF
--- a/argus/backend/assets/ReleasePlanner/ReleasePlanTable.svelte
+++ b/argus/backend/assets/ReleasePlanner/ReleasePlanTable.svelte
@@ -150,6 +150,9 @@
                                         {users}
                                         on:deleteSchedule
                                         on:refreshSchedules
+                                        on:closeSchedule={(e) => {
+                                            selectedSchedule = "";
+                                        }}
                                     />
                                 {/if}
                             </td>

--- a/argus/backend/assets/ReleasePlanner/Schedule.svelte
+++ b/argus/backend/assets/ReleasePlanner/Schedule.svelte
@@ -4,6 +4,7 @@
         faTrashAlt,
         faEdit,
         faCheck,
+        faTimes,
         faExternalLinkSquareAlt,
     } from "@fortawesome/free-solid-svg-icons";
     import Select from "svelte-select";
@@ -120,9 +121,20 @@
 </script>
 
 <div class="card-schedule card-popout" class:position-absolute={absolute}>
+
     <div
         class="border rounded bg-white shadow-sm mb-3 p-3 d-flex flex-column align-items-start justify-content-center"
     >
+        <div class="text-end w-100">
+            <button class="btn btn-sm btn-dark" on:click={
+                (e) => {
+                    e.stopPropagation();
+                    dispatch("closeSchedule", scheduleData);
+                }
+            }>
+                <Fa icon={faTimes}/>
+            </button>
+        </div>
         <div class="d-flex w-100 mb-3">
             <div
                 class="me-3"

--- a/argus/backend/assets/ReleasePlanner/ScheduleTable.svelte
+++ b/argus/backend/assets/ReleasePlanner/ScheduleTable.svelte
@@ -51,7 +51,6 @@
     const onAssigneeCellClick = function(schedule, group, date) {
         if (schedule) {
             if (clickedCell == `${group.name}/${date.dateKey}`) {
-                clickedCell = "";
                 return;
             }
             clickedCell = `${group.name}/${date.dateKey}`;
@@ -140,7 +139,9 @@
                                 {users[group.schedules[date.dateKey].assignees[0]]?.full_name}
                             {/if}
                             {#if clickedCell == `${group.name}/${date.dateKey}`}
-                            <Schedule {releaseData} scheduleData={group.schedules[date.dateKey]} {users} on:deleteSchedule on:clearGroups on:refreshSchedules/>
+                            <Schedule {releaseData} scheduleData={group.schedules[date.dateKey]} {users} on:closeSchedule={(e) => {
+                                clickedCell = "";
+                            }} on:deleteSchedule on:clearGroups on:refreshSchedules/>
                             {/if}
                         </td>
                     {/each}


### PR DESCRIPTION
This fixes an issue where a click on one of the schedule buttons would
cause schedule to close on Duty Planner table due to being parented to a
cell which contains an onClick handler.

[Trello](https://trello.com/c/niFvCoCh/4878-unable-to-edit-schedule)