### PR TITLE
feature(argus.frontend): Github Issue state display

### DIFF
--- a/argus/backend/assets/Common/TextUtils.js
+++ b/argus/backend/assets/Common/TextUtils.js
@@ -1,3 +1,31 @@
 export const titleCase = function (string) {
     return string[0].toUpperCase() + string.slice(1).toLowerCase();
 };
+
+export const lightenDarkenColor = function(col, amt) {
+    let num = parseInt(col, 16);
+    let r = Math.max(Math.min((num >> 16) * amt, 255), 0);
+    let g = Math.max(Math.min((num & 0x0000FF) * amt), 0);
+    let b = Math.max(Math.min(((num >> 8) & 0x00FF) * amt), 0);
+    let newColor = g | (b << 8) | (r << 16);
+    return newColor.toString(16);
+}
+
+/**
+ * Determines luma
+ * true - bright color
+ * false - dark color
+ * @param {string} col Color in hex format
+ * @returns {bool}
+ */
+export const determineLuma = function(col) {
+    let num = parseInt(col, 16);
+    let r = (num >> 16);
+    let g = num & 0x0000FF;
+    let b = (num >> 8) & 0x00FF;
+    let luma = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    if (luma >= 100) {
+        return true
+    }
+    return false;
+}

--- a/argus/backend/assets/Github/GithubIssue.svelte
+++ b/argus/backend/assets/Github/GithubIssue.svelte
@@ -2,25 +2,28 @@
     import { createEventDispatcher } from "svelte";
     import Fa from "svelte-fa";
     import { faGithub } from "@fortawesome/free-brands-svg-icons";
-    import { faCheckCircle } from "@fortawesome/free-regular-svg-icons";
     import {
-        faExclamationCircle,
+        faCheckCircle,
+        faDotCircle,
         faTrash,
     } from "@fortawesome/free-solid-svg-icons";
     import { sendMessage } from "../Stores/AlertStore";
     import { userList } from "../Stores/UserlistSubscriber";
     import { timestampToISODate } from "../Common/DateUtils";
+    import { apiMethodCall } from "../Common/ApiUtils";
+    import { determineLuma } from "../Common/TextUtils";
 
     const dispatch = createEventDispatcher();
     let users = {};
     $: users = $userList;
+    let githubToken;
     const IssueColorMap = {
-        open: "text-success",
-        closed: "text-danger",
+        open: "issue-open",
+        closed: "issue-closed",
     };
 
     const IssueIcon = {
-        open: faExclamationCircle,
+        open: faDotCircle,
         closed: faCheckCircle,
     };
     export let issue = {
@@ -34,13 +37,53 @@
         run_id: "",
         test_id: "",
         title: "NO ISSUE",
+        runs: [],
         type: "issues",
         url: "https://github.com/",
         user_id: "",
         added_on: "Mon, 1 Jan 1970 9:00:00 GMT",
     };
 
+    export let deleteEnabled = true;
+    export let aggregated = false;
+
     let deleting = false;
+
+    const fetchGithubToken = async function() {
+        let tokenRequest = await apiMethodCall("/api/v1/profile/github/token", undefined, "GET");
+        if (tokenRequest.status != "ok") {
+            return Promise.reject(new Error('noToken'));
+        } else {
+            return Promise.resolve(tokenRequest.response);
+        }
+    };
+
+    const fetchIssueState = async function() {
+        if (!githubToken) {
+            try {
+                githubToken = await fetchGithubToken();
+            } catch (error) {
+                sendMessage("error", "Github Oauth token not found.");
+                return;
+            }
+        }
+        let issue_url = `https://api.github.com/repos/${issue.owner}/${issue.repo}/issues/${issue.issue_number}`;
+        let issueStateResponse = await fetch(issue_url, {
+            headers: {
+                "Accept": "application/vnd.github.v3+json",
+                "Authorization": `token ${githubToken}`,
+            }
+        });
+        if (issueStateResponse.status < 200 || issueStateResponse.status >= 300) {
+            return Promise.reject(new Error('API Error'));
+        }
+
+        if (parseInt(issueStateResponse.headers.get("x-ratelimit-remaining")) === 0) {
+            return Promise.reject(new Error('Rate limit exceeded'));
+        }
+        return issueStateResponse.json();
+    };
+
 
     const deleteIssue = async function () {
         deleting = true;
@@ -78,44 +121,91 @@
     };
 </script>
 
