### PR TITLE
feature(scripts): Stuck runs remover

### DIFF
--- a/argus/backend/controller/testrun_api.py
+++ b/argus/backend/controller/testrun_api.py
@@ -257,3 +257,15 @@ def test_run_delete_comment(test_id: str, run_id: str, comment_id: str):
         "status": "ok",
         "response": result
     }
+
+
+@bp.route("/terminate_stuck_runs", methods=["POST"])
+@api_login_required
+def sct_terminate_stuck_runs():
+    result = TestRunService().terminate_stuck_runs()
+    return {
+        "status": "ok",
+        "response": {
+            "total": result
+        }
+    }


### PR DESCRIPTION
This change adds an endpoint to the TestRun API allowing a periodic cleanup
of "stuck", i.e. runs that have not had their heartbeat updated for more than
45 minutes. The endpoint call will set them as "ABORTED" in such case.

Task: scylladb/qa-tasks#940
