### PR TITLE
improvement(TestRuns.svelte): Allow any user to to select test type

### DIFF
--- a/argus/backend/controller/api.py
+++ b/argus/backend/controller/api.py
@@ -332,8 +332,6 @@ def set_test_plugin(test_id: str):
     payload = get_payload(request)
 
     current_user: User = g.user
-    if not current_user.is_admin():
-        raise Exception("Cannot set plugin as a non-administrator")
     test: ArgusTest = ArgusTest.get(id=UUID(test_id))
     test.plugin_name = payload["plugin_name"]
     test.save()

--- a/frontend/WorkArea/TestRuns.svelte
+++ b/frontend/WorkArea/TestRuns.svelte
@@ -150,7 +150,6 @@
                     <div class="rounded shadow-sm bg-white p-2 text-center">
                         <span class="fw-bold">Unsupported plugin</span> <span class="d-inline-block text-danger bg-light-one rounded p-1">{testInfo.test.plugin_name ? testInfo.test.plugin_name : "#empty-test-name"}</span>
                     </div>
-                    {#if currentUser.roles.indexOf("ROLE_ADMIN") != -1}
                         <div>
                             {#if !pluginFixed}
                                 <div class="p-2 alert alert-warning my-2">This looks like a newly added test and it will need to have its plugin name specified. If you know which plugin this test should use, select it from the list below and click save.</div>
@@ -173,7 +172,6 @@
                                 </div>
                             {/if}
                         </div>
-                    {/if}
                 {/if}
                 <TestRunsSelector
                     {runs}


### PR DESCRIPTION
This change will allow any user to select a plugin (test) type for a test entity


Task: scylladb/qa-tasks#1050
