### PR TITLE
improvement(ReleaseDashboard.svelte): Responsive breakpoints for blocks

### DIFF
--- a/argus/backend/assets/ReleaseDashboard/ReleaseDashboard.svelte
+++ b/argus/backend/assets/ReleaseDashboard/ReleaseDashboard.svelte
@@ -37,7 +37,7 @@
         </div>
     </div>
     <div class="row mb-2">
-        <div class="col-8">
+        <div class="col-xs-2 col-sm-6 col-md-7">
             <ReleaseStats
                 releaseName={releaseData.release.name}
                 showTestMap={true}
@@ -46,7 +46,7 @@
                 on:testClick={handleTestClick}
             />
         </div>
-        <div class="col-4">
+        <div class="col-xs-10 col-sm-6 col-md-5">
             <TestPopoutSelector
                 bind:tests={clickedTests}
                 on:deleteRequest={handleDeleteRequest}

--- a/argus/backend/assets/ReleaseDashboard/TestPopoutSelector.svelte
+++ b/argus/backend/assets/ReleaseDashboard/TestPopoutSelector.svelte
@@ -52,7 +52,7 @@
 <div class="sticky">
     {#if Object.values(tests).length > 0}
         <div class="d-flex flex-column">
-            <ul class="list-group" style="height: 600px;overflow-y: scroll;">
+            <ul class="list-group popout-tests">
                 {#each Object.values(tests) as test (test.name)}
                     <li class="list-group-item">
                         <div class="d-flex align-items-center">
@@ -177,5 +177,36 @@
     .sticky {
         position: sticky;
         top: 1em;
+    }
+
+    .popout-tests {
+        height: 1100px;
+        overflow-y: scroll;
+    }
+
+    @media screen and (max-height: 1080px) {
+        .popout-tests {
+            height: 900px;
+        }
+    }
+
+    @media screen and (max-height: 720px) {
+        .popout-tests {
+            height: 500px;
+        }
+    }
+
+    @media screen and (max-height: 480px) {
+        .popout-tests {
+            height: 320px;
+        }
+
+    }
+
+    @media screen and (max-height: 320px) {
+
+        .popout-tests {
+            height: 200px;
+        }
     }
 </style>


### PR DESCRIPTION
This adds responsive breakpoints for both width (TestMapStats and
TestPopoutSelector) and height (TestPopoutSelector).

[Trello](https://trello.com/c/pVvTjImC/4883-adjust-columns-on-release-dashboard)