### PR TITLE
feature(argus): Run organization and management rework 

### DIFF
--- a/argus/backend/__init__.py
+++ b/argus/backend/__init__.py
@@ -4,7 +4,7 @@ from yaml import safe_load
 from argus.db.models import User
 from argus.backend.db import ScyllaCluster
 from argus.backend.build_system_monitor import scan_jenkins_command
-from argus.backend import auth, main, api
+from argus.backend import auth, main, api, admin
 
 
 def create_app(config=None) -> Flask:
@@ -18,11 +18,12 @@ def create_app(config=None) -> Flask:
     app.register_blueprint(auth.bp)
     app.register_blueprint(main.bp)
     app.register_blueprint(api.bp)
+    app.register_blueprint(admin.bp)
     app.cli.add_command(scan_jenkins_command)
 
     @app.template_filter('from_timestamp')
     def from_timestamp_filter(timestamp: int):
-        return datetime.fromtimestamp(timestamp)
+        return datetime.utcfromtimestamp(timestamp)
 
     @app.template_filter('safe_user')
     def from_timestamp_filter(user: User):

--- a/argus/backend/admin.py
+++ b/argus/backend/admin.py
@@ -1,0 +1,32 @@
+import logging
+from uuid import UUID
+from flask import (
+    Blueprint,
+    g,
+    request,
+    session,
+    flash,
+    redirect,
+    render_template,
+    url_for,
+    make_response
+)
+from flask.json import jsonify
+from argus.backend.argus_service import ArgusService
+from argus.backend.service.admin import AdminService
+from argus.backend.admin_api import bp as admin_api_bp
+from argus.backend.auth import login_required, check_roles
+from argus.db.models import UserRoles
+
+# pylint: disable=broad-except
+bp = Blueprint('admin', __name__, url_prefix='/admin')
+bp.register_blueprint(admin_api_bp)
+LOGGER = logging.getLogger(__name__)
+
+
+@bp.route("/")
+@bp.route("/<string:path>")
+@check_roles(UserRoles.Admin)
+@login_required
+def index(path: str = "index"):
+    return render_template("admin/index.html.j2", current_route=path)

--- a/argus/backend/admin_api.py
+++ b/argus/backend/admin_api.py
@@ -1,0 +1,269 @@
+import logging
+from uuid import UUID
+from flask import (
+    Blueprint,
+    g,
+    request,
+    Request,
+    session,
+    flash,
+    redirect,
+    render_template,
+    url_for,
+    make_response
+)
+from flask.json import jsonify
+from argus.backend.argus_service import ArgusService
+from argus.backend.service.admin import AdminService
+from argus.backend.service.release_manager import ReleaseManagerService
+from argus.backend.auth import login_required, check_roles
+from argus.db.models import UserRoles
+
+# pylint: disable=broad-except
+bp = Blueprint('admin_api', __name__, url_prefix='/api/v1')
+LOGGER = logging.getLogger(__name__)
+
+
+def get_payload(request: Request):
+    if not request.is_json:
+        raise Exception(
+            "Content-Type mismatch, expected application/json, got:", request.content_type)
+    request_payload = request.get_json()
+
+    return request_payload
+
+
+@bp.route("/", methods=["GET"])
+def index():
+    return jsonify({
+        "version": "v1"
+    })
+
+
+@bp.route("/release/create", methods=["POST"])
+def create_release():
+    res = {
+        "status": "ok"
+    }
+    try:
+        payload = get_payload(request)
+        release = ReleaseManagerService().create_release(**payload)
+        res["response"] = {
+            "new_release": dict(release.items())
+        }
+    except Exception as exc:
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
+        res["status"] = "error"
+        res["response"] = {
+            "exception": exc.__class__.__name__,
+            "arguments": exc.args
+        }
+    return jsonify(res)
+
+
+@bp.route("/release/set_perpetual", methods=["POST"])
+def set_release_perpetual():
+    res = {
+        "status": "ok"
+    }
+    try:
+        payload = get_payload(request)
+        result = ReleaseManagerService().set_release_perpetuality(**payload)
+        res["response"] = {
+            "updated": result
+        }
+    except Exception as exc:
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
+        res["status"] = "error"
+        res["response"] = {
+            "exception": exc.__class__.__name__,
+            "arguments": exc.args
+        }
+    return jsonify(res)
+
+
+@bp.route("/release/set_state", methods=["POST"])
+def set_release_state():
+    res = {
+        "status": "ok"
+    }
+    try:
+        payload = get_payload(request)
+        result = ReleaseManagerService().set_release_state(**payload)
+        res["response"] = {
+            "updated": result
+        }
+    except Exception as exc:
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
+        res["status"] = "error"
+        res["response"] = {
+            "exception": exc.__class__.__name__,
+            "arguments": exc.args
+        }
+    return jsonify(res)
+
+@bp.route("/release/set_dormant", methods=["POST"])
+def set_release_dormancy():
+    res = {
+        "status": "ok"
+    }
+    try:
+        payload = get_payload(request)
+        result = ReleaseManagerService().set_release_dormancy(**payload)
+        res["response"] = {
+            "updated": result
+        }
+    except Exception as exc:
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
+        res["status"] = "error"
+        res["response"] = {
+            "exception": exc.__class__.__name__,
+            "arguments": exc.args
+        }
+    return jsonify(res)
+
+@bp.route("/group/create", methods=["POST"])
+def create_group():
+    res = {
+        "status": "ok"
+    }
+    try:
+        payload = get_payload(request)
+        group = ReleaseManagerService().create_group(**payload)
+        res["response"] = {
+            "new_group": dict(group.items())
+        }
+    except Exception as exc:
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
+        res["status"] = "error"
+        res["response"] = {
+            "exception": exc.__class__.__name__,
+            "arguments": exc.args
+        }
+    return jsonify(res)
+
+
+@bp.route("/group/update", methods=["POST"])
+def update_group():
+    res = {
+        "status": "ok"
+    }
+    try:
+        payload = get_payload(request)
+        result = ReleaseManagerService().update_group(**payload)
+        res["response"] = {
+            "updated": result
+        }
+    except Exception as exc:
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
+        res["status"] = "error"
+        res["response"] = {
+            "exception": exc.__class__.__name__,
+            "arguments": exc.args
+        }
+    return jsonify(res)
+
+
+@bp.route("/group/delete", methods=["POST"])
+def delete_group():
+    res = {
+        "status": "ok"
+    }
+    try:
+        payload = get_payload(request)
+        result = ReleaseManagerService().delete_group(**payload)
+        res["response"] = {
+            "deleted": result
+        }
+    except Exception as exc:
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
+        res["status"] = "error"
+        res["response"] = {
+            "exception": exc.__class__.__name__,
+            "arguments": exc.args
+        }
+    return jsonify(res)
+
+
+@bp.route("/test/create", methods=["POST"])
+def create_test():
+    res = {
+        "status": "ok"
+    }
+    try:
+        payload = get_payload(request)
+        test = ReleaseManagerService().create_test(**payload)
+        res["response"] = {
+            "new_test": dict(test.items())
+        }
+    except Exception as exc:
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
+        res["status"] = "error"
+        res["response"] = {
+            "exception": exc.__class__.__name__,
+            "arguments": exc.args
+        }
+    return jsonify(res)
+
+
+@bp.route("/test/update", methods=["POST"])
+def update_test():
+    res = {
+        "status": "ok"
+    }
+    try:
+        payload = get_payload(request)
+        result = ReleaseManagerService().update_test(**payload)
+        res["response"] = {
+            "updated": result
+        }
+    except Exception as exc:
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
+        res["status"] = "error"
+        res["response"] = {
+            "exception": exc.__class__.__name__,
+            "arguments": exc.args
+        }
+    return jsonify(res)
+
+
+@bp.route("/test/batch_move", methods=["POST"])
+def batch_move_tests():
+    res = {
+        "status": "ok"
+    }
+    try:
+        payload = get_payload(request)
+        result = ReleaseManagerService().batch_move_tests(**payload)
+        res["response"] = {
+            "moved": result
+        }
+    except Exception as exc:
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
+        res["status"] = "error"
+        res["response"] = {
+            "exception": exc.__class__.__name__,
+            "arguments": exc.args
+        }
+    return jsonify(res)
+
+
+@bp.route("/test/delete", methods=["POST"])
+def delete_test():
+    res = {
+        "status": "ok"
+    }
+    try:
+        payload = get_payload(request)
+        result = ReleaseManagerService().delete_test(**payload)
+        res["response"] = {
+            "deleted": result
+        }
+    except Exception as exc:
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
+        res["status"] = "error"
+        res["response"] = {
+            "exception": exc.__class__.__name__,
+            "arguments": exc.args
+        }
+    return jsonify(res)

--- a/argus/backend/api.py
+++ b/argus/backend/api.py
@@ -317,34 +317,6 @@ def tests_last_status():
     return jsonify(res)
 
 
-@bp.route("/test_runs", methods=["POST"])
-@login_required
-def test_runs():
-    res = {
-        "status": "ok"
-    }
-    try:
-        if not request.is_json:
-            raise Exception(
-                "Content-Type mismatch, expected application/json, got:", request.content_type)
-        request_payload = request.get_json()
-        service = ArgusService()
-        release_group_runs = service.get_runs_by_name_for_release_group(
-            release_name=request_payload["release"],
-            test_name=request_payload["test_name"],
-            limit=request_payload.get("limit", 10)
-        )
-        res["response"] = release_group_runs
-    except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
-        res["status"] = "error"
-        res["response"] = {
-            "exception": exc.__class__.__name__,
-            "arguments": exc.args
-        }
-    return jsonify(res)
-
-
 @bp.route("/test_run", methods=["POST"])
 @login_required
 def test_run():

--- a/argus/backend/api.py
+++ b/argus/backend/api.py
@@ -1,12 +1,15 @@
+import json
 import logging
 from uuid import UUID
 from flask import (
     Blueprint,
+    make_response,
     request
 )
 from flask.json import jsonify
 from argus.backend.argus_service import ArgusService
 from argus.backend.auth import login_required
+from argus.db.argus_json import ArgusJSONEncoder
 
 # pylint: disable=broad-except
 
@@ -30,28 +33,28 @@ def version():
 @login_required
 def releases():
     service = ArgusService()
+    force_all = request.args.get("all", False)
     all_releases = service.get_releases()
     return jsonify({
         "status": "ok",
-        "response": [dict(d.items()) for d in all_releases]
+        "response": [dict(d.items()) for d in all_releases if d.enabled or force_all]
     })
 
 
-@bp.route("/release/activity", methods=["POST"])
+@bp.route("/release/activity", methods=["GET"])
 @login_required
 def release_activity():
     res = {
         "status": "ok"
     }
     try:
-        if not request.is_json:
-            raise Exception(
-                "Content-Type mismatch, expected application/json, got:", request.content_type)
-        request_payload = request.get_json()
+        release_name = request.args.get("releaseName")
+        if not release_name:
+            raise Exception("Release name not specified in the request")
         service = ArgusService()
-        res["response"] = service.fetch_release_activity(request_payload)
+        res["response"] = service.fetch_release_activity(release_name)
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,
@@ -60,21 +63,20 @@ def release_activity():
     return jsonify(res)
 
 
-@bp.route("/release/planner/data", methods=["POST"])
+@bp.route("/release/planner/data", methods=["GET"])
 @login_required
 def release_planner_data():
     res = {
         "status": "ok"
     }
     try:
-        if not request.is_json:
-            raise Exception(
-                "Content-Type mismatch, expected application/json, got:", request.content_type)
-        request_payload = request.get_json()
+        release_id = request.args.get("releaseId")
+        if not release_id:
+            raise Exception("Release Id not specified")
         service = ArgusService()
-        res["response"] = service.get_planner_data(request_payload)
+        res["response"] = service.get_planner_data(release_id)
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,
@@ -97,7 +99,7 @@ def release_schedules_comment_update():
         service = ArgusService()
         res["response"] = service.update_schedule_comment(request_payload)
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,
@@ -106,21 +108,20 @@ def release_schedules_comment_update():
     return jsonify(res)
 
 
-@bp.route("/release/schedules", methods=["POST"])
+@bp.route("/release/schedules", methods=["GET"])
 @login_required
 def release_schedules():
     res = {
         "status": "ok"
     }
     try:
-        if not request.is_json:
-            raise Exception(
-                "Content-Type mismatch, expected application/json, got:", request.content_type)
-        request_payload = request.get_json()
+        release = request.args.get("releaseId")
+        if not release:
+            raise Exception("No releaseId provided")
         service = ArgusService()
-        res["response"] = service.get_schedules_for_release(request_payload)
+        res["response"] = service.get_schedules_for_release(release)
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,
@@ -143,7 +144,7 @@ def release_schedules_assignee_update():
         service = ArgusService()
         res["response"] = service.update_schedule_assignees(request_payload)
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,
@@ -152,21 +153,41 @@ def release_schedules_assignee_update():
     return jsonify(res)
 
 
-@bp.route("/release/schedules/today/assignees", methods=["POST"])
+@bp.route("/release/assignees/groups", methods=["GET"])
 @login_required
-def release_schedules_today_assignees():
+def group_assignees():
     res = {
         "status": "ok"
     }
     try:
-        if not request.is_json:
-            raise Exception(
-                "Content-Type mismatch, expected application/json, got:", request.content_type)
-        request_payload = request.get_json()
+        release_id = request.args.get("releaseId")
+        if not release_id:
+            raise Exception("Missing releaseId")
         service = ArgusService()
-        res["response"] = service.get_assignees(request_payload)
+        res["response"] = service.get_groups_assignees(release_id)
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
+        res["status"] = "error"
+        res["response"] = {
+            "exception": exc.__class__.__name__,
+            "arguments": exc.args
+        }
+    return jsonify(res)
+
+@bp.route("/release/assignees/tests", methods=["GET"])
+@login_required
+def tests_assignees():
+    res = {
+        "status": "ok"
+    }
+    try:
+        group_id = request.args.get("groupId")
+        if not group_id:
+            raise Exception("Missing groupId")
+        service = ArgusService()
+        res["response"] = service.get_tests_assignees(group_id)
+    except Exception as exc:
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,
@@ -185,11 +206,12 @@ def release_schedules_submit():
         if not request.is_json:
             raise Exception(
                 "Content-Type mismatch, expected application/json, got:", request.content_type)
-        request_payload = request.get_json()
-        service = ArgusService()
-        res["response"] = service.submit_new_schedule(request_payload)
+        j = request.get_json()
+        service = ArgusService()        
+        res["response"] = service.submit_new_schedule(release=j["releaseId"], start_time=j["start"], end_time=j["end"],
+                                                      tests=j["tests"], groups=j["groups"], assignees=j["assignees"], tag=j["tag"])
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,
@@ -212,7 +234,7 @@ def release_schedules_delete():
         service = ArgusService()
         res["response"] = service.delete_schedule(request_payload)
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,
@@ -224,6 +246,7 @@ def release_schedules_delete():
 @bp.route("/release/issues", methods=["POST"])
 @login_required
 def release_issues():
+    # TODO: Unused
     res = {
         "status": "ok"
     }
@@ -235,7 +258,7 @@ def release_issues():
         service = ArgusService()
         res["response"] = service.fetch_release_issues(request_payload)
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,
@@ -244,23 +267,19 @@ def release_issues():
     return jsonify(res)
 
 
-@bp.route("/release_groups", methods=["POST"])
+@bp.route("/groups", methods=["GET"])
 @login_required
-def release_groups():
+def groups():
     res = {
         "status": "ok"
     }
     try:
-        if not request.is_json:
-            raise Exception(
-                "Content-Type mismatch, expected application/json, got:", request.content_type)
-        request_payload = request.get_json()
+        force_all = request.args.get("all", False)
         service = ArgusService()
-        groups = service.get_groups_for_release(
-            UUID(request_payload["release"]["id"]))
-        res["response"] = [dict(g.items()) for g in groups]
+        groups = service.get_groups()
+        res["response"] = [dict(g.items()) for g in groups if g.enabled or force_all]
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,
@@ -269,23 +288,19 @@ def release_groups():
     return jsonify(res)
 
 
-@bp.route("/tests", methods=["POST"])
+@bp.route("/tests", methods=["GET"])
 @login_required
 def tests():
     res = {
         "status": "ok"
     }
     try:
-        if not request.is_json:
-            raise Exception(
-                "Content-Type mismatch, expected application/json, got:", request.content_type)
-        request_payload = request.get_json()
+        force_all = request.args.get("all", False)
         service = ArgusService()
-        release_group_tests = service.get_tests_for_release_group(
-            group_id=request_payload["group"]["id"])
-        res["response"] = {"tests": [dict(t.items()) for t in release_group_tests]}
+        tests = service.get_tests()
+        res["response"] = [dict(t.items()) for t in tests if t.enabled or force_all]
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,
@@ -294,71 +309,46 @@ def tests():
     return jsonify(res)
 
 
-@bp.route("/tests/last_status", methods=["POST"])
-@login_required
-def tests_last_status():
-    res = {
-        "status": "ok"
-    }
-    try:
-        if not request.is_json:
-            raise Exception(
-                "Content-Type mismatch, expected application/json, got:", request.content_type)
-        request_payload = request.get_json()
-        service = ArgusService()
-        res["response"] = service.get_test_last_run_status(request_payload)
-    except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
-        res["status"] = "error"
-        res["response"] = {
-            "exception": exc.__class__.__name__,
-            "arguments": exc.args
-        }
-    return jsonify(res)
-
-
-@bp.route("/test_run", methods=["POST"])
+@bp.route("/test_run", methods=["GET"])
 @login_required
 def test_run():
     res = {
         "status": "ok"
     }
     try:
-        if not request.is_json:
-            raise Exception(
-                "Content-Type mismatch, expected application/json, got:", request.content_type)
-        request_payload = request.get_json()
+        run_id = request.args.get("runId")
         service = ArgusService()
         loaded_run = service.load_test_run(
-            test_run_id=UUID(request_payload["test_id"]))
-        res["response"] = loaded_run.serialize()
+            test_run_id=UUID(run_id))
+        res["response"] = loaded_run
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,
             "arguments": exc.args
         }
-    return jsonify(res)
+    response = make_response()
+    response.content_type = "application/json"
+    response.data = json.dumps(res, cls=ArgusJSONEncoder)
+    return response
 
 
-@bp.route("/test_run/comments", methods=["POST"])
+@bp.route("/test_run/comments", methods=["GET"])
 @login_required
 def test_run_comments():
     res = {
         "status": "ok"
     }
     try:
-        if not request.is_json:
-            raise Exception(
-                "Content-Type mismatch, expected application/json, got:", request.content_type)
-        request_payload = request.get_json()
+        test_id = request.args.get("testId")
+        if not test_id:
+            raise Exception("TestId wasn't specified in the request")
         service = ArgusService()
-        comments = service.get_comments(
-            test_id=UUID(request_payload["test_id"]))
+        comments = service.get_comments(test_id=UUID(test_id))
         res["response"] = [dict(c.items()) for c in comments]
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,
@@ -382,7 +372,7 @@ def test_run_submit_comment():
         result = service.post_comment(payload=request_payload)
         res["response"] = [dict(c.items()) for c in result]
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,
@@ -406,7 +396,7 @@ def test_run_update_comment():
         result = service.update_comment(payload=request_payload)
         res["response"] = [dict(c.items()) for c in result]
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,
@@ -430,7 +420,7 @@ def test_run_delete_comment():
         result = service.delete_comment(payload=request_payload)
         res["response"] = [dict(c.items()) for c in result]
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,
@@ -439,21 +429,17 @@ def test_run_delete_comment():
     return jsonify(res)
 
 
-@bp.route("/users", methods=["POST"])
+@bp.route("/users", methods=["GET"])
 @login_required
 def user_info():
     res = {
         "status": "ok"
     }
     try:
-        if not request.is_json:
-            raise Exception(
-                "Content-Type mismatch, expected application/json, got:", request.content_type)
-        service = ArgusService()
-        result = service.get_user_info()
+        result = ArgusService().get_user_info()
         res["response"] = result
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,
@@ -462,21 +448,20 @@ def user_info():
     return jsonify(res)
 
 
-@bp.route("/stats", methods=["POST"])
+@bp.route("/release/stats", methods=["GET"])
 @login_required
-def run_stats():
+def release_stats():
     res = {
         "status": "ok"
     }
     try:
