### PR TITLE
improvement(IssueTemplate.svelte): Allow partial selection

### DIFF
--- a/frontend/TestRun/IssueTemplate.svelte
+++ b/frontend/TestRun/IssueTemplate.svelte
@@ -89,8 +89,22 @@
                             id="issueTemplateRaw-{test_run.id}"
                             role="tabpanel"
                         >
+                            <div class="p-1 mb-2">
+                                <button
+                                    class="btn btn-sm btn-primary"
+                                    on:click={() => {
+                                        let range = document.createRange();
+                                        range.selectNodeContents(templateElement);
+                                        let selection = window.getSelection();
+                                        selection.removeAllRanges();
+                                        selection.addRange(range);
+                                    }}
+                                >
+                                    Select All
+                                </button>
+                            </div>
                             <pre
-                                class="code user-select-all"
+                                class="code"
                                 bind:this={templateElement}
                                 id="issueTemplateText-{test_run.id}">
 ## Installation details


### PR DESCRIPTION
This changes issue template back to normal selection behaviour, and adds
a button to select all text within issue template

[Trello](https://trello.com/c/EdqkPNAJ/4957-issue-template-allow-partial-copy-of-the-text)
![image](https://user-images.githubusercontent.com/7761415/164444797-3a74be6d-d738-4187-b3d7-bcf077d55867.png)
