### PR TITLE
fix(EventsTab.svelte): Fix operator precedence in timestamp parsing

### DIFF
--- a/frontend/TestRun/EventsTab.svelte
+++ b/frontend/TestRun/EventsTab.svelte
@@ -85,7 +85,7 @@
 
         parsedEvent.fields = parsedFields;
         parsedEvent.logLine = logLine.trim();
-        parsedEvent.time = new Date(Date.parse(parsedEvent?.eventTimestamp ?? "1970-01-01" + " UTC"));
+        parsedEvent.time = new Date(Date.parse((parsedEvent?.eventTimestamp ?? "1970-01-01") + " UTC"));
         parsedEvent.parsed = true;
         parsedEvent.eventText = event;
 


### PR DESCRIPTION
This fix corrects an issue where due to operator precedence between ??
and + the " UTC" would not be concatenated if eventTimestamp field
is present on the event object, leading to timestamp being shifted to N
amount of hours due to being interpreted as a local timestamp, instead
of UTC one.
