### PR TITLE
fix(driver_matrix_tests): Determine status server-side

### DIFF
--- a/argus/client/driver_matrix_tests/client.py
+++ b/argus/client/driver_matrix_tests/client.py
@@ -185,9 +185,6 @@ class ArgusDriverMatrixClient(ArgusClient):
         results = self.get_results(result_path, test_type)
 
         self.submit_driver_matrix_run(job_name=build_id, job_url=build_url, test_environment=env, results=results)
-        failures = reduce(lambda total, coll: (coll["failures"] + coll["errors"]) + total, results, 0)
-        status = TestStatus.FAILED if failures > 0 else TestStatus.PASSED
-        self.set_matrix_status(status)
 
     def submit_driver_matrix_run(self, job_name: str, job_url: str,
                                  results: list[RawMatrixTestResult], test_environment: dict[str, str]) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "argus-alm"
-version = "0.11.0"
+version = "0.11.2"
 description = "Argus"
 authors = ["Alexey Kartashov <alexey.kartashov@scylladb.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
This commit moves test status logic from client into backend and
additionally introduces additional logic to help determine final status.
Runs are now considered failed if they lack at least two submitted
results and are also considered failed if the runs lack at least one
'datastax' driver and one 'scylla' driver.
