### PR TITLE
fix(TestMapStats.svelte): Highlight tests that are being investigated

### DIFF
--- a/frontend/Stats/TestMapStats.svelte
+++ b/frontend/Stats/TestMapStats.svelte
@@ -165,6 +165,7 @@ TestStatusChangeable,
                 {#each Object.entries(filterTestsForGroup(group.name, group.tests ?? {})) as [testName, test] (test.test_id)}
                     <div
                         class:status-block-active={test.start_time != 0}
+                        class:investigating={test?.investigation_status == TestInvestigationStatus.IN_PROGRESS}
                         class:should-be-investigated={test?.investigation_status == TestInvestigationStatus.NOT_INVESTIGATED && test?.status == TestStatus.FAILED}
                         class="rounded bg-main status-block m-1 d-flex flex-column overflow-hidden shadow-sm"
                         on:click={() => {
@@ -238,6 +239,7 @@ TestStatusChangeable,
     .status-block {
         width: 178px;
         max-height: 160px;
+        box-sizing: border-box;
         cursor: pointer;
     }
 
@@ -255,7 +257,10 @@ TestStatusChangeable,
     }
 
     .should-be-investigated {
-        box-sizing: content-box;
         border: 3px solid #dc3545 !important;
+    }
+
+    .investigating {
+        border: 3px solid #ff9036 !important;
     }
 </style>


### PR DESCRIPTION
[Trello](https://trello.com/c/n7fCaoOn/5025-orange-square-for-in-progress-jobs-in-release-dashboard-the-eye-icon-isnt-that-clear)
![image](https://user-images.githubusercontent.com/7761415/169108830-45e5cd77-db36-46cc-88a6-1cfb7a64cdc7.png)
