### PR TITLE
feature(WorkArea.svelte): TestRuns selector & state refactor

### DIFF
--- a/argus/backend/controller/main.py
+++ b/argus/backend/controller/main.py
@@ -1,3 +1,4 @@
+import logging
 from uuid import UUID
 from flask import (
     Blueprint, flash, g, redirect, render_template, request, session, url_for, make_response
@@ -6,6 +7,8 @@ from argus.backend.controller.notifications import bp as notifications_bp
 from argus.backend.service.argus_service import ArgusService
 from argus.db.models import WebFileStorage
 from argus.backend.controller.auth import login_required
+
+LOGGER = logging.getLogger(__name__)
 
 bp = Blueprint('main', __name__)
 bp.register_blueprint(notifications_bp)
@@ -21,6 +24,13 @@ def test_runs():
 @login_required
 def test_run(run_id: UUID):
     return render_template("test_run.html.j2", id=run_id)
+
+
+@bp.route("/test/<string:test_id>/runs")
+@login_required
+def runs(test_id: UUID):
+    additional_runs = request.args.getlist("additionalRuns[]")
+    return render_template("standalone_test_with_runs.html.j2", test_id=test_id, additional_runs=additional_runs)
 
 
 @bp.route("/")

--- a/frontend/Common/StateManagement.js
+++ b/frontend/Common/StateManagement.js
@@ -13,5 +13,5 @@ export const stateDecoder = function () {
         let decodedState = JSON.parse(Base64.decode(state));
         return decodedState;
     }
-    return {};
+    return [];
 }

--- a/frontend/Profile/JobsList.svelte
+++ b/frontend/Profile/JobsList.svelte
@@ -1,9 +1,9 @@
 <script>
     export let runs = [];
     import Fa from "svelte-fa";
-    import { StatusBackgroundCSSClassMap } from "../Common/TestStatus";
-    import { faExternalLinkSquareAlt } from "@fortawesome/free-solid-svg-icons";
-    import TestRun from "../TestRun/TestRun.svelte";
+    import { StatusCSSClassMap } from "../Common/TestStatus";
+    import { faCircle, faExternalLinkSquareAlt } from "@fortawesome/free-solid-svg-icons";
+    import TestRuns from "../WorkArea/TestRuns.svelte";
     import { timestampToISODate } from "../Common/DateUtils";
     let filterString = "";
 
@@ -31,6 +31,32 @@
             .at(-1);
     };
 
+    const fetchReleaseDetails = async function(releaseId) {
+        let res = await fetch(`/api/v1/release/${releaseId}/details`);
+        if (res.status != 200) {
+            return Promise.reject("API Error");
+        }
+        let json = await res.json();
+        if (json.status != "ok") {
+            return Promise.reject(json.exception);
+        }
+
+        return json.response;
+    };
+
+    const fetchTestDetails = async function(testId) {
+        let res = await fetch(`/api/v1/test/${testId}/details`);
+        if (res.status != 200) {
+            return Promise.reject("API Error");
+        }
+        let json = await res.json();
+        if (json.status != "ok") {
+            return Promise.reject(json.exception);
+        }
+
+        return json.response;
+    };
+
     let clickedRuns = {};
 </script>
 
@@ -47,40 +73,47 @@
         />
     </div>
 {/if}
