### PR TITLE
fix(argus): Add migration scripts required for cluster upgrade

### DIFF
--- a/argus/backend/plugins/sct/testrun.py
+++ b/argus/backend/plugins/sct/testrun.py
@@ -45,7 +45,7 @@ class SCTTestRunSubmissionRequest():
 
 
 class SCTTestRun(PluginModelBase):
-    __table_name__ = "test_runs_v8"
+    __table_name__ = "sct_test_run"
     _plugin_name = "scylla-cluster-tests"
 
     # Test Details

--- a/scripts/migration/migration_2023-04-07.py
+++ b/scripts/migration/migration_2023-04-07.py
@@ -1,0 +1,40 @@
+import logging
+from cassandra.cqlengine.management import sync_table
+
+from argus.backend.db import ScyllaCluster
+from argus.backend.util.logsetup import setup_application_logging
+from argus.backend.plugins.sct.testrun import SCTTestRun
+
+setup_application_logging()
+LOGGER = logging.getLogger(__name__)
+
+def up():
+    db = ScyllaCluster.get()
+    db.session.default_timeout = 3600
+    old_table_name = "test_runs_v8"
+    new_table_name = SCTTestRun.__table_name__
+    sync_table(SCTTestRun)
+
+    all_ids = [row["id"] for row in list(db.session.execute(f"SELECT id FROM {old_table_name}").all())]
+    total_ids = len(all_ids)
+
+    broken_runs = []
+    for idx, run_id in enumerate(all_ids):
+        LOGGER.info("[%s/%s] Migrating %s...", idx + 1, total_ids, run_id)
+        SCTTestRun._table_name = old_table_name
+        run: SCTTestRun = SCTTestRun.get(id=run_id)
+        if not run.build_id:
+            broken_runs.append(run_id)
+            LOGGER.warning("Broken run: %s", run_id)
+        run._is_persisted = False
+        SCTTestRun._table_name = new_table_name
+        run.save()
+
+    LOGGER.warning("Broken runs: %s (missing build_id PK)", broken_runs)
+    new_ids = [row["id"] for row in list(db.session.execute(f"SELECT id FROM {new_table_name}").all())]
+    total_new_ids = len(new_ids)
+    if total_ids - total_new_ids - len(broken_runs) != 0:
+        LOGGER.critical("Mismatch detected when comparing updated tables, %s != %s", total_ids, total_new_ids + len(broken_runs))
+
+if __name__ == "__main__":
+    up()


### PR DESCRIPTION
The migration script included in this commit will migrate all runs from
old test_runs_v8 table to the new one, ignoring any that have an empty
string primary key.

The commit also updates the backend table name to the new one.

Task: scylladb/qa-tasks#1043

Details about planned migration:

To facilitate argus cluster upgrade to 2022.2 we need to fix a repair problem currently affecting the cluster - some of the rows contain empty string primary key, preventing repair from fully completing. The idea of this migration is to just create a new table and move every run there. Planned window for it is on April 12th evening, which should provide a window to do the changeover  without affecting many (if any) runs currently in progress).
