### PR TITLE
improvement(build_system_monitor.py): Prefix-based group filter

### DIFF
--- a/argus_web.example.yaml
+++ b/argus_web.example.yaml
@@ -11,3 +11,11 @@ GITHUB_REQUIRED_ORGANIZATIONS:
   # at least one is required for user to successfully authenticate
   - myorg
   - otherorg
+BUILD_SYSTEM_FILTERED_PREFIXES:
+  - prefixToExclude
+JENKINS_URL: https://your_jenkins_hostname
+JENKINS_USER: user
+JENKINS_API_TOKEN_NAME: Optional
+JENKINS_API_TOKEN: hex-token
+JENKINS_MONITORED_RELEASES:
+  - toplevel-folder-name


### PR DESCRIPTION
This adds a prefix-based group filter to make it possible to filter out
unnecessary groups per release

[Trello](https://trello.com/c/HzC1Al7W/4871-remove-releng-testing-from-argus-planning)