### PR TITLE
fix(start_argus): Use master process for uWSGI and replace bash shell

### DIFF
--- a/start_argus.sh
+++ b/start_argus.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 export PATH="$HOME/.local/bin:$PATH"
 export CQLENG_ALLOW_SCHEMA_MANAGEMENT=1
-poetry run uwsgi --ini uwsgi.ini
+exec poetry run uwsgi --master --ini uwsgi.ini


### PR DESCRIPTION
This addresses the problem where systemd would kill the entire service
when the "main" worker exits. Use of exec removes extra "bash" process
from the resulting CGroup