### PR TITLE
fix(driver_matrix_tests): Do not alter scylla_version

### DIFF
--- a/argus/backend/plugins/driver_matrix_tests/model.py
+++ b/argus/backend/plugins/driver_matrix_tests/model.py
@@ -58,7 +58,7 @@ class DriverTestRun(PluginModelBase):
             env_info.value = value
             run.environment_info.append(env_info)
 
-        run.scylla_version = req.test_environment.get("scylla-version").replace("~", ".")
+        run.scylla_version = req.test_environment.get("scylla-version")
         run.test_collection = []
 
         for result in req.matrix_results:


### PR DESCRIPTION
Make scylla-version field as in to sync up with other types of runs we
have (previously we had been doing replacements in sct runs)
