### PR TITLE
fix(DriverMatrixRun): Show collections with errors as failed

### DIFF
--- a/frontend/TestRun/DriverMatrixTestCollection.svelte
+++ b/frontend/TestRun/DriverMatrixTestCollection.svelte
@@ -7,7 +7,7 @@
     export let testId: string;
 
     const calculateCollectionStatus = function(collection: TestCollection): string {
-        return collection.failures > 0 ? "danger" : "success";
+        return collection.failures > 0 || collection.errors > 0 ? "danger" : "success";
     };
 </script>
 


### PR DESCRIPTION
This change fixes an issue where a failed driver matrix test run could
show detailed breakdown as "Passed" if the cause of failures were errors
during the tests.
