### PR TITLE
fix(controller/auth.py): Configurable scopes and addition of repo scope

### DIFF
--- a/argus/backend/controller/auth.py
+++ b/argus/backend/controller/auth.py
@@ -44,7 +44,7 @@ def login():
     return render_template('auth/login.html.j2',
                            csrf_token=token,
                            github_cid=current_app.config.get("GITHUB_CLIENT_ID", "NO_CLIENT_ID"),
-                           github_scopes="user:email read:user read:org"
+                           github_scopes=current_app.config.get("GITHUB_SCOPES", "user:email read:user read:org repo")
                            )
 
 

--- a/argus_web.example.yaml
+++ b/argus_web.example.yaml
@@ -18,6 +18,8 @@ APP_LOG_LEVEL: INFO
 SECRET_KEY: MUSTBEUNIQUE
 # Client ID of a github oauth application
 GITHUB_CLIENT_ID: YOUR_GITHUB_CLIENT_ID
+# Scopes used for Github Application:
+# GITHUB_SCOPES: 'user:email read:user read:org repo'
 # Client secret of a github oauth application
 GITHUB_CLIENT_SECRET: YOUR_GITHUB_CLIENT_SECRET
 # Github personal access token


### PR DESCRIPTION
This fixes an issue where private repositiories' issues could not be
read due to missing 'repo' scope. This commit also adds a config
property to override default github scopes\

Fixes #110 

[Trello](https://trello.com/c/ArkIaxcr/4980-argus-failing-to-get-state-of-enterprise-issues)