### PR TITLE
fix(argus_service.py): Use Github login if name isn't specified

### DIFF
--- a/argus/backend/argus_service.py
+++ b/argus/backend/argus_service.py
@@ -1191,7 +1191,7 @@ class ArgusService:
             user = User()
             user.username = user_info.get("login")
             user.email = email_info[-1].get("email")
-            user.full_name = user_info.get("name")
+            user.full_name = user_info.get("name", user_info.get("login"))
             user.registration_date = datetime.datetime.utcnow()
             user.roles = ["ROLE_USER"]
             temp_password = base64.encodebytes(


### PR DESCRIPTION
This fixes a problem where a user registering using github oAuth would
have "null" as their name due to them having no name specified in their
github profile

[Trello](https://trello.com/c/LiFbRTrZ/4880-null-user-name)