-<div class="row m-2 border rounded p-2">
-    <div class="col hstack">
-        <div
-            class="me-2 text-truncate"
-            style="width: 20em;"
-            title={issue.title}
-        >
-            <Fa icon={faGithub} /> <a href={issue.url}>{issue.title}</a>
-        </div>
-        <div class="text-muted me-auto">{issue.repo}#{issue.issue_number}</div>
-        {#if Object.keys(users).length > 0}
-            <div
-                class="text-muted me-2"
-                title={new Date(issue.added_on).toISOString()}
-            >
-                Added by <span class="fw-bold">@{users[issue.user_id].username}</span> on {timestampToISODate(new Date(issue.added_on))}
-            </div>
-        {/if}
-        <div class="text-muted">
-            {#if deleting}
-            <button
-                class="btn btn-sm btn-danger"
-                title="Please wait"
-                type="button"
-            >
-                <span class="spinner-border spinner-border-sm"></span>
-            </button>
-            {:else}
-                <button
-                    class="btn btn-sm btn-danger"
-                    title="Remove this issue from this run"
-                    type="button"
-                    data-bs-toggle="modal"
-                    data-bs-target="#modalIssueConfirmDelete-{issue.id}"
+<div class="row m-2">
+    <div class="col rounded p-2 bg-white shadow-sm">
+        <div class="d-flex">
+            {#await fetchIssueState()}
+                <div
+                    class="me-2"
+                    style="width: 30em;"
+                    title={issue.title}
                 >
-                    <Fa icon={faTrash} />
-                </button>
-            {/if}
+                    <Fa icon={faGithub} /> <a target="_blank" class="link-dark" href={issue.url}>{issue.title}</a>
+                </div>
+                <div class="ms-2 me-2">
+                    <span class="spinner-border spinner-border-sm"></span> Loading issue state...
+                </div>
+            {:then issueState}
+                <div class="ms-2 align-self-center">
+                    <div class="mb-1 py-1 shadow-sm rounded-pill d-inline-flex {IssueColorMap[issueState.state]}">
+                        <div class="ms-2 me-1"><Fa icon={IssueIcon[issueState.state]} /></div>
+                        <div class="me-2">{issueState.state}</div>
+                    </div>
+                </div>
+                <div
+                    class="ms-2 me-2"
+                    style="width: 30em;"
+                    title={issue.title}
+                >
+                    <Fa icon={faGithub} /> <a target="_blank" class="link-dark" href={issue.url}>{issue.title}</a>
+                    <div class="text-muted ms-auto me-2">{issue.repo}#{issue.issue_number}</div>
+                </div>
+                <div class="ms-2 me-2">
+                    {#each issueState.labels as label (label.id)}
+                        <div
+                            class="d-inline-block align-items-center me-1 px-2 rounded-pill label-text"
+                            style="color: {determineLuma(label.color) ? '#ffffff' : 'black'}; background-color: #{label.color};"
+                        >
+                            <div>{label.name}</div>
+                        </div>
+                    {/each}
+                </div>
+            {:catch error}
+                <div class="ms-2 me-2">
+                    Error fetching state: {error?.message ?? "Unknown"}
+                </div>
+            {/await}
+            <div class="ms-auto me-2">
+                {#if Object.keys(users).length > 0}
+                    <div
+                        class="text-muted d-flex align-items-center"
+                        title={new Date(issue.added_on).toISOString()}
+                    >
+                        <div>Added by <span class="fw-bold">@{users[issue.user_id].username}</span> on {timestampToISODate(new Date(issue.added_on))}</div>
+                        {#if deleteEnabled && !aggregated}
+                            <div class="ms-2 text-muted">
+                                {#if deleting}
+                                <button
+                                    class="btn btn-sm btn-danger"
+                                    title="Please wait"
+                                    type="button"
+                                >
+                                    <span class="spinner-border spinner-border-sm"></span>
+                                </button>
+                                {:else}
+                                    <button
+                                        class="btn btn-sm btn-danger"
+                                        title="Remove this issue from this run"
+                                        type="button"
+                                        data-bs-toggle="modal"
+                                        data-bs-target="#modalIssueConfirmDelete-{issue.id}"
+                                    >
+                                        <Fa icon={faTrash} />
+                                    </button>
+                                {/if}
+                            </div>
+                        {/if}
+                    </div>
+                {/if}
+                {#if aggregated}
+                    <div class="d-flex justify-content-end">
+                        <div class="ms-1">Runs:</div>
+                        {#each issue.runs as run, idx}
+                            <a class="ms-1" href="/test_run/{run}">[{idx + 1}]</a>
+                        {/each}
+                    </div>
+                {/if}
+            </div>
         </div>
     </div>
 </div>
@@ -157,3 +247,22 @@
         </div>
     </div>
 </div>
+
+<style>
+    .label-text {
+        font-size: 0.9em;
+        font-weight: 500;
+    }
+
+    .issue-open {
+        color: #f4faff;
+        background-color: #347d39;
+    }
+
+    .issue-closed {
+        color: #f4faff;
+        background-color: #8256d0;
+    }
+
+
+</style>

--- a/argus/backend/assets/Github/GithubIssues.svelte
+++ b/argus/backend/assets/Github/GithubIssues.svelte
@@ -6,6 +6,7 @@
     export let id = "";
     export let filter_key = "run_id";
     export let submitDisabled = false;
+    export let aggregateByIssue = false;
     let newIssueUrl = "";
     let issues = [];
     let fetching = false;
@@ -16,6 +17,7 @@
             let params = new URLSearchParams({
                 filterKey: filter_key,
                 id: id,
+                aggregateByIssue: new Number(aggregateByIssue),
             }).toString();
             let apiResponse = await fetch("/api/v1/issues/get?" + params);
             let apiJson = await apiResponse.json();
@@ -126,7 +128,7 @@
             <h6>Issues</h6>
         {/if}
         {#each sortIssuesByDate(issues) as issue}
-            <GithubIssue {issue} on:issueDeleted={fetchIssues} />
+            <GithubIssue {issue} aggregated={aggregateByIssue} deleteEnabled={!submitDisabled} on:issueDeleted={fetchIssues} />
         {:else}
             <div class="row">
                 <div class="col text-center text-muted">

--- a/argus/backend/assets/ReleaseDashboard/ReleaseDashboard.svelte
+++ b/argus/backend/assets/ReleaseDashboard/ReleaseDashboard.svelte
@@ -37,6 +37,37 @@
         </div>
     </div>
     <div class="row mb-2">
+        <div class="col">
+            <div class="accordion">
+                <div class="accordion-item">
+                    <h2 class="accordion-header">
+                        <button
+                            class="accordion-button collapsed"
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapseIssues"
+                        >
+                            All Issues
+                        </button>
+                    </h2>
+                    <div
+                        id="collapseIssues"
+                        class="accordion-collapse collapse bg-light-one"
+                    >
+                        <div class="accordion-body">
+                            <GithubIssues
+                                id={releaseData.release.id}
+                                filter_key="release_id"
+                                submitDisabled={true}
+                                aggregateByIssue={true}
+                            />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="row mb-2">
         <div class="col-xs-2 col-sm-6 col-md-7">
             <ReleaseStats
                 releaseName={releaseData.release.name}
@@ -57,35 +88,5 @@
     </div>
     <div class="row mb-2">
         <ReleaseActivity releaseName={releaseData.release.name} />
-    </div>
-    <div class="row mb-2">
-        <div class="col">
-            <div class="accordion">
-                <div class="accordion-item">
-                    <h2 class="accordion-header">
-                        <button
-                            class="accordion-button collapsed"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#collapseIssues"
-                        >
-                            All Issues
-                        </button>
-                    </h2>
-                    <div
-                        id="collapseIssues"
-                        class="accordion-collapse collapse"
-                    >
-                        <div class="accordion-body">
-                            <GithubIssues
-                                id={releaseData.release.id}
-                                filter_key="release_id"
-                                submitDisabled={true}
-                            />
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
     </div>
 </div>

--- a/argus/db/models.py
+++ b/argus/db/models.py
@@ -291,6 +291,17 @@ class ArgusGithubIssue(Model):
     title = columns.Text()
     url = columns.Text()
 
+    def __hash__(self) -> int:
+        return hash((self.owner, self.repo, self.issue_number))
+
+    def __eq__(self, other):
+        if isinstance(other, ArgusGithubIssue):
+            return self.owner == other.owner and self.repo == other.repo and self.issue_number == other.issue_number
+        return super().__eq__(other)
+
+    def __ne__(self, other):
+        return not(self == other)
+
 
 class ArgusReleaseSchedule(Model):
     __table_name__ = "argus_schedule_v4"


### PR DESCRIPTION
This commit adds a way to fetch github issue state, labels to the
GithubIssue component, which is done client-side via first acquiring
User Oauth token from the server. It also changes issue display in
release dashboard, aggregating runs per unique issues, instead of issue
per run like it was previously.

[Trello One](https://trello.com/c/ADpZWAC6/4907-show-labels-in-all-issues-part-of-release-dashboard)
[Trello Two](https://trello.com/c/7uPRetcd/4897-release-dashboard-all-issues-add-run-info)
![image](https://user-images.githubusercontent.com/7761415/164034034-17f3d5ca-32c5-4514-9e63-57822db001ba.png)
