### PR TITLE
feature(EventsTab.svelte): Structured events and event parsing

### DIFF
--- a/frontend/TestRun/Event.svelte
+++ b/frontend/TestRun/Event.svelte
@@ -1,7 +1,0 @@
-<script>
-    export let eventText;
-</script>
-
-<pre class="mb-1 p-1 border font-monospace">
-{eventText.trim()}
-</pre>

--- a/frontend/TestRun/EventsTab.svelte
+++ b/frontend/TestRun/EventsTab.svelte
@@ -1,42 +1,162 @@
 <script>
-    import Event from "./Event.svelte";
+    import { onMount } from "svelte";
+    import RawEvent from "./RawEvent.svelte";
+    import StructuredEvent from "./StructuredEvent.svelte";
     export let testRun;
+
+    let parsedEvents = [];
+    let filterString = "";
+
+    const displayCategories = {
+        CRITICAL: true,
+        ERROR: true,
+        WARNING: false,
+        NORMAL: false,
+        DEBUG: false,
+    };
+
+    /* OH GDO */
+    const eventRegex = /(?<eventTimestamp>\d{2,4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3})( <(?<receiveTimestamp>\d{2,4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3})>)?: \((?<eventType>\w+) Severity\.(?<severity>[A-Z]+)\) (?<rawFields>.+)\n?/s;
+
+    /**
+     * @param {string} rawFields
+     */
+    const parseEventFields = function (rawFields) {
+        let pos = 0;
+        let currentChar;
+        let splitPoints = [pos];
+        let potentialSplit = false;
+        let potentialSplitPos = 0;
+        while (currentChar = rawFields.at(pos++)) { // eslint-disable-line
+            if (currentChar == " ") {
+                potentialSplit = true;
+                potentialSplitPos = pos;
+            } else if (potentialSplit && currentChar == "=") {
+                splitPoints.push(potentialSplitPos);
+                potentialSplit = false;
+                potentialSplitPos = -1;
+            }
+        }
+
+        let parsed = splitPoints.reduce((acc, value, idx, src) => {
+            let field = rawFields.slice(value, src[idx + 1]);
+            let [fieldKey, fieldVal] = field.split("=", 2);
+            if (!fieldKey || !fieldVal) return acc;
+            acc[fieldKey.trim()] = fieldVal.trim().replace(/[:,]$/, "");
+            return acc;
+        }, {});
+
+        return parsed;
+    };
+
+    /**
+     * @param {string} event
+    */
+    const parseEvent = function (event) {
+        let eventMetaIndex = event.match(/\n/)?.index;
+        const eventMeta = event.slice(0, eventMetaIndex);
+        const logLine = event.slice(eventMetaIndex);
+        const match = eventRegex.exec(eventMeta);
+        if (!match) throw new Error("Unable to parse the event");
+        let parsedEvent = Object.assign({}, match.groups);
+        let parsedFields = parseEventFields(parsedEvent.rawFields.trim());
+
+        parsedEvent.fields = parsedFields;
+        parsedEvent.logLine = logLine.trim();
+        parsedEvent.time = new Date(Date.parse(parsedEvent?.eventTimestamp ?? "1970-01-01" + " UTC"));
+        parsedEvent.parsed = true;
+        parsedEvent.eventText = event;
+
+        return parsedEvent;
+    };
+
+    /**
+     * @param {{last_events: string[]}[]} events
+     */
+    const prepareEvents = function (events) {
+        let flatEvents = events.reduce((acc, val) => {
+            return [...acc, ...val.last_events];
+        }, []);
+
+        let parsedEvents = flatEvents.map((val) => {
+            let parsed = {};
+            try {
+                parsed = parseEvent(val);
+            } catch (error) {
+                parsed = {
+                    time: new Date(0),
+                    parsed: false,
+                    text: val,
+                    error: error.message
+                };
+            }
+            return parsed;
+        });
+
+        return parsedEvents.sort((a, b) => b.time - a.time);
+    };
+
+    onMount(() => {
+        parsedEvents = prepareEvents(testRun?.events ?? []);
+    });
 </script>
 