+
 {#each runs as run}
     <div class="row" class:d-none={filterJob(run)}>
-        <div class="col border rounded mb-2">
-            <div class="d-flex align-items-center">
-                <div
-                    class="p-2 border rounded {StatusBackgroundCSSClassMap[
-                        run.status
-                    ]} text-light text-center"
-                    style="width: 156px"
-                >
-                    {run.status.toUpperCase()}
-                </div>
-                <h3 class="ms-2 p-2">
-                    <span class="text-muted">{run.build_id}#</span
-                    >{getBuildNumber(run.build_job_url)}
+        <div class="col shadow rounded bg-white mb-2">
+            <div class="row p-2">
+                <h3 class="col-9 d-flex align-items-center">
+                    <div title={run.status}>
+                        <Fa icon={faCircle} class={StatusCSSClassMap[run.status]} />
+                    </div>
+                    <div class="ms-3">
+                        {#await Promise.all([fetchTestDetails(run.test_id), fetchReleaseDetails(run.release_id)])}
+                            <span class="spinner-border spinner-border-sm"></span> Getting name...
+                        {:then [test, release]}
+                            <div>
+                                {test.name}<span class="text-muted">#{getBuildNumber(run.build_job_url)}</span>
+                            </div>
+                            <div class="text-muted" style="font-size: 0.75em;">
+                                {release.name}
+                            </div>
+                        {/await}
+                    </div>
                 </h3>
-                <div class="ms-auto">
+                <div class="col-2">
                     <h6 class="text-muted">Started at</h6>
                     <div>
                         {timestampToISODate(run.start_time , true)}
                     </div>
                 </div>
-                <div class="ms-2">
-                    <div class="btn-group">
+                <div class="col-1">
+                    <div class="btn-group d-flex align-items-center h-100">
                         <button
-                            class="btn btn-sm btn-secondary"
+                            class="btn btn-sm btn-outline-secondary"
                             data-bs-toggle="collapse"
                             data-bs-target="#testRun_{run.id}"
-                            on:click={() => (clickedRuns[run.id] = true)}
-                            >Open</button
+                            on:click={() => (clickedRuns[run.id] = !clickedRuns[run.id])}
                         >
+                            {clickedRuns[run.id] ? "Close" : "Open"}
+                        </button>
                         <a
-                            href="/test_run/{run.id}"
-                            class="btn btn-sm btn-secondary"
+                            href="/test/{run.test_id}/runs?additionalRuns[]={run.id}"
+                            class="btn btn-sm btn-outline-secondary"
                             ><Fa icon={faExternalLinkSquareAlt} /></a
                         >
                     </div>
@@ -88,9 +121,9 @@
             </div>
             <div class="collapse" id="testRun_{run.id}">
                 {#if clickedRuns[run.id]}
-                    <TestRun
-                        id={run.id}
-                        build_number={getBuildNumber(run.build_job_url)}
+                    <TestRuns
+                        testId={run.test_id}
+                        additionalRuns={[run.id]}
                     />
                 {/if}
             </div>

--- a/frontend/Profile/ProfileSchedules.svelte
+++ b/frontend/Profile/ProfileSchedules.svelte
@@ -5,54 +5,12 @@
         faExternalLinkAlt,
         faTasks,
     } from "@fortawesome/free-solid-svg-icons";
-    import { allTests, allGroups, allReleases} from "../Stores/WorkspaceStore";
     import { stateEncoder } from "../Common/StateManagement";
-
-    let releases = {};
-    let groups = {};
-    let tests = {};
-
-    allReleases.subscribe((value) => {
-        if (!value) return;
-        releases = value.reduce((acc, val) => {
-            acc[val.id] = val;
-            return acc;
-        }, {});
-    });
-
-    allGroups.subscribe((value) => {
-        if (!value) return;
-        groups = value.reduce((acc, val) => {
-            acc[val.id] = val;
-            return acc;
-        }, {});
-    });
-
-    allTests.subscribe((value) => {
-        if (!value) return;
-        tests = value.reduce((acc, val) => {
-            acc[val.id] = val;
-            return acc;
-        }, {});
-    });
-
-    const generateJenkinsUrl = function(id, type = "test") {
-        // TODO: Store URLs in entities
-        if (!id) return "";
+    const generateJenkinsGroupUrl = function(details, releaseDetails) {
         const baseURL = "https://jenkins.scylladb.com/";
-        switch (type) {
-            case "test": {
-                let test = tests?.[id];
-                let group = groups?.[test.group_id];
-                let release = releases?.[test.release_id];
-                return `${baseURL}job/${release?.name}/job/${group?.name}/job/${test?.name}`;
-            }
-            case "group": {
-                let group = groups?.[id];
-                let release = releases?.[group.release_id];
-                return `${baseURL}job/${release?.name}/job/${group?.name}`;
-            }
-        }
+        let group = details;
+        let release = releaseDetails;
+        return `${baseURL}job/${release?.name}/job/${group?.name}`;
     };
 
     const sortByStartTime = function () {
@@ -68,23 +26,47 @@
         });
     };
 
