### PR TITLE
feature(TestRunsSelector.svelte): Show close button for open cards

### DIFF
--- a/frontend/WorkArea/TestRuns.svelte
+++ b/frontend/WorkArea/TestRuns.svelte
@@ -118,7 +118,13 @@
             <div class="text-muted text-center m-3"><span class="spinner-border spinner-border-sm"></span> Loading...</div>
         {:then runs}
             <div class="p-2" bind:this={runsBody}>
-                <TestRunsSelector {runs} {testInfo} bind:clickedTestRuns={clickedTestRuns} on:runClick={handleTestRunClick} />
+                <TestRunsSelector
+                    {runs}
+                    {testInfo}
+                    bind:clickedTestRuns={clickedTestRuns}
+                    on:runClick={handleTestRunClick}
+                    on:closeRun={handleTestRunClose}
+                />
                 {#each runs as run (run.id)}
                     <div class:show={clickedTestRuns[run.id]} class="collapse mb-2" id="collapse{run.id}">
                         <div class="container-fluid p-0 bg-light">

--- a/frontend/WorkArea/TestRunsSelector.svelte
+++ b/frontend/WorkArea/TestRunsSelector.svelte
@@ -1,5 +1,7 @@
 <script>
     import { createEventDispatcher, onMount } from "svelte";
+    import Fa from "svelte-fa";
+    import { faTimes } from "@fortawesome/free-solid-svg-icons";
     import { extractBuildNumber } from "../Common/RunUtils";
     import { StatusButtonCSSClassMap } from "../Common/TestStatus";
 
@@ -37,19 +39,35 @@
     {/if}
     {#each runs as run (run.id)}
         <div class="me-2 d-inline-block">
-            <button
-                class:active={clickedTestRuns[run.id]}
-                class="btn {StatusButtonCSSClassMap[run.status]}"
-                type="button"
-                on:click={() => dispatch("runClick", { runId: run.id })}
-            >
-                #{extractBuildNumber(run)}
-            </button>
+            <div class="btn-group">
+                <button
+                    class:active={clickedTestRuns[run.id]}
+                    class="btn {StatusButtonCSSClassMap[run.status]}"
+                    type="button"
+                    on:click={() => dispatch("runClick", { runId: run.id })}
+                >
+                    #{extractBuildNumber(run)}
+                </button>
+                {#if clickedTestRuns[run.id]}
+                    <button
+                        class="btn border-start-dark {StatusButtonCSSClassMap[run.status]}"
+                        data-run-id={run.id}
+                        on:click={() => {
+                            dispatch("closeRun", { id: run.id });
+                        }}
+                    >
+                        <Fa icon={faTimes} />
+                    </button>
+                {/if}
+            </div>
         </div>
     {/each}
 </div>
 
 <style>
+    .border-start-dark {
+        border-left: 1px solid rgb(81, 81, 81);
+    }
     .active::before {
         font-family: "Noto Sans Packaged", "Noto Sans", sans-serif;
         content: "● ";


### PR DESCRIPTION
This adds a close buttons to the selector pills, allowing quicker
closing of opened runs.

Task: scylladb/qa-tasks#780