### PR TITLE
improvement(api.py): Cache stats requests

### DIFF
--- a/argus/backend/controller/api.py
+++ b/argus/backend/controller/api.py
@@ -519,7 +519,9 @@ def release_stats():
             "exception": exc.__class__.__name__,
             "arguments": exc.args
         }
-    return jsonify(res)
+    res = jsonify(res)
+    res.cache_control.max_age = 60
+    return res
 
 
 @bp.route("/test_runs/poll", methods=["GET"])


### PR DESCRIPTION
This commit changes behaviour of /release/stats endpoint to set a
max-age cache control header.