### PR TITLE
improvement(GithubIssues.svelte): Show sorted issues with title

### DIFF
--- a/frontend/Github/GithubIssues.svelte
+++ b/frontend/Github/GithubIssues.svelte
@@ -75,7 +75,9 @@
     };
 
     const exportIssueAsFormattedList = function(issues) {
-        let issueFormattedList = issues.map(val => ` * ${val.owner}/${val.repo}#${val.issue_number} - ${val.url}`);
+        let issueFormattedList = issues
+            .sort((a, b) => a.issue_number - b.issue_number)
+            .map(val => ` * ${val.owner}/${val.repo}#${val.issue_number}: ${val.title} - ${val.url}`);
         navigator.clipboard.writeText(`Current Issues\n${issueFormattedList.join("\n")}`);
     };
 


### PR DESCRIPTION
This change adds issue title to the list of exported issues, and
additionally sorts them in ascending order based on issue number
