### PR TITLE
fix(GithubIssue.svelte): Correct route for test runs

### DIFF
--- a/frontend/Github/GithubIssue.svelte
+++ b/frontend/Github/GithubIssue.svelte
@@ -209,7 +209,7 @@
                     <div class="d-flex justify-content-end">
                         <div class="ms-1">Runs:</div>
                         {#each issue.runs as run, idx}
-                            <a class="ms-1" href="/test_run/{run}">[{idx + 1}]</a>
+                            <a class="ms-1" href="/test/{issue.test_id}/runs?additionalRuns[]={run}">[{idx + 1}]</a>
                         {/each}
                     </div>
                 {/if}


### PR DESCRIPTION
This fix corrects an issue where a test run link on an aggregated issue
would use the old test_run endpoint, which has been deprecated and no
longer works as runs endpoint now requires a valid test_id in addition
to run_id.
