### PR TITLE
fix(frontend): Increase polling times for stat and testrun refreshes

### DIFF
--- a/argus/backend/controller/api.py
+++ b/argus/backend/controller/api.py
@@ -454,7 +454,7 @@ def release_stats_v2():
         "status": "ok",
         "response": stats
     })
-    res.cache_control.max_age = 60
+    res.cache_control.max_age = 300
     return res
 
 

--- a/frontend/ReleaseDashboard/TestDashboard.svelte
+++ b/frontend/ReleaseDashboard/TestDashboard.svelte
@@ -167,10 +167,10 @@
 
     onMount(() => {
         fetchStats();
-
+        let refreshInterval = 300 + 15 + Math.round((Math.random() * 10));
         statRefreshInterval = setInterval(() => {
             fetchStats();
-        }, 30 * 1000);
+        }, refreshInterval * 1000);
     });
 
     onDestroy(() => {

--- a/frontend/Stats/ReleaseStats.svelte
+++ b/frontend/Stats/ReleaseStats.svelte
@@ -44,10 +44,10 @@
 
     onMount(() => {
         fetchStats();
-
+        let refreshInterval = 300 + 15 + Math.round((Math.random() * 10));
         statRefreshInterval = setInterval(() => {
             fetchStats();
-        }, 30 * 1000);
+        }, refreshInterval * 1000);
     });
 
     onDestroy(() => {

--- a/frontend/Stores/SingleTestRunSubscriber.js
+++ b/frontend/Stores/SingleTestRunSubscriber.js
@@ -5,7 +5,7 @@ export const polledTestRuns = readable({}, set => {
 
     const interval = setInterval(() => {
         pollTestRun(set);
-    }, 20 * 1000);
+    }, 120 * 1000);
 
     return () => clearInterval(interval);
 });

--- a/frontend/Stores/TestRunsSubscriber.js
+++ b/frontend/Stores/TestRunsSubscriber.js
@@ -8,7 +8,7 @@ export const polledRuns = writable({}, set => {
 
     const interval = setInterval(() => {
         pollTestRuns(set);
-    }, 20 * 1000);
+    }, 120 * 1000);
 
     return () => clearInterval(interval);
 });

--- a/frontend/WorkArea/RunRelease.svelte
+++ b/frontend/WorkArea/RunRelease.svelte
@@ -80,9 +80,10 @@
     };
 
     onMount(() => {
+        let refreshInterval = 600 + 15 + Math.round((Math.random() * 10));
         releaseStatsRefreshInterval = setInterval(() => {
             fetchStats();
-        }, 60 * 1000);
+        }, refreshInterval * 1000);
     });
 
     onDestroy(() => {


### PR DESCRIPTION
This should alleviate the load on the particularly heavy requests such as stats and remove needless refreshing on the workspace page.