### PR TITLE
fix(uwsgi.ini): Add max-worker-lifetime and max-requests settings

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -5,3 +5,5 @@ callable = argus_app
 processes = 4
 threads = 8
 buffer-size = 48000
+max-requests = 2048
+max-worker-lifetime = 86400


### PR DESCRIPTION
To mitigate memory leaks, uwsgi.ini will now reload workers after either 24 hours of running or 2048 requests served.