-<div class="accordion accordion-flush" id="accordionEvents">
-    {#each testRun.events as event_container}
-        <div class="accordion-item">
-            <h2
-                class="accordion-header"
-                id="accordionHeadingEvents{event_container.severity}-{testRun.id}"
-            >
-                <button
-                    class="accordion-button collapsed"
-                    type="button"
-                    data-bs-toggle="collapse"
-                    data-bs-target="#accordionBodyEvents{event_container.severity}-{testRun.id}"
-                >
-                    {event_container.severity.toUpperCase()}
-                    ({event_container.event_amount})
-                </button>
-            </h2>
-            <div
-                id="accordionBodyEvents{event_container.severity}-{testRun.id}"
-                class="accordion-collapse collapse"
-                data-bs-parent="#accordionEvents"
-            >
-                <div class="accordion-body">
-                    {#each event_container.last_events as event}
-                        <Event eventText={event} />
-                    {/each}
+{#if parsedEvents.length > 0}
+    <div class="p-2 event-container">
+        <div class="d-flex justify-content-end mb-2 rounded bg-light p-1">
+            {#each Object.keys(displayCategories) as category}
+                <!-- svelte-ignore a11y-label-has-associated-control -->
+                <div class="ms-2 p-1 rounded border severity-{category.toLowerCase()}">
+                    <input class="form-check-input me-1" type="checkbox" bind:checked={displayCategories[category]}>
+                    <label class="form-check-label">{category}</label>
                 </div>
-            </div>
+            {/each}
         </div>
-    {:else}
-        <div class="row">
-            <div class="col text-center p-1 text-muted">
-                No events submitted yet.
-            </div>
+        <div class="p-2">
+            <input
+                class="form-control"
+                type="text"
+                placeholder="Filter events"
+                bind:value={filterString}
+            />
         </div>
-    {/each}
-</div>
+        {#each parsedEvents as event}
+            {#if event.parsed}
+                <StructuredEvent bind:filterString={filterString} display={displayCategories[event.severity] ?? true} {event} />
+            {:else}
+                <RawEvent eventText={event.text} errorMessage={event.error} />
+            {/if}
+        {/each}
+    </div>
+{:else}
+    <div class="text-center p-1 text-muted">
+            No events submitted yet.
+    </div>
+{/if}
+
+<style>
+
+    .event-container {
+        max-height: 768px;
+        overflow-y: scroll;
+    }
+
+    .severity-warning {
+        background-color: #ffc830;
+    }
+    .severity-normal {
+        background-color: #33b4e7;
+    }
+    .severity-debug {
+        background-color: #7e6262;
+    }
+    .severity-info {
+        background-color: #bdbdbd;
+    }
+    .severity-error {
+        background-color: #e91f1f;
+    }
+    .severity-critical {
+        background-color: #ff033a;
+    }
+</style>

--- a/frontend/TestRun/RawEvent.svelte
+++ b/frontend/TestRun/RawEvent.svelte
@@ -1,0 +1,13 @@
+<script>
+
+    export let eventText;
+    export let errorMessage;
+
+</script>
+
+<div class="mb-1 p-1 shadow rounded bg-white font-monospace">
+    {#if errorMessage}
+        <div>{errorMessage}</div>
+    {/if}
+    <pre>{eventText.trim()}</pre>
+</div>

--- a/frontend/TestRun/StructuredEvent.svelte
+++ b/frontend/TestRun/StructuredEvent.svelte
@@ -1,0 +1,93 @@
+<script>
+    export let event;
+    export let display = true;
+    export let filterString = "";
+
+    let displayShortPeriodBlock = true;
+
+    const shouldFilter = function (filterString) {
+        if (!filterString) return;
+        try {
+            return !(new RegExp(filterString.toLowerCase()).test((event.logLine.toLowerCase() ?? "")));
+        } catch {
+            return false;
+        }
+    };
+
+</script>
+
+
+<div
+    class:d-none={!display || shouldFilter(filterString)}
+    class="mb-2 p-2 shadow rounded bg-white font-monospace"
+>
+    <div class="event-header d-flex justify-content-end flex-wrap">
+        <div class="ms-2 mb-2 bg-dark text-light rounded px-2">{event.eventType}</div>
+        <div class="ms-2 mb-2 me-auto rounded px-2 severity-{event.severity.toLowerCase()}">{event.severity}</div>
+        <div class="w-100"></div>
+        {#if !["one-time", "not-set"].includes(event.fields.period_type)}
+            {#if !displayShortPeriodBlock}
+                <div
+                    role="button"
+                    class="ms-2 mb-2 rounded px-2 bg-light-two"
+                    title="Period type"
+                    on:click={() => (displayShortPeriodBlock = !displayShortPeriodBlock)}
+                >
+                    <div>Event period type: {event.fields.period_type}</div>
+                    {#if event.fields.start}
+                        <div>Start: {event.fields.start}</div>
+                    {/if}
+                    {#if event.fields.end}
+                        <div>End: {event.fields.end}</div>
+                        <div>Duration: {event.fields.duration}</div>
+                    {/if}
+                </div>
+            {:else}
+                <div
+                    role="button"
+                    class="ms-2 mb-2 rounded px-2 bg-light-two"
+                    title="Period type"
+                    on:click={() => (displayShortPeriodBlock = !displayShortPeriodBlock)}
+                >
+                    <div>{event.fields.period_type}</div>
+                </div>
+            {/if}
+        {/if}
+        <div class="w-100"></div>
+        <div class="ms-2 mb-2 rounded px-2 bg-light-two" title="Timestamp">{event.eventTimestamp}</div>
+        {#if event.receiveTimestamp}
+            <div class="ms-2 mb-2 rounded px-2 bg-warning" title="Timestamp">Received: {event.receiveTimestamp}</div>
+        {/if}
+
+        {#if event.fields.node}
+            <div class="w-100"></div>
+            <div class="ms-2 rounded px-2 bg-info fs-6 justify-self-start">{event.fields.node}</div>
+        {/if}
+    </div>
+    <pre class="bg-light-one rounded m-2 p-2 log-line">{event?.message ?? ""}{event.logLine}</pre>
+</div>
+
+<style>
+    .log-line {
+        white-space: pre-wrap
+    }
+
+    .severity-warning {
+        background-color: #ffc830;
+    }
+    .severity-normal {
+        background-color: #33b4e7;
+    }
+    .severity-debug {
+        background-color: #7e6262;
+    }
+    .severity-info {
+        background-color: #bdbdbd;
+    }
+    .severity-error {
+        background-color: #e91f1f;
+    }
+    .severity-critical {
+        background-color: #ff033a;
+    }
+</style>

--- a/frontend/TestRun/TestRun.svelte
+++ b/frontend/TestRun/TestRun.svelte
@@ -27,6 +27,7 @@
     let testRun = undefined;
     let runRefreshInterval;
     let activityOpen = false;
+    let eventsOpen = false;
     let commentsOpen = false;
     let issuesOpen = false;
     let artifactTabOpened = false;
@@ -145,6 +146,7 @@
                         data-bs-target="#nav-events-{runId}"
                         type="button"
                         role="tab"
+                        on:click={() => (eventsOpen = true)}
                         ><i class="fas fa-rss-square" /> Events</button
                     >
                     <button
@@ -226,7 +228,9 @@
                     </div>
                 </div>
                 <div class="tab-pane fade" id="nav-events-{runId}" role="tabpanel">
-                    <EventsTab {testRun} />
+                    {#if eventsOpen}
+                        <EventsTab {testRun} />
+                    {/if}
                 </div>
                 <div
                     class="tab-pane fade"


### PR DESCRIPTION
This commits adds a rudimentary parser for the current text events
inside test run entities. The window is changed to allow better
organization - the events are now sorted by time on a single timeline
and can be individually hidden (by default, only Error and Critical
events are shown). The events can also be filtered by a substring inside
the displayed event message.

Demo:

https://user-images.githubusercontent.com/7761415/226166706-c6e66a4a-690c-4467-b811-91daa40f7d64.mp4




