### PR TITLE
improvement(ReleaseDashboard.svelte): Store product version in the qs

### DIFF
--- a/frontend/ReleaseDashboard/ReleaseDashboard.svelte
+++ b/frontend/ReleaseDashboard/ReleaseDashboard.svelte
@@ -1,4 +1,5 @@
 <script>
+    import queryString from "query-string";
     import ReleaseStats from "../Stats/ReleaseStats.svelte";
     import ReleaseActivity from "./ReleaseActivity.svelte";
     import GithubIssues from "../Github/GithubIssues.svelte";
@@ -7,7 +8,7 @@
     import TestDashboard from "./TestDashboard.svelte";
     export let releaseData = {};
     let clickedTests = {};
-    let productVersion = "";
+    let productVersion = queryString.parse(document.location.search)?.productVersion;
 
     const handleTestClick = function (e) {
         console.log(e);

--- a/frontend/ReleaseDashboard/TestDashboard.svelte
+++ b/frontend/ReleaseDashboard/TestDashboard.svelte
@@ -1,5 +1,6 @@
 <script>
     import { createEventDispatcher, onDestroy, onMount } from "svelte";
+    import queryString from "query-string";
     import Fa from "svelte-fa";
     import {
         faSearch,
@@ -64,7 +65,7 @@
 
 
     const fetchStats = async function () {
-        let params = new URLSearchParams({
+        let params = queryString.stringify({
             release: releaseName,
             limited: new Number(false),
             force: new Number(true),
@@ -103,6 +104,9 @@
 
     const handleVersionClick = function(versionString) {
         productVersion = versionString;
+        let params = queryString.parse(document.location.search);
+        params.productVersion = versionString;
+        history.pushState(undefined, "", `?${queryString.stringify(params, { arrayFormat: "bracket" })}`);
         fetchStats();
         dispatch("versionChange", { version: productVersion });
     };
@@ -142,7 +146,7 @@
     };
 
     const fetchGroupAssignees = async function(releaseId) {
-        let params = new URLSearchParams({
+        let params = queryString.stringify({
             releaseId: releaseId,
         });
         let result = await apiMethodCall("/api/v1/release/assignees/groups?" + params, undefined, "GET");
@@ -152,7 +156,7 @@
     };
 
     const fetchTestAssignees = async function(groupId) {
-        let params = new URLSearchParams({
+        let params = queryString.stringify({
             groupId: groupId,
         });
         let result = await apiMethodCall("/api/v1/release/assignees/tests?" + params, undefined, "GET");


### PR DESCRIPTION
This improvement adds a way for a user to save/share a specific version
of the release dashboard. By clicking on the version button, the version
is saved into the url, allowing the selection to persist between
refreshes and different sessions.

Closes #205

Must be merged after #215
