### PR TITLE
feature(sct plugin): Kernels by Scylla Version API Endpoint

### DIFF
--- a/argus/backend/plugins/sct/controller.py
+++ b/argus/backend/plugins/sct/controller.py
@@ -95,3 +95,13 @@ def sct_events_submit(run_id: str):
         "status": "ok",
         "response": result
     }
+
+
+@bp.route("/release/<string:release_name>/kernels", methods=["GET"])
+@api_login_required
+def sct_get_kernel_report(release_name: str):
+    result = SCTService.get_scylla_version_kernels_report(release_name=release_name)
+    return {
+        "status": "ok",
+        "response": result
+    }

--- a/argus/backend/plugins/sct/service.py
+++ b/argus/backend/plugins/sct/service.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 import logging
 from time import time
+from argus.backend.models.web import ArgusRelease
 from argus.backend.plugins.sct.testrun import SCTTestRun
 from argus.backend.plugins.sct.udt import (
     CloudInstanceDetails,
@@ -180,3 +181,38 @@ class SCTService:
             raise SCTServiceException("Run not found", run_id) from exception
 
         return "added"
+
+    @staticmethod
+    def get_scylla_version_kernels_report(release_name: str):
+        release = ArgusRelease.get(name=release_name)
+        all_release_runs = SCTTestRun.filter(release_id=release.id).all()
+        kernels_by_version = {}
+        kernel_metadata = {}
+        for run in all_release_runs:
+            scylla_pkgs = {p.name: p for p in run.packages if "scylla-server" in p.name}
+            scylla_pkg = scylla_pkgs["scylla-server-upgraded"] if scylla_pkgs.get(
+                "scylla-server-upgraded") else scylla_pkgs.get("scylla-server")
+            version = f"{scylla_pkg.version}-{scylla_pkg.date}.{scylla_pkg.revision_id}" if scylla_pkgs else "unknown"
+            kernel_packages = [p for p in run.packages if "kernel" in p.name]
+            kernel_package = kernel_packages[0] if len(kernel_packages) > 0 else None
+            if not kernel_package:
+                continue
+            version_list = set(kernels_by_version.get(version, []))
+            version_list.add(kernel_package.version)
+            kernels_by_version[version] = list(version_list)
+            metadata = kernel_metadata.get(
+                kernel_package.version,
+                {
+                    "passed": 0,
+                    "failed": 0,
+                    "aborted": 0,
+                }
+            )
+            if run.status in ["passed", "failed", "aborted"]:
+                metadata[run.status] += 1
+            kernel_metadata[kernel_package.version] = metadata
+
+        return {
+            "versions": kernels_by_version,
+            "metadata": kernel_metadata
+        }


### PR DESCRIPTION
Per @tarzanek request this adds an endpoint that contains kernels used during runs in SCT. The report JSON contains kernels used for each version, and in a separate object, for each kernel, quick stats for it - passes, failures, aborts.