### PR TITLE
fix(TestRunComments.svelte): Do not fetch during editing

### DIFF
--- a/frontend/Discussion/Comment.svelte
+++ b/frontend/Discussion/Comment.svelte
@@ -14,12 +14,12 @@
     export let commentBody = {
         id: "",
         message: "",
-        release: releaseName,
+        release: "",
         reactions: {},
         mentions: [],
         user_id: "",
         release_id: "",
-        test_run_id: id,
+        test_run_id: "",
         posted_at: new Date(),
     };
 
@@ -91,7 +91,10 @@
                 <button
                     class="btn btn-light bg-editor"
                     title="Edit"
-                    on:click={() => (editing = true)}
+                    on:click={() => {
+                        editing = true;
+                        dispatch("commentEditing");
+                    }}
                 >
                     <Fa icon={faEdit} />
                 </button>

--- a/frontend/Discussion/CommentEditor.svelte
+++ b/frontend/Discussion/CommentEditor.svelte
@@ -137,28 +137,28 @@
     const editorHandleKeyDown = function (e) {
         if (!e.code) return;
         switch (e.code) {
-            case "Tab": {
-                performButtonAction("tab");
-                e.preventDefault();
-                break;
-            }
-            case "Enter": {
-                if (!e.ctrlKey) break;
-                e.preventDefault();
-                handleSubmitComment();
-                break;
-            }
+        case "Tab": {
+            performButtonAction("tab");
+            e.preventDefault();
+            break;
+        }
+        case "Enter": {
+            if (!e.ctrlKey) break;
+            e.preventDefault();
+            handleSubmitComment();
+            break;
+        }
         }
     };
 
     const editorBeforeInput = function (e) {
         switch (e.data) {
-            case "@": {
-                mentioning = true;
-                mentionKeyPressed = true;
-                e.preventDefault();
-                break;
-            }
+        case "@": {
+            mentioning = true;
+            mentionKeyPressed = true;
+            e.preventDefault();
+            break;
+        }
         }
     };
 

--- a/frontend/TestRun/TestRunComments.svelte
+++ b/frontend/TestRun/TestRunComments.svelte
@@ -8,6 +8,7 @@
     export let id;
     export let releaseName;
     let fetchIntervalId;
+    let suppressFetch = false;
     let comments = [];
     let users = {};
     let fetching = false;
@@ -87,6 +88,7 @@
 
     const handleCommentUpdate = async function (e) {
         let commentBody = e.detail;
+        suppressFetch = false;
         try {
             let apiResponse = await fetch("/api/v1/test_run/comments/update", {
                 method: "POST",
@@ -152,6 +154,7 @@
     onMount(() => {
         fetchComments();
         fetchIntervalId = setInterval(() => {
+            if (suppressFetch) return;
             fetchComments();
         }, 60 * 1000);
     });
@@ -171,6 +174,7 @@
                         {users}
                         on:commentDelete={handleCommentDelete}
                         on:commentUpdated={handleCommentUpdate}
+                        on:commentEditing={() => (suppressFetch = true)}
                     />
                 </div>
             </div>


### PR DESCRIPTION
This commit fixes an issue where comments collection would be refreshed
during editing, causing state to reset and edited data to be lost.

Fixes #142