### PR TITLE
fix(service/stats.py): Sort last runs by timestamp and build_number

### DIFF
--- a/argus/backend/service/argus_service.py
+++ b/argus/backend/service/argus_service.py
@@ -180,7 +180,7 @@ class ArgusService:
             except ValueError:
                 setattr(row, "build_number", -1)
 
-        return rows
+        return sorted(rows, reverse=True, key=lambda r: r.build_number)
 
     def poll_test_runs_single(self, runs: list[UUID]):
         rows: list[SCTTestRun] = []

--- a/argus/backend/service/stats.py
+++ b/argus/backend/service/stats.py
@@ -218,7 +218,9 @@ class TestStats:
 
     def collect(self, limited=False):
 
-        last_runs = [r for r in self.parent_group.parent_release.rows if r["build_id"] == self.test.build_system_id]
+        # TODO: Parametrize run limit
+        # FIXME: This is only a mitigation, build_number overflows on the build system side.
+        last_runs = [r for r in self.parent_group.parent_release.rows if r["build_id"] == self.test.build_system_id][:15]
         last_runs: list[TestRunStatRow] = sorted(
             last_runs, reverse=True, key=lambda r: get_build_number(r["build_job_url"]))
         try:


### PR DESCRIPTION
Mitigates an issue where build numbers overflow and start from beginning leading to stats reporting ancient runs instead of new ones.