### PR TITLE
fix(plugins/core.py): Assign plugin if it doesn't match

### DIFF
--- a/argus/backend/plugins/core.py
+++ b/argus/backend/plugins/core.py
@@ -57,7 +57,7 @@ class PluginModelBase(Model):
             self.release_id = test.release_id
             self.group_id = test.group_id
             self.test_id = test.id
-            if not test.plugin_name:
+            if not test.plugin_name or test.plugin_name != self._plugin_name:
                 test.plugin_name = self._plugin_name
                 test.save()
         except ArgusTest.DoesNotExist:


### PR DESCRIPTION
This fix is intended to correct older tests which may have been
created as "scylla-cluster-tests" plugin, instead of the plugin they
would be using in the future (or empty for this fix to work)
