### PR TITLE
GithubIssue and TestRunService fixes

### DIFF
--- a/argus/backend/plugins/core.py
+++ b/argus/backend/plugins/core.py
@@ -134,8 +134,8 @@ class PluginModelBase(Model):
     @classmethod
     def get_run_meta_by_run_id(cls, run_id: UUID | str):
         cluster = ScyllaCluster.get()
-        query = ("SELECT id, test_id, group_id, release_id, status, start_time, build_job_url, build_id, "
-                 f"assignee, end_time, investigation_status, heartbeat FROM {cls.table_name()} WHERE id = ?")
+        query = cluster.prepare("SELECT id, test_id, group_id, release_id, status, start_time, build_job_url, build_id, "
+                                f"assignee, end_time, investigation_status, heartbeat FROM {cls.table_name()} WHERE id = ?")
         rows = cluster.session.execute(query=query, parameters=(run_id,))
 
         return list(rows)

--- a/argus/backend/service/testrun.py
+++ b/argus/backend/service/testrun.py
@@ -72,7 +72,7 @@ class TestRunService:
         last_runs_ids = [run["id"] for run in last_runs]
         for added_run in additional_runs:
             if added_run not in last_runs_ids:
-                last_runs.append(plugin.model.get_run_meta_by_run_id(run_id=added_run))
+                last_runs.extend(plugin.model.get_run_meta_by_run_id(run_id=added_run))
 
         for row in last_runs:
             row["build_number"] = get_build_number(build_job_url=row["build_job_url"])

--- a/argus/backend/service/testrun.py
+++ b/argus/backend/service/testrun.py
@@ -391,7 +391,7 @@ class TestRunService:
             response = []
             for issue in all_issues:
                 runs = runs_by_issue.get(issue, [])
-                runs.append(issue.run_id)
+                runs.append({"test_id": issue.test_id, "run_id": issue.run_id})
                 runs_by_issue[issue] = runs
 
             for issue, runs in runs_by_issue.items():

--- a/frontend/Github/GithubIssue.svelte
+++ b/frontend/Github/GithubIssue.svelte
@@ -209,7 +209,7 @@
                     <div class="d-flex justify-content-end">
                         <div class="ms-1">Runs:</div>
                         {#each issue.runs as run, idx}
-                            <a class="ms-1" href="/test/{issue.test_id}/runs?additionalRuns[]={run}">[{idx + 1}]</a>
+                            <a class="ms-1" href="/test/{run.test_id}/runs?additionalRuns[]={run.run_id}">[{idx + 1}]</a>
                         {/each}
                     </div>
                 {/if}


### PR DESCRIPTION
- fix(service.testruns): Fix single run retrieval by id
- improvement(GithubIssue.svelte): Store test_id in aggregated issues