-        if not request.is_json:
-            raise Exception(
-                "Content-Type mismatch, expected application/json, got:", request.content_type)
-        request_payload = request.get_json()
-        service = ArgusService()
-        res["response"] = service.collect_stats(request_payload)
+        request.query_string.decode(encoding="UTF-8")
+        release = request.args.get("release")
+        limited = bool(int(request.args.get("limited")))
+        force = bool(int(request.args.get("force")))
+        res["response"] = ArgusService().collect_stats(release, limited, force)
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         LOGGER.error("Details: ", exc_info=True)
         res["status"] = "error"
         res["response"] = {
@@ -486,21 +471,24 @@ def run_stats():
     return jsonify(res)
 
 
-@bp.route("/test_runs/poll", methods=["POST"])
+@bp.route("/test_runs/poll", methods=["GET"])
 @login_required
 def test_runs_poll():
     res = {
         "status": "ok"
     }
     try:
-        if not request.is_json:
-            raise Exception(
-                "Content-Type mismatch, expected application/json, got:", request.content_type)
-        request_payload = request.get_json()
+        limit = request.args.get("limit")
+        if not limit:
+            limit = 10
+        else:
+            limit = int(limit)
+        runs = request.args.get('runs')
+        runs = runs.split(',')
         service = ArgusService()
-        res["response"] = service.poll_test_runs(request_payload)
+        res["response"] = service.poll_test_runs(runs=runs, limit=limit)
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,
@@ -509,21 +497,21 @@ def test_runs_poll():
     return jsonify(res)
 
 
-@bp.route("/test_run/poll", methods=["POST"])
+@bp.route("/test_run/poll", methods=["GET"])
 @login_required
 def test_run_poll_single():
     res = {
         "status": "ok"
     }
     try:
-        if not request.is_json:
-            raise Exception(
-                "Content-Type mismatch, expected application/json, got:", request.content_type)
-        request_payload = request.get_json()
+        runs = request.args.get("runs")
+        if not runs:
+            raise Exception("Runs weren't provided")
+        runs = [UUID(r) for r in runs.split(",")]
         service = ArgusService()
-        res["response"] = service.poll_test_runs_single(request_payload)
+        res["response"] = service.poll_test_runs_single(runs=runs)
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,
@@ -546,7 +534,7 @@ def test_run_change_status():
         service = ArgusService()
         res["response"] = service.toggle_test_status(request_payload)
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,
@@ -569,7 +557,7 @@ def test_run_change_investigation_status():
         service = ArgusService()
         res["response"] = service.toggle_test_investigation_status(request_payload)
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,
@@ -592,7 +580,7 @@ def test_run_change_assignee():
         service = ArgusService()
         res["response"] = service.change_assignee(request_payload)
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,
@@ -601,21 +589,22 @@ def test_run_change_assignee():
     return jsonify(res)
 
 
-@bp.route("/test_run/activity", methods=["POST"])
+@bp.route("/test_run/activity", methods=["GET"])
 @login_required
 def test_run_activity():
     res = {
         "status": "ok"
     }
     try:
-        if not request.is_json:
-            raise Exception(
-                "Content-Type mismatch, expected application/json, got:", request.content_type)
-        request_payload = request.get_json()
+        run_id = request.args.get("runId")
+        if not run_id:
+            raise Exception("RunId not provided in the request")
+        else:
+            run_id = UUID(run_id)
         service = ArgusService()
-        res["response"] = service.fetch_run_activity(request_payload)
+        res["response"] = service.fetch_run_activity(run_id=run_id)
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,
@@ -627,6 +616,7 @@ def test_run_activity():
 @bp.route("/release/create", methods=["POST"])
 @login_required
 def release_create():
+    # TODO: Old
     res = {
         "status": "ok"
     }
@@ -638,7 +628,7 @@ def release_create():
         service = ArgusService()
         res["response"] = service.create_release(request_payload)
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,
@@ -661,7 +651,7 @@ def issues_submit():
         service = ArgusService()
         res["response"] = service.submit_github_issue(request_payload)
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         LOGGER.error("Details: ", exc_info=True)
         res["status"] = "error"
         res["response"] = {
@@ -671,21 +661,25 @@ def issues_submit():
     return jsonify(res)
 
 
-@bp.route("/issues/get", methods=["POST"])
+@bp.route("/issues/get", methods=["GET"])
 @login_required
 def issues_get():
     res = {
         "status": "ok"
     }
     try:
-        if not request.is_json:
-            raise Exception(
-                "Content-Type mismatch, expected application/json, got:", request.content_type)
-        request_payload = request.get_json()
+        filter_key = request.args.get("filterKey")
+        if not filter_key:
+            raise Exception("Filter key not provided in the request")
+        key_value = request.args.get("id")
+        if not key_value:
+            raise Exception("Id wasn't provided in the request")
+        else:
+            key_value = UUID(key_value)
         service = ArgusService()
-        res["response"] = service.get_github_issues(request_payload)
+        res["response"] = service.get_github_issues(filter_key=filter_key, filter_id=key_value)
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,
@@ -708,30 +702,7 @@ def issues_delete():
         service = ArgusService()
         res["response"] = service.delete_github_issue(request_payload)
     except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
-        res["status"] = "error"
-        res["response"] = {
-            "exception": exc.__class__.__name__,
-            "arguments": exc.args
-        }
-    return jsonify(res)
-
-
-@bp.route("/issues/state", methods=["POST"])
-@login_required
-def issues_state():
-    res = {
-        "status": "ok"
-    }
-    try:
-        if not request.is_json:
-            raise Exception(
-                "Content-Type mismatch, expected application/json, got:", request.content_type)
-        request_payload = request.get_json()
-        service = ArgusService()
-        res["response"] = service.get_github_issue_state(request_payload)
-    except Exception as exc:
-        LOGGER.error("Something happened during request %s", request)
+        LOGGER.error("Exception in %s", request.endpoint, exc_info=True)
         res["status"] = "error"
         res["response"] = {
             "exception": exc.__class__.__name__,

--- a/argus/backend/assets/AdminPanel/AdminPanel.svelte
+++ b/argus/backend/assets/AdminPanel/AdminPanel.svelte
@@ -1,0 +1,68 @@
+<script>
+    import { onMount } from "svelte";
+    import { titleCase } from "../Common/TextUtils";
+    import AdminPanelWelcome from "./AdminPanelWelcome.svelte";
+    import UserManager from "./UserManager.svelte";
+    import ReleaseManager from "./ReleaseManager.svelte";
+
+    export let currentRoute;
+
+    const routes = {
+        index: AdminPanelWelcome,
+        users: UserManager,
+        releases: ReleaseManager,
+    };
+
+    const handleRouteClick = function(route, event) {
+        history.pushState({}, "", `/admin/${route}`);
+        let prevRoute = currentRoute;
+        currentRoute = route;
+        document.title = document.title.replace(titleCase(prevRoute), titleCase(route));
+    };
+
+    onMount(() => {
+        document.title = document.title.replace("%ROUTE", titleCase(currentRoute));
+    });
+</script>
+
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-2 min-vh-100 border-end p-0 bg-light-two">
+            <ul class="list-group list-group-flush">
+                <li class="list-group-item">
+                    <button
+                        class:btn-primary={currentRoute == "index"}
+                        class:btn-outline-primary={currentRoute != "index"}
+                        class="btn h-100 w-100"
+                        on:click={(e) => handleRouteClick("index", e)}
+                    >
+                        Home
+                    </button>
+                </li>
+                <li class="list-group-item">
+                    <button
+                        class:btn-primary={currentRoute == "users"}
+                        class:btn-outline-primary={currentRoute != "users"}
+                        class="btn h-100 w-100"
+                        on:click={(e) => handleRouteClick("users", e)}
+                    >
+                        Users
+                    </button>
+                </li>
+                <li class="list-group-item">
+                    <button
+                        class:btn-primary={currentRoute == "releases"}
+                        class:btn-outline-primary={currentRoute != "releases"}
+                        class="btn h-100 w-100"
+                        on:click={(e) => handleRouteClick("releases", e)}
+                    >
+                        Releases
+                    </button>
+                </li>
+            </ul>
+        </div>
+        <div class="col-9 min-vh-100 ">
+            <svelte:component this={routes[currentRoute] ?? routes["index"]} />
+        </div>
+    </div>
+</div>

--- a/argus/backend/assets/AdminPanel/AdminPanelWelcome.svelte
+++ b/argus/backend/assets/AdminPanel/AdminPanelWelcome.svelte
@@ -1,0 +1,5 @@
+<div class="d-flex align-items-center justify-content-center h-100">
+    <div class="text-muted rounded bg-main shadow-sm p-4">
+        Welcome to admin area! Select a category you wish to manage on the left side.
+    </div>
+</div>

--- a/argus/backend/assets/AdminPanel/BatchTestMover.svelte
+++ b/argus/backend/assets/AdminPanel/BatchTestMover.svelte
@@ -1,0 +1,72 @@
+<script>
+    import { createEventDispatcher } from "svelte";
+    export let tests;
+    export let groups;
+    const dispatch = createEventDispatcher();
+
+    let selectedGroup = tests.length > 0 ? tests[0].group_id : undefined;
+    let selectedTests = [];
+
+    const handleTestsMove = function () {
+        dispatch("testsMove", {
+            new_group_id: selectedGroup,
+            tests: selectedTests,
+        });
+    };
+
+    const handleCancel = function () {
+        dispatch("testsMoveCancel");
+    };
+</script>
+
+<div class="position-fixed popup-test-mover">
+    <div class="row h-100 justify-content-center align-items-center">
+        <div class="col-5 rounded bg-white shadow-sm p-2">
+            <div class="form-group mb-2">
+                <label for="" class="form-label">Target group</label>
+                <select id="" class="form-select" bind:value={selectedGroup}>
+                    {#each groups as group}
+                        <option value={group.id}
+                            >{group.pretty_name || group.name}</option
+                        >
+                    {/each}
+                </select>
+            </div>
+            <div class="form-group mb-2">
+                <label for="" class="form-label">Tests</label>
+                <select
+                    name=""
+                    multiple
+                    class="form-select"
+                    size=16
+                    bind:value={selectedTests}
+                >
+                    {#each tests as test}
+                        <option value={test.id}
+                            >{test.name ?? test.pretty_name}</option
+                        >
+                    {/each}
+                </select>
+            </div>
+            <div class="form-group text-end">
+                <button class="btn btn-secondary" on:click={handleCancel}>
+                    Cancel
+                </button>
+                <button class="btn btn-success" on:click={handleTestsMove}>
+                    Move
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<style>
+    .popup-test-mover {
+        background-color: rgba(0, 0, 0, 0.5);
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: 999;
+    }
+</style>

--- a/argus/backend/assets/AdminPanel/GroupCreator.svelte
+++ b/argus/backend/assets/AdminPanel/GroupCreator.svelte
@@ -1,0 +1,68 @@
+<script>
+    import { createEventDispatcher } from "svelte";
+    import * as urlSlug from "url-slug";
+    const dispatch = createEventDispatcher();
+    export let releaseId = "";
+    let newGroup = {
+        group_name: "",
+        pretty_name: "",
+    };
+
+    $: newGroup.group_name = urlSlug.convert(newGroup.pretty_name);
+
+    const handleGroupCreate = function() {
+        dispatch("groupCreate", Object.assign({
+            release_id: releaseId,
+        }, newGroup));
+    };
+
+    const handleGroupCreationCancel = function() {
+        dispatch("groupCreateCancel");
+    };
+</script>
+
+<div class="position-fixed popup-group-creator">
+    <div class="row h-100 justify-content-center align-items-center">
+        <div class="col-5 rounded bg-white shadow-sm p-2">
+            <div class="form-group">
+                <label for="" class="form-label">New group name</label>
+                <input
+                    type="text"
+                    class="form-control"
+                    disabled
+                    bind:value={newGroup.group_name}
+                />
+            </div>
+            <div class="form-group">
+                <label for="" class="form-label">Friendly name</label>
+                <input
+                    type="text"
+                    class="form-control"
+                    bind:value={newGroup.pretty_name}
+                />
+            </div>
+            <div class="mt-2 text-end">
+                <button
+                    class="btn btn-secondary"
+                    on:click={handleGroupCreationCancel}
+                >
+                    Cancel
+                </button>
+                <button class="btn btn-success" on:click={handleGroupCreate}>
+                    Create
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<style>
+    .popup-group-creator {
+        background-color: rgba(0, 0, 0, 0.5);
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: 999;
+    }
+</style>

--- a/argus/backend/assets/AdminPanel/ReleaseCreator.svelte
+++ b/argus/backend/assets/AdminPanel/ReleaseCreator.svelte
@@ -1,0 +1,73 @@
+<script>
+    import { createEventDispatcher } from "svelte";
+    import * as urlSlug from "url-slug";
+    const dispatch = createEventDispatcher();
+    let newRelease = {
+        release_name: "",
+        pretty_name: "",
+        perpetual: false,
+    };
+    $: newRelease.release_name = urlSlug.convert(newRelease.pretty_name);
+
+    const handleReleaseCreate = function() {
+        dispatch("releaseCreate", newRelease);
+    };
+
+    const handleReleaseCreationCancel = function() {
+        dispatch("releaseCreateCancel");
+    };
+</script>
+
+<div class="position-fixed popup-release-creator">
+    <div class="row h-100 justify-content-center align-items-center">
+        <div class="col-5 rounded bg-white text-start shadow-sm p-2">
+            <div class="form-group">
+                <label for="" class="form-label">New Release name</label>
+                <input
+                    type="text"
+                    class="form-control"
+                    disabled
+                    bind:value={newRelease.release_name}
+                />
+            </div>
+            <div class="form-group">
+                <label for="" class="form-label">Friendly name</label>
+                <input
+                    type="text"
+                    class="form-control"
+                    bind:value={newRelease.pretty_name}
+                />
+            </div>
+            <div class="form-group">
+                <label for="" class="form-label">Perpetual release</label>
+                <input
+                    type="checkbox"
+                    class="form-input-check"
+                    bind:checked={newRelease.perpetual}
+                />
+            </div>
+            <div class="mt-2 text-end">
+                <button
+                    class="btn btn-secondary"
+                    on:click={handleReleaseCreationCancel}
+                >
+                    Cancel
+                </button>
+                <button class="btn btn-success" on:click={handleReleaseCreate}>
+                    Create
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<style>
+    .popup-release-creator {
+        background-color: rgba(0, 0, 0, 0.5);
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: 999;
+    }
+</style>

--- a/argus/backend/assets/AdminPanel/ReleaseManager.svelte
+++ b/argus/backend/assets/AdminPanel/ReleaseManager.svelte
@@ -1,0 +1,482 @@
+<script>
+    import { onMount } from "svelte";
+    import Fa from "svelte-fa";
+    import {
+        faAngleRight,
+        faPlusCircle,
+        faDolly,
+    } from "@fortawesome/free-solid-svg-icons";
+    import { sendMessage } from "../Stores/AlertStore";
+    import ReleaseManagerGroup from "./ReleaseManagerGroup.svelte";
+    import ReleaseManagerTest from "./ReleaseManagerTest.svelte";
+    import BatchTestMover from "./BatchTestMover.svelte";
+    import ReleaseCreator from "./ReleaseCreator.svelte";
+    import GroupCreator from "./GroupCreator.svelte";
+    import TestCreator from "./TestCreator.svelte";
+    let releases = [];
+    let currentRelease;
+    let currentReleaseId;
+    let currentReleaseData;
+    let currentGroup;
+    let creatingRelease = false;
+    let creatingGroup = false;
+    let creatingTest = false;
+    let moving = false;
+    let fetching = false;
+
+    const fetchReleases = async function () {
+        try {
+            fetching = true;
+            let apiResponse = await fetch("/api/v1/releases?all=true");
+            let apiJson = await apiResponse.json();
+            if (apiJson.status === "ok") {
+                releases = apiJson.response;
+                if (releases.length > 0) {
+                    if (!currentRelease?.id) {
+                        currentRelease = releases[0];
+                        currentReleaseId = currentRelease.id;
+                    }
+                    fetchReleaseData(currentRelease.id);
+                }
+            } else {
+                throw apiJson;
+            }
+        } catch (error) {
+            if (error?.status === "error") {
+                sendMessage(
+                    "error",
+                    `API Error when fetching releases.\nMessage: ${error.response.arguments[0]}`
+                );
+            } else {
+                sendMessage(
+                    "error",
+                    "A backend error occurred during releases fetch"
+                );
+            }
+        } finally {
+            fetching = false;
+        }
+    };
+
+    const fetchReleaseData = async function (id) {
+        currentReleaseData = undefined;
+        try {
+            fetching = true;
+            let params = new URLSearchParams({
+                releaseId: id,
+            });
+            let apiResponse = await fetch(
+                "/api/v1/release/planner/data?" + params,
+                {
+                    method: "GET",
+                }
+            );
+            let apiJson = await apiResponse.json();
+            if (apiJson.status === "ok") {
+                currentReleaseData = apiJson.response ?? {};
+            } else {
+                throw apiJson;
+            }
+        } catch (error) {
+            if (error?.status === "error") {
+                sendMessage(
+                    "error",
+                    `Unable to fetch release data.\nMessage: ${error.response.arguments[0]}`
+                );
+            } else {
+                sendMessage(
+                    "error",
+                    "A backend error occurred during release data fetch"
+                );
+            }
+        } finally {
+            fetching = false;
+        }
+    };
+
+    const apiMethodCall = async function (endpoint, body, method = "POST") {
+        try {
+            fetching = true;
+            let apiResponse = await fetch(endpoint, {
+                method: method,
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify(body),
+            });
+            let res = await apiResponse.json();
+            if (res.status === "ok") {
+                return res;
+            } else {
+                throw res;
+            }
+        } catch (error) {
+            if (error?.status === "error") {
+                sendMessage(
+                    "error",
+                    `API Error.\nMessage: ${error.response.arguments[0]}`
+                );
+            } else {
+                sendMessage(
+                    "error",
+                    "Unhandled API Error occured. \nCheck response for details."
+                );
+            }
+        } finally {
+            fetching = false;
+        }
+    };
+
+    const handleReleaseSelection = function (e) {
+        currentGroup = undefined;
+        currentRelease = releases.find(
+            (release) => release.id == currentReleaseId
+        );
+        fetchReleaseData(currentRelease.id);
+    };
+
+    const handleGroupChange = function (id) {
+        currentGroup = id;
+    };
+
+    const handleGroupCreate = async function (e) {
+        creatingGroup = false;
+        let result = await apiMethodCall(
+            "/admin/api/v1/group/create",
+            e.detail
+        );
+        if (result.status === "ok") {
+            fetchReleaseData(currentRelease.id);
+        }
+    };
+
+    const handleGroupUpdate = async function (e) {
+        creatingGroup = false;
+        let result = await apiMethodCall(
+            "/admin/api/v1/group/update",
+            e.detail
+        );
+        if (result.status === "ok") {
+            fetchReleaseData(currentRelease.id);
+        }
+    };
+
+    const handleGroupDelete = async function (e) {
+        creatingGroup = false;
+        let result = await apiMethodCall(
+            "/admin/api/v1/group/delete",
+            e.detail
+        );
+        if (result.status === "ok") {
+            fetchReleaseData(currentRelease.id);
+        }
+    };
+
+    const handleGroupCreateCancel = function (e) {
+        creatingGroup = false;
+    };
+
+    const handleTestsMove = async function (e) {
+        moving = false;
+        let result = await apiMethodCall(
+            "/admin/api/v1/test/batch_move",
+            e.detail
+        );
+        if (result.status === "ok") {
+            fetchReleaseData(currentRelease.id);
+        }
+    };
+
+    const handleTestsMoveCancel = function (e) {
+        moving = false;
+    };
+
+    const handleTestCreate = async function (e) {
+        creatingTest = false;
+        let result = await apiMethodCall("/admin/api/v1/test/create", e.detail);
+        if (result.status === "ok") {
+            fetchReleaseData(currentRelease.id);
+        }
+    };
+
+    const handleTestUpdate = async function (e) {
+        creatingTest = false;
+        let result = await apiMethodCall("/admin/api/v1/test/update", e.detail);
+        if (result.status === "ok") {
+            fetchReleaseData(currentRelease.id);
+        }
+    };
+
+    const handleTestDelete = async function (e) {
+        creatingTest = false;
+        let result = await apiMethodCall("/admin/api/v1/test/delete", e.detail);
+        if (result.status === "ok") {
+            fetchReleaseData(currentRelease.id);
+        }
+    };
+
+    const handleTestCreateCancel = function (e) {
+        creatingTest = false;
+    };
+
+    const handleReleaseCreate = async function (e) {
+        creatingRelease = false;
+        let result = await apiMethodCall(
+            "/admin/api/v1/release/create",
+            e.detail
+        );
+        if (result.status === "ok") {
+            fetchReleases();
+        }
+    };
+
+    const handleReleaseCreateCancel = function (e) {
+        creatingRelease = false;
+    };
+
+    const handleReleaseStateChange = async function (e) {
+        let result = await apiMethodCall("/admin/api/v1/release/set_state", {
+            release_id: currentReleaseId,
+            state: currentRelease.enabled,
+        });
+
+        if (result.status === "ok") {
+            fetchReleases();
+        }
+    };
+
+    const handleReleaseDormancyChange = async function (e) {
+        let result = await apiMethodCall("/admin/api/v1/release/set_dormant", {
+            release_id: currentReleaseId,
+            dormant: currentRelease.dormant,
+        });
+
+        if (result.status === "ok") {
+            fetchReleases();
+        }
+    };
+
+    const handleReleasePerpetualityChange = async function (e) {
+        let result = await apiMethodCall(
+            "/admin/api/v1/release/set_perpetual",
+            {
+                release_id: currentReleaseId,
+                perpetual: currentRelease.perpetual,
+            }
+        );
+
+        if (result.status === "ok") {
+            fetchReleases();
+        }
+    };
+
+    onMount(() => {
+        fetchReleases();
+    });
+</script>
+
+<div class="bg-white m-2 p-2 rounded shadow-sm">
+    <div class="row mb-2">
+        <div class="col-4 px-2">
+            <select
+                class="form-select"
+                bind:value={currentReleaseId}
+                on:change={handleReleaseSelection}
+            >
+                {#each releases as release (release.id)}
+                    <option value={release.id}
+                        >{release.pretty_name || release.name}</option
+                    >
+                {/each}
+            </select>
+        </div>
+        <div class="col-6 d-flex align-items-center">
+            {#if currentRelease}
+                <div class="form-check form-switch">
+                    <input
+                        class="form-check-input"
+                        type="checkbox"
+                        role="switch"
+                        title="Whether this is a trunk branch, e.g. master"
+                        bind:checked={currentRelease.perpetual}
+                        on:change={handleReleasePerpetualityChange}
+                        id="releaseManagerSwitchPerpetual"
+                    />
+                    <label
+                        class="form-check-label"
+                        for="releaseManagerSwitchPerpetual">Perpetual</label
+                    >
+                </div>
+                <div class="ms-2 form-check form-switch">
+                    <input
+                        class="form-check-input"
+                        type="checkbox"
+                        role="switch"
+                        title="Whether or not fetch stats for this release in some cases"
+                        bind:checked={currentRelease.dormant}
+                        on:change={handleReleaseDormancyChange}
+                        id="releaseManagerSwitchDormant"
+                    />
+                    <label
+                        class="form-check-label"
+                        for="releaseManagerSwitchDormant">Dormant</label
+                    >
+                </div>
+                <div class="ms-2 form-check form-switch">
+                    <input
+                        class="form-check-input"
+                        type="checkbox"
+                        role="switch"
+                        title="Hide this release from Workspace and Releases page"
+                        bind:checked={currentRelease.enabled}
+                        on:change={handleReleaseStateChange}
+                        id="releaseManagerSwitchEnabled"
+                    />
+                    <label
+                        class="form-check-label"
+                        for="releaseManagerSwitchEnabled">Enabled</label
+                    >
+                </div>
+            {/if}
+        </div>
+        <div class="col-2 text-end">
+            <button
+                class="btn btn-success"
+                on:click={() => (creatingRelease = true)}
+            >
+                New Release
+            </button>
+            {#if creatingRelease}
+                <ReleaseCreator
+                    on:releaseCreateCancel={handleReleaseCreateCancel}
+                    on:releaseCreate={handleReleaseCreate}
+                />
+            {/if}
+        </div>
+    </div>
+    {#if fetching}
+        <div class="row border-top mt-2">
+            <div class="col">
+                <div class="text-center bg-white py-4">
+                    <span class="spinner-border" /> Loading...
+                </div>
+            </div>
+        </div>
+    {/if}
+    {#if currentRelease && currentReleaseData}
+        <div class="row border-top mt-2 manager-row">
+            <div class="col-5">
+                <div class="d-flex align-items-center my-2">
+                    <div class="fw-bold">Groups</div>
+                    <div class="ms-auto">
+                        <button
+                            class="ms-2 btn btn-sm btn-success"
+                            title="Create new"
+                            on:click={() => (creatingGroup = true)}
+                        >
+                            New Group
+                        </button>
+                        {#if creatingGroup}
+                            <GroupCreator
+                                releaseId={currentReleaseId}
+                                on:groupCreate={handleGroupCreate}
+                                on:groupCreateCancel={handleGroupCreateCancel}
+                            />
+                        {/if}
+                    </div>
+                </div>
+                <ul class="list-group manager-list">
+                    {#each Object.values(currentReleaseData.groups) as group (group.id)}
+                        <li
+                            class="list-group-item d-flex"
+                            role="button"
+                            class:active={currentGroup == group.id}
+                            on:click={() => handleGroupChange(group.id)}
+                        >
+                            <ReleaseManagerGroup
+                                {group}
+                                groups={Object.values(
+                                    currentReleaseData.groups
+                                )}
+                                on:groupDelete={handleGroupDelete}
+                                on:groupUpdate={handleGroupUpdate}
+                            />
+                        </li>
+                    {/each}
+                </ul>
+            </div>
+            {#if currentGroup}
+                <div
+                    class="col-1 d-flex fs-1 align-items-top justify-content-center"
+                >
+                    <Fa icon={faAngleRight} />
+                </div>
+                <div class="col-5">
+                    <div class="d-flex align-items-center mb-2 my-2">
+                        <div class="fw-bold">Tests</div>
+                        <button
+                            class="ms-2 btn btn-sm btn-success"
+                            title="Batch move"
+                            on:click={() => (moving = true)}
+                            ><Fa icon={faDolly} /></button
+                        >
+                        {#if moving}
+                            <BatchTestMover
+                                groups={Object.values(
+                                    currentReleaseData.groups
+                                )}
+                                tests={currentReleaseData.tests_by_group[
+                                    currentReleaseData.groups[currentGroup].name
+                                ]}
+                                on:testsMoveCancel={handleTestsMoveCancel}
+                                on:testsMove={handleTestsMove}
+                            />
+                        {/if}
+                        <div class="ms-auto">
+                            <button
+                                class="ms-2 btn btn-sm btn-success"
+                                title="Create new"
+                                on:click={() => (creatingTest = true)}
+                                >New Test</button
+                            >
+                            {#if creatingTest}
+                                <TestCreator
+                                    groups={Object.values(
+                                        currentReleaseData.groups
+                                    )}
+                                    releaseId={currentReleaseId}
+                                    groupId={currentGroup}
+                                    on:testCreate={handleTestCreate}
+                                    on:testCreateCancel={handleTestCreateCancel}
+                                />
+                            {/if}
+                        </div>
+                    </div>
+                    <ul class="list-group manager-list">
+                        {#each currentReleaseData.tests_by_group[currentReleaseData.groups[currentGroup].name] ?? [] as test (test.id)}
+                            <ReleaseManagerTest
+                                {test}
+                                releaseData={currentReleaseData}
+                                on:testUpdate={handleTestUpdate}
+                                on:testDelete={handleTestDelete}
+                            />
+                        {/each}
+                    </ul>
+                </div>
+            {/if}
+        </div>
+    {/if}
+</div>
+
+<style>
+    .manager-list {
+        min-height: 480px;
+        max-height: 720px;
+        overflow-y: scroll;
+    }
+
+    .manager-row {
+        min-height: 480px;
+        max-height: 900px;
+    }
+</style>

--- a/argus/backend/assets/AdminPanel/ReleaseManagerGroup.svelte
+++ b/argus/backend/assets/AdminPanel/ReleaseManagerGroup.svelte
@@ -1,0 +1,194 @@
+<script>
+    import { createEventDispatcher, onMount } from "svelte";
+    import Fa from "svelte-fa";
+    import { Modal } from "bootstrap/dist/js/bootstrap.esm";
+    import { faEdit, faTrash } from "@fortawesome/free-solid-svg-icons";
+    export let group;
+    export let groups;
+    const dispatch = createEventDispatcher();
+    let editing = false;
+    let editedGroup = Object.assign({}, group);
+    let modal;
+    let deleteTests = true;
+    let newGroupId = "";
+
+    const handleGroupUpdate = function (e) {
+        e.stopPropagation();
+        dispatch("groupUpdate", {
+            group_id: editedGroup.id, 
+            name: editedGroup.name, 
+            pretty_name: editedGroup.pretty_name, 
+            enabled: editedGroup.enabled,
+        });
+    };
+
+    const handleGroupDelete = function (e) {
+        e.stopPropagation();
+        dispatch("groupDelete", {
+            group_id: group.id,
+            delete_tests: deleteTests,
+            new_group_id: newGroupId,
+        });
+    };
+
+    onMount(() => {
+        newGroupId = groups?.[0]?.id ?? "";
+    });
+</script>
+
+<div class="d-flex align-items-center w-100">
+    <div>
+        {group.name} {#if group.pretty_name}
+            [{group.pretty_name}]
+        {/if}
+    </div>
+    <div class="ms-auto">
+        <button
+            class="btn btn-light"
+            title="Edit"
+            on:click={() => (editing = true)}
+        >
+            <Fa icon={faEdit} />
+        </button>
+    </div>
+    <div class="ms-2">
+        <button
+            class="btn btn-light"
+            title="Delete"
+            on:click={(e) => {
+                e.stopPropagation();
+                Modal.getOrCreateInstance(modal).show();
+            }}
+        >
+            <Fa icon={faTrash} />
+        </button>
+    </div>
+</div>
+
+<div class="position-fixed popup-group-editor" class:d-none={!editing}>
+    <div
+        class="row justify-content-center align-items-center h-100"
+        on:click|self={() => {
+            editing = false;
+        }}
+    >
+        <div class="col-4 mt-6 bg-white rounded shadow-sm shadow-light p-2">
+            <div class="fs-6 text-muted mb-2">
+                <span class="fw-bold">Argus Group Id</span>: {editedGroup.id}
+            </div>
+            <div class="form-group">
+                <label for="" class="form-label">Group name</label>
+                <input
+                    type="text"
+                    class="form-control"
+                    bind:value={editedGroup.name}
+                />
+            </div>
+            <div class="form-group">
+                <label for="" class="form-label">Friendly name</label>
+                <input
+                    type="text"
+                    class="form-control"
+                    bind:value={editedGroup.pretty_name}
+                />
+            </div>
+            <div class="mt-2 text-end">
+                <button
+                    class="btn btn-secondary"
+                    on:click={() => (editing = false)}
+                >
+                    Cancel
+                </button>
+                <button class="btn btn-success" on:click={handleGroupUpdate}>
+                    Update
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div
+    class="modal group-delete-modal position-fixed"
+    tabindex="-1"
+    bind:this={modal}
+    id="modalGroupConfirmDelete-{editedGroup.id}"
+    on:click={(e) => e.stopPropagation()}
+>
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Deleting a group</h5>
+                <button
+                    type="button"
+                    class="btn-close"
+                    data-bs-dismiss="modal"
+                    aria-label="Close"
+                />
+            </div>
+            <div class="modal-body">
+                <p>
+                    Are you sure you want to delete group <span class="fw-bold"
+                        >{editedGroup.name}</span
+                    >?
+                </p>
+                <div class="form-group">
+                    <label for="" class="form-label">Also delete associated tests</label>
+                    <input
+                        type="checkbox"
+                        class="form-check-input"
+                        bind:checked={deleteTests}
+                    />
+                </div>
+                {#if !deleteTests}
+                    <div class="form-group">
+                        <label for="" class="form-label">Select new group for orphaned tests</label>
+                        <select
+                            class="form-select"
+                            id=""
+                            bind:value={newGroupId}
+                        >
+                            {#each groups as group (group.id)}
+                                <option value={group.id}
+                                    >{group.pretty_name || group.name}</option
+                                >
+                            {/each}
+                        </select>
+                    </div>
+                {/if}
+            </div>
+            <div class="modal-footer">
+                <button
+                    type="button"
+                    class="btn btn-secondary"
+                    data-bs-dismiss="modal"
+                    >No</button
+                >
+                <button
+                    type="button"
+                    class="btn btn-danger"
+                    data-bs-dismiss="modal"
+                    on:click={handleGroupDelete}
+                >
+                    Yes
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<style>
+    .popup-group-editor {
+        background-color: rgba(0, 0, 0, 0.5);
+        color: black;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: 999;
+    }
+
+    .group-delete-modal {
+        z-index: 1200;
+        color: black;
+    }
+</style>

--- a/argus/backend/assets/AdminPanel/ReleaseManagerTest.svelte
+++ b/argus/backend/assets/AdminPanel/ReleaseManagerTest.svelte
@@ -1,0 +1,187 @@
+<script>
+    import { createEventDispatcher } from "svelte";
+    import Fa from "svelte-fa";
+    import {
+        faEdit,
+        faTrash,
+    } from "@fortawesome/free-solid-svg-icons";
+    export let test;
+    export let releaseData;
+    const dispatch = createEventDispatcher();
+    let editing = false;
+    let editedTest = Object.assign({}, test);
+
+    const handleTestUpdate = function () {
+        dispatch("testUpdate", {
+            test_id: editedTest.id, 
+            name: editedTest.name, 
+            pretty_name: editedTest.pretty_name, 
+            enabled: editedTest.enabled, 
+            build_system_id: editedTest.build_system_id,
+            build_system_url: editedTest.build_system_url,
+            group_id: editedTest.group_id,
+        });
+    };
+
+    const handleTestDelete = function () {
+        dispatch("testDelete", {
+            test_id: editedTest.id
+        });
+    };
+</script>
+
+<li class="list-group-item d-flex align-items-center">
+    <div>
+        {test.name}
+    </div>
+    <div class="ms-auto">
+        <button
+            class="btn btn-light"
+            title="Edit"
+            on:click={() => (editing = true)}
+        >
+            <Fa icon={faEdit} />
+        </button>
+    </div>
+    <div class="ms-2">
+        <button
+            class="btn btn-light"
+            title="Delete"
+            data-bs-toggle="modal"
+            data-bs-target="#modalTestConfirmDelete-{editedTest.id}"
+        >
+            <Fa icon={faTrash} />
+        </button>
+    </div>
+</li>
+
+<div class="position-fixed popup-test-editor" class:d-none={!editing}>
+    <div
+        class="row justify-content-center align-items-center h-100"
+        on:click|self={() => {
+            editing = false;
+        }}
+    >
+        <div class="col-4 mt-6 bg-white rounded shadow-sm shadow-light p-2">
+            <div class="fs-6 text-muted mb-2">
+                <span class="fw-bold">Argus Test Id</span>: {editedTest.id}
+            </div>
+
+            <div class="form-group">
+                <label for="" class="form-label">Build System Id</label>
+                <input
+                    type="text"
+                    class="form-control"
+                    bind:value={editedTest.build_system_id}
+                />
+            </div>
+            <div class="form-group">
+                <label for="" class="form-label">Build System URL</label>
+                <input
+                    type="text"
+                    class="form-control"
+                    bind:value={editedTest.build_system_url}
+                />
+            </div>
+            <div class="form-group">
+                <label for="" class="form-label">Test name</label>
+                <input
+                    type="text"
+                    class="form-control"
+                    bind:value={editedTest.name}
+                />
+            </div>
+            <div class="form-group">
+                <label for="" class="form-label">Friendly name</label>
+                <input
+                    type="text"
+                    class="form-control"
+                    bind:value={editedTest.pretty_name}
+                />
+            </div>
+            <div class="form-group">
+                <label for="" class="form-label">Group</label>
+                <select
+                    class="form-select"
+                    id=""
+                    bind:value={editedTest.group_id}
+                >
+                    {#each Object.values(releaseData.groups) as group (group.id)}
+                        <option value={group.id}
+                            >{group.pretty_name || group.name}</option
+                        >
+                    {/each}
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="" class="form-label">Enabled</label>
+                <input
+                    type="checkbox"
+                    class="form-check-input"
+                    bind:checked={editedTest.enabled}
+                />
+            </div>
+            <div class="mt-2 text-end">
+                <button
+                    class="btn btn-secondary"
+                    on:click={() => (editing = false)}
+                >
+                    Cancel
+                </button>
+                <button class="btn btn-success" on:click={handleTestUpdate}>
+                    Update
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal" tabindex="-1" id="modalTestConfirmDelete-{editedTest.id}">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Deleting an issue</h5>
+                <button
+                    type="button"
+                    class="btn-close"
+                    data-bs-dismiss="modal"
+                    aria-label="Close"
+                />
+            </div>
+            <div class="modal-body">
+                <p>
+                    Are you sure you want to delete <span class="fw-bold"
+                        >{editedTest.name} ({editedTest.build_system_id})</span
+                    >?
+                </p>
+            </div>
+            <div class="modal-footer">
+                <button
+                    type="button"
+                    class="btn btn-secondary"
+                    data-bs-dismiss="modal">No</button
+                >
+                <button
+                    type="button"
+                    class="btn btn-danger"
+                    data-bs-dismiss="modal"
+                    on:click={handleTestDelete}
+                >
+                    Yes
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+<style>
+    .popup-test-editor {
+        background-color: rgba(0, 0, 0, 0.5);
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: 999;
+    }
+</style>

--- a/argus/backend/assets/AdminPanel/TestCreator.svelte
+++ b/argus/backend/assets/AdminPanel/TestCreator.svelte
@@ -1,0 +1,100 @@
+<script>
+    import { createEventDispatcher } from "svelte";
+    import * as urlSlug from "url-slug";
+    export let groups = [];
+    export let releaseId = "";
+    export let groupId = "";
+    const dispatch = createEventDispatcher();
+    let newTest = {
+        test_name: "",
+        pretty_name: "",
+        group_id: groupId,
+        build_id: "",
+        build_url: "",
+
+    };
+    $: newTest.test_name = urlSlug.convert(newTest.pretty_name);
+
+    const handleTestCreate = function() {
+        dispatch("testCreate", Object.assign({
+            release_id: releaseId,
+            group_id: groupId,
+        }, newTest));
+    };
+
+    const handleTestCreationCancel = function() {
+        dispatch("testCreateCancel");
+    };
+</script>
+
+<div class="position-fixed popup-test-creator">
+    <div class="row h-100 justify-content-center align-items-center">
+        <div class="col-5 rounded bg-white shadow-sm p-2">
+            <div class="form-group">
+                <label for="" class="form-label">New test name</label>
+                <input
+                    type="text"
+                    class="form-control"
+                    disabled
+                    bind:value={newTest.test_name}
+                />
+            </div>
+            <div class="form-group">
+                <label for="" class="form-label">Friendly name</label>
+                <input
+                    type="text"
+                    class="form-control"
+                    bind:value={newTest.pretty_name}
+                />
+            </div>
+            <div class="form-group">
+                <label for="" class="form-label">Build System Id</label>
+                <input
+                    type="text"
+                    class="form-control"
+                    bind:value={newTest.build_id}
+                />
+            </div>
+            <div class="form-group">
+                <label for="" class="form-label">Build System URL (Optional)</label>
+                <input
+                    type="text"
+                    class="form-control"
+                    bind:value={newTest.build_url}
+                />
+            </div>
+            <div class="form-group mb-2">
+                <label for="" class="form-label">Target group</label>
+                <select id="" class="form-select" bind:value={newTest.group_id}>
+                    {#each groups as group}
+                        <option value={group.id}
+                            >{group.pretty_name || group.name}</option
+                        >
+                    {/each}
+                </select>
+            </div>
+            <div class="mt-2 text-end">
+                <button
+                    class="btn btn-secondary"
+                    on:click={handleTestCreationCancel}
+                >
+                    Cancel
+                </button>
+                <button class="btn btn-success" on:click={handleTestCreate}>
+                    Create
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<style>
+    .popup-test-creator {
+        background-color: rgba(0, 0, 0, 0.5);
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: 999;
+    }
+</style>

--- a/argus/backend/assets/AdminPanel/UserManager.svelte
+++ b/argus/backend/assets/AdminPanel/UserManager.svelte
@@ -1,0 +1,1 @@
+User manager placeholder

--- a/argus/backend/assets/Common/ApiUtils.js
+++ b/argus/backend/assets/Common/ApiUtils.js
@@ -1,0 +1,34 @@
+import { sendMessage } from "../Stores/AlertStore";
+
+export const apiMethodCall = async function (endpoint, body, method = "POST") {
+    try {
+        let apiResponse = await fetch(endpoint, {
+            method: method,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(body),
+        });
+        let res = await apiResponse.json();
+        if (res.status === "ok") {
+            return res;
+        } else {
+            throw res;
+        }
+    } catch (error) {
+        if (error?.status === "error") {
+            sendMessage(
+                "error",
+                `API Error.\nMessage: ${error.response.arguments[0]}`
+            );
+        } else {
+            sendMessage(
+                "error",
+                "Unhandled API Error occured. \nCheck console for details."
+            );
+            console.log(error);
+        }
+    } finally {
+
+    }
+};

--- a/argus/backend/assets/Common/AssigneeUtils.js
+++ b/argus/backend/assets/Common/AssigneeUtils.js
@@ -1,0 +1,10 @@
+import { apiMethodCall } from "./ApiUtils";
+
+const fetchAssigneesForGroup = async function(group) {
+
+};
+
+
+const fetchAssigneesForTests = async function(group) {
+
+};

--- a/argus/backend/assets/Github/GithubIssues.svelte
+++ b/argus/backend/assets/Github/GithubIssues.svelte
@@ -13,16 +13,11 @@
         issues = [];
         fetching = true;
         try {
-            let apiResponse = await fetch("/api/v1/issues/get", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    filter_key: filter_key,
-                    id: id,
-                }),
-            });
+            let params = new URLSearchParams({
+                filterKey: filter_key,
+                id: id,
+            }).toString();
+            let apiResponse = await fetch("/api/v1/issues/get?" + params);
             let apiJson = await apiResponse.json();
             if (apiJson.status === "ok") {
                 issues = apiJson.response;
@@ -47,6 +42,7 @@
                     run_id: id,
                 }),
             });
+            newIssueUrl = "";
             let apiJson = await apiResponse.json();
             if (apiJson.status === "ok") {
 

--- a/argus/backend/assets/Profile/JobsList.svelte
+++ b/argus/backend/assets/Profile/JobsList.svelte
@@ -60,13 +60,13 @@
                     {run.status.toUpperCase()}
                 </div>
                 <h3 class="ms-2 p-2">
-                    <span class="text-muted">{run.build_job_name}#</span
+                    <span class="text-muted">{run.build_id}#</span
                     >{getBuildNumber(run.build_job_url)}
                 </h3>
                 <div class="ms-auto">
                     <h6 class="text-muted">Started at</h6>
                     <div>
-                        {timestampToISODate(run.start_time * 1000, true)}
+                        {timestampToISODate(run.start_time , true)}
                     </div>
                 </div>
                 <div class="ms-2">

--- a/argus/backend/assets/Profile/ProfileSchedules.svelte
+++ b/argus/backend/assets/Profile/ProfileSchedules.svelte
@@ -1,8 +1,59 @@
 <script>
     export let schedules = [];
     import Fa from "svelte-fa";
-    import { faExternalLinkAlt, faTasks } from "@fortawesome/free-solid-svg-icons";
+    import {
+        faExternalLinkAlt,
+        faTasks,
+    } from "@fortawesome/free-solid-svg-icons";
+    import { allTests, allGroups, allReleases} from "../Stores/WorkspaceStore";
     import { stateEncoder } from "../Common/StateManagement";
+
+    let releases = {};
+    let groups = {};
+    let tests = {};
+
+    allReleases.subscribe((value) => {
+        if (!value) return;
+        releases = value.reduce((acc, val) => {
+            acc[val.id] = val;
+            return acc;
+        }, {});
+    });
+
+    allGroups.subscribe((value) => {
+        if (!value) return;
+        groups = value.reduce((acc, val) => {
+            acc[val.id] = val;
+            return acc;
+        }, {});
+    });
+
+    allTests.subscribe((value) => {
+        if (!value) return;
+        tests = value.reduce((acc, val) => {
+            acc[val.id] = val;
+            return acc;
+        }, {});
+    });
+
+    const generateJenkinsUrl = function(id, type = "test") {
+        // TODO: Store URLs in entities
+        if (!id) return "";
+        const baseURL = "https://jenkins.scylladb.com/";
+        switch (type) {
+            case "test": {
+                let test = tests?.[id];
+                let group = groups?.[test.group_id];
+                let release = releases?.[test.release_id];
+                return `${baseURL}job/${release?.name}/job/${group?.name}/job/${test?.name}`;
+            }
+            case "group": {
+                let group = groups?.[id];
+                let release = releases?.[group.release_id];
+                return `${baseURL}job/${release?.name}/job/${group?.name}`;
+            }
+        }
+    };
 
     const sortByStartTime = function () {
         return [...schedules].sort((a, b) => {
@@ -17,105 +68,147 @@
         });
     };
 
-    const prepareState = function(schedule) {
+    const prepareState = function (schedule, releases, groups, tests) {
         return schedule.tests.reduce((acc, scheduledTest) => {
-            let [group, test] = scheduledTest.split("/");
-            let release = schedule.release;
-            acc[`${release}/${group}/${test}`] = {
-                release: release,
-                group: group,
-                test: test,
+            let testId = scheduledTest;
+            let releaseId = schedule.release_id;
+            let groupId = tests?.[testId]?.group_id;
+            let releaseName = releases?.[releaseId]?.name;
+            let groupName = groups?.[groupId]?.name;
+            let testName = tests?.[testId]?.name;
+            let buildSystemId = tests?.[testId]?.build_system_id;
+            acc[`${releaseName}/${groupName}/${testName}`] = {
+                release: releaseName,
+                group: groupName,
+                test: testName,
+                build_system_id: buildSystemId,
             };
             return acc;
         }, {});
     };
-
 </script>
 
-<div class="row p-2 justify-content-center">
-    {#each sortByStartTime() as schedule}
-        <div class="col-3 border rounded bg-white shadow-sm mb-2 p-2 me-2">
-            <div class="d-flex flex-column text-center">
-                <div class="border-bottom">
-                    <h5>Release</h5>
-                    <div>{schedule.release}</div>
-                </div>
-                <div class="border-bottom">
-                    <h5>From</h5>
-                    <div class="text-danger">
-                        {new Date(schedule.period_start).toLocaleDateString(
-                            "en-CA"
-                        )}
+{#each sortByStartTime() as schedule}
+    <div class="row p-2 justify-content-center">
+        <div class="col-12 border rounded bg-white shadow-sm mb-2 p-2 me-2">
+            <div class="row">
+                <div class="col-4">
+                    <div>
+                        <h5>Release</h5>
+                        <div>{releases?.[schedule.release_id]?.name}</div>
                     </div>
-                </div>
-                <div class="border-bottom">
-                    <h5>To</h5>
-                    <div class="text-success">
-                        {new Date(schedule.period_end).toLocaleDateString(
-                            "en-CA"
-                        )}
+                    <div>
+                        <h5>From</h5>
+                        <div class="text-danger">
+                            {new Date(schedule.period_start).toLocaleDateString(
+                                "en-CA"
+                            )}
+                        </div>
+                    </div>
+                    <div>
+                        <h5>To</h5>
+                        <div class="text-success">
+                            {new Date(schedule.period_end).toLocaleDateString(
+                                "en-CA"
+                            )}
+                        </div>
                     </div>
                 </div>
                 <div
-                    class="border-bottom"
+                    class:col-4={schedule.groups.length > 0}
+                    class:col-8={schedule.groups.length == 0}
                     class:d-none={schedule.tests.length == 0}
+                    class="border-start"
                 >
-                    <h5>Tests</h5>
-                    <div>
-                        <div class="mb-1 text-start">
-                            <a
-                                href="/run_dashboard?{stateEncoder(prepareState(schedule))}"
-                                class="btn btn-sm btn-outline-primary"
-                            >
-                                Open Workspace <Fa icon={faTasks}/>
-                            </a>
+                    <div class:d-none={schedule.tests.length == 0}>
+                        <div class="d-flex mb-2 align-items-center">
+                            <div class="fw-bold fs-5">Tests</div>
+
+                            <div class="ms-4 text-start">
+                                <a
+                                    href="/workspace?{stateEncoder(
+                                        prepareState(
+                                            schedule,
+                                            releases,
+                                            groups,
+                                            tests
+                                        )
+                                    )}"
+                                    class="btn btn-sm btn-outline-primary"
+                                >
+                                    Open Workspace <Fa icon={faTasks} />
+                                </a>
+                            </div>
                         </div>
-                        <ul class="list-group">
-                            {#each schedule.tests as test}
-                                <li class="list-group-item text-start">
-                                    <div>
-                                        {test}
-                                        <div class="">
-                                            <a
-                                                target="_blank"
-                                                href="https://jenkins.scylladb.com/job/{schedule.release}/job/{test.split(
-                                                    '/'
-                                                )[0]}/job/{test.split('/')[1]}"
-                                                class="btn btn-sm btn-outline-dark"
-                                                >To Jenkins <Fa
-                                                    icon={faExternalLinkAlt}
-                                                /></a
-                                            >
+                        <div>
+                            <ul class="list-group list-height-limit">
+                                {#each schedule.tests as test}
+                                    <li class="list-group-item text-start">
+                                        <div class="d-flex align-items-center">
+                                            <div>
+                                                {tests?.[test]?.pretty_name ||
+                                                    tests?.[test]?.name}
+                                            </div>
+                                            <div class="ms-auto">
+                                                <a
+                                                    target="_blank"
+                                                    href={tests?.[test]?.build_system_url}
+                                                    class="btn btn-sm btn-outline-dark"
+                                                    >To Jenkins <Fa
+                                                        icon={faExternalLinkAlt}
+                                                    /></a
+                                                >
+                                            </div>
                                         </div>
-                                    </div>
-                                </li>
-                            {/each}
-                        </ul>
+                                    </li>
+                                {/each}
+                            </ul>
+                        </div>
                     </div>
                 </div>
-                <div class="" class:d-none={schedule.groups.length == 0}>
-                    <h5>Groups</h5>
-                    <div>
-                        <ul class="list-group">
-                            {#each schedule.groups as group}
-                                <li class="list-group-item text-start">
-                                    {group}
-                                    <div class="">
-                                        <a
-                                            target="_blank"
-                                            href="https://jenkins.scylladb.com/job/{schedule.release}/job/{group}"
-                                            class="btn btn-dark btn-outline"
-                                            >Jenkins <Fa
-                                                icon={faExternalLinkAlt}
-                                            /></a
-                                        >
-                                    </div>
-                                </li>
-                            {/each}
-                        </ul>
+                <div
+                    class:col-4={schedule.tests.length > 0}
+                    class:col-8={schedule.tests.length == 0}
+                    class="border-start"
+                >
+                    <div class:d-none={schedule.groups.length == 0}>
+                        <div class="d-flex mb-2 align-items-center">
+                            <div class="fw-bold fs-5">Groups</div>
+                        </div>
+                        <div>
+                            <ul class="list-group list-height-limit">
+                                {#each schedule.groups as group}
+                                    <li class="list-group-item text-start">
+                                        <div class="d-flex align-items-center">
+                                            <div class="fs-3 fw-bold">
+                                                {groups?.[group]?.pretty_name ||
+                                                    groups?.[group]?.name}
+                                            </div>
+                                            <div class="ms-auto">
+                                                <a
+                                                    target="_blank"
+                                                    href={generateJenkinsUrl(groups?.[group]?.id, "group")}
+                                                    class="btn btn-dark btn-outline"
+                                                    >Jenkins <Fa
+                                                        icon={faExternalLinkAlt}
+                                                    /></a
+                                                >
+                                            </div>
+                                        </div>
+                                    </li>
+                                {/each}
+                            </ul>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
-    {/each}
-</div>
+    </div>
+{/each}
+
+<style>
+    .list-height-limit {
+        max-height: 256px;
+        overflow-y: scroll;
+    }
+</style>

--- a/argus/backend/assets/ReleaseDashboard/ReleaseActivity.svelte
+++ b/argus/backend/assets/ReleaseDashboard/ReleaseActivity.svelte
@@ -35,15 +35,10 @@
     const fetchActivity = async function () {
         fetching = true;
         try {
-            let apiResponse = await fetch("/api/v1/release/activity", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    release_name: releaseName,
-                }),
-            });
+            let params = new URLSearchParams({
+                releaseName: releaseName,
+            }).toString();
+            let apiResponse = await fetch("/api/v1/release/activity?" + params);
             let apiJson = await apiResponse.json();
             if (apiJson.status === "ok") {
                 activity = apiJson.response;

--- a/argus/backend/assets/ReleaseDashboard/ReleaseDashboard.svelte
+++ b/argus/backend/assets/ReleaseDashboard/ReleaseDashboard.svelte
@@ -40,6 +40,7 @@
         <div class="col-xs-2 col-sm-6 col-md-7">
             <ReleaseStats
                 releaseName={releaseData.release.name}
+                releaseId={releaseData.release.id}
                 showTestMap={true}
                 horizontal={false}
                 bind:clickedTests={clickedTests}

--- a/argus/backend/assets/ReleaseDashboard/TestPopoutSelector.svelte
+++ b/argus/backend/assets/ReleaseDashboard/TestPopoutSelector.svelte
@@ -24,6 +24,7 @@
                 test: val.name,
                 group: val.group,
                 release: releaseName,
+                build_system_id: val.build_system_id
             };
             return acc;
         }, {})

--- a/argus/backend/assets/ReleaseDashboard/TestPopoutSelector.svelte
+++ b/argus/backend/assets/ReleaseDashboard/TestPopoutSelector.svelte
@@ -4,7 +4,6 @@
     import { timestampToISODate } from "../Common/DateUtils";
     import { createEventDispatcher } from "svelte";
     import { stateEncoder } from "../Common/StateManagement";
-    import { assigneeStore } from "../Stores/AssigneeSubscriber";
     import AssigneeList from "../WorkArea/AssigneeList.svelte";
     import {
         faCircle,
@@ -29,24 +28,13 @@
             return acc;
         }, {})
     );
-    let assigneeList = {};
-    $: assigneeList = $assigneeStore?.[releaseName] ?? {
-        groups: {},
-        tests: {},
-    };
+
     const dispatch = createEventDispatcher();
     const handleTrashClick = function (name, group) {
         dispatch("deleteRequest", {
             name: name,
             group: group,
         });
-    };
-
-    const getAssigneesForTest = function (test) {
-        let testAssignees =
-            assigneeList.tests?.[`${test.group}/${test.name}`] ?? [];
-        let groupAssignees = assigneeList.groups?.[test.group] ?? [];
-        return [...testAssignees, ...groupAssignees];
     };
 </script>
 
@@ -59,11 +47,9 @@
                         <div class="d-flex align-items-center">
                             <div class="d-flex">
                                 <div>
-                                    {#if assigneeList}
+                                    {#if test.assignees}
                                         <AssigneeList
-                                            assignees={getAssigneesForTest(
-                                                test
-                                            )}
+                                            assignees={test.assignees}
                                         />
                                     {/if}
                                 </div>
@@ -121,7 +107,7 @@
                                             </div>
                                             <div class="text-muted small-text">
                                                 {timestampToISODate(
-                                                    run.start_time * 1000
+                                                    run.start_time 
                                                 )}
                                             </div>
                                         </div>
@@ -161,9 +147,8 @@
                 {/each}
             </ul>
             <a
-                href="/run_dashboard?{encodedState}"
+                href="/workspace?{encodedState}"
                 class="btn btn-primary"
-                target="_blank"
                 >Investigate selected <Fa icon={faExternalLinkSquareAlt} /></a
             >
         </div>

--- a/argus/backend/assets/ReleasePlanner/CommentTableRow.svelte
+++ b/argus/backend/assets/ReleasePlanner/CommentTableRow.svelte
@@ -19,9 +19,9 @@
                     "Content-Type": "application/json",
                 },
                 body: JSON.stringify({
-                    release: release,
-                    group: group,
-                    test: test,
+                    releaseId: release,
+                    groupId: group,
+                    testId: test,
                     newComment: commentText,
                 }),
             });

--- a/argus/backend/assets/ReleasePlanner/DutyPlanner.svelte
+++ b/argus/backend/assets/ReleasePlanner/DutyPlanner.svelte
@@ -14,12 +14,13 @@
     let selectedTests = [];
 
     const PayloadTemplate = {
-        release: releaseData.release.name,
+        releaseId: releaseData.release.id,
         groups: [],
         tests: [],
         start: undefined,
         end: undefined,
         assignees: [],
+        tag: "",
     };
 
     const generateNewScheduleDate = function(today = new Date()) {
@@ -47,14 +48,11 @@
 
     const fetchSchedules = async function () {
         try {
-            let apiResponse = await fetch("/api/v1/release/schedules", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    release: releaseData.release.name,
-                }),
+            let params = new URLSearchParams({
+                releaseId: releaseData.release.id,
+            }).toString();
+            let apiResponse = await fetch("/api/v1/release/schedules?" + params, {
+                method: "GET",
             });
             let apiJson = await apiResponse.json();
             if (apiJson.status === "ok") {
@@ -119,8 +117,8 @@
                     "Content-Type": "application/json",
                 },
                 body: JSON.stringify({
-                    release: releaseData.release.name,
-                    schedule_id: scheduleId,
+                    releaseId: releaseData.release.id,
+                    scheduleId: scheduleId,
                 }),
             });
             let apiJson = await apiResponse.json();
@@ -150,8 +148,8 @@
     const extractGroups = function (releaseData) {
         return Object.values(releaseData.groups).map((val) => {
             return {
-                label: val.pretty_name ?? val.name,
-                value: val.name,
+                label: val.pretty_name || val.name,
+                value: val.id,
             };
         });
     };
@@ -201,8 +199,8 @@
         if (!selectedGroups) {
             selectedGroups = [];
         }
-        if (selectedGroups.findIndex(val => val.value == data.group.name) == -1) {
-            selectedGroups.push({ label: data.group.pretty_name ?? data.group.name, value: data.group.name });
+        if (selectedGroups.findIndex(val => val.value == data.group.id) == -1) {
+            selectedGroups.push({ label: data.group.pretty_name || data.group.name, value: data.group.id });
             selectedGroups = selectedGroups;
             handleGroupSelect({
                 detail: selectedGroups

--- a/argus/backend/assets/ReleasePlanner/ReleasePlanTable.svelte
+++ b/argus/backend/assets/ReleasePlanner/ReleasePlanTable.svelte
@@ -23,10 +23,20 @@
 
     let schedulesByTest = {};
     const dispatch = createEventDispatcher();
+
+    const getTestsByBuildSystemId = function(plannerData) {
+        return plannerData.tests.reduce((acc, test) => {
+            acc[test.build_system_id] = test;
+            return acc;
+        }, {});
+    }
+
     const sortSchedulesByTest = function (schedules) {
+        let tests = getTestsByBuildSystemId(plannerData);
         schedulesByTest = schedules.reduce((acc, schedule) => {
             schedule.tests.forEach((test) => {
-                let [groupName, testName] = test.split("/");
+                let groupName = tests[test].group_name;
+                let testName = tests[test].name;
                 if (!testName) return;
                 if (!acc[groupName]) {
                     acc[groupName] = {};

--- a/argus/backend/assets/ReleasePlanner/ReleaseScheduler.svelte
+++ b/argus/backend/assets/ReleasePlanner/ReleaseScheduler.svelte
@@ -31,7 +31,7 @@
     };
 
     const PayloadTemplate = {
-        release: releaseData.release.name,
+        releaseId: releaseData.release.id,
         groups: [],
         tests: [],
         start: generateNewScheduleDate(),
@@ -44,14 +44,11 @@
 
     const fetchPlannerData = async function () {
         try {
-            let apiResponse = await fetch("/api/v1/release/planner/data", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    release: releaseData.release.name,
-                }),
+            let params = new URLSearchParams({
+                releaseId: releaseData.release.id
+            }).toString()
+            let apiResponse = await fetch("/api/v1/release/planner/data?" + params, {
+                method: "GET",
             });
             let apiJson = await apiResponse.json();
             if (apiJson.status === "ok") {
@@ -76,15 +73,14 @@
 
     const fetchSchedules = async function () {
         try {
-            let apiResponse = await fetch("/api/v1/release/schedules", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    release: releaseData.release.name,
-                }),
+            let params = new URLSearchParams({
+                releaseId: releaseData.release.id
             });
+
+            let apiResponse = await fetch("/api/v1/release/schedules?" + params, {
+                method: "GET",
+            });
+
             let apiJson = await apiResponse.json();
             if (apiJson.status === "ok") {
                 schedules = apiJson.response?.schedules ?? [];
@@ -148,8 +144,8 @@
                     "Content-Type": "application/json",
                 },
                 body: JSON.stringify({
-                    release: releaseData.release.name,
-                    schedule_id: scheduleId,
+                    releaseId: releaseData.release.id,
+                    scheduleId: scheduleId,
                 }),
             });
             let apiJson = await apiResponse.json();
@@ -200,7 +196,7 @@
             .map((val) => {
                 return {
                     label: `${val.group_name}/${val.name}`,
-                    value: val.name,
+                    value: val.id,
                     test: val,
                 };
             })
@@ -224,7 +220,7 @@
         if (selectedTests.findIndex((test) => test.label == testLabel) == -1) {
             selectedTests.push({
                 label: testLabel,
-                value: data.test.build_system_id,
+                value: data.test.id,
             });
             selectedTests = selectedTests;
             clickedTests[testLabel] = true;

--- a/argus/backend/assets/ReleasePlanner/ReleaseScheduler.svelte
+++ b/argus/backend/assets/ReleasePlanner/ReleaseScheduler.svelte
@@ -224,7 +224,7 @@
         if (selectedTests.findIndex((test) => test.label == testLabel) == -1) {
             selectedTests.push({
                 label: testLabel,
-                value: data.test.name,
+                value: data.test.build_system_id,
             });
             selectedTests = selectedTests;
             clickedTests[testLabel] = true;
@@ -256,7 +256,7 @@
     const handleTestSelect = function (e) {
         newSchedule.tests =
             e.detail?.map((val) => {
-                return val.label;
+                return val.value;
             }) ?? [];
         newSchedule = newSchedule;
     };

--- a/argus/backend/assets/ReleasePlanner/Schedule.svelte
+++ b/argus/backend/assets/ReleasePlanner/Schedule.svelte
@@ -75,8 +75,8 @@
                         "Content-Type": "application/json",
                     },
                     body: JSON.stringify({
-                        release: releaseData.release.name,
-                        scheduleId: scheduleData.schedule_id,
+                        releaseId: releaseData.release.id,
+                        scheduleId: scheduleData.id,
                         newAssignees: reassigned.map((v) => v.value),
                     }),
                 }
@@ -112,7 +112,7 @@
         e.stopPropagation();
         deleting = true;
         dispatch("deleteSchedule", {
-            id: scheduleData.schedule_id,
+            id: scheduleData.id,
         });
     };
 
@@ -149,8 +149,10 @@
                         <li class="list-group-item d-flex align-items-center">
                             <div>
                                 {releaseData.groups.find(
-                                    (val) => val.name == group
-                                ).pretty_name ?? group}
+                                    (val) => val.id == group
+                                ).pretty_name || releaseData.groups.find(
+                                    (val) => val.id == group
+                                ).name}
                             </div>
                         </li>
                     {/each}
@@ -166,7 +168,9 @@
                 <ul class="list-group list-schedule">
                     {#each scheduleData.tests as test}
                         <li class="list-group-item d-flex align-items-center">
-                            <div>{test}</div>
+                            <div>{releaseData.tests.find(
+                                (val) => val.id == test
+                            ).name}</div>
                         </li>
                     {/each}
                 </ul>
@@ -260,8 +264,7 @@
             <div class="text-end">
                 <a
                     class="btn btn-primary"
-                    href="/run_dashboard?{state}"
-                    target="_blank"
+                    href="/workspace?{state}"
                 >
                     <Fa icon={faExternalLinkSquareAlt} />
                 </a>
@@ -279,7 +282,7 @@
                         title="Delete schedule"
                         type="button"
                         data-bs-toggle="modal"
-                        data-bs-target="#modalScheduleConfirmDelete-{scheduleData.schedule_id}"
+                        data-bs-target="#modalScheduleConfirmDelete-{scheduleData.id}"
                     >
                         <Fa icon={faTrashAlt} />
                     </button>
@@ -292,7 +295,7 @@
 <div
     class="modal"
     tabindex="-1"
-    id="modalScheduleConfirmDelete-{scheduleData.schedule_id}"
+    id="modalScheduleConfirmDelete-{scheduleData.id}"
 >
     <div class="modal-dialog">
         <div class="modal-content">

--- a/argus/backend/assets/ReleasePlanner/ScheduleTable.svelte
+++ b/argus/backend/assets/ReleasePlanner/ScheduleTable.svelte
@@ -38,7 +38,7 @@
         groups = releaseData.groups.reduce((acc, group) => {
             let groupWithSchedules = Object.assign(group);
             groupWithSchedules.schedules = schedules
-                .filter(schedule => schedule.groups.includes(group.name))
+                .filter(schedule => schedule.groups.includes(group.id))
                 .reduce((acc, schedule) => {
                     let dateKey = getStartOfTheWeekForDay(new Date(schedule.period_start))
                         .toISOString()
@@ -128,7 +128,7 @@
             {#each groups as group (group.name)}
                 <tr>
                     <td
-                        >{group.pretty_name ?? group.name}</td
+                        >{group.pretty_name || group.name}</td
                     >
                     {#each dates as date}
                         <td

--- a/argus/backend/assets/Stats/ReleaseStats.svelte
+++ b/argus/backend/assets/Stats/ReleaseStats.svelte
@@ -1,9 +1,10 @@
 <script>
-    import { releaseRequests, stats } from "../Stores/StatsSubscriber";
+    import { requestReleaseStats, stats } from "../Stores/StatsSubscriber";
     import NumberStats from "./NumberStats.svelte";
     import TestMapStats from "./TestMapStats.svelte";
     import { createEventDispatcher } from "svelte";
     export let releaseName = "";
+    export let releaseId = "";
     export let DisplayItem = NumberStats;
     export let TestMapItem = TestMapStats;
     export let showTestMap = false;
@@ -25,7 +26,7 @@
         total: -1,
     };
     let releaseStats = releaseStatsDefault;
-    releaseRequests.update((val) => [...val, releaseName]);
+    requestReleaseStats(releaseName, false, true);
     $: releaseStats = $stats["releases"]?.[releaseName] ?? releaseStatsDefault;
     $: dispatch("statsUpdate", { stats: releaseStats });
 </script>
@@ -39,7 +40,7 @@
         {/if}
         {#if showTestMap}
             <div>
-                <svelte:component this={TestMapItem} stats={releaseStats} {releaseName} bind:clickedTests={clickedTests} on:testClick />
+                <svelte:component this={TestMapItem} stats={releaseStats} {releaseId} {releaseName} bind:clickedTests={clickedTests} on:testClick />
             </div>
         {/if}
     {:else if releaseStats?.total == -1}

--- a/argus/backend/assets/Stats/TestMapStats.svelte
+++ b/argus/backend/assets/Stats/TestMapStats.svelte
@@ -58,6 +58,7 @@
             status: test.status,
             start_time: test.start_time,
             last_runs: test.last_runs,
+            build_system_id: test.build_system_id,
         });
     };
 
@@ -82,11 +83,11 @@
     const requestTestAssignees = function () {
         console.log(stats);
         Object.entries(stats.groups).map((entry) => {
-            let [groupName, groupStats] = entry;
+            let [_, groupStats] = entry;
             let tests = Object.values(groupStats.tests).filter(
                 (test) => test.status != "unknown"
             );
-            requestAssigneesForReleaseTests(releaseName, tests, groupName);
+            requestAssigneesForReleaseTests(releaseName, tests);
         });
     };
 

--- a/argus/backend/assets/Stores/AssigneeSubscriber.js
+++ b/argus/backend/assets/Stores/AssigneeSubscriber.js
@@ -61,8 +61,8 @@ export const requestAssigneesForReleaseGroups = function (release, groups) {
     }, 250);
 }
 
-export const requestAssigneesForReleaseTests = function (release, tests, group) {
-    tests = tests.map((test) => `${group}/${test.name}`);
+export const requestAssigneesForReleaseTests = function (release, tests) {
+    tests = tests.map((test) => test.build_system_id);
     assigneeRequests.update((value) => {
         let releaseBody = value[release] ?? {};
         let testSet = new Set([...(releaseBody.tests ?? []), ...tests]);

--- a/argus/backend/assets/Stores/SingleTestRunSubscriber.js
+++ b/argus/backend/assets/Stores/SingleTestRunSubscriber.js
@@ -17,15 +17,10 @@ testRunStore.subscribe((val) => {
 })
 
 const pollTestRun = function (set) {
-    fetch("/api/v1/test_run/poll", {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-            runs: runCollection
-        }),
-    })
+    let params = new URLSearchParams({
+        runs: runCollection,
+    }).toString();
+    fetch("/api/v1/test_run/poll?" + params)
         .then((res) => {
             if (res.status == 200) {
                 return res.json();
@@ -36,7 +31,6 @@ const pollTestRun = function (set) {
         .then((res) => {
             if (res.status == "ok") {
                 set(res.response);
-                console.log(res.response);
             } else {
                 console.log("Error parsing batch test_run data");
                 console.log(res.response);

--- a/argus/backend/assets/Stores/StatsSubscriber.js
+++ b/argus/backend/assets/Stores/StatsSubscriber.js
@@ -1,103 +1,68 @@
-import { writable } from "svelte/store";
-let releaseRequestsBody = [];
-let releaseGroupRequestsBody = [];
-let testRequestsBody = [];
-let releaseBurst = 0;
-let groupBurst = 0;
+import {
+    writable
+} from "svelte/store";
+import {
+    apiMethodCall
+} from "../Common/ApiUtils";
+
+const releaseRequests = new Set();
+const refreshPeriod = 60;
+
+let fetchTimeout;
+let oldStats = {};
+
 let fetching = false;
-
-const checkBurst = function() {
-    if (groupBurst > 7) {
-        setTimeout(() => {
-            fetchStats((new_stats) => {
-                stats.update(() => new_stats);
-            });
-        }, 200);
-        groupBurst = 0;
-        return;
-    }
-
-    if (releaseBurst > 5) {
-        setTimeout(() => {
-            fetchStats((new_stats) => {
-                stats.update(() => new_stats);
-            });
-        }, 200);
-        releaseBurst = 0;
-        return;
-    }
+const fetchStats = async function (set) {
+    if (fetching) return;
+    fetching = true;
+    Array.from(releaseRequests)
+        .forEach(async releaseRequest => {
+            let [releaseName, limitedFetch, forcedFetch] = releaseRequest;
+            let params = new URLSearchParams({
+                release: releaseName,
+                limited: new Number(limitedFetch),
+                force: new Number(forcedFetch),
+            })
+            let result = await apiMethodCall("/api/v1/release/stats?" + params, undefined, "GET");
+            if (result.status === "ok") {
+                let newStats = {
+                    releases: Object.assign(oldStats?.releases ?? {}, result.response.releases)
+                };
+                set(newStats);
+            }
+        });
+    fetching = false;
 };
 
-export const releaseRequests = writable([]);
-export const groupRequests = writable([]);
-export const testRequests = writable([]);
+export const requestReleaseStats = function (releaseName, limited, force) {
+    releaseRequests.add([releaseName, limited, force]);
+    if (fetchTimeout) {
+        clearTimeout(fetchTimeout);
+        fetchTimeout = undefined;
+    }
+    
+    fetchTimeout = setTimeout(() => {
+        fetchStats((val) => {
+            stats.set(val);
+        });
+    }, 50);
+};
+
+export const removeReleaseRequest = function(releaseName) {
+    releaseRequests = new Set(Array.from(releaseRequests).filter(req => req[0] != releaseName));
+};
+
 export const stats = writable({}, set => {
-    setTimeout(() => {
+    fetchTimeout = setTimeout(() => {
         fetchStats(set);
-    }, 400);
+    }, 1000);
     const interval = setInterval(() => {
         fetchStats(set);
-    }, 20 * 1000);
+    }, refreshPeriod * 1000);
 
     return () => clearInterval(interval);
 });
 
-releaseRequests.subscribe(val => {
-    releaseRequestsBody = val;
-    releaseBurst++;
-    checkBurst();
+stats.subscribe(val => {
+    oldStats = val;
 });
-
-groupRequests.subscribe(val => {
-    releaseGroupRequestsBody = val;
-    groupBurst++;
-    checkBurst();
-});
-
-testRequests.subscribe(val => {
-    testRequestsBody = val;
-});
-
-const fetchStats = function (set) {
-    if (fetching) return;
-    let body = {};
-    releaseRequestsBody.forEach(element => {
-        body[element] = {
-            tests: [],
-            groups: []
-        };
-    });
-
-    releaseGroupRequestsBody.forEach(element => {
-        let [release, group] = element;
-        body[release].groups.push(group);
-    });
-
-    testRequestsBody.forEach(element => {
-        let [release, _, test] = element;
-        body[release].tests.push(test);
-    });
-
-    fetching = true;
-    fetch("/api/v1/stats", {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-        },
-        body: JSON.stringify(body),
-    })
-        .then((res) => {
-            if (res.status == 200) {
-                return res.json();
-            } else {
-                console.log(res);
-            }
-        })
-        .then((res) => {
-            console.log(res);
-            if (res.status === "ok") {
-                set(res.response);
-                fetching = false;
-            }
-        });
-};

--- a/argus/backend/assets/Stores/TestRunsSubscriber.js
+++ b/argus/backend/assets/Stores/TestRunsSubscriber.js
@@ -1,5 +1,5 @@
 import { writable } from "svelte/store";
-export const runStore = writable({});
+export const runStore = writable([]);
 export const TestRunsEventListener = writable({
     type: "init",
     args: []
@@ -43,16 +43,11 @@ TestRunsEventListener.subscribe(value => {
 const pollTestRuns = function (set) {
     if (fetching) return;
     fetching = true;
-    fetch("/api/v1/test_runs/poll", {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-            limit: 10,
-            runs: runCollection
-        }),
+    let params = new URLSearchParams({
+        limit: 10,
+        runs: runCollection
     })
+    fetch("/api/v1/test_runs/poll?" + params)
         .then((res) => {
             if (res.status == 200) {
                 return res.json();
@@ -64,7 +59,6 @@ const pollTestRuns = function (set) {
             if (res.status == "ok") {
                 set(res.response);
                 fetching = false;
-                console.log(res.response);
             } else {
                 console.log("Error parsing batch test_run data");
                 console.log(res.response);

--- a/argus/backend/assets/Stores/UserlistSubscriber.js
+++ b/argus/backend/assets/Stores/UserlistSubscriber.js
@@ -15,13 +15,7 @@ export const userList = readable({}, (set) => {
 });
 
 const fetchUsers = function (set) {
-    return fetch("/api/v1/users", {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-        },
-        body: JSON.stringify({}),
-    })
+    return fetch("/api/v1/users")
         .then((res) => {
             if (res.status == 200) {
                 return res.json();
@@ -33,7 +27,6 @@ const fetchUsers = function (set) {
         .then((res) => {
             if (res.status === "ok") {
                 set(res.response);
-                console.log(res.response);
             } else {
                 console.log("Something went wrong...");
                 console.log(res);

--- a/argus/backend/assets/Stores/WorkspaceStore.js
+++ b/argus/backend/assets/Stores/WorkspaceStore.js
@@ -1,0 +1,58 @@
+import {
+    readable
+} from "svelte/store";
+import { apiMethodCall } from "../Common/ApiUtils";
+
+const fetchReleases = async function (cb) {
+    let result = await apiMethodCall("/api/v1/releases", undefined, "GET");
+    if (result.status === "ok") {
+        cb(result.response);
+    }
+};
+
+const fetchGroups = async function (cb) {
+    let result = await apiMethodCall("/api/v1/groups", undefined, "GET");
+    if (result.status === "ok") {
+        cb(result.response);
+    }
+};
+
+const fetchTests = async function (cb) {
+    let result = await apiMethodCall("/api/v1/tests", undefined, "GET");
+    if (result.status === "ok") {
+        cb(result.response);
+    }
+};
+
+
+export const allReleases = readable(undefined, function (set) {
+
+    fetchReleases(set);
+
+    setInterval(
+        () => {
+            fetchReleases(set);
+        }, 120 * 1000
+    );
+});
+
+export const allGroups = readable(undefined, function (set) {
+    fetchGroups(set);
+
+    setInterval(
+        () => {
+            fetchGroups(set);
+        }, 120 * 1000
+    );
+});
+
+
+export const allTests = readable(undefined, function (set) {
+    fetchTests(set);
+
+    setInterval(
+        () => {
+            fetchTests(set);
+        }, 120 * 1000
+    );
+});

--- a/argus/backend/assets/TestRun/ActivityTab.svelte
+++ b/argus/backend/assets/TestRun/ActivityTab.svelte
@@ -22,15 +22,10 @@
     const fetchActivity = async function () {
         fetching = true;
         try {
-            let apiResponse = await fetch("/api/v1/test_run/activity", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    test_run_id: id,
-                }),
-            });
+            let params = new URLSearchParams({
+                runId: id,
+            }).toString();
+            let apiResponse = await fetch("/api/v1/test_run/activity?" + params);
             let apiJson = await apiResponse.json();
             if (apiJson.status === "ok") {
                 activity = apiJson.response;

--- a/argus/backend/assets/TestRun/TestRunComments.svelte
+++ b/argus/backend/assets/TestRun/TestRunComments.svelte
@@ -26,15 +26,10 @@
 
     const fetchComments = async function () {
         try {
-            let apiResponse = await fetch("/api/v1/test_run/comments", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    test_id: id,
-                }),
-            });
+            let params = new URLSearchParams({
+                testId: id,
+            }).toString();
+            let apiResponse = await fetch("/api/v1/test_run/comments?" + params);
             let apiJson = await apiResponse.json();
             if (apiJson.status === "ok") {
                 comments = apiJson.response;

--- a/argus/backend/assets/TestRun/TestRunInfo.svelte
+++ b/argus/backend/assets/TestRun/TestRunInfo.svelte
@@ -4,11 +4,15 @@
         faSearch,
         faCopy,
     } from "@fortawesome/free-solid-svg-icons";
+    import humanizeDuration from "humanize-duration";
     import Fa from "svelte-fa";
     import { InProgressStatuses } from "../Common/TestStatus";
     import { timestampToISODate } from "../Common/DateUtils";
     import { getScyllaPackage, getKernelPackage } from "../Common/RunUtils";
     export let test_run = {};
+    export let release;
+    export let group;
+    export let test;
 
     let cmd_hydraInvestigateShowMonitor = `hydra investigate show-monitor ${test_run.id}`;
     let cmd_hydraInvestigateShowLogs = `hydra investigate show-logs ${test_run.id}`;
@@ -32,15 +36,15 @@
             <ul class="list-unstyled border-start ps-2">
                 <li>
                     <span class="fw-bold">Release:</span>
-                    {test_run.release_name}
+                    {release?.name ?? "#NO_RELEASE"}
                 </li>
                 <li>
                     <span class="fw-bold">Group:</span>
-                    {test_run.group}
+                    {(group?.pretty_name || group?.name) ?? "#NO_GROUP"}
                 </li>
                 <li>
                     <span class="fw-bold">Test:</span>
-                    {test_run.name}
+                    {(test?.pretty_name || test?.name) ?? "#NO_TEST"}
                 </li>
                 <li>
                     <span class="fw-bold">Id:</span>
@@ -48,12 +52,24 @@
                 </li>
                 <li>
                     <span class="fw-bold">Start Time:</span>
-                    {timestampToISODate(test_run.start_time * 1000, true)}
+                    {timestampToISODate(test_run.start_time, true)}
                 </li>
-                {#if test_run.end_time != -1}
+                {#if new Date(test_run.end_time).getUTCFullYear() != 1970}
                     <li>
                         <span class="fw-bold">End Time:</span>
-                        {timestampToISODate(test_run.end_time * 1000, true)}
+                        {timestampToISODate(test_run.end_time, true)}
+                    </li>
+                    <li>
+                        <span class="fw-bold">Duration:</span>
+                        {humanizeDuration(
+                            new Date(test_run.end_time) -
+                                new Date(test_run.start_time),
+                            {
+                                round: true,
+                                units: ["y", "mo", "w", "d", "h", "m"],
+                                largest: 1,
+                            }
+                        )}
                     </li>
                 {/if}
                 <li>
@@ -63,7 +79,7 @@
                 <li>
                     <span class="fw-bold">Build Job:</span>
                     <a href={test_run.build_job_url} target="_blank">
-                        {test_run.build_job_name}
+                        {test_run.build_id}
                     </a>
                 </li>
             </ul>
@@ -178,7 +194,6 @@
                     >
                 {/if}
                 <a
-                    target="_blank"
                     href="/dashboard/{test_run.release_name}"
                     class="btn btn-outline-success"
                     ><Fa icon={faBusinessTime} /> Release Dashboard</a

--- a/argus/backend/assets/WorkArea/RunGroup.svelte
+++ b/argus/backend/assets/WorkArea/RunGroup.svelte
@@ -94,7 +94,7 @@
                 tests = apiJson.response["tests"];
                 clickedGroups[group.name] = true;
                 sortTestsByStatus();
-                requestAssigneesForReleaseTests(release, tests, group.name);
+                requestAssigneesForReleaseTests(release, tests);
                 testsReady = true;
             } else {
                 throw apiJson;

--- a/argus/backend/assets/WorkArea/Test.svelte
+++ b/argus/backend/assets/WorkArea/Test.svelte
@@ -16,11 +16,12 @@
         name: "ERROR",
         pretty_name: null,
         release_id: null,
+        build_system_id: "",
     };
     export let lastStatus = "unknown";
     export let runs = {};
     let assigneeList = [];
-    $: assigneeList = $assigneeStore?.[release]?.["tests"]?.[`${group}/${test.name}`] ?? [];
+    $: assigneeList = $assigneeStore?.[release]?.["tests"]?.[test.build_system_id] ?? [];
     const dispatch = createEventDispatcher();
 
     let startTime = 0;
@@ -43,7 +44,7 @@
         fetching = true;
         dispatch("testRunRequest", {
             uuid: `${release}/${group}/${test.name}`,
-            runs: [],
+            key: test.build_system_id,
             test: test.name,
             group: group,
             release: release

--- a/argus/backend/assets/WorkArea/Test.svelte
+++ b/argus/backend/assets/WorkArea/Test.svelte
@@ -1,9 +1,8 @@
 <script>
     import { createEventDispatcher } from "svelte";
-    import { testRequests, stats } from "../Stores/StatsSubscriber";
+    import { stats } from "../Stores/StatsSubscriber";
     import { StatusBackgroundCSSClassMap } from "../Common/TestStatus.js";
     import { timestampToISODate } from "../Common/DateUtils";
-    import { assigneeStore } from "../Stores/AssigneeSubscriber";
     import AssigneeList from "./AssigneeList.svelte";
     export let release = "";
     export let group = "";
@@ -20,13 +19,10 @@
     };
     export let lastStatus = "unknown";
     export let runs = {};
-    let assigneeList = [];
-    $: assigneeList = $assigneeStore?.[release]?.["tests"]?.[test.build_system_id] ?? [];
+    export let assigneeList = [];
     const dispatch = createEventDispatcher();
-
-    let startTime = 0;
+    let startTime;
     let fetching = false;
-    testRequests.update((val) => [...val, [release, group, test.name]]);
     $: lastStatus = $stats?.["releases"]?.[release]?.["groups"]?.[group]?.["tests"]?.[test.name]["status"] ?? lastStatus;
     $: startTime = $stats?.["releases"]?.[release]?.["groups"]?.[group]?.["tests"]?.[test.name]["start_time"] ?? startTime;
 
@@ -73,18 +69,18 @@
             </div>
             <div class="col-10 overflow-hidden">
                 <div class="d-flex">
-                    <div>{test.pretty_name ?? test.name}</div>
+                    <div>{test.pretty_name || test.name}</div>
                     <div class="ms-auto text-right">
                         <AssigneeList assignees={assigneeList}/>
                     </div>
                 </div>
-                {#if startTime > 1}
+                {#if startTime}
                 <div
                     class:text-muted={!runs[`${release}/${test.name}`]}
                     class:active-test-text-muted={runs[`${release}/${test.name}`]}
                     style="font-size: 0.75em"
                 >
-                    {timestampToISODate(startTime * 1000)}
+                    {timestampToISODate(startTime)}
                 </div>
                 {/if}
             </div>

--- a/argus/backend/assets/WorkArea/TestRuns.svelte
+++ b/argus/backend/assets/WorkArea/TestRuns.svelte
@@ -23,7 +23,7 @@
     let runsBody = undefined;
 
     runStore.update((val) => {
-        val[myId] = data.build_system_id;
+        val.push(data.build_system_id);
         return val;
     });
 
@@ -112,7 +112,7 @@
             {/if}
             <div>{testName} ({releaseName}/{groupName})</div>
             {#if runs.length > 0}
-            <div class="ms-auto flex-fill text-end">{timestampToISODate(runs[0].start_time * 1000)}</div>
+            <div class="ms-auto flex-fill text-end">{timestampToISODate(runs[0].start_time)}</div>
             <div class="mx-2">#{runs[0].build_number}</div>
             {/if}
             {#if removableRuns}

--- a/argus/backend/assets/WorkArea/TestRuns.svelte
+++ b/argus/backend/assets/WorkArea/TestRuns.svelte
@@ -23,7 +23,7 @@
     let runsBody = undefined;
 
     runStore.update((val) => {
-        val[myId] = [releaseName, testName, groupName]
+        val[myId] = data.build_system_id;
         return val;
     });
 

--- a/argus/backend/assets/WorkArea/WorkArea.svelte
+++ b/argus/backend/assets/WorkArea/WorkArea.svelte
@@ -59,6 +59,7 @@
             test: event.detail.test,
             release: event.detail.release,
             group: event.detail.group,
+            build_system_id: event.detail.key,
         };
         test_runs = test_runs;
         let state = stateEncoder(test_runs);

--- a/argus/backend/assets/WorkArea/WorkArea.svelte
+++ b/argus/backend/assets/WorkArea/WorkArea.svelte
@@ -1,86 +1,55 @@
 <script>
-    import { onMount } from "svelte";
-    import { stateEncoder, stateDecoder} from "../Common/StateManagement";
-    import { stats } from "../Stores/StatsSubscriber";
-    import { sendMessage } from "../Stores/AlertStore";
+    import { onDestroy, onMount } from "svelte";
+    import { stateEncoder, stateDecoder } from "../Common/StateManagement";
+    import { allReleases } from "../Stores/WorkspaceStore";
     import TestRunsPanel from "./TestRunsPanel.svelte";
     import RunRelease from "./RunRelease.svelte";
-    let releases = [];
-    let test_runs = {};
-    let releaseStats = {};
+    let testRuns = {};
+    let releases;
     let filterString = "";
+    $: releases = $allReleases;
 
-    stats.subscribe((value) => {
-        releaseStats = value.releases;
-        releases = releases.sort((a, b) => {
-            let leftOrder =
-                releaseStats[a.name]?.total - releaseStats[a.name]?.not_run ??
-                0;
-            let rightOrder =
-                releaseStats[b.name]?.total - releaseStats[b.name]?.not_run ??
-                0;
-            if (leftOrder > rightOrder) {
-                return -1;
-            } else if (rightOrder > leftOrder) {
-                return 1;
-            } else {
-                return 0;
-            }
-        });
-    });
-
-    const isFiltered = function(name = "", filterString = "") {
+    const isFiltered = function (name = "", filterString = "") {
         if (filterString == "") {
             return false;
         }
         return !RegExp(filterString).test(name);
     };
 
-    const fetchNewReleases = async function () {
-        try {
-            let apiResponse = await fetch("/api/v1/releases");
-            let apiJson = await apiResponse.json();
-            if (apiJson.status === "ok") {
-                releases = apiJson.response;
-            } else {
-                throw apiJson;
-            }
-        } catch (error) {
-            if (error?.status === "error") {
-                sendMessage("error", `API Error when fetching releases.\nMessage: ${error.response.arguments[0]}`);
-            } else {
-                sendMessage("error", "A backend error occurred during release fetch");
-            }
-        }
-    };
-
     const onTestRunRequest = function (event) {
-        test_runs[event.detail.uuid] = {
+        testRuns[event.detail.uuid] = {
             test: event.detail.test,
             release: event.detail.release,
             group: event.detail.group,
             build_system_id: event.detail.key,
         };
-        test_runs = test_runs;
-        let state = stateEncoder(test_runs);
+        testRuns = testRuns;
+        let state = stateEncoder(testRuns);
         history.pushState({}, "", `?${state}`);
-
     };
 
-    const onTestRunRemove = function(event) {
+    const onTestRunRemove = function (event) {
         let id = event.detail.runId;
-        delete test_runs[id];
-        test_runs = test_runs;
-        let state = stateEncoder(test_runs);
+        delete testRuns[id];
+        testRuns = testRuns;
+        let state = stateEncoder(testRuns);
         history.pushState({}, "", `?${state}`);
     };
 
     onMount(() => {
-        fetchNewReleases();
-        test_runs = stateDecoder();
+        testRuns = stateDecoder();
+    });
+
+    onDestroy(() => {
+        unsub();
     });
 </script>
-<svelte:window on:popstate={() => { test_runs = stateDecoder() }}/>
+
+<svelte:window
+    on:popstate={() => {
+        testRuns = stateDecoder();
+    }}
+/>
 
 <div class="container-fluid bg-lighter">
     <div class="row p-4" id="dashboard-main">
@@ -88,29 +57,42 @@
             class="col-3 p-0 py-4 me-3 border rounded shadow-sm bg-white"
             id="run-sidebar"
         >
-            <div class="p-2">
-                <input class="form-control" type="text" placeholder="Filter releases" bind:value={filterString} on:input={() => { releases = releases }}>
-            </div>
-            <div class="accordion accordion-flush" id="releaseAccordion">
-                {#each releases as release (release.id)}
-                    <RunRelease
-                        {release}
-                        on:testRunRequest={onTestRunRequest}
-                        filtered={isFiltered(release.name, filterString)}
-                        bind:runs={test_runs}
-                        on:testRunRemove={onTestRunRemove}
+            {#if releases}
+                <div class="p-2">
+                    <input
+                        class="form-control"
+                        type="text"
+                        placeholder="Filter releases"
+                        bind:value={filterString}
+                        on:input={() => {
+                            releases = releases;
+                        }}
                     />
-                {/each}
-            </div>
+                </div>
+                <div class="accordion accordion-flush" id="releaseAccordion">
+                    {#each releases as release (release.id)}
+                        <RunRelease
+                            {release}
+                            on:testRunRequest={onTestRunRequest}
+                            filtered={isFiltered(release.name, filterString)}
+                            bind:runs={testRuns}
+                            on:testRunRemove={onTestRunRemove}
+                        />
+                    {/each}
+                </div>
+            {/if}
         </div>
         <div class="col-8 p-2 border rounded shadow-sm bg-main">
-            <TestRunsPanel bind:test_runs={test_runs} on:testRunRemove={onTestRunRemove} workAreaAttached={true}/>
+            <TestRunsPanel
+                bind:test_runs={testRuns}
+                on:testRunRemove={onTestRunRemove}
+                workAreaAttached={true}
+            />
         </div>
     </div>
 </div>
 
 <style>
-
     #run-sidebar {
         height: 960px;
         overflow-y: scroll;

--- a/argus/backend/assets/admin-panel.js
+++ b/argus/backend/assets/admin-panel.js
@@ -1,0 +1,10 @@
+import AdminPanel from "./AdminPanel/AdminPanel.svelte";
+
+const applicationCurrentRoute = gCurrentRoute ?? "index";
+
+const app = new AdminPanel({
+    target: document.querySelector("div#adminPanel"),
+    props: {
+        currentRoute: applicationCurrentRoute,
+    }
+});

--- a/argus/backend/assets/argus.css
+++ b/argus/backend/assets/argus.css
@@ -59,3 +59,15 @@ div#argusErrors {
 .bg-lighter {
     background-color: #e5e5e5;
 }
+
+.bg-light-one {
+    background-color: #eaeaea;
+}
+
+.bg-light-two {
+    background-color: #ededed;
+}
+
+.bg-light-three {
+    background-color: #f5f5f5;
+}

--- a/argus/backend/auth.py
+++ b/argus/backend/auth.py
@@ -78,3 +78,26 @@ def login_required(view):
         return view(**kwargs)
 
     return wrapped_view
+
+
+def check_roles(needed_roles: list[str] | str = None):
+    def inner(view):
+        @functools.wraps(view)
+        def wrapped_view(**kwargs):
+            def check_roles(roles, user):
+                if isinstance(roles, str):
+                    return roles in user.roles
+                elif isinstance(roles, list):
+                    for role in roles:
+                        if role in user.roles:
+                            return True
+                return False
+
+            if not check_roles(needed_roles, g.user):
+                flash(message='Not authorized to access this area', category='error')
+                return redirect(url_for('main.home'))
+
+            return view(**kwargs)
+
+        return wrapped_view
+    return inner

--- a/argus/backend/build_system_monitor.py
+++ b/argus/backend/build_system_monitor.py
@@ -37,12 +37,14 @@ class ArgusTestsMonitor(ABC):
 
         return group
 
-    def create_test(self, release: ArgusRelease, group: ArgusReleaseGroup, test_name: str):
+    def create_test(self, release: ArgusRelease, group: ArgusReleaseGroup,
+                    test_name: str, build_id: str) -> ArgusReleaseGroupTest:
         # pylint: disable=no-self-use
         test = ArgusReleaseGroupTest()
         test.name = test_name
         test.group_id = group.id
         test.release_id = release.id
+        test.build_system_id = build_id
         test.save()
 
         return test
@@ -102,14 +104,14 @@ class JenkinsMonitor(ArgusTestsMonitor):
                                 test["name"], saved_group.name, saved_release.name)
                     saved_test = None
                     for t in self._existing_tests:  # pylint: disable=invalid-name
-                        if t.release_id == saved_release.id and t.group_id == saved_group.id and t.name == test["name"]:
+                        if t.build_system_id == test["fullname"]:
                             saved_test = t
                             break
                     if not saved_test:
                         LOGGER.warning("Test %s for release %s (group %s) doesn't exist, creating...",
                                        test["name"], saved_release.name, saved_group.name)
                         saved_test = self.create_test(
-                            saved_release, saved_group, test["name"])
+                            saved_release, saved_group, test["name"], test["fullname"])
                         self._existing_tests.append(saved_test)
 
     def collect_groups_for_release(self, jobs):

--- a/argus/backend/main.py
+++ b/argus/backend/main.py
@@ -27,6 +27,7 @@ def home():
 
 
 @bp.route("/run_dashboard")
+@bp.route("/workspace")
 @login_required
 def run_dashboard():
     return render_template('dashboard.html.j2')

--- a/argus/backend/service/admin.py
+++ b/argus/backend/service/admin.py
@@ -1,0 +1,27 @@
+
+from flask import g, current_app, session
+
+from argus.backend.db import ScyllaCluster
+from argus.db.models import (
+    ArgusGithubIssue,
+    ArgusRelease,
+    ArgusReleaseGroup,
+    ArgusReleaseGroupTest,
+    ArgusReleaseSchedule,
+    ArgusReleaseScheduleAssignee,
+    ArgusReleaseScheduleGroup,
+    ArgusReleaseScheduleTest,
+    ArgusTestRunComment,
+    ArgusEvent,
+    ArgusEventTypes,
+    ReleasePlannerComment,
+    User,
+    UserOauthToken,
+    WebFileStorage,
+)
+
+
+class AdminService:
+    def __init__(self, database_session=None):
+        self.session = database_session if database_session else ScyllaCluster.get_session()
+        self.database = ScyllaCluster.get()

--- a/argus/backend/service/release_manager.py
+++ b/argus/backend/service/release_manager.py
@@ -1,0 +1,164 @@
+import logging
+from uuid import UUID
+from argus.backend.db import ScyllaCluster
+from argus.db.models import ArgusRelease, ArgusReleaseGroup, ArgusReleaseGroupTest
+from argus.db.testrun import TestRun
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ReleaseManagerException(Exception):
+    pass
+
+
+class ReleaseManagerService:
+    def __init__(self) -> None:
+        self.session = ScyllaCluster.get_session()
+        self.database = ScyllaCluster.get()
+        self.runs_by_build_id_stmt = self.database.prepare(
+            "SELECT id, test_id, group_id, release_id, build_id, start_time "
+            f"FROM {TestRun.table_name()} WHERE build_id = ?"
+        )
+        self.update_run_stmt = self.database.prepare(
+            f"UPDATE {TestRun.table_name()} SET test_id = ?, group_id = ?, release_id = ? "
+            "WHERE build_id = ? AND start_time = ?"
+        )
+
+    def create_release(self, release_name: str, pretty_name: str, perpetual: bool) -> ArgusRelease:
+        try:
+            release = ArgusRelease.get(name=release_name)
+        except ArgusRelease.DoesNotExist:
+            release = ArgusRelease()
+            release.name = release_name
+            release.pretty_name = pretty_name
+            release.perpetual = perpetual
+
+            release.save()
+        else:
+            raise ReleaseManagerException(
+                f"Release {release_name} already exists!", release_name)
+
+        return release
+
+    def create_group(self, group_name: str, pretty_name: str, release_id: str) -> ArgusReleaseGroup:
+        release = ArgusRelease.get(id=UUID(release_id))
+
+        new_group = ArgusReleaseGroup()
+        new_group.name = group_name
+        new_group.pretty_name = pretty_name
+        new_group.release_id = release.id
+        new_group.save()
+
+        return new_group
+
+    def create_test(self, test_name, pretty_name, build_id, build_url, group_id, release_id) -> ArgusReleaseGroupTest:
+        release = ArgusRelease.get(id=UUID(release_id))
+        group = ArgusReleaseGroup.get(id=UUID(group_id))
+
+        new_test = ArgusReleaseGroupTest()
+        new_test.name = test_name
+        new_test.pretty_name = pretty_name
+        new_test.build_system_id = build_id
+        new_test.release_id = release.id
+        new_test.group_id = group.id
+        new_test.build_system_url = build_url
+        new_test.validate_build_system_id()
+        new_test.save()
+        self.move_test_runs(new_test)
+        return new_test
+
+    def delete_group(self, group_id: str, delete_tests: bool = True, new_group_id: str = "") -> bool:
+        group_to_delete = ArgusReleaseGroup.get(id=UUID(group_id))
+
+        tests_to_change = ArgusReleaseGroupTest.filter(
+            group_id=group_to_delete.id)
+        if delete_tests:
+            for test in tests_to_change.all():
+                test.delete()
+        else:
+            new_group = ArgusReleaseGroup.get(id=UUID(new_group_id))
+            for test in tests_to_change.all():
+                test.group_id = new_group.id
+                test.save()
+
+        group_to_delete.delete()
+
+        return True
+
+    def delete_test(self, test_id: str) -> bool:
+        test_to_delete = ArgusReleaseGroupTest.get(id=test_id)
+        test_to_delete.delete()
+
+        return True
+
+    def update_group(self, group_id: str, name: str, pretty_name: str, enabled: bool) -> bool:
+        group = ArgusReleaseGroup.get(id=UUID(group_id))
+
+        group.name = name
+        group.pretty_name = pretty_name
+        group.enabled = enabled
+
+        group.save()
+
+        return True
+
+    def update_test(self, test_id: str, name: str, pretty_name: str,
+                    enabled: bool, build_system_id: str, build_system_url: str, group_id) -> bool:
+        test: ArgusReleaseGroupTest = ArgusReleaseGroupTest.get(id=UUID(test_id))
+        group = ArgusReleaseGroup.get(id=UUID(group_id))
+
+        test.name = name
+        test.pretty_name = pretty_name
+        test.enabled = enabled
+        test.build_system_id = build_system_id
+        test.build_system_url = build_system_url
+        if test.group_id != group.id:
+            test.group_id = group.id
+            LOGGER.info("Relocating old test runs into a new group")
+
+        test.validate_build_system_id()
+        test.save()
+        self.move_test_runs(test)
+        return True
+
+    def set_release_state(self, release_id: str, state: bool) -> bool:
+        release = ArgusRelease.get(id=UUID(release_id))
+        release.enabled = state
+        release.save()
+
+        return True
+
+    def set_release_dormancy(self, release_id: str, dormant: bool) -> bool:
+        release = ArgusRelease.get(id=UUID(release_id))
+        release.dormant = dormant
+        release.save()
+
+        return True
+
+    def set_release_perpetuality(self, release_id: str, perpetual: bool) -> bool:
+        release = ArgusRelease.get(id=UUID(release_id))
+        release.perpetual = perpetual
+        release.save()
+
+        return True
+
+    def batch_move_tests(self, new_group_id: str, tests: list[str]) -> bool:
+        group = ArgusReleaseGroup.get(id=UUID(new_group_id))
+
+        tests: list[ArgusReleaseGroupTest] = [ArgusReleaseGroupTest.get(id=UUID(test_id)) for test_id in tests]
+
+        for test in tests:
+            test.group_id = group.id
+            test.save()
+            self.move_test_runs(test)
+
+        return True
+
+    def move_test_runs(self, test: ArgusReleaseGroupTest) -> None:
+        run_rows = self.session.execute(self.runs_by_build_id_stmt, parameters=(
+            test.build_system_id,), execution_profile="read_fast")
+        for run in run_rows:
+            run["test_id"] = test.id
+            run["group_id"] = test.group_id
+            run["release_id"] = test.release_id
+            self.session.execute(self.update_run_stmt, parameters=run)

--- a/argus/backend/templates/admin/base.html.j2
+++ b/argus/backend/templates/admin/base.html.j2
@@ -1,0 +1,14 @@
+{% extends "base.html.j2" %}
+{% block javascripts %}
+{{ super() }}
+{% endblock javascripts %}
+{% block title %}
+Admin Area
+{% endblock %}
+{% block body %}
+<div class="m-2 min-vh-100 rounded bg-light-one shadow overflow-hidden">
+    {% block content %}
+
+    {% endblock content %}
+</div>
+{% endblock %}

--- a/argus/backend/templates/admin/index.html.j2
+++ b/argus/backend/templates/admin/index.html.j2
@@ -1,0 +1,18 @@
+{% extends "admin/base.html.j2" %}
+{% block javascripts %}
+{{ super() }}
+    {% if current_route %}
+        <script>const gCurrentRoute = "{{ current_route }}";</script>
+    {% endif %}
+    <script defer src="/static/dist/adminPanel.bundle.js"></script>
+{% endblock javascripts %}
+
+{% block title %}
+{{ super() }} - %ROUTE
+{% endblock %}
+
+{% block content %}
+<div id="adminPanel">
+
+</div>
+{% endblock %}

--- a/argus/backend/templates/partials/nav_bar.html.j2
+++ b/argus/backend/templates/partials/nav_bar.html.j2
@@ -5,12 +5,15 @@
             <img src="/static/argus.png" alt="" width="64" height="64" class="d-inline-block align-text-middle">  Argus
         </a>
         <div class="navbar-nav">
-            <a class="nav-link" aria-current="page" href="{{ url_for('main.run_dashboard')}}"><i class="fas fa-tasks"></i> Work Area</a>
-            <a class="nav-link" href="{{ url_for('main.releases')}}"><i class="fas fa-business-time"></i> Releases</a>
+            <a class="{% if request.path == url_for('main.run_dashboard')%}active{%endif%} nav-link" aria-current="page" href="{{ url_for('main.run_dashboard')}}"><i class="fas fa-tasks"></i> Workspace</a>
+            <a class="{% if request.path == url_for('main.releases')%}active{%endif%} nav-link" href="{{ url_for('main.releases')}}"><i class="fas fa-business-time"></i> Releases</a>
             {% if g.user %}
-            <a class="nav-link" href="{{ url_for('main.profile_jobs')}}"><i class="fas fa-archive"></i> My Jobs</a>
-            <a class="nav-link" href="{{ url_for('main.profile_schedules')}}"><i class="fas fa-calendar-week"></i> My Schedule</a>
-            <a class="nav-link d-flex align-items-center" href="{{ url_for('main.profile')}}">
+            <a class="{% if request.path == url_for('main.profile_jobs')%}active{%endif%} nav-link" href="{{ url_for('main.profile_jobs')}}"><i class="fas fa-archive"></i> My Jobs</a>
+            <a class="{% if request.path == url_for('main.profile_schedules')%}active{%endif%} nav-link" href="{{ url_for('main.profile_schedules')}}"><i class="fas fa-calendar-week"></i> My Schedule</a>
+                {% if g.user.is_admin() %}
+                    <a class="{% if request.path == url_for('admin.index')%}active{%endif%} nav-link" href="{{ url_for('admin.index')}}"><i class="fas fa-wrench"></i> Admin Area</a>
+                {% endif %}
+            <a class="{% if request.path == url_for('main.profile')%}active{%endif%} nav-link d-flex align-items-center" href="{{ url_for('main.profile')}}">
             {% if g.user.picture_id %}
             <img class="me-1" src="/storage/picture/{{ g.user.picture_id }}" style="height: 24px; border-radius: 50%" alt="">
             {% else %}
@@ -20,7 +23,7 @@
             </a>
             <a href="{{ url_for('auth.logout')}}" class="nav-link text-danger"><i class="fas fa-sign-out-alt"></i> Logout</a>
             {% else %}
-            <a href="{{ url_for('auth.login')}}" class="nav-link"><i class="fas fa-sign-in-alt"></i> Login</a>
+            <a href="{{ url_for('auth.login')}}" class="{% if request.path == url_for('auth.login')%}active{%endif%} nav-link"><i class="fas fa-sign-in-alt"></i> Login</a>
             {% endif %}
         </div>
     </div>

--- a/argus/backend/templates/releases.html.j2
+++ b/argus/backend/templates/releases.html.j2
@@ -10,29 +10,29 @@ Releases
 {% endblock javascripts %}
 
 {% block body %}
-    <div class="container my-2">
-        <div class="row justify-content-center">
-        {% for release in releases %}
-            <div class="col-3 card m-1 release-card" data-argus-release-name="{{ release.name }}">
-                <div class="card-body">
-                        <h3 class="card-title">{{ release.name if not release.pretty_name else release.pretty_name }}</h3>
-                        <p class="card-subtitle text-muted">{{ release.description if release.description else "No description provided" }}</p>
-                        <div class="release-stats mb-1"></div>
+    <div class="container my-2 rounded overflow-hidden shadow-sm bg-light-three p-4">
+        {% for release in releases if release.enabled %}
+            <div class="row rounded overflow-hidden shadow-sm bg-white mb-2">
+                <div class="col-8 release-card" data-argus-release-name="{{ release.name }}">
+                    <div class="card-body">
+                            <h3 class="card-title">{{ release.name if not release.pretty_name else release.pretty_name }}</h3>
+                            <p class="card-subtitle text-muted">{{ release.description if release.description else "No description provided" }}</p>
+                            <div class="release-stats mb-1"></div>
+                    </div>
+                </div>
+                <div class="col-4">
+                    <div class="d-flex align-items-center h-100">
                         <div class="btn-group">
-                            <a target="_blank" href="{{ url_for('main.release_dashboard', release_name=release.name) }}" class="btn btn-primary"><i class="fas fa-tachometer-alt"></i> Dashboard</a>
+                            <a href="{{ url_for('main.release_dashboard', release_name=release.name) }}" class="btn btn-primary"><i class="fas fa-tachometer-alt"></i> Dashboard</a>
                             {% if release.perpetual %}
-                            <a target="_blank" href="{{ url_for('main.duty_planner', name=release.name) }}" class="btn btn-primary"><i class="fas fa-calendar-alt"></i> Duty Planning</a>
+                            <a href="{{ url_for('main.duty_planner', name=release.name) }}" class="btn btn-primary"><i class="fas fa-calendar-alt"></i> Duty Planning</a>
                             {% else %}
-                            <a target="_blank" href="{{ url_for('main.release_scheduler', name=release.name) }}" class="btn btn-primary"><i class="fas fa-calendar-alt"></i> Duty Planning</a>
+                            <a href="{{ url_for('main.release_scheduler', name=release.name) }}" class="btn btn-primary"><i class="fas fa-calendar-alt"></i> Duty Planning</a>
                             {% endif %}
                         </div>
+                    </div>
                 </div>
             </div>
-            {% if loop.index % 3 == 0 %}
-            <div class="w-100"></div>
-            {% else %}
-            {% endif %}
         {% endfor %}
-        </div>
     </div>
 {% endblock %}

--- a/argus/db/argus_json.py
+++ b/argus/db/argus_json.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+import json
+from uuid import UUID
+
+
+class ArgusJSONEncoder(json.JSONEncoder):
+    def default(self, obj):
+        match obj:
+            case UUID():
+                return str(obj)
+            case datetime():
+                return obj.isoformat(sep=' ', timespec='milliseconds')
+            case _:
+                return json.JSONEncoder.default(self, obj)

--- a/argus/db/interface.py
+++ b/argus/db/interface.py
@@ -22,7 +22,7 @@ from argus.db.config import BaseConfig, FileConfig
 from argus.db.db_types import ColumnInfo, CollectionHint, ArgusUDTBase
 from argus.db.cloud_types import ResourceState
 from argus.db.models import ArgusReleaseSchedule, ArgusReleaseScheduleAssignee, \
-    ArgusReleaseScheduleGroup, ArgusReleaseScheduleTest
+    ArgusReleaseScheduleGroup, ArgusReleaseScheduleTest, ArgusRelease, ArgusReleaseGroup, ArgusReleaseGroupTest
 
 LOGGER = logging.getLogger(__name__)
 
@@ -52,6 +52,9 @@ class ArgusDatabase:
         ArgusReleaseScheduleGroup,
         ArgusReleaseScheduleTest,
         ArgusReleaseScheduleAssignee,
+        ArgusReleaseGroupTest,
+        ArgusReleaseGroup,
+        ArgusRelease,
     ]
     PYTHON_SCYLLA_TYPE_MAPPING = {
         int: cassandra.cqltypes.IntegerType.typename,

--- a/argus/db/models.py
+++ b/argus/db/models.py
@@ -101,6 +101,7 @@ class ArgusReleaseGroupTest(Model):
     pretty_name = columns.Text()
     description = columns.Text()
     assignee = columns.List(value_type=columns.UUID)
+    build_system_id = columns.Text(index=True)
     enabled = columns.Boolean(default=lambda: True)
 
     def __eq__(self, other):

--- a/argus/db/testrun.py
+++ b/argus/db/testrun.py
@@ -14,7 +14,7 @@ from argus.db.cloud_types import CloudResource, CloudInstanceDetails, BaseCloudS
 from argus.db.interface import ArgusDatabase
 from argus.db.db_types import ColumnInfo, CollectionHint, NemesisRunInfo, TestStatus, TestInvestigationStatus, \
     EventsBySeverity, PackageVersion
-from argus.db.models import ArgusReleaseGroup, ArgusReleaseGroupTest, ArgusReleaseSchedule, ArgusReleaseScheduleAssignee, ArgusReleaseScheduleGroup, \
+from argus.db.models import ArgusRelease, ArgusReleaseGroup, ArgusReleaseGroupTest, ArgusReleaseSchedule, ArgusReleaseScheduleAssignee, ArgusReleaseScheduleGroup, \
     ArgusReleaseScheduleTest
 
 LOGGER = logging.getLogger(__name__)
@@ -53,7 +53,8 @@ class BaseTestInfo:
                 value = cls.schema_process_collection(attr)
                 column_type = CollectionHint
             constraints = cls.ATTRIBUTE_CONSTRAINTS.get(attr, [])
-            column_info = ColumnInfo(name=attr, type=column_type, value=value, constraints=constraints)
+            column_info = ColumnInfo(
+                name=attr, type=column_type, value=value, constraints=constraints)
             data[attr] = column_info
 
         return data
@@ -62,7 +63,8 @@ class BaseTestInfo:
     def schema_process_collection(cls, attr_name: str):
         hint = cls.COLLECTION_HINTS.get(attr_name)
         if not hint:
-            raise TestInfoSchemaError("Encountered a collection and no collection hint was found")
+            raise TestInfoSchemaError(
+                "Encountered a collection and no collection hint was found")
 
         return hint
 
@@ -105,31 +107,32 @@ class BaseTestInfo:
 
 class TestDetails(BaseTestInfo):
     # pylint: disable=too-many-instance-attributes
-    EXPOSED_ATTRIBUTES = {"name": str, "scm_revision_id": str, "started_by": str,
-                          "build_job_name": str, "build_job_url": str, "start_time": int, "yaml_test_duration": int,
-                          "config_files": list,
-                          "packages": list, "end_time": int}
+    EXPOSED_ATTRIBUTES = {"scm_revision_id": str, "started_by": str, "build_job_url": str,
+                          "start_time": datetime.datetime, "end_time": datetime.datetime,
+                          "config_files": list, "packages": list,
+                          "yaml_test_duration": int,
+                          }
     COLLECTION_HINTS = {
         "packages": CollectionHint(list[PackageVersion]),
         "config_files": CollectionHint(list[str]),
     }
 
-    def __init__(self, name: str, scm_revision_id: str,
-                 started_by: str, build_job_name: str, build_job_url: str,
-                 yaml_test_duration: int, start_time: int,
-                 config_files: list[str], packages: list[PackageVersion], end_time: int = -1):
+    def __init__(self, scm_revision_id: str,
+                 started_by: str, build_job_url: str,
+                 yaml_test_duration: int, start_time: datetime,
+                 config_files: list[str], packages: list[PackageVersion],
+                 end_time: datetime.datetime = datetime.datetime.utcfromtimestamp(0)):
         # pylint: disable=too-many-arguments
         super().__init__()
-        self.name = name
         self.scm_revision_id = scm_revision_id
         self.started_by = started_by
-        self.build_job_name = build_job_name
         self.build_job_url = build_job_url
         self.start_time = start_time
         self.yaml_test_duration = yaml_test_duration
         if not (is_list_homogeneous(packages) or (
                 len(packages) > 0 and isinstance(next(iter(packages)), PackageVersion))):
-            raise TestInfoValueError("Package list contains incorrect values", packages)
+            raise TestInfoValueError(
+                "Package list contains incorrect values", packages)
         self.packages = packages
         self.config_files = config_files
         self.end_time = end_time
@@ -137,20 +140,20 @@ class TestDetails(BaseTestInfo):
     @classmethod
     def from_db_row(cls, row):
         if row.packages:
-            packages = [PackageVersion.from_db_udt(udt) for udt in row.packages]
+            packages = [PackageVersion.from_db_udt(
+                udt) for udt in row.packages]
         else:
             packages = []
 
         config_files = row.config_files if row.config_files else []
 
-        return cls(name=row.name, scm_revision_id=row.scm_revision_id, started_by=row.started_by,
-                   build_job_name=row.build_job_name, build_job_url=row.build_job_url,
+        return cls(scm_revision_id=row.scm_revision_id, started_by=row.started_by, build_job_url=row.build_job_url,
                    start_time=row.start_time, end_time=row.end_time, yaml_test_duration=row.yaml_test_duration,
                    config_files=config_files,
                    packages=packages)
 
     def set_test_end_time(self):
-        self.end_time = int(time.time())
+        self.end_time = datetime.datetime.utcnow().replace(microsecond=0)
 
 
 class TestResourcesSetup(BaseTestInfo):
@@ -229,7 +232,8 @@ class TestResources(BaseTestInfo):
         self._allocated_resources.sort(key=lambda v: v.name)
 
     def detach_resource(self, resource: CloudResource, reason: str = "unspecified reason"):
-        resource_to_detach = next(r for r in self._allocated_resources if r == resource)
+        resource_to_detach = next(
+            r for r in self._allocated_resources if r == resource)
         resource_to_detach.terminate(reason=reason)
 
     @property
@@ -249,7 +253,8 @@ class TestResources(BaseTestInfo):
 
 class TestResults(BaseTestInfo):
     # pylint: disable=too-many-arguments
-    EXPOSED_ATTRIBUTES = {"status": str, "events": list, "nemesis_data": list, "screenshots": list}
+    EXPOSED_ATTRIBUTES = {"status": str, "events": list,
+                          "nemesis_data": list, "screenshots": list}
     COLLECTION_HINTS = {
         "events": CollectionHint(list[EventsBySeverity]),
         "nemesis_data": CollectionHint(list[NemesisRunInfo]),
@@ -272,12 +277,14 @@ class TestResults(BaseTestInfo):
     @classmethod
     def from_db_row(cls, row):
         if row.events:
-            events = [EventsBySeverity.from_db_udt(event) for event in row.events]
+            events = [EventsBySeverity.from_db_udt(
+                event) for event in row.events]
         else:
             events = []
 
         if row.nemesis_data:
-            nemesis_data = [NemesisRunInfo.from_db_udt(nemesis) for nemesis in row.nemesis_data]
+            nemesis_data = [NemesisRunInfo.from_db_udt(
+                nemesis) for nemesis in row.nemesis_data]
         else:
             nemesis_data = []
 
@@ -290,7 +297,8 @@ class TestResults(BaseTestInfo):
 
     def _add_new_event_type(self, event: EventsBySeverity):
         if len([v for v in self.events if v.severity == event.severity]) > 0:
-            raise TestInfoValueError(f"Severity event collection {event.severity} already exists in TestResults")
+            raise TestInfoValueError(
+                f"Severity event collection {event.severity} already exists in TestResults")
 
         self.events.append(event)
 
@@ -306,9 +314,11 @@ class TestResults(BaseTestInfo):
 
     def add_event(self, event_severity: str, event_message: str):
         try:
-            event = next(filter(lambda v: v.severity == event_severity, self.events))
+            event = next(filter(lambda v: v.severity ==
+                         event_severity, self.events))
         except StopIteration:
-            event = EventsBySeverity(severity=event_severity, event_amount=0, last_events=[])
+            event = EventsBySeverity(
+                severity=event_severity, event_amount=0, last_events=[])
             self._add_new_event_type(event)
 
         self._collect_event_message(event, event_message)
@@ -336,19 +346,25 @@ class TestRunInfo:
 
 class TestRun:
     # pylint: disable=too-many-instance-attributes
-    EXPOSED_ATTRIBUTES = {"id": UUID, "group": str, "release_name": str,
-                          "assignee": str, "heartbeat": int, "investigation_status": str}
+    EXPOSED_ATTRIBUTES = {"id": UUID, "group_id": UUID, "release_id": UUID,
+                          "build_id": str, "test_id": UUID,
+                          "assignee": UUID, "heartbeat": int, "investigation_status": str}
     ATTRIBUTE_CONSTRAINTS = {
     }
     PRIMARY_KEYS = {
-        "id": (UUID, "partition"),
+        "build_id": (str, "partition"),
+        "start_time": (datetime.datetime, "clustering"),
     }
+    CLUSTERING_ORDER = {
+        "start_time": "DESC",
+    }
+    INDICES = ["release_id", "group_id", "test_id", "id", "assignee", "status"]
     _USING_RUNINFO = TestRunInfo
-    _TABLE_NAME = "test_runs_v6"
+    _TABLE_NAME = "test_runs_v7"
     _IS_TABLE_INITIALIZED = False
     _ARGUS_DB_INTERFACE = None
 
-    def __init__(self, test_id: UUID, group: str, release_name: str, assignee: str,
+    def __init__(self, test_id: UUID, assignee: UUID, build_id: str,
                  run_info: TestRunInfo, config: BaseConfig = None, argus_interface: ArgusDatabase = None,
                  investigation_status: str = TestInvestigationStatus.NOT_INVESTIGATED):
         # pylint: disable=too-many-arguments
@@ -356,8 +372,10 @@ class TestRun:
             test_id = uuid4()
         self._save_lock = threading.Lock()
         self._id = test_id
-        self._group = group
-        self._release_name = release_name
+        self._build_id = build_id
+        self._group_id = None
+        self._release_id = None
+        self._test_id = None
         self._assignee = assignee
         self._investigation_status = investigation_status
         self._run_info = run_info
@@ -382,9 +400,12 @@ class TestRun:
             nested_fields[field.name] = field.type.from_db_row(row)
 
         run_info = cls._USING_RUNINFO(**nested_fields)
-        run = cls(test_id=row.id, group=row.group, release_name=row.release_name,
-                  assignee=row.assignee, run_info=run_info, investigation_status=row.investigation_status)
+        run = cls(test_id=row.id, assignee=row.assignee, build_id=row.build_id,
+                  run_info=run_info, investigation_status=row.investigation_status)
         run.heartbeat = row.heartbeat
+        run.group_id = row.group_id
+        run.release_id = row.release_id
+        run.test_id = row.test_id
         return run
 
     @classmethod
@@ -393,6 +414,16 @@ class TestRun:
             cls.init_own_table(config)
         database = cls.get_argus()
         if row := database.fetch(cls._TABLE_NAME, test_id):
+            return cls.from_db_row(row)
+
+        return None
+
+    @classmethod
+    def from_pk(cls, pk: tuple[str, datetime.datetime], config: BaseConfig = None):
+        if not cls._IS_TABLE_INITIALIZED:
+            cls.init_own_table(config)
+        database = cls.get_argus()
+        if row := database.fetch_generic(cls._TABLE_NAME, pk, "WHERE build_id = ? and start_time = ?"):
             return cls.from_db_row(row)
 
         return None
@@ -428,24 +459,48 @@ class TestRun:
         self._heartbeat = int(value)
 
     @property
+    def build_id(self) -> str:
+        return self._build_id
+
+    @build_id.setter
+    def build_id(self, value: str) -> None:
+        self._build_id = str(value)
+
+    @property
     def id(self) -> UUID:  # pylint: disable=invalid-name
         return self._id
 
     @property
-    def group(self) -> str:
-        return self._group
+    def group_id(self) -> UUID:
+        return self._group_id
 
     @property
-    def release_name(self) -> str:
-        return self._release_name
+    def release_id(self) -> UUID:
+        return self._release_id
 
     @property
-    def assignee(self) -> str:
+    def test_id(self) -> UUID:
+        return self._test_id
+
+    @release_id.setter
+    def release_id(self, value: UUID) -> None:
+        self._release_id = value
+
+    @group_id.setter
+    def group_id(self, value: UUID) -> None:
+        self._group_id = value
+
+    @test_id.setter
+    def test_id(self, value: UUID) -> None:
+        self._test_id = value
+
+    @property
+    def assignee(self) -> UUID:
         return self._assignee
 
     @assignee.setter
     def assignee(self, value):
-        self._assignee = str(value)
+        self._assignee = value
 
     @property
     def investigation_status(self) -> str:
@@ -467,9 +522,11 @@ class TestRun:
             }
 
         data = {
-            "id": str(self._id),
-            "group": self._group,
-            "release_name": self._release_name,
+            "build_id": self._build_id,
+            "id": self._id,
+            "group_id": self._group_id,
+            "release_id": self._release_id,
+            "test_id": self._test_id,
             "assignee": self._assignee,
             "heartbeat": self._heartbeat,
             "investigation_status": self._investigation_status,
@@ -481,7 +538,8 @@ class TestRun:
     @classmethod
     def init_own_table(cls, config: BaseConfig = None):
         LOGGER.debug("Initializing TestRun table...")
-        cls.get_argus(config).init_table(table_name=cls._TABLE_NAME, column_info=cls.schema())
+        cls.get_argus(config).init_table(
+            table_name=cls._TABLE_NAME, column_info=cls.schema())
         cls._IS_TABLE_INITIALIZED = True
 
     @classmethod
@@ -496,7 +554,8 @@ class TestRun:
         for attr, column_type in cls.EXPOSED_ATTRIBUTES.items():
             value = None
             constraints = cls.ATTRIBUTE_CONSTRAINTS.get(attr, [])
-            column_info = ColumnInfo(name=attr, type=column_type, value=value, constraints=constraints)
+            column_info = ColumnInfo(
+                name=attr, type=column_type, value=value, constraints=constraints)
             data[attr] = column_info
 
         schema_dump = {}
@@ -508,6 +567,8 @@ class TestRun:
 
         full_schema = dict(
             **{"$tablekeys$": cls.PRIMARY_KEYS},
+            **{"$clustering_order$": cls.CLUSTERING_ORDER},
+            **{"$indices$": cls.INDICES},
             **data,
             **schema_dump
         )
@@ -519,7 +580,8 @@ class TestRun:
             if not self._IS_TABLE_INITIALIZED:
                 self.init_own_table(self._config)
             if not self.exists():
-                if self.assignee == "":
+                self._assign_categories()
+                if not self.assignee:
                     try:
                         self.assignee = self._get_current_assignee_from_schedule()
                     except Exception:  # pylint: disable=broad-except
@@ -527,10 +589,12 @@ class TestRun:
                         LOGGER.debug("Details: ", exc_info=True)
 
                 LOGGER.debug("Inserting data for test run: %s", self.id)
-                self.argus.insert(table_name=self._TABLE_NAME, run_data=self.serialize())
+                self.argus.insert(table_name=self._TABLE_NAME,
+                                  run_data=self.serialize())
             else:
                 LOGGER.debug("Updating data for test run: %s", self.id)
-                self.argus.update(table_name=self._TABLE_NAME, run_data=self.serialize())
+                self.argus.update(table_name=self._TABLE_NAME,
+                                  run_data=self.serialize())
 
     def exists(self) -> bool:
         if not self._IS_TABLE_INITIALIZED:
@@ -540,34 +604,51 @@ class TestRun:
             return True
         return False
 
-    # TODO: build_system_id refactor (check e2e tests)
-    def _get_current_assignee_from_schedule(self) -> str:
+    def _assign_categories(self):
+        key = self._build_id
+        try:
+            test: ArgusReleaseGroupTest = ArgusReleaseGroupTest.using(
+                connection=self.argus.CQL_ENGINE_CONNECTION_NAME
+            ).get(build_system_id=key)
+            self.release_id = test.release_id
+            self.group_id = test.group_id
+            self.test_id = test.id
+        except ArgusReleaseGroupTest.DoesNotExist:
+            LOGGER.warning(
+                "Test entity missing for key \"%s\", run won't be visible until this is corrected", key)
+
+    def _get_current_assignee_from_schedule(self) -> UUID:
         """
             Iterate over all schedules (groups and tests) and return first available assignee
         """
         associated_test = ArgusReleaseGroupTest.using(
             connection=self.argus.CQL_ENGINE_CONNECTION_NAME
-        ).get(build_system_id=self.run_info.details.build_job_name)
+        ).get(build_system_id=self.build_id)
         associated_group = ArgusReleaseGroup.using(
             connection=self.argus.CQL_ENGINE_CONNECTION_NAME
         ).get(id=associated_test.group_id)
+        associated_release = ArgusRelease.using(
+            connection=self.argus.CQL_ENGINE_CONNECTION_NAME
+        ).get(id=associated_test.release_id)
 
         scheduled_groups = ArgusReleaseScheduleGroup.filter(
-            release=self.release_name, name=associated_group.name
+            release_id=associated_release.id, group_id=associated_group.id
         ).all().using(
             connection=self.argus.CQL_ENGINE_CONNECTION_NAME
         )
 
         scheduled_tests = ArgusReleaseScheduleTest.filter(
-            release=self.release_name, name=associated_test.build_system_id
+            release_id=associated_release.id, test_id=associated_test.id
         ).all().using(
             connection=self.argus.CQL_ENGINE_CONNECTION_NAME
         )
 
-        unique_schedule_ids = {scheduled_obj.schedule_id for scheduled_obj in [*scheduled_tests, *scheduled_groups]}
+        unique_schedule_ids = {scheduled_obj.schedule_id for scheduled_obj in [
+            *scheduled_tests, *scheduled_groups]}
 
         schedules = ArgusReleaseSchedule.filter(
-            release=self.release_name, schedule_id__in=tuple(unique_schedule_ids)
+            release_id=associated_release.id, id__in=tuple(
+                unique_schedule_ids)
         ).all().using(
             connection=self.argus.CQL_ENGINE_CONNECTION_NAME
         )
@@ -582,13 +663,14 @@ class TestRun:
         assignees_uuids = []
         for schedule in valid_schedules:
             assignees = ArgusReleaseScheduleAssignee.filter(
-                schedule_id=schedule.schedule_id
+                schedule_id=schedule.id
             ).all().using(
                 connection=self.argus.CQL_ENGINE_CONNECTION_NAME
             )
-            assignees_uuids.append(*[str(assignee.assignee) for assignee in assignees])
+            assignees_uuids.append(
+                *[assignee.assignee for assignee in assignees])
 
-        return assignees_uuids[0] if len(assignees_uuids) > 0 else ""
+        return assignees_uuids[0] if len(assignees_uuids) > 0 else None
 
     def shutdown(self):
         LOGGER.debug("Shutting down cluster connection...")
@@ -600,19 +682,19 @@ class TestRun:
 
 
 class TestRunWithHeartbeat(TestRun):
-    def __init__(self, test_id: UUID, group: str, release_name: str, assignee: str,
+    def __init__(self, test_id: UUID, assignee: UUID, build_id: str,
                  run_info: TestRunInfo, heartbeat_interval=30, config: BaseConfig = None,
                  argus_interface: ArgusDatabase = None, investigation_status: str = TestInvestigationStatus.NOT_INVESTIGATED,):
         # pylint: disable=too-many-arguments
         self._heartbeat_interval = heartbeat_interval
         self._shutdown_event = threading.Event()
-        super().__init__(test_id=test_id, group=group, release_name=release_name, assignee=assignee,
+        super().__init__(test_id=test_id, assignee=assignee, build_id=build_id,
                          investigation_status=investigation_status, run_info=run_info,
                          config=config, argus_interface=argus_interface)
         self._thread = threading.Thread(target=self._heartbeat_entry,
                                         name=f"{self.__class__.__name__}-{self.id}-heartbeat", daemon=True)
         self._heartbeat_statement = self.argus.session.prepare(
-            f"UPDATE {TestRun.table_name()} SET heartbeat = ? WHERE id = ?")
+            f"UPDATE {TestRun.table_name()} SET heartbeat = ? WHERE build_id = ? AND start_time = ?")
         self._thread.start()
 
     @property
@@ -634,7 +716,8 @@ class TestRunWithHeartbeat(TestRun):
                 break
             LOGGER.debug("Sending heartbeat...")
             self.heartbeat = time.time()
-            bound_statement = self._heartbeat_statement.bind((self.heartbeat, self.id))
+            bound_statement = self._heartbeat_statement.bind(
+                (self.heartbeat, self.build_id, self.run_info.details.start_time))
             self.argus.session.execute(bound_statement)
         LOGGER.debug("Heartbeat exit")
 
@@ -643,10 +726,12 @@ class TestRunWithHeartbeat(TestRun):
         LOGGER.debug("Waiting for the heartbeat thread to exit...")
         self._thread.join(timeout=self.heartbeat_interval + 10)
         if self._thread.is_alive():
-            LOGGER.warning("Heartbeat thread was not able to shut down correctly. Stack trace:")
+            LOGGER.warning(
+                "Heartbeat thread was not able to shut down correctly. Stack trace:")
             # pylint: disable=protected-access
             current_threads = sys._current_frames()
-            stack_trace = traceback.extract_stack(current_threads[self._thread.ident])
+            stack_trace = traceback.extract_stack(
+                current_threads[self._thread.ident])
             LOGGER.warning(
                 "\n".join([f'#{lineno:3} : {line:50}: {fname}' for fname, lineno, _, line in stack_trace]))
         super().shutdown()

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
     "@fortawesome/free-brands-svg-icons": "^5.15.4",
     "@fortawesome/free-regular-svg-icons": "^5.15.4",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
-    "@popperjs/core": "^2.9.2",
-    "bootstrap": "^5.0.1",
+    "@popperjs/core": "^2.11.5",
+    "bootstrap": "^5.1.3",
     "chart.js": "^3.6.0",
     "chrono-node": "^2.3.4",
     "css-loader": "^5.2.6",
@@ -24,6 +24,7 @@
     "svelte-fa": "^2.4.0",
     "svelte-loader": "^3.1.2",
     "svelte-select": "^4.4.5",
+    "url-slug": "^3.0.3",
     "uuid": "^8.3.2",
     "webpack": "^5.39.1"
   },

--- a/requirements_web.txt
+++ b/requirements_web.txt
@@ -7,3 +7,4 @@ python-magic==0.4.24
 requests==2.26.0
 uwsgi==2.0.20
 python-jenkins==1.7.0
+python-slugify==6.1.1

--- a/start_argus.sh
+++ b/start_argus.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
+export CQLENG_ALLOW_SCHEMA_MANAGEMENT=1
 eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"
 pyenv activate argus

--- a/tests/scylladb-cluster/docker-compose.yml
+++ b/tests/scylladb-cluster/docker-compose.yml
@@ -1,47 +1,26 @@
 version: "3.7"
 services:
-  node_a:
-    image: "scylladb/scylla:4.4.4"
+  scylla-a:
+    image: "scylladb/scylla:4.5.2"
     networks:
       scylla_bridge:
         aliases:
           - initialnode
     command: --smp 1 --overprovisioned 1
 
-  node_b:
-    image: "scylladb/scylla:4.4.4"
+  scylla-b:
+    image: "scylladb/scylla:4.5.2"
     networks:
       scylla_bridge:
     depends_on:
-      - node_a
+      - scylla-a
     command: --smp 1 --overprovisioned 1 --seeds="initialnode"
-  node_c:
-    image: "scylladb/scylla:4.4.4"
+  scylla-c:
+    image: "scylladb/scylla:4.5.2"
     networks:
       scylla_bridge:
     depends_on:
-      - node_a
-    command: --smp 1 --overprovisioned 1 --seeds="initialnode"
-  node_e:
-    image: "scylladb/scylla:4.4.4"
-    networks:
-      scylla_bridge:
-    depends_on:
-      - node_a
-    command: --smp 1 --overprovisioned 1 --seeds="initialnode"
-  node_d:
-    image: "scylladb/scylla:4.4.4"
-    networks:
-      scylla_bridge:
-    depends_on:
-      - node_a
-    command: --smp 1 --overprovisioned 1 --seeds="initialnode"
-  node_f:
-    image: "scylladb/scylla:4.4.4"
-    networks:
-      scylla_bridge:
-    depends_on:
-      - node_a
+      - scylla-a
     command: --smp 1 --overprovisioned 1 --seeds="initialnode"
 networks:
   scylla_bridge:

--- a/tests/test_db_interface.py
+++ b/tests/test_db_interface.py
@@ -48,11 +48,11 @@ def test_interface_schema_init(mock_cluster, mock_cql_engine, preset_test_detail
     argus_interface_default.init_table("test_table", schema)
     # pylint: disable=unsubscriptable-object
     assert MockSession.MOCK_LAST_QUERY[0] == "CREATE TABLE IF NOT EXISTS test_table" \
-                                             "(name varchar , scm_revision_id varchar , started_by varchar , " \
-                                             "build_job_name varchar , build_job_url varchar , start_time varint ," \
+                                             "(scm_revision_id varchar , started_by varchar , " \
+                                             "build_job_url varchar , start_time timestamp ," \
                                              " yaml_test_duration varint , config_files list<varchar> , " \
-                                             "packages list<frozen<PackageVersion_v2>> , end_time varint , " \
-                                             "PRIMARY KEY (id))"
+                                             "packages list<frozen<PackageVersion_v2>> , end_time timestamp , " \
+                                             "PRIMARY KEY (id, timer)) WITH CLUSTERING ORDER BY (id DESC)"
 
 
 def test_interface_init_table_twice(mock_cluster, mock_cql_engine, preset_test_details_schema, simple_primary_key,
@@ -135,11 +135,12 @@ def test_interface_update(mock_cluster, mock_cql_engine, simple_primary_key, pre
     test_id = str(uuid4())
     data = {
         "id": test_id,
+        "timer": 42,
         **preset_test_details_serialized
     }
 
     argus_interface_default.update("test_table", data)
-    assert str(MockSession.MOCK_LAST_QUERY[1][-1:][0]) == test_id  # pylint: disable=unsubscriptable-object
+    assert str(MockSession.MOCK_LAST_QUERY[1][-2:][0]) == test_id  # pylint: disable=unsubscriptable-object
 
 
 def test_interface_update_uninitialized_table(mock_cluster, mock_cql_engine, simple_primary_key, preset_test_details_schema,

--- a/tests/test_e2e_argus.py
+++ b/tests/test_e2e_argus.py
@@ -86,7 +86,7 @@ class TestEndToEnd:
 
     @staticmethod
     @pytest.mark.docker_required
-    def test_auto_assign_run_by_group(completed_testrun: TestRunInfo, argus_database: ArgusDatabase):
+    def test_auto_assign_run_by_group(completed_testrun: TestRunInfo, argus_with_release: ArgusDatabase):
         group_assignee_user = uuid4()
 
         today = datetime.datetime.utcnow()
@@ -97,34 +97,34 @@ class TestEndToEnd:
         schedule.release = "4_5rc5"
         schedule.period_start = this_monday
         schedule.period_end = next_week
-        schedule.using(connection=argus_database.CQL_ENGINE_CONNECTION_NAME).save()
+        schedule.using(connection=argus_with_release.CQL_ENGINE_CONNECTION_NAME).save()
 
         scheduled_group = ArgusReleaseScheduleGroup()
         scheduled_group.schedule_id = schedule.schedule_id
         scheduled_group.release = "4_5rc5"
-        scheduled_group.name = "longevity-test"
-        scheduled_group.using(connection=argus_database.CQL_ENGINE_CONNECTION_NAME).save()
+        scheduled_group.name = "arbitrary-group"
+        scheduled_group.using(connection=argus_with_release.CQL_ENGINE_CONNECTION_NAME).save()
 
         scheduled_assignee = ArgusReleaseScheduleAssignee()
         scheduled_assignee.schedule_id = schedule.schedule_id
         scheduled_assignee.release = "4_5rc5"
         scheduled_assignee.assignee = group_assignee_user
-        scheduled_assignee.using(connection=argus_database.CQL_ENGINE_CONNECTION_NAME).save()
+        scheduled_assignee.using(connection=argus_with_release.CQL_ENGINE_CONNECTION_NAME).save()
 
-        TestRun.set_argus(argus_database)
+        TestRun.set_argus(argus_with_release)
         test_id = uuid4()
         test_run = TestRun(test_id=test_id, group="longevity-test", release_name="4_5rc5", assignee="",
                            run_info=completed_testrun, investigation_status=TestInvestigationStatus.INVESTIGATED)
         test_run.save()
         assert group_assignee_user == UUID(test_run.assignee)
 
-        row = argus_database.fetch(table_name=TestRun.table_name(), run_id=test_id)
+        row = argus_with_release.fetch(table_name=TestRun.table_name(), run_id=test_id)
         rebuilt_testrun = TestRun.from_db_row(row)
         assert group_assignee_user == UUID(rebuilt_testrun.assignee)
 
     @staticmethod
     @pytest.mark.docker_required
-    def test_auto_assign_run_by_test_name(completed_testrun: TestRunInfo, argus_database: ArgusDatabase):
+    def test_auto_assign_run_by_test_name(completed_testrun: TestRunInfo, argus_with_release: ArgusDatabase):
         test_assignee_user = uuid4()
 
         today = datetime.datetime.utcnow()
@@ -135,27 +135,27 @@ class TestEndToEnd:
         schedule.release = "4_5rc5"
         schedule.period_start = this_monday
         schedule.period_end = next_week
-        schedule.using(connection=argus_database.CQL_ENGINE_CONNECTION_NAME).save()
+        schedule.using(connection=argus_with_release.CQL_ENGINE_CONNECTION_NAME).save()
 
         scheduled_test = ArgusReleaseScheduleTest()
         scheduled_test.schedule_id = schedule.schedule_id
         scheduled_test.release = "4_5rc5"
-        scheduled_test.name = "longevity-test/longevity-test-100gb-4h"
-        scheduled_test.using(connection=argus_database.CQL_ENGINE_CONNECTION_NAME).save()
+        scheduled_test.name = "komachi-longevity-test-100gb-4h"
+        scheduled_test.using(connection=argus_with_release.CQL_ENGINE_CONNECTION_NAME).save()
 
         scheduled_assignee = ArgusReleaseScheduleAssignee()
         scheduled_assignee.schedule_id = schedule.schedule_id
         scheduled_assignee.release = "4_5rc5"
         scheduled_assignee.assignee = test_assignee_user
-        scheduled_assignee.using(connection=argus_database.CQL_ENGINE_CONNECTION_NAME).save()
+        scheduled_assignee.using(connection=argus_with_release.CQL_ENGINE_CONNECTION_NAME).save()
 
-        TestRun.set_argus(argus_database)
+        TestRun.set_argus(argus_with_release)
         test_id = uuid4()
         test_run = TestRun(test_id=test_id, group="longevity-test", release_name="4_5rc5", assignee="",
                            run_info=completed_testrun, investigation_status=TestInvestigationStatus.INVESTIGATED)
         test_run.save()
         assert test_assignee_user == UUID(test_run.assignee)
 
-        row = argus_database.fetch(table_name=TestRun.table_name(), run_id=test_id)
+        row = argus_with_release.fetch(table_name=TestRun.table_name(), run_id=test_id)
         rebuilt_testrun = TestRun.from_db_row(row)
         assert test_assignee_user == UUID(rebuilt_testrun.assignee)

--- a/tests/test_testinfo.py
+++ b/tests/test_testinfo.py
@@ -18,16 +18,14 @@ def test_details_serialization(preset_test_details: TestDetails, preset_test_det
 
 def test_details_validation_invalid_packages():
     with pytest.raises(TestInfoValueError):
-        TestDetails(name="some-test", scm_revision_id="abcde", started_by="someone",
-                    build_job_name="some-test-job",
+        TestDetails(scm_revision_id="abcde", started_by="someone",
                     build_job_url="https://job.tld/1", start_time=1600000000, yaml_test_duration=120,
                     config_files=["some-test.yaml"],
                     packages=["peckege", 123])
 
 
 def test_details_no_exception_on_empty_package_list():
-    TestDetails(name="some-test", scm_revision_id="abcde", started_by="someone",
-                build_job_name="some-test-job",
+    TestDetails(scm_revision_id="abcde", started_by="someone",
                 build_job_url="https://job.tld/1", start_time=1600000000, yaml_test_duration=120,
                 config_files=["some-test.yaml"],
                 packages=[])
@@ -35,12 +33,13 @@ def test_details_no_exception_on_empty_package_list():
 
 def test_details_ctor_from_named_tuple(preset_test_details):
     ResultSet = namedtuple("Row",
-                           ["name", "scm_revision_id", "started_by", "build_job_name", "build_job_url", "start_time",
+                           ["scm_revision_id", "started_by", "build_job_url", "start_time",
                             "yaml_test_duration", "config_files", "packages", "end_time"])
     PackageMapped = namedtuple("PackageMapped", ["name", "version", "date", "revision_id", "build_id"])
     package = PackageMapped("package-server", "1.0", "2021-10-01", "dfcedb3", "dfeeeffffff330fddd")
-    row = ResultSet(preset_test_details.name, preset_test_details.scm_revision_id, preset_test_details.started_by,
-                    preset_test_details.build_job_name, preset_test_details.build_job_url,
+    row = ResultSet(preset_test_details.scm_revision_id,
+                    preset_test_details.started_by,
+                    preset_test_details.build_job_url,
                     preset_test_details.start_time,
                     preset_test_details.yaml_test_duration,
                     preset_test_details.config_files,

--- a/tests/test_threaded_test_run.py
+++ b/tests/test_threaded_test_run.py
@@ -20,7 +20,8 @@ def test_heartbeat_thread(completed_testrun: TestRunInfo, mock_cluster: ArgusDat
     # pylint: disable=unused-argument
     monkeypatch.setattr(MockSession, "MOCK_RESULT_SET", FakeCursor())
     test_id = uuid4()
-    test_run = TestRunWithHeartbeat(test_id=test_id, group="longevity-test", release_name="4_5rc5", assignee="k0machi",
+    assignee = uuid4()
+    test_run = TestRunWithHeartbeat(test_id=test_id, build_id="argus-test/argus/argus-testing", assignee=assignee,
                                     run_info=completed_testrun, heartbeat_interval=3)
 
     old_ts = test_run.heartbeat
@@ -41,7 +42,8 @@ def test_heartbeat_thread_shutdown(completed_testrun: TestRunInfo, mock_cluster:
     # pylint: disable=unused-argument
     monkeypatch.setattr(MockSession, "MOCK_RESULT_SET", FakeCursor())
     test_id = uuid4()
-    test_run = TestRunWithHeartbeat(test_id=test_id, group="longevity-test", release_name="4_5rc5", assignee="k0machi",
+    assignee = uuid4()
+    test_run = TestRunWithHeartbeat(test_id=test_id, build_id="argus-test/argus/argus-testing", assignee=assignee,
                                     run_info=completed_testrun, heartbeat_interval=15)
 
     test_run.shutdown()

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -2,6 +2,6 @@
 socket = 127.0.0.1:3031
 wsgi-file = argus_callable.py
 callable = app
-processes = 2
-threads = 4
-buffer-size = 20384
+processes = 4
+threads = 8
+buffer-size = 48000

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = {
         globalAlert: { import: './argus/backend/assets/Alert.js', dependOn: 'main'},
         flashDebug: { import: './argus/backend/assets/flashDebug.js', dependOn: 'globalAlert'},
         workArea: { import: './argus/backend/assets/work-area.js', dependOn: 'globalAlert'},
+        adminPanel: { import: './argus/backend/assets/admin-panel.js', dependOn: 'globalAlert'},
         releasePage: { import: './argus/backend/assets/release-page.js', dependOn: 'globalAlert'},
         testRunDetails: { import: './argus/backend/assets/test-run-details.js', dependOn: 'globalAlert'},
         testRuns: { import: './argus/backend/assets/test-runs-breakout.js', dependOn: 'globalAlert'},

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,9 +3,9 @@
 
 
 "@discoveryjs/json-ext@^0.5.0":
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.5.tgz#9283c9ce5b289a3c4f61c12757469e59377f81f3"
-  integrity sha512-6nFkfkmSeV/rqSaS4oWHgmpnYw194f6hmWF5is6b0J1naJZoiD0NTc9AiUwPHvWsowkjuHErCZT1wa0jg+BLIA==
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
+  integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
 "@fortawesome/fontawesome-common-types@^0.2.36":
   version "0.2.36"
@@ -38,41 +38,41 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "^0.2.36"
 
-"@popperjs/core@^2.9.2":
-  version "2.10.2"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.10.2.tgz#0798c03351f0dea1a5a4cabddf26a55a7cbee590"
-  integrity sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ==
+"@popperjs/core@^2.11.5":
+  version "2.11.5"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.5.tgz#db5a11bf66bdab39569719555b0f76e138d7bd64"
+  integrity sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==
 
-"@types/eslint-scope@^3.7.0":
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.1.tgz#8dc390a7b4f9dd9f1284629efce982e41612116e"
-  integrity sha512-SCFeogqiptms4Fg29WpOTk5nHIzfpKCemSN63ksBQYKTcXoJEmJagV+DhVmbapZzY4/5YaOV1nZwrsU79fFm1g==
+"@types/eslint-scope@^3.7.3":
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.3.tgz#125b88504b61e3c8bc6f870882003253005c3224"
+  integrity sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==
   dependencies:
     "@types/eslint" "*"
     "@types/estree" "*"
 
 "@types/eslint@*":
-  version "7.28.2"
-  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.28.2.tgz#0ff2947cdd305897c52d5372294e8c76f351db68"
-  integrity sha512-KubbADPkfoU75KgKeKLsFHXnU4ipH7wYg0TRT33NK3N3yiu7jlFAAoygIWBV+KbuHx/G+AvuGX6DllnK35gfJA==
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.4.1.tgz#c48251553e8759db9e656de3efc846954ac32304"
+  integrity sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==
   dependencies:
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-"@types/estree@*", "@types/estree@^0.0.50":
-  version "0.0.50"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.50.tgz#1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83"
-  integrity sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
+"@types/estree@*", "@types/estree@^0.0.51":
+  version "0.0.51"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
+  integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
 
 "@types/json-schema@*", "@types/json-schema@^7.0.8":
-  version "7.0.9"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
-  integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
+  version "7.0.11"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
+  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
 "@types/node@*":
-  version "16.11.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.7.tgz#36820945061326978c42a01e56b61cd223dfdc42"
-  integrity sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==
+  version "17.0.23"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.23.tgz#3b41a6e643589ac6442bdbd7a4a3ded62f33f7da"
+  integrity sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
@@ -195,22 +195,22 @@
     "@webassemblyjs/ast" "1.11.1"
     "@xtuc/long" "4.2.2"
 
-"@webpack-cli/configtest@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-1.1.0.tgz#8342bef0badfb7dfd3b576f2574ab80c725be043"
-  integrity sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==
+"@webpack-cli/configtest@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-1.1.1.tgz#9f53b1b7946a6efc2a749095a4f450e2932e8356"
+  integrity sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==
 
-"@webpack-cli/info@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-1.4.0.tgz#b9179c3227ab09cbbb149aa733475fcf99430223"
-  integrity sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==
+"@webpack-cli/info@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-1.4.1.tgz#2360ea1710cbbb97ff156a3f0f24556e0fc1ebea"
+  integrity sha512-PKVGmazEq3oAo46Q63tpMr4HipI3OPfP7LiNOEJg963RMgT0rqheag28NCML0o3GIzA3DmxP1ZIAv9oTX1CUIA==
   dependencies:
     envinfo "^7.7.3"
 
-"@webpack-cli/serve@^1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.6.0.tgz#2c275aa05c895eccebbfc34cfb223c6e8bd591a2"
-  integrity sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==
+"@webpack-cli/serve@^1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.6.1.tgz#0de2875ac31b46b6c5bb1ae0a7d7f0ba5678dffe"
+  integrity sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -227,10 +227,10 @@ acorn-import-assertions@^1.7.6:
   resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz#ba2b5939ce62c238db6d93d81c9b111b29b855e9"
   integrity sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==
 
-acorn@^8.4.1:
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.5.0.tgz#4512ccb99b3698c752591e9bb4472e38ad43cee2"
-  integrity sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==
+acorn@^8.4.1, acorn@^8.5.0:
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
+  integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
 
 ajv-keywords@^3.5.2:
   version "3.5.2"
@@ -252,20 +252,20 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
-bootstrap@^5.0.1:
+bootstrap@^5.1.3:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.1.3.tgz#ba081b0c130f810fa70900acbc1c6d3c28fa8f34"
   integrity sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==
 
 browserslist@^4.14.5:
-  version "4.17.6"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.17.6.tgz#c76be33e7786b497f66cad25a73756c8b938985d"
-  integrity sha512-uPgz3vyRTlEiCv4ee9KlsKgo2V6qPk7Jsn0KAn2OBqbqKo3iNcPEC1Ti6J4dwnz+aIRfEEEuOzC9IBk8tXUomw==
+  version "4.20.2"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.20.2.tgz#567b41508757ecd904dab4d1c646c612cd3d4f88"
+  integrity sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==
   dependencies:
-    caniuse-lite "^1.0.30001274"
-    electron-to-chromium "^1.3.886"
+    caniuse-lite "^1.0.30001317"
+    electron-to-chromium "^1.4.84"
     escalade "^3.1.1"
-    node-releases "^2.0.1"
+    node-releases "^2.0.2"
     picocolors "^1.0.0"
 
 buffer-from@^1.0.0:
@@ -273,15 +273,15 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
-caniuse-lite@^1.0.30001274:
-  version "1.0.30001279"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz#eb06818da481ef5096a3b3760f43e5382ed6b0ce"
-  integrity sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ==
+caniuse-lite@^1.0.30001317:
+  version "1.0.30001325"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz#2b4ad19b77aa36f61f2eaf72e636d7481d55e606"
+  integrity sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ==
 
 chart.js@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.6.0.tgz#a87fce8431d4e7c5523d721f487f53aada1e42fe"
-  integrity sha512-iOzzDKePL+bj+ccIsVAgWQehCXv8xOKGbaU2fO/myivH736zcx535PGJzQGanvcSGVOqX6yuLZsN3ygcQ35UgQ==
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.7.1.tgz#0516f690c6a8680c6c707e31a4c1807a6f400ada"
+  integrity sha512-8knRegQLFnPQAheZV8MjxIXc5gQEfDFD897BJgv/klO/vtIyFFmgMXrNfgrXpbTr/XbTturxRgxIXx/Y+ASJBA==
 
 chrome-trace-event@^1.0.2:
   version "1.0.3"
@@ -289,9 +289,9 @@ chrome-trace-event@^1.0.2:
   integrity sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==
 
 chrono-node@^2.3.4:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/chrono-node/-/chrono-node-2.3.4.tgz#37bfd43a514866507bccdb80f899e3d48e9406b2"
-  integrity sha512-FxVbEoT1XU/HgObJvHaT2Ad2B6yqsnvV6MshyrBGhskCtKliVgl+bi0bS4GuItxHhxaCAZqDRYeLaAR15MGf3A==
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/chrono-node/-/chrono-node-2.3.8.tgz#c53ab3a9fd55ec1f78623582570de07da2e23c6f"
+  integrity sha512-cOCUKFHkGKJ//2VK0Vjwd8qh/tDJNraZHYb4DNB48mRUyfL7ag9lCDXgos30fPmV1pha4sP4qHLYItKNS0YpRw==
   dependencies:
     dayjs "^1.10.0"
 
@@ -350,24 +350,24 @@ cssesc@^3.0.0:
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
 dayjs@^1.10.0, dayjs@^1.10.7:
-  version "1.10.7"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.7.tgz#2cf5f91add28116748440866a0a1d26f3a6ce468"
-  integrity sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.0.tgz#009bf7ef2e2ea2d5db2e6583d2d39a4b5061e805"
+  integrity sha512-JLC809s6Y948/FuCZPm5IX8rRhQwOiyMb2TfVVQEixG7P8Lm/gt5S7yoQZmC8x1UehI9Pb7sksEt4xx14m+7Ug==
 
-electron-to-chromium@^1.3.886:
-  version "1.3.893"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.893.tgz#9d804c68953b05ede35409dba0d73dd54c077b4d"
-  integrity sha512-ChtwF7qB03INq1SyMpue08wc6cve+ktj2UC/Y7se9vB+JryfzziJeYwsgb8jLaCA5GMkHCdn5M62PfSMWhifZg==
+electron-to-chromium@^1.4.84:
+  version "1.4.106"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.106.tgz#e7a3bfa9d745dd9b9e597616cb17283cc349781a"
+  integrity sha512-ZYfpVLULm67K7CaaGP7DmjyeMY4naxsbTy+syVVxT6QHI1Ww8XbJjmr9fDckrhq44WzCrcC5kH3zGpdusxwwqg==
 
 emojis-list@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
 
-enhanced-resolve@^5.8.3:
-  version "5.8.3"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz#6d552d465cce0423f5b3d718511ea53826a7b2f0"
-  integrity sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==
+enhanced-resolve@^5.9.2:
+  version "5.9.2"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.9.2.tgz#0224dcd6a43389ebfb2d55efee517e5466772dd9"
+  integrity sha512-GIm3fQfwLJ8YZx2smuHpBKkXC1yOk+OBEmKckVyL0i/ea8mqDEykK3ld5dgH1QYPNyT/lIllxV2LULnxCHaHkA==
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
@@ -475,10 +475,10 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-graceful-fs@^4.1.2, graceful-fs@^4.2.4:
-  version "4.2.8"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
-  integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
+graceful-fs@^4.1.2, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
+  version "4.2.10"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
+  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
 has-flag@^4.0.0:
   version "4.0.0"
@@ -503,9 +503,9 @@ human-signals@^2.1.0:
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
 humanize-duration@^3.27.0:
-  version "3.27.0"
-  resolved "https://registry.yarnpkg.com/humanize-duration/-/humanize-duration-3.27.0.tgz#3f781b7cf8022ad587f76b9839b60bc2b29636b2"
-  integrity sha512-qLo/08cNc3Tb0uD7jK0jAcU5cnqCM0n568918E7R2XhMr/+7F37p4EY062W/stg7tmzvknNn9b/1+UhVRzsYrQ==
+  version "3.27.1"
+  resolved "https://registry.yarnpkg.com/humanize-duration/-/humanize-duration-3.27.1.tgz#2cd4ea4b03bd92184aee6d90d77a8f3d7628df69"
+  integrity sha512-jCVkMl+EaM80rrMrAPl96SGG4NRac53UyI1o/yAzebDntEY6K6/Fj2HOjdPg8omTqIe5Y0wPBai2q5xXrIbarA==
 
 icss-utils@^5.0.0, icss-utils@^5.1.0:
   version "5.1.0"
@@ -513,9 +513,9 @@ icss-utils@^5.0.0, icss-utils@^5.1.0:
   integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
 
 import-local@^3.0.2:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/import-local/-/import-local-3.0.3.tgz#4d51c2c495ca9393da259ec66b62e022920211e0"
-  integrity sha512-bE9iaUY3CXH8Cwfan/abDKAxe1KGT9kyGsBPqf6DMK/z0a2OzAsrukeYNgIH6cH5Xr452jb1TUL8rSfCLjZ9uA==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/import-local/-/import-local-3.1.0.tgz#b4479df8a5fd44f6cdce24070675676063c95cb4"
+  integrity sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==
   dependencies:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
@@ -525,10 +525,10 @@ interpret@^2.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
-is-core-module@^2.2.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.0.tgz#0321336c3d0925e497fd97f5d95cb114a5ccd548"
-  integrity sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==
+is-core-module@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.1.tgz#f59fdfca701d5879d0a6b100a40aa1560ce27211"
+  integrity sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
   dependencies:
     has "^1.0.3"
 
@@ -554,10 +554,10 @@ isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
-jest-worker@^27.0.6:
-  version "27.3.1"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.3.1.tgz#0def7feae5b8042be38479799aeb7b5facac24b2"
-  integrity sha512-ks3WCzsiZaOPJl/oMsDjaf0TRiSv7ctNgs0FqRr2nARsovz6AWWy4oLElwcquGSz692DzgZQrCLScPNs5YlC4g==
+jest-worker@^27.4.5:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.5.1.tgz#8d146f0900e8973b106b6f73cc1e9a8cb86f8db0"
+  integrity sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==
   dependencies:
     "@types/node" "*"
     merge-stream "^2.0.0"
@@ -589,11 +589,9 @@ json-schema-traverse@^0.4.1:
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
 json5@^2.1.2:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
-  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
-  dependencies:
-    minimist "^1.2.5"
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
+  integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
 kind-of@^6.0.2:
   version "6.0.3"
@@ -621,12 +619,10 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lru-cache@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
-  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
-  dependencies:
-    yallist "^4.0.0"
+lru-cache@^7.4.0:
+  version "7.7.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.7.3.tgz#98cd19eef89ce6a4a3c4502c17c833888677c252"
+  integrity sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==
 
 lz-string@^1.4.4:
   version "1.4.4"
@@ -634,26 +630,26 @@ lz-string@^1.4.4:
   integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
 
 marked@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.3.tgz#986760a428d8fd666251ec578429bf9a239a34bc"
-  integrity sha512-vSwKKtw+lCA0uFK/02JT4tBfNxEREpoTg21NoXqcmX0ySBIEyLMYWmt8WPsM61QNFaDBZkggupyNXLsV7uPuRg==
+  version "4.0.12"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.12.tgz#2262a4e6fd1afd2f13557726238b69a48b982f7d"
+  integrity sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==
 
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-mime-db@1.51.0:
-  version "1.51.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
-  integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
 mime-types@^2.1.27:
-  version "2.1.34"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
-  integrity sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
-    mime-db "1.51.0"
+    mime-db "1.52.0"
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -669,25 +665,20 @@ mini-css-extract-plugin@^1.6.0:
     schema-utils "^3.0.0"
     webpack-sources "^1.1.0"
 
-minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
-
-nanoid@^3.1.30:
-  version "3.1.30"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.30.tgz#63f93cc548d2a113dc5dfbc63bfa09e2b9b64362"
-  integrity sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==
+nanoid@^3.3.1:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.2.tgz#c89622fafb4381cd221421c69ec58547a1eec557"
+  integrity sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA==
 
 neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-node-releases@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.1.tgz#3d1d395f204f1f2f29a54358b9fb678765ad2fc5"
-  integrity sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==
+node-releases@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.2.tgz#7139fe71e2f4f11b47d4d2986aaf8c48699e0c01"
+  integrity sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==
 
 npm-run-path@^4.0.1:
   version "4.0.1"
@@ -732,7 +723,7 @@ path-key@^3.0.0, path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@^1.0.6:
+path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
@@ -778,26 +769,26 @@ postcss-modules-values@^4.0.0:
     icss-utils "^5.0.0"
 
 postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4:
-  version "6.0.6"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz#2c5bba8174ac2f6981ab631a42ab0ee54af332ea"
-  integrity sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz#79b61e2c0d1bfc2602d549e11d0876256f8df88d"
+  integrity sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
 postcss-value-parser@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
-  integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
+  integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
 postcss@^8.2.15:
-  version "8.3.11"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.3.11.tgz#c3beca7ea811cd5e1c4a3ec6d2e7599ef1f8f858"
-  integrity sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==
+  version "8.4.12"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.12.tgz#1e7de78733b28970fa4743f7da6f3763648b1905"
+  integrity sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==
   dependencies:
-    nanoid "^3.1.30"
+    nanoid "^3.3.1"
     picocolors "^1.0.0"
-    source-map-js "^0.6.2"
+    source-map-js "^1.0.2"
 
 punycode@^2.1.0:
   version "2.1.1"
@@ -831,12 +822,13 @@ resolve-from@^5.0.0:
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
 resolve@^1.9.0:
-  version "1.20.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
-  integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.0.tgz#5e0b8c67c15df57a89bdbabe603a002f21731198"
+  integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
   dependencies:
-    is-core-module "^2.2.0"
-    path-parse "^1.0.6"
+    is-core-module "^2.8.1"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
 
 safe-buffer@^5.1.0:
   version "5.2.1"
@@ -853,11 +845,11 @@ schema-utils@^3.0.0, schema-utils@^3.1.0, schema-utils@^3.1.1:
     ajv-keywords "^3.5.2"
 
 semver@^7.3.5:
-  version "7.3.5"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
-  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  version "7.3.6"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.6.tgz#5d73886fb9c0c6602e79440b97165c29581cbb2b"
+  integrity sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==
   dependencies:
-    lru-cache "^6.0.0"
+    lru-cache "^7.4.0"
 
 serialize-javascript@^6.0.0:
   version "6.0.0"
@@ -886,24 +878,24 @@ shebang-regex@^3.0.0:
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 signal-exit@^3.0.3:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.5.tgz#9e3e8cc0c75a99472b44321033a7702e7738252f"
-  integrity sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
+  integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
 source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
-source-map-js@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
-  integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
+source-map-js@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
 source-map-support@~0.5.20:
-  version "0.5.20"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.20.tgz#12166089f8f5e5e8c56926b377633392dd2cb6c9"
-  integrity sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -938,6 +930,11 @@ supports-color@^8.0.0:
   dependencies:
     has-flag "^4.0.0"
 
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
 svelte-dev-helper@^1.1.9:
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/svelte-dev-helper/-/svelte-dev-helper-1.1.9.tgz#7d187db5c6cdbbd64d75a32f91b8998bde3273c3"
@@ -949,9 +946,9 @@ svelte-fa@^2.4.0:
   integrity sha512-0bnbMGbsE1LUnlioDcf27tl2O8kjuXlTXMXzIxC7LoIOWmqn0D+zd539HfLiQbdLuOHGTaynwN9V+4ehhEu1Jw==
 
 svelte-hmr@^0.14.2:
-  version "0.14.7"
-  resolved "https://registry.yarnpkg.com/svelte-hmr/-/svelte-hmr-0.14.7.tgz#7fa8261c7b225d9409f0a86f3b9ea5c3ca6f6607"
-  integrity sha512-pDrzgcWSoMaK6AJkBWkmgIsecW0GChxYZSZieIYfCP0v2oPyx2CYU/zm7TBIcjLVUPP714WxmViE9Thht4etog==
+  version "0.14.11"
+  resolved "https://registry.yarnpkg.com/svelte-hmr/-/svelte-hmr-0.14.11.tgz#63d532dc9c2c849ab708592f034765fa2502e568"
+  integrity sha512-R9CVfX6DXxW1Kn45Jtmx+yUe+sPhrbYSUp7TkzbW0jI5fVPn6lsNG9NEs5dFg5qRhFNAoVdRw5qQDLALNKhwbQ==
 
 svelte-loader@^3.1.2:
   version "3.1.2"
@@ -963,14 +960,14 @@ svelte-loader@^3.1.2:
     svelte-hmr "^0.14.2"
 
 svelte-select@^4.4.5:
-  version "4.4.5"
-  resolved "https://registry.yarnpkg.com/svelte-select/-/svelte-select-4.4.5.tgz#ee6996e4ea54c613de3781c160546c378bb8592f"
-  integrity sha512-TvBA5ZHY8ULaiwCgXGpslf/3iSfGOsyGEFDjIUefSnwD6I+rKwoBKfMRAN34G1oaLD/vUHV1lhUWDhMlomTHjQ==
+  version "4.4.7"
+  resolved "https://registry.yarnpkg.com/svelte-select/-/svelte-select-4.4.7.tgz#fc85414af070487d68e438f7249c653178860af3"
+  integrity sha512-fIf9Z8rPI6F8naHZ9wjXT0Pv5gLyhdHAFkHFJnCfVVfELE8e82uOoF0xEVQP6Kir+b4Q5yOvNAzZ61WbSU6A0A==
 
 svelte@^3.38.3:
-  version "3.44.1"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.44.1.tgz#5cc772a8340f4519a4ecd1ac1a842325466b1a63"
-  integrity sha512-4DrCEJoBvdR689efHNSxIQn2pnFwB7E7j2yLEJtHE/P8hxwZWIphCtJ8are7bjl/iVMlcEf5uh5pJ68IwR09vQ==
+  version "3.46.6"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.46.6.tgz#23046a361ba5f8bafcc9cf9f6fca6d011fb005a7"
+  integrity sha512-o9nNft/OzCz/9kJpmWa1S52GAM+huCjPIsNWydYmgei74ZWlOA9/hN9+Z12INdklghu31seEXZMRHhS1+8DETw==
 
 tapable@^2.1.1, tapable@^2.2.0:
   version "2.2.1"
@@ -978,21 +975,22 @@ tapable@^2.1.1, tapable@^2.2.0:
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
 terser-webpack-plugin@^5.1.3:
-  version "5.2.5"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.2.5.tgz#ce65b9880a0c36872555c4874f45bbdb02ee32c9"
-  integrity sha512-3luOVHku5l0QBeYS8r4CdHYWEGMmIj3H1U64jgkdZzECcSOJAyJ9TjuqcQZvw1Y+4AOBN9SeYJPJmFn2cM4/2g==
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.1.tgz#0320dcc270ad5372c1e8993fabbd927929773e54"
+  integrity sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==
   dependencies:
-    jest-worker "^27.0.6"
+    jest-worker "^27.4.5"
     schema-utils "^3.1.1"
     serialize-javascript "^6.0.0"
     source-map "^0.6.1"
     terser "^5.7.2"
 
 terser@^5.7.2:
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.9.0.tgz#47d6e629a522963240f2b55fcaa3c99083d2c351"
-  integrity sha512-h5hxa23sCdpzcye/7b8YqbE5OwKca/ni0RQz1uRX3tGh8haaGHqcuSqbGRybuAKNdntZ0mDgFNXPJ48xQ2RXKQ==
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.12.1.tgz#4cf2ebed1f5bceef5c83b9f60104ac4a78b49e9c"
+  integrity sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==
   dependencies:
+    acorn "^8.5.0"
     commander "^2.20.0"
     source-map "~0.7.2"
     source-map-support "~0.5.20"
@@ -1004,6 +1002,11 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+url-slug@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/url-slug/-/url-slug-3.0.3.tgz#23cf0d91c4591f56382b7d8ad67b8dad54d486da"
+  integrity sha512-6iRFiPGMTuu5vBeVk6U7URwqRoMpvzRUg/Ycx0nqeD2g6AULolOTgI928lZeeSX9AIs8Hboh1/SGZTHymTVvRg==
+
 util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -1014,23 +1017,23 @@ uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-watchpack@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.2.0.tgz#47d78f5415fe550ecd740f99fe2882323a58b1ce"
-  integrity sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==
+watchpack@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.3.1.tgz#4200d9447b401156eeca7767ee610f8809bc9d25"
+  integrity sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==
   dependencies:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
 webpack-cli@^4.7.2:
-  version "4.9.1"
-  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-4.9.1.tgz#b64be825e2d1b130f285c314caa3b1ba9a4632b3"
-  integrity sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-4.9.2.tgz#77c1adaea020c3f9e2db8aad8ea78d235c83659d"
+  integrity sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==
   dependencies:
     "@discoveryjs/json-ext" "^0.5.0"
-    "@webpack-cli/configtest" "^1.1.0"
-    "@webpack-cli/info" "^1.4.0"
-    "@webpack-cli/serve" "^1.6.0"
+    "@webpack-cli/configtest" "^1.1.1"
+    "@webpack-cli/info" "^1.4.1"
+    "@webpack-cli/serve" "^1.6.1"
     colorette "^2.0.14"
     commander "^7.0.0"
     execa "^5.0.0"
@@ -1056,18 +1059,18 @@ webpack-sources@^1.1.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack-sources@^3.2.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.1.tgz#251a7d9720d75ada1469ca07dbb62f3641a05b6d"
-  integrity sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==
+webpack-sources@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
+  integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
 webpack@^5.39.1:
-  version "5.63.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.63.0.tgz#4b074115800e0526d85112985e46c64b95e04aaf"
-  integrity sha512-HYrw6bkj/MDmphAXvqLEvn2fVoDZsYu6O638WjK6lSNgIpjb5jl/KtOrqJyU9EC/ZV9mLUmZW5h4mASB+CVA4A==
+  version "5.71.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.71.0.tgz#b01fcf379570b8c5ee06ca06c829ca168c951884"
+  integrity sha512-g4dFT7CFG8LY0iU5G8nBL6VlkT21Z7dcYDpJAEJV5Q1WLb9UwnFbrem1k7K52ILqEmomN7pnzWFxxE6SlDY56A==
   dependencies:
-    "@types/eslint-scope" "^3.7.0"
-    "@types/estree" "^0.0.50"
+    "@types/eslint-scope" "^3.7.3"
+    "@types/estree" "^0.0.51"
     "@webassemblyjs/ast" "1.11.1"
     "@webassemblyjs/wasm-edit" "1.11.1"
     "@webassemblyjs/wasm-parser" "1.11.1"
@@ -1075,12 +1078,12 @@ webpack@^5.39.1:
     acorn-import-assertions "^1.7.6"
     browserslist "^4.14.5"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.8.3"
+    enhanced-resolve "^5.9.2"
     es-module-lexer "^0.9.0"
     eslint-scope "5.1.1"
     events "^3.2.0"
     glob-to-regexp "^0.4.1"
-    graceful-fs "^4.2.4"
+    graceful-fs "^4.2.9"
     json-parse-better-errors "^1.0.2"
     loader-runner "^4.2.0"
     mime-types "^2.1.27"
@@ -1088,8 +1091,8 @@ webpack@^5.39.1:
     schema-utils "^3.1.0"
     tapable "^2.1.1"
     terser-webpack-plugin "^5.1.3"
-    watchpack "^2.2.0"
-    webpack-sources "^3.2.0"
+    watchpack "^2.3.1"
+    webpack-sources "^3.2.3"
 
 which@^2.0.1:
   version "2.0.2"
@@ -1102,8 +1105,3 @@ wildcard@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.0.tgz#a77d20e5200c6faaac979e4b3aadc7b3dd7f8fec"
   integrity sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==
-
-yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==


### PR DESCRIPTION
This commit contains a very large refactor, which completely reworks
the way argus tracks runs - it includes:

Plugin:
        - Primary Keys are now (build_id, start_time)
        - Clustering order options
        - Index support
        - Automatic test acqusition (Runs now start with only build id
          and acquire their respective tests, groups and releases
          during saving
        - Removal of some textual fields like release_name
        - DateTime fields support
Backend:
        - Admin API and ReleaseManager Service
        - Role-based access controls
        - Refactoring of certain endpoints to use GET/simplify logic
        - Removal of unused methods and endpoints
        - Release Scheduling rework, now tied to internal IDs instead of
          text
Frontend:
        - Workspace stats fetch optimizations
        - Admin Area interface
        - Slight redesign of Releases and Schedules page
        - Work Area has been renamed to Workspace and route is now
          "/workspace" (preserving old route "/run_dashboard" for now)
        - New Stores for Releases, Groups and Tests, making them
          available globally if needed.

[Trello](https://trello.com/c/2iTzdhTD/4888-allow-grouping-tests-via-admin-interface-instead-of-build-system-based)