-    const prepareState = function (schedule, releases, groups, tests) {
-        return schedule.tests.reduce((acc, scheduledTest) => {
-            let testId = scheduledTest;
-            let releaseId = schedule.release_id;
-            let groupId = tests?.[testId]?.group_id;
-            let releaseName = releases?.[releaseId]?.name;
-            let groupName = groups?.[groupId]?.name;
-            let testName = tests?.[testId]?.name;
-            let buildSystemId = tests?.[testId]?.build_system_id;
-            acc[`${releaseName}/${groupName}/${testName}`] = {
-                release: releaseName,
-                group: groupName,
-                test: testName,
-                build_system_id: buildSystemId,
-            };
-            return acc;
-        }, {});
+    const prepareState = function (schedule) {
+        return schedule.tests;
+    };
+
+    const fetchReleaseDetails = async function(releaseId) {
+        let res = await fetch(`/api/v1/release/${releaseId}/details`);
+        if (res.status != 200) {
+            return Promise.reject("API Error");
+        }
+        let json = await res.json();
+        if (json.status != "ok") {
+            return Promise.reject(json.exception);
+        }
+
+        return json.response;
+    };
+
+    const fetchGroupDetails = async function(groupId) {
+        let res = await fetch(`/api/v1/group/${groupId}/details`);
+        if (res.status != 200) {
+            return Promise.reject("API Error");
+        }
+        let json = await res.json();
+        if (json.status != "ok") {
+            return Promise.reject(json.exception);
+        }
+
+        return json.response;
+    };
+
+    const fetchTestDetails = async function(testId) {
+        let res = await fetch(`/api/v1/test/${testId}/details`);
+        if (res.status != 200) {
+            return Promise.reject("API Error");
+        }
+        let json = await res.json();
+        if (json.status != "ok") {
+            return Promise.reject(json.exception);
+        }
+
+        return json.response;
     };
 
     const fetchTestComment = async function (testId) {
@@ -106,132 +88,141 @@
 
 {#each sortByStartTime() as schedule}
     <div class="row p-2 justify-content-center">
-        <div class="col-12 border rounded bg-white shadow-sm mb-2 p-2 me-2">
-            <div class="row">
-                <div class="col-4">
-                    <div>
-                        <h5>Release</h5>
-                        <div>{releases?.[schedule.release_id]?.name}</div>
-                    </div>
-                    <div>
-                        <h5>From</h5>
-                        <div class="text-danger">
-                            {new Date(schedule.period_start).toLocaleDateString(
-                                "en-CA"
-                            )}
+        {#await fetchReleaseDetails(schedule.release_id)}
+            <div class="col-12 text-center border rounded bg-white shadow-sm mb-2 p-2 me-2">
+                <span class="spinner-border spinner-border-sm"></span> Fetching release...
+            </div>
+        {:then release}
+            <div class="col-12 border rounded bg-white shadow-sm mb-2 p-2 me-2">
+                <div class="row">
+                    <div class="col-4">
+                        <div>
+                            <h5>Release</h5>
+                                {release.name}
                         </div>
-                    </div>
-                    <div>
-                        <h5>To</h5>
-                        <div class="text-success">
-                            {new Date(schedule.period_end).toLocaleDateString(
-                                "en-CA"
-                            )}
-                        </div>
-                    </div>
-                </div>
-                <div
-                    class:col-4={schedule.groups.length > 0}
-                    class:col-8={schedule.groups.length == 0}
-                    class:d-none={schedule.tests.length == 0}
-                    class="border-start"
-                >
-                    <div class:d-none={schedule.tests.length == 0}>
-                        <div class="d-flex mb-2 align-items-center">
-                            <div class="fw-bold fs-5">Tests</div>
-
-                            <div class="ms-4 text-start">
-                                <a
-                                    href="/workspace?{stateEncoder(
-                                        prepareState(
-                                            schedule,
-                                            releases,
-                                            groups,
-                                            tests
-                                        )
-                                    )}"
-                                    class="btn btn-sm btn-outline-primary"
-                                >
-                                    Open Workspace <Fa icon={faTasks} />
-                                </a>
+                        <div>
+                            <h5>From</h5>
+                            <div class="text-danger">
+                                {new Date(schedule.period_start).toLocaleDateString(
+                                    "en-CA"
+                                )}
                             </div>
                         </div>
                         <div>
-                            <ul class="list-group list-height-limit">
-                                {#each schedule.tests as test}
-                                    <li class="list-group-item text-start">
-                                        <div class="d-flex align-items-center">
-                                            <div>
-                                                {tests?.[test]?.pretty_name ||
-                                                    tests?.[test]?.name}
-                                            </div>
-                                            <div class="ms-auto">
-                                                {#await fetchTestComment(test)}
-                                                    <span class="spinner-border spinner-border-sm"></span> Loading comment...
-                                                {:then res}
-                                                    {#if res.status === "ok" && res.response}
-                                                        <div class="rounded border p-1 comment-text">
-                                                            {res.response}
-                                                        </div>
-                                                    {/if}
-                                                {:catch error}
-                                                    <div class="rounded border border-danger p-1">Error fetching comment: {error?.message ?? "Unknown"}</div>
-                                                {/await}
-                                            </div>
-                                            <div class="ms-2">
-                                                <a
-                                                    target="_blank"
-                                                    href={tests?.[test]?.build_system_url}
-                                                    class="btn btn-sm btn-outline-dark"
-                                                    >To Jenkins <Fa
-                                                        icon={faExternalLinkAlt}
-                                                    /></a
-                                                >
-                                            </div>
-                                        </div>
-                                    </li>
-                                {/each}
-                            </ul>
+                            <h5>To</h5>
+                            <div class="text-success">
+                                {new Date(schedule.period_end).toLocaleDateString(
+                                    "en-CA"
+                                )}
+                            </div>
                         </div>
                     </div>
-                </div>
-                <div
-                    class:col-4={schedule.tests.length > 0}
-                    class:col-8={schedule.tests.length == 0}
-                    class="border-start"
-                >
-                    <div class:d-none={schedule.groups.length == 0}>
-                        <div class="d-flex mb-2 align-items-center">
-                            <div class="fw-bold fs-5">Groups</div>
+                    <div
+                        class:col-4={schedule.groups.length > 0}
+                        class:col-8={schedule.groups.length == 0}
+                        class:d-none={schedule.tests.length == 0}
+                        class="border-start"
+                    >
+                        <div class:d-none={schedule.tests.length == 0}>
+                            <div class="d-flex mb-2 align-items-center">
+                                <div class="fw-bold fs-5">Tests</div>
+
+                                <div class="ms-4 text-start">
+                                    <a
+                                        href="/workspace?{stateEncoder(prepareState(schedule))}"
+                                        class="btn btn-sm btn-outline-primary"
+                                    >
+                                    <Fa icon={faTasks} /> To Workspace
+                                    </a>
+                                </div>
+                            </div>
+                            <div>
+                                <ul class="list-group list-height-limit">
+                                    {#each schedule.tests as test}
+                                        <li class="list-group-item text-start">
+                                            {#await fetchTestDetails(test)}
+                                                <div>
+                                                    <span class="spinner-border spinner-border-sm"></span> Fetching test...
+                                                </div>
+                                            {:then testDetails}
+                                                <div class="d-flex align-items-center">
+                                                    <div>
+                                                            {testDetails.pretty_name || testDetails.name}
+                                                    </div>
+                                                    <div class="ms-auto">
+                                                        {#await fetchTestComment(test)}
+                                                            <span class="spinner-border spinner-border-sm"></span> Loading comment...
+                                                        {:then res}
+                                                            {#if res.status === "ok" && res.response}
+                                                                <div class="rounded border p-1 comment-text">
+                                                                    {res.response}
+                                                                </div>
+                                                            {/if}
+                                                        {:catch error}
+                                                            <div class="rounded border border-danger p-1">Error fetching comment: {error?.message ?? "Unknown"}</div>
+                                                        {/await}
+                                                    </div>
+                                                    <div class="ms-2">
+                                                        <a
+                                                            target="_blank"
+                                                            href={testDetails.build_system_url}
+                                                            class="btn btn-sm btn-outline-dark"
+                                                            >To Jenkins <Fa
+                                                                icon={faExternalLinkAlt}
+                                                            /></a
+                                                        >
+                                                    </div>
+                                                </div>
+                                            {/await}
+                                        </li>
+                                    {/each}
+                                </ul>
+                            </div>
                         </div>
-                        <div>
-                            <ul class="list-group list-height-limit">
-                                {#each schedule.groups as group}
-                                    <li class="list-group-item text-start">
-                                        <div class="d-flex align-items-center">
-                                            <div class="fs-3 fw-bold">
-                                                {groups?.[group]?.pretty_name ||
-                                                    groups?.[group]?.name}
+                    </div>
+                    <div
+                        class:col-4={schedule.tests.length > 0}
+                        class:col-8={schedule.tests.length == 0}
+                        class="border-start"
+                    >
+                        <div class:d-none={schedule.groups.length == 0}>
+                            <div class="d-flex mb-2 align-items-center">
+                                <div class="fw-bold fs-5">Groups</div>
+                            </div>
+                            <div>
+                                <ul class="list-group list-height-limit">
+                                    {#each schedule.groups as group}
+                                        <li class="list-group-item text-start">
+                                        {#await fetchGroupDetails(group)}
+                                            <div>
+                                                <span class="spinner-border spinner-border-sm"></span> Fetching group...
                                             </div>
-                                            <div class="ms-auto">
-                                                <a
-                                                    target="_blank"
-                                                    href={generateJenkinsUrl(groups?.[group]?.id, "group")}
-                                                    class="btn btn-dark btn-outline"
-                                                    >Jenkins <Fa
-                                                        icon={faExternalLinkAlt}
-                                                    /></a
-                                                >
+                                        {:then groupDetails}
+                                            <div class="d-flex align-items-center">
+                                                <div class="fs-3 fw-bold">
+                                                        {groupDetails.pretty_name || groupDetails.name}
+                                                </div>
+                                                <div class="ms-auto">
+                                                    <a
+                                                        target="_blank"
+                                                        href={generateJenkinsGroupUrl(groupDetails, release)}
+                                                        class="btn btn-dark btn-outline"
+                                                        >Jenkins <Fa
+                                                            icon={faExternalLinkAlt}
+                                                        /></a
+                                                    >
+                                                </div>
                                             </div>
-                                        </div>
-                                    </li>
-                                {/each}
-                            </ul>
+                                        {/await}
+                                        </li>
+                                    {/each}
+                                </ul>
+                            </div>
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
+        {/await}
     </div>
 {/each}
 

--- a/frontend/ReleaseDashboard/TestPopoutSelector.svelte
+++ b/frontend/ReleaseDashboard/TestPopoutSelector.svelte
@@ -18,15 +18,7 @@
     export let releaseName = "";
     let encodedState = "state=e30";
     $: encodedState = stateEncoder(
-        Object.values(tests).reduce((acc, val) => {
-            acc[`${releaseName}/${val.group}/${val.name}`] = {
-                test: val.name,
-                group: val.group,
-                release: releaseName,
-                build_system_id: val.build_system_id
-            };
-            return acc;
-        }, {})
+        Object.values(tests).map(v => v.id)
     );
 
     const dispatch = createEventDispatcher();

--- a/frontend/Stores/TestRunsSubscriber.js
+++ b/frontend/Stores/TestRunsSubscriber.js
@@ -13,7 +13,7 @@ export const polledRuns = writable({}, set => {
     return () => clearInterval(interval);
 });
 
-let runCollection = {};
+let runCollection = [];
 let fetching = false;
 runStore.subscribe((val) => {
     runCollection = val;
@@ -45,9 +45,13 @@ const pollTestRuns = function (set) {
     fetching = true;
     let params = new URLSearchParams({
         limit: 10,
-        runs: runCollection
-    })
-    fetch("/api/v1/test_runs/poll?" + params)
+    }).toString();
+    let runs = runCollection.map(val => {
+        let [buildId, additionalIds] = val;
+        let idsQs = additionalIds.map(val => `additionalRuns${buildId}[]=${val}`);
+        return [`runs[]=${buildId}`, ...idsQs].join("&");
+    }).join("&");
+    fetch("/api/v1/test_runs/poll?" + params + "&" + runs)
         .then((res) => {
             if (res.status == 200) {
                 return res.json();

--- a/frontend/Stores/WorkspaceStore.js
+++ b/frontend/Stores/WorkspaceStore.js
@@ -1,58 +1,16 @@
 import {
     readable
 } from "svelte/store";
-import { apiMethodCall } from "../Common/ApiUtils";
-
-const fetchReleases = async function (cb) {
-    let result = await apiMethodCall("/api/v1/releases", undefined, "GET");
-    if (result.status === "ok") {
-        cb(result.response);
-    }
-};
-
-const fetchGroups = async function (cb) {
-    let result = await apiMethodCall("/api/v1/groups", undefined, "GET");
-    if (result.status === "ok") {
-        cb(result.response);
-    }
-};
-
-const fetchTests = async function (cb) {
-    let result = await apiMethodCall("/api/v1/tests", undefined, "GET");
-    if (result.status === "ok") {
-        cb(result.response);
-    }
-};
-
 
 export const allReleases = readable(undefined, function (set) {
 
-    fetchReleases(set);
-
-    setInterval(
-        () => {
-            fetchReleases(set);
-        }, 120 * 1000
-    );
 });
 
 export const allGroups = readable(undefined, function (set) {
-    fetchGroups(set);
 
-    setInterval(
-        () => {
-            fetchGroups(set);
-        }, 120 * 1000
-    );
 });
 
 
 export const allTests = readable(undefined, function (set) {
-    fetchTests(set);
 
-    setInterval(
-        () => {
-            fetchTests(set);
-        }, 120 * 1000
-    );
 });

--- a/frontend/TestRun/TestRun.svelte
+++ b/frontend/TestRun/TestRun.svelte
@@ -38,6 +38,7 @@
     import Event from "./Event.svelte";
     export let id = "";
     export let build_number = -1;
+    export let testInfo = {};
     const dispatch = createEventDispatcher();
     let test_run = undefined;
     let heartbeatHuman = "";
@@ -105,21 +106,6 @@
         test_run = data[id] ?? test_run;
     });
 
-
-    const findRelease = function(releases) {
-        if (!releases) return;
-        return releases.find(release => release.id == test_run.release_id);
-    };
-
-    const findGroup = function(groups) {
-        if (!groups) return;
-        return groups.find(group => group.id == test_run.group_id);
-    };
-
-    const findTest = function(tests) {
-        if (!tests) return;
-        return tests.find(test => test.id == test_run.test_id);
-    };
     const findAssignee = function (test_run, userSelect) {
         const placeholder = {
             value: "unassigned",
@@ -329,7 +315,7 @@
     <div class="d-flex px-2 py-2 mb-1 border-bottom bg-white ">
         <div class="p-1">
             {#if test_run}
-                <a class="link-dark" href="/test_run/{id}">
+                <a class="link-dark" href="/test/{test_run.test_id}/runs?additionalRuns[]={test_run.id}">
                     {test_run.build_id}#{build_number}
                 </a>
             {/if}
@@ -564,7 +550,7 @@
                     id="nav-details-{id}"
                     role="tabpanel"
                 >
-                    <TestRunInfo {test_run} release={findRelease(releases)} group={findGroup(groups)} test={findTest(tests)}/>
+                    <TestRunInfo {test_run} release={testInfo.release} group={testInfo.group} test={testInfo.test}/>
                 </div>
                 <div
                     class="tab-pane fade"
@@ -670,11 +656,11 @@
                     role="tabpanel"
                 >
                     {#if commentsOpen}
-                        <TestRunComments {id} releaseName={findRelease(releases)?.name} assignee={test_run.assignee} starter={test_run.started_by}/>
+                        <TestRunComments {id} releaseName={testInfo.release.name} assignee={test_run.assignee} starter={test_run.started_by}/>
                     {/if}
                 </div>
                 <div class="tab-pane fade" id="nav-issues-{id}" role="tabpanel">
-                    <IssueTemplate {test_run} test={findTest(tests)} />
+                    <IssueTemplate {test_run} test={testInfo.test} />
                     {#if issuesOpen}
                         <GithubIssues {id} />
                     {/if}

--- a/frontend/WorkArea/Test.svelte
+++ b/frontend/WorkArea/Test.svelte
@@ -3,8 +3,6 @@
     import { StatusBackgroundCSSClassMap } from "../Common/TestStatus.js";
     import { timestampToISODate } from "../Common/DateUtils";
     import AssigneeList from "./AssigneeList.svelte";
-    export let release = "";
-    export let group = "";
     export let filtered = false;
     export let test = {
         assignee: [],
@@ -14,10 +12,10 @@
         name: "ERROR",
         pretty_name: null,
         release_id: null,
-        build_system_id: "",
+        id: "",
     };
     export let testStats;
-    export let runs = {};
+    export let runs = [];
     export let assigneeList = [];
     const dispatch = createEventDispatcher();
     let fetching = false;
@@ -28,18 +26,14 @@
 
 
     const handleTestClick = function (e) {
-        if (runs[`${release}/${group}/${test.name}`]) {
-            dispatch("testRunRemove", { runId: `${release}/${group}/${test.name}`});
+        if (runs.find(v => v == test.id)) {
+            dispatch("testRunRemove", { testId: test.id });
             return;
         }
         if (fetching) return;
         fetching = true;
         dispatch("testRunRequest", {
-            uuid: `${release}/${group}/${test.name}`,
-            key: test.build_system_id,
-            test: test.name,
-            group: group,
-            release: release
+            testId: test.id
         });
         fetching = false;
     };
@@ -47,8 +41,8 @@
 
 <li
     class:d-none={filtered}
-    class:active={runs[`${release}/${group}/${test.name}`]}
-    class:active-test-text={runs[`${release}/${group}/${test.name}`]}
+    class:active={runs.find(v => v == test.id)}
+    class:active-test-text={runs.find(v => v == test.id)}
     class="list-group-item argus-test"
     on:click={handleTestClick}
 >
@@ -72,8 +66,8 @@
                 </div>
                 {#if testStats?.start_time}
                 <div
-                    class:text-muted={!runs[`${release}/${test.name}`]}
-                    class:active-test-text-muted={runs[`${release}/${test.name}`]}
+                    class:text-muted={!runs.find(v => v == test.id)}
+                    class:active-test-text-muted={runs.find(v => v == test.id)}
                     style="font-size: 0.75em"
                 >
                     {timestampToISODate(testStats.start_time)}

--- a/frontend/WorkArea/TestRunsPanel.svelte
+++ b/frontend/WorkArea/TestRunsPanel.svelte
@@ -1,10 +1,10 @@
 <script>
     import { stateEncoder } from "../Common/StateManagement";
     import TestRuns from "./TestRuns.svelte";
-    export let test_runs = {};
+    export let testRuns = [];
     export let workAreaAttached = false;
     let serializedState = "";
-    $: serializedState = stateEncoder(test_runs);
+    $: serializedState = stateEncoder(testRuns);
     let filterStringRuns = "";
     const isFiltered = function(name = "", filterString = "") {
         if (filterString == "") {
@@ -14,17 +14,17 @@
     };
 </script>
 
-{#if Object.keys(test_runs).length > 0}
+{#if Object.keys(testRuns).length > 0}
 <div class="p-2 mb-1 text-end"><a href="/test_runs?{serializedState}" class="btn btn-secondary btn-sm">Share</a></div>
 <div class="p-2">
-    <input class="form-control" type="text" placeholder="Filter runs" bind:value={filterStringRuns} on:input={() => { test_runs = test_runs }}>
+    <input class="form-control" type="text" placeholder="Filter runs" bind:value={filterStringRuns} on:input={() => { testRuns = testRuns }}>
 </div>
 <div class="accordion mb-2" id="accordionTestRuns">
-    {#each Object.entries(test_runs).reverse() as [id, data] (id)}
+    {#each testRuns as testId (testId)}
         <TestRuns
-            {data}
+            {testId}
             parent="#accordionTestRuns"
-            filtered={isFiltered(data.test, filterStringRuns)}
+            filtered={isFiltered(testId, filterStringRuns)}
             removableRuns={workAreaAttached}
             on:testRunRemove
         />

--- a/frontend/WorkArea/TestRunsSelector.svelte
+++ b/frontend/WorkArea/TestRunsSelector.svelte
@@ -1,0 +1,68 @@
+<script>
+    import { createEventDispatcher, onMount } from "svelte";
+    import { StatusButtonCSSClassMap } from "../Common/TestStatus";
+
+    export let testInfo = {};
+    export let runs = [];
+    export let clickedTestRuns = {};
+
+    const dispatch = createEventDispatcher();
+    let sticky = false;
+    let header;
+
+    onMount(() => {
+        let observer = new IntersectionObserver((entries, observer) => {
+            let entry = entries[0];
+            if (!entry) return;
+            if (entry.intersectionRatio == 0 && !entry.isIntersecting) {
+                sticky = true;
+            } else {
+                sticky = false;
+            }
+        }, {
+            threshold: [0, 0.25, 0.5, 0.75, 1]
+        })
+        observer.observe(header);
+    });
+
+</script>
+
+<div class="h-small" bind:this={header}></div>
+<div class="p-2 mb-2 bg-main" class:sticky={sticky} class:border={sticky} class:shadow={sticky}>
+    {#if sticky}
+        <div class="mb-1 p-1">
+            {testInfo.test.name} ({testInfo.release.name}/{testInfo.group.name})
+        </div>
+    {/if}
+    {#each runs as run (run.id)}
+        <div class="me-2 d-inline-block">
+            <button
+                class:active={clickedTestRuns[run.id]}
+                class="btn {StatusButtonCSSClassMap[run.status]}"
+                type="button"
+                on:click={() => dispatch("runClick", { runId: run.id })}
+            >
+                #{run.build_number}
+            </button>
+        </div>
+    {/each}
+</div>
+
+<style>
+    .active::before {
+        font-family: "Noto Sans Packaged", "Noto Sans", sans-serif;
+        content: "● ";
+    }
+
+    .sticky {
+        position: sticky;
+        top: 12px;
+        z-index: 999;
+        margin: 1em;
+        border-radius: 4px;
+    }
+
+    .h-small {
+        height: 4px;
+    }
+</style>

--- a/frontend/test-runs-standalone.js
+++ b/frontend/test-runs-standalone.js
@@ -1,0 +1,9 @@
+import TestRuns from "./WorkArea/TestRuns.svelte";
+
+const app = new TestRuns({
+    target: document.querySelector("div#testRunBody"),
+    props: {
+        testId: gTestId,
+        additionalRuns: additionalRuns
+    }
+});

--- a/templates/profile_jobs.html.j2
+++ b/templates/profile_jobs.html.j2
@@ -14,7 +14,7 @@ My Jobs
 
 {% block body %}
 {% if g.user %}
-<div class="container" id="jobsContainer">
+<div class="container"  id="jobsContainer">
 
 </div>
 {% else %}

--- a/templates/standalone_test_with_runs.html.j2
+++ b/templates/standalone_test_with_runs.html.j2
@@ -1,0 +1,20 @@
+{% extends "base.html.j2" %}
+
+{% block title %}
+Test Run
+{% endblock %}
+
+{% block javascripts %}
+{{ super() }}
+<script>
+    const gTestId = "{{ test_id }}";
+    const additionalRuns = JSON.parse('{{ additional_runs | tojson | safe }}');
+</script>
+<script defer src="/s/dist/testRunsStandalone.bundle.js"></script>
+{% endblock javascripts %}
+
+{% block body %}
+<div class="container p-1" id="testRunBody">
+
+</div>
+{% endblock %}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,6 +38,10 @@ module.exports = {
             import: './frontend/test-run-details.js',
             dependOn: 'globalAlert'
         },
+        testRunsStandalone: {
+            import: './frontend/test-runs-standalone.js',
+            dependOn: 'globalAlert'
+        },
         testRuns: {
             import: './frontend/test-runs-breakout.js',
             dependOn: 'globalAlert'


### PR DESCRIPTION
This commit refactors TestRuns component to instead depend only on
provided testId, fetching remaining information from backend. In
addition, this reworks sidebar to instead do lazy fetches on user
clicks, instead of trying to load everything at once. This also adds
TestRuns selector onto the Single Run page and onto the My Jobs page.
In addition, My Jobs page has received a slight redesign, intended to
help readability and to make it consistent.

[Trello](https://trello.com/c/XVLQWW0a/4955-show-all-runs-in-my-jobs-page)