### PR TITLE
fix(ArgusNotification): Check capital letters in username regex

### DIFF
--- a/argus/backend/service/argus_service.py
+++ b/argus/backend/service/argus_service.py
@@ -235,7 +235,7 @@ class ArgusService:
         message_stripped = strip_html_tags(message)
 
         mentions = set(mentions)
-        for potential_mention in re.findall(r"@[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}", message_stripped):
+        for potential_mention in re.findall(r"@[A-Za-z\d](?:[A-Za-z\d]|-(?=[A-Za-z\d])){0,38}", message_stripped):
             if user := User.exists_by_name(potential_mention.lstrip("@")):
                 mentions.add(user)
 

--- a/frontend/Discussion/MarkedMentionExtension.js
+++ b/frontend/Discussion/MarkedMentionExtension.js
@@ -10,7 +10,7 @@ export const MarkdownUserMention = {
     },
 
     tokenizer(src, tokens) {
-        const rule = /^\s(@[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38})/;
+        const rule = /^\s(@[A-Za-z\d](?:[A-Za-z\d]|-(?=[A-Za-z\d])){0,38})/;
         const match = rule.exec(src);
         if (match) {
             const token = {
@@ -26,4 +26,4 @@ export const MarkdownUserMention = {
         let selfMention = token.text.includes(applicationCurrentUser.username) ? "user-mention-self" : "";
         return ` <span class="user-mention ${selfMention}">${token.text}</span>`;
     }
-}
+};


### PR DESCRIPTION
[Trello](https://trello.com/c/6PrnW1ut/5166-notifications-manager-ignores-users-with-capital-letters-in-the-name)