### PR TITLE
improvement(IssueTemplate.svelte): Add Argus run link

### DIFF
--- a/frontend/TestRun/IssueTemplate.svelte
+++ b/frontend/TestRun/IssueTemplate.svelte
@@ -191,6 +191,7 @@ Logs and commands
 {/each}
 
 [Jenkins job URL]({test_run.build_job_url})
+[Argus]({document.location.origin}/test/{test_run.test_id}/runs?additionalRuns[]={test_run.id})
 &lt;/details&gt;
 
                             </pre>


### PR DESCRIPTION
This commit adds a link to the test run in the run issue template.
