### PR TITLE
fix(ProfileJobs.svelte): Filter "investigated" not "not_investigated"

### DIFF
--- a/argus/backend/assets/Profile/ProfileJobs.svelte
+++ b/argus/backend/assets/Profile/ProfileJobs.svelte
@@ -12,7 +12,7 @@
     const filterNotInvestigated = function (jobs) {
         return jobs.filter(
             (job) =>
-                job.investigation_status == "not_investigated" &&
+                job.investigation_status != "investigated" &&
                 job.status != "passed"
         ).sort((a, b) => new Date(b.start_time).getTime() - new Date(a.start_time).getTime());
     };


### PR DESCRIPTION
This fixes a problem where ProfileJobs would hide jobs that have
"investigating" status from view.