### PR TITLE
feature(issue_template): add relocatable pkg to issue template

### DIFF
--- a/frontend/Common/RunUtils.js
+++ b/frontend/Common/RunUtils.js
@@ -13,3 +13,8 @@ export const getUpgradedScyllaPackage = function(packages) {
 export const extractBuildNumber = function (run) {
     return run.build_job_url.trim().split("/").reverse()[1];
 };
+
+export const getRelocatableScyllaPackage = function(packages) {
+    // relocatable package: https://docs.scylladb.com/stable/getting-started/install-scylla/unified-installer.html
+    return packages.find((pkg) => pkg.name == "relocatable_pkg");
+};

--- a/frontend/TestRun/IssueTemplate.svelte
+++ b/frontend/TestRun/IssueTemplate.svelte
@@ -5,7 +5,7 @@
     import { faCopy } from "@fortawesome/free-solid-svg-icons";
     import { parse } from "marked";
     import { onMount } from "svelte";
-    import { getScyllaPackage, getKernelPackage } from "../Common/RunUtils";
+    import { getScyllaPackage, getKernelPackage, getRelocatableScyllaPackage } from "../Common/RunUtils";
     import { markdownRendererOptions } from "../markdownOptions";
     let renderedElement;
     let templateElement;
@@ -23,8 +23,10 @@
 
     let scyllaServerPackage = getScyllaPackage(test_run.packages);
     let kernelPackage = getKernelPackage(test_run.packages);
+    let relocatablePackage = getRelocatableScyllaPackage(test_run.packages);
     $: scyllaServerPackage = getScyllaPackage(test_run.packages);
     $: kernelPackage = getKernelPackage(test_run.packages);
+    $: relocatablePackage = getRelocatableScyllaPackage(test_run.packages);
 
     onMount(() => {
         renderedElement.innerHTML = parse(templateElement.innerHTML, markdownRendererOptions);
@@ -114,6 +116,9 @@ Kernel Version: {kernelPackage.version}
 {/if}
 {#if scyllaServerPackage}
 Scylla version (or git commit hash): `{scyllaServerPackage.version}-{scyllaServerPackage.date}.{scyllaServerPackage.revision_id}` with build-id `{scyllaServerPackage.build_id}`
+{/if}
+{#if relocatablePackage}
+Relocatable Package: {relocatablePackage.version}
 {/if}
 Cluster size: {test_run.cloud_setup.db_node.node_amount} nodes ({test_run.cloud_setup.db_node.instance_type})
 


### PR DESCRIPTION
This commit adds info about relocatable package to issue template. It gets this info from `Packages` in `test_runs` table.

implements: https://github.com/scylladb/argus/issues/120