### PR TITLE
fix(Comment.svelte): Let markdown parser handle background color

### DIFF
--- a/argus/backend/assets/Discussion/Comment.svelte
+++ b/argus/backend/assets/Discussion/Comment.svelte
@@ -116,7 +116,7 @@
             />
         {:else}
             <div class="p-2 rounded bg-light">
-                <div class="border rounded p-2 bg-white markdown-body">
+                <div class="border rounded p-2 markdown-body">
                     {@html marked.parse(commentBody.message, markdownRendererOptions)}
                 </div>
             </div>


### PR DESCRIPTION
This fixes issues with browser theme preference set to dark.