### PR TITLE
feature(ProfileJobs.svelte): Rework My Jobs page

### DIFF
--- a/argus/backend/controller/api.py
+++ b/argus/backend/controller/api.py
@@ -472,3 +472,15 @@ def resolve_artifact_size():
             "artifactSize": length,
         }
     }
+
+
+@bp.route("/user/jobs")
+@api_login_required
+def user_jobs():
+    service = ArgusService()
+    result = list(service.get_jobs_for_user(user=g.user))
+
+    return {
+        "status": "ok",
+        "response": result
+    }

--- a/argus/backend/controller/main.py
+++ b/argus/backend/controller/main.py
@@ -241,9 +241,7 @@ def update_password():
 @bp.route("/profile/jobs", methods=["GET"])
 @login_required
 def profile_jobs():
-    service = ArgusService()
-    jobs = service.get_jobs_for_user(g.user)
-    return render_template("profile_jobs.html.j2", runs=jobs)
+    return render_template("profile_jobs.html.j2")
 
 
 @bp.route("/profile/schedules", methods=["GET"])

--- a/argus/backend/controller/team.py
+++ b/argus/backend/controller/team.py
@@ -107,7 +107,7 @@ def user_teams(user_id: str):
 @api_login_required
 def user_jobs(user_id: str):
     user = User.get(id=UUID(user_id))
-    result = ArgusService().get_jobs_for_user(user)
+    result = list(ArgusService().get_jobs_for_user(user))
 
     return {
         "status": "ok",

--- a/argus/backend/controller/testrun_api.py
+++ b/argus/backend/controller/testrun_api.py
@@ -269,3 +269,19 @@ def sct_terminate_stuck_runs():
             "total": result
         }
     }
+
+
+@bp.route("/ignore_jobs", methods=["POST"])
+@api_login_required
+def ignore_jobs():
+    payload = get_payload(request)
+    service = TestRunService()
+
+    result = service.ignore_jobs(test_id=payload["testId"], reason=payload["reason"])
+
+    return {
+        "status": "ok",
+        "response": {
+            "affectedJobs": result
+        }
+    }

--- a/argus/backend/events/event_processors.py
+++ b/argus/backend/events/event_processors.py
@@ -30,4 +30,5 @@ EVENT_PROCESSORS = {
     ArgusEventTypes.TestRunIssueAdded: event_process_issue_added,
     ArgusEventTypes.TestRunIssueRemoved: event_process_issue_added,
     ArgusEventTypes.TestRunInvestigationStatusChanged: event_process_investigation_status_changed,
+    ArgusEventTypes.TestRunBatchInvestigationStatusChange: event_process_investigation_status_changed,
 }

--- a/argus/backend/models/web.py
+++ b/argus/backend/models/web.py
@@ -190,6 +190,7 @@ class ArgusEventTypes(str, Enum):
     AssigneeChanged = "ARGUS_ASSIGNEE_CHANGE"
     TestRunStatusChanged = "ARGUS_TEST_RUN_STATUS_CHANGE"
     TestRunInvestigationStatusChanged = "ARGUS_TEST_RUN_INVESTIGATION_STATUS_CHANGE"
+    TestRunBatchInvestigationStatusChange = "ARGUS_TEST_RUN_INVESTIGATION_BATCH_STATUS_CHANGE"
     TestRunCommentPosted = "ARGUS_TEST_RUN_COMMENT_POSTED"
     TestRunCommentUpdated = "ARGUS_TEST_RUN_COMMENT_UPDATED"
     TestRunCommentDeleted = "ARGUS_TEST_RUN_COMMENT_DELETED"

--- a/argus/backend/service/argus_service.py
+++ b/argus/backend/service/argus_service.py
@@ -7,7 +7,7 @@ from uuid import UUID
 from cassandra.util import uuid_from_time  # pylint: disable=no-name-in-module
 from flask import current_app
 from argus.backend.db import ScyllaCluster
-from argus.backend.plugins.loader import all_plugin_models
+from argus.backend.plugins.loader import AVAILABLE_PLUGINS, all_plugin_models
 from argus.backend.plugins.sct.testrun import SCTTestRun
 from argus.backend.service.notification_manager import NotificationManagerService
 from argus.backend.models.web import (
@@ -425,12 +425,16 @@ class ArgusService:
         full_schedule["assignees"] = [assignee.assignee for assignee in assignees]
 
         schedule_user = User.get(id=assignees[0].assignee)
-
-        jobs_for_schedule = self.get_jobs_for_user(user=schedule_user, ignore_time=True, schedules=[full_schedule])
-
         service = TestRunService()
-        for job in jobs_for_schedule:
-            service.change_run_assignee(test_id=job["test_id"], run_id=job["id"], new_assignee=None)
+
+        for model in all_plugin_models():
+            for run in model.get_jobs_assigned_to_user(schedule_user):
+                if run["release_id"] != release.id:
+                    continue
+                if run["test_id"] not in full_schedule["tests"]:
+                    continue
+                if schedule.period_start < run["start_time"] < schedule.period_end:
+                    service.change_run_assignee(test_id=run["test_id"], run_id=run["id"], new_assignee=None)
 
         for entities in [tests, groups, assignees]:
             for entity in entities:
@@ -531,33 +535,13 @@ class ArgusService:
 
         return response
 
-    def get_jobs_for_user(self, user: User, ignore_time: bool = False, schedules: list[dict] = None):
-        runs = [run for plugin in all_plugin_models() for run in plugin.get_jobs_assigned_to_user(user=user)]
-        schedules = self.get_schedules_for_user(user) if not schedules else schedules
-        valid_runs = []
+    def get_jobs_for_user(self, user: User):
         today = datetime.datetime.now()
-        month_ago = today - datetime.timedelta(days=30)
-        for run in runs:
-            run_date = run["start_time"]
-            if user.id == run["assignee"] and run_date >= month_ago and not ignore_time:
-                valid_runs.append(run)
-                continue
-            for schedule in schedules:
-                if not run["release_id"] == schedule["release_id"]:
-                    continue
-                if not schedule["period_start"] < run_date < schedule["period_end"]:
-                    continue
-                if run["assignee"] in schedule["assignees"]:
-                    valid_runs.append(run)
-                    break
-                if run["group_id"] in schedule["groups"]:
-                    valid_runs.append(run)
-                    break
-                filtered_tests = [test for test in schedule["tests"] if test == run["test_id"]]
-                if len(filtered_tests) > 0:
-                    valid_runs.append(run)
-                    break
-        return valid_runs
+        validity_period = today - datetime.timedelta(days=current_app.config.get("JOB_VALIDITY_PERIOD_DAYS", 30))
+        for plugin in all_plugin_models():
+            for run in plugin.get_jobs_assigned_to_user(user=user):
+                if run["start_time"] >= validity_period:
+                    yield run
 
     def get_schedules_for_user(self, user: User) -> list[dict]:
         all_assigned_schedules = ArgusScheduleAssignee.filter(assignee=user.id).all()

--- a/argus/backend/util/enums.py
+++ b/argus/backend/util/enums.py
@@ -24,6 +24,7 @@ class TestInvestigationStatus(str, Enum):
     NOT_INVESTIGATED = "not_investigated"
     IN_PROGRESS = "in_progress"
     INVESTIGATED = "investigated"
+    IGNORED = "ignored"
 
 
 class ResourceState(str, Enum):

--- a/argus_web.example.yaml
+++ b/argus_web.example.yaml
@@ -45,3 +45,7 @@ EMAIL_SENDER_USER: ""
 EMAIL_SENDER_PASS: ""
 EMAIL_SERVER: "smtp.gmail.com"
 EMAIL_SERVER_PORT: "587"
+
+# Used to determine whether or not assigned job is still considered valid.
+# TODO: Move to user settings
+JOB_VALIDITY_PERIOD_DAYS: 30

--- a/frontend/Common/TestStatus.js
+++ b/frontend/Common/TestStatus.js
@@ -1,3 +1,5 @@
+import { faBan, faEye, faEyeSlash, faSearch } from "@fortawesome/free-solid-svg-icons";
+
 export const TestStatus = {
     PASSED: "passed",
     FAILED: "failed",
@@ -20,18 +22,36 @@ export const TestInvestigationStatus = {
     INVESTIGATED: "investigated",
     NOT_INVESTIGATED: "not_investigated",
     IN_PROGRESS: "in_progress",
+    IGNORED: "ignored",
+};
+
+export const InvestigationStatusIcon = {
+    in_progress: faSearch,
+    not_investigated: faEyeSlash,
+    investigated: faEye,
+    ignored: faBan,
 };
 
 export const InvestigationButtonCSSClassMap = {
     "in_progress": "btn-warning",
     "not_investigated": "btn-danger",
     "investigated": "btn-success",
+    "ignored": "btn-dark"
 };
+
+export const InvestigationBackgroundCSSClassMap = {
+    "in_progress": "bg-warning",
+    "not_investigated": "bg-danger",
+    "investigated": "bg-success",
+    "ignored": "bg-dark"
+};
+
 
 export const TestInvestigationStatusStrings = {
     "in_progress": "In progress",
     "not_investigated": "Not Investigated",
     "investigated": "Investigated",
+    "ignored": "Ignored",
 };
 
 export const StatusBackgroundCSSClassMap = {

--- a/frontend/Profile/ProfileJob.svelte
+++ b/frontend/Profile/ProfileJob.svelte
@@ -1,0 +1,95 @@
+<script>
+    import { createEventDispatcher, onMount } from "svelte";
+    import { fade } from "svelte/transition";
+    import { sendMessage } from "../Stores/AlertStore";
+    import { extractBuildNumber } from "../Common/RunUtils";
+    import { InvestigationBackgroundCSSClassMap, InvestigationStatusIcon, StatusBackgroundCSSClassMap } from "../Common/TestStatus";
+    import { faChevronCircleDown, faChevronCircleUp } from "@fortawesome/free-solid-svg-icons";
+    import Fa from "svelte-fa";
+    import TestRuns from "../WorkArea/TestRuns.svelte";
+
+    export let jobId = "";
+    export let jobs = [];
+    const dispatch = createEventDispatcher();
+    let testInfo;
+    let investigating = false;
+
+    const fetchTestInfo = async function () {
+        try{
+            let res = await fetch(`/api/v1/test-info?testId=${jobId}`);
+            if (res.status != 200) throw new Error("HTTP Transport Error");
+            let data = await res.json();
+            if (data.status != "ok") {
+                throw new Error([data.exception, ...data.arguments].join(" "));
+            }
+            dispatch("testIdResolved", {
+                testId: jobId,
+                record: data.response,
+            });
+            return data.response;
+        } catch (e) {
+            if (e instanceof Error) {
+                sendMessage("error", `Error fetching user jobs\n${e.message}`);
+            } else {
+                sendMessage("error", "Error fetching user jobs\nUnknown error. Check console for details");
+            }
+            console.log(e);
+        }
+    };
+
+    onMount(async () => {
+        testInfo = await fetchTestInfo();
+    });
+</script>
+
+<div class="rounded bg-white p-2 mb-2" transition:fade>
+    {#if testInfo}
+        <div class="d-flex mb-2">
+            <div>
+                <h6>{testInfo.test.pretty_name ?? testInfo.test.name}</h6>
+                {#if !investigating}
+                    <div class="d-flex align-items-center">
+                        {#each jobs.slice(0, 5) as job}
+                            <div class="{StatusBackgroundCSSClassMap[job.status] ?? StatusBackgroundCSSClassMap.unknown} px-2 py-1 ms-1 rounded-start text-light">
+                                #{extractBuildNumber(job)}
+                            </div>
+                            <div class="bg-dark rounded-end me-1 px-2 py-1 text-light">
+                                <Fa icon={InvestigationStatusIcon[job.investigation_status]}/>
+                            </div>
+                        {/each}
+                        {#if jobs.length > 5}
+                            <div>...and {Math.max(jobs.length - 5, 0)} more.</div>
+                        {/if}
+                    </div>
+                {/if}
+            </div>
+            <div class="ms-auto text-end p-2">
+                <div>
+                    <span class="fw-bold">Release: </span> {testInfo.release.pretty_name ?? testInfo.release.name}
+                </div>
+                <div>
+                    <span class="fw-bold">Group: </span> {testInfo.group.pretty_name ?? testInfo.group.name}
+                </div>
+            </div>
+            <div class="ms-2 text-end align-self-center">
+                <button class="btn btn-dark" on:click={() => investigating = !investigating}>
+                    {#if investigating}
+                        <Fa icon={faChevronCircleUp}/>
+                    {:else}
+                        <Fa icon={faChevronCircleDown}/>
+                    {/if}
+                </button>
+            </div>
+        </div>
+        <div class="overflow-hidden rounded border" class:d-none={!investigating}>
+            {#if investigating}
+            <TestRuns testId={jobId} additionalRuns={jobs.map(v => v.id).slice(0, 5)} on:investigationStatusChange on:batchIgnoreDone/>
+            {/if}
+        </div>
+    {:else}
+        JobId: {jobId} <span class="spinner-grow"></span> Loading...
+        <div>
+            Total Jobs: {jobs.length}
+        </div>
+    {/if}
+</div>

--- a/frontend/Profile/ProfileJobs.svelte
+++ b/frontend/Profile/ProfileJobs.svelte
@@ -1,17 +1,116 @@
 <script>
-    import { filterInvestigated, filterNotInvestigated } from "../Common/RunUtils";
-    export let runs = [];
-    import JobsList from "./JobsList.svelte";
+    import { faCalendar, faCheck, faSearch } from "@fortawesome/free-solid-svg-icons";
+    import Fa from "svelte-fa";
+    import { sendMessage } from "../Stores/AlertStore";
+    import { onMount } from "svelte";
+    import ProfileJobsTab from "./ProfileJobsTab.svelte";
+    import { TestInvestigationStatus } from "../Common/TestStatus";
+    export let jobs;
+    export let userId;
 
+    let activeTab = "todo";
+    let jobsToDo = [];
+    let jobsDone = [];
+
+    const fetchUserJobs = async function() {
+        if (jobs) {
+            prepareJobs(jobs);
+            jobs = undefined;
+            return;
+        }
+
+        try {
+            let response = await fetch(userId ? `/api/v1/team/user/${userId}/jobs` :"/api/v1/user/jobs");
+            if (response.status != 200) throw new Error("HTTP Transport Error");
+            let json = await response.json();
+            if (json.status != "ok") throw new Error(`API Error: ${json.exception.arguments.join(" ")}`);
+            prepareJobs(json.response);
+        } catch (e) {
+            if (e instanceof Error) {
+                sendMessage("error", `Error fetching user jobs\n${e.message}`);
+            } else {
+                sendMessage("error", "Error fetching user jobs\nUnknown error. Check console for details");
+            }
+            console.log(e);
+        }
+    };
+
+    const prepareJobs = function(jobs) {
+        jobsToDo = jobs.filter(v => v.investigation_status != "investigated" && v.status != "passed" && v.investigation_status != "ignored");
+        jobsDone = jobs.filter(v => ["investigated", "ignored"].includes(v.investigation_status) || v.status == "passed");
+    };
+
+    const handleInvestigationStatusChangeToDo = async function(e) {
+        let runId = e.detail.runId;
+        let status = e.detail.status;
+        if (status != TestInvestigationStatus.INVESTIGATED) return;
+        let investigatedJob = jobsToDo.find(v => v.id == runId);
+        jobsDone.push(investigatedJob);
+        jobsDone = jobsDone;
+        jobsToDo = jobsToDo.filter(v => v.id != runId);
+    };
+
+    const handleInvestigationStatusChangeDone = async function(e) {
+        let runId = e.detail.runId;
+        let status = e.detail.status;
+        if (status == TestInvestigationStatus.INVESTIGATED || status == TestInvestigationStatus.IGNORED) return;
+        let investigatedJob = jobsDone.find(v => v.id == runId);
+        jobsToDo.push(investigatedJob);
+        jobsToDo = jobsToDo;
+        jobsDone = jobsDone.filter(v => v.id != runId);
+    };
+
+    const handleBatchIgnore = function() {
+        fetchUserJobs();
+    };
+
+
+    onMount(async () => {
+        await fetchUserJobs();
+    });
 </script>
-
-<div class="container-fluid bg-white border rounded my-4 shadow-sm">
-    <div class="row justify-content-center border-bottom mb-2">
-        <h2 class="mt-2 display-6">Not Investigated</h2>
-        <JobsList runs={filterNotInvestigated(runs)}/>
-    </div>
-    <div class="row justify-content-center mb-2">
-        <h2 class="mt-2 display-6">Investigated</h2>
-        <JobsList runs={filterInvestigated(runs)}/>
+<div class="container">
+    <div class="bg-white rounded my-4 border-start border-end border-bottom ">
+        <div class="d-flex btn-group p-2">
+                <button 
+                    class="btn btn-dark"
+                    class:active={activeTab == "todo"}
+                    on:click={() => (activeTab = "todo")}
+                >
+                    <Fa icon={faSearch}/> To Do
+                </button>
+                <button 
+                    class="btn btn-dark"
+                    class:active={activeTab == "done"}
+                    on:click={() => (activeTab = "done")}
+                >
+                    <Fa icon={faCheck}/> Done
+                </button>
+                <button 
+                    class="btn btn-dark"
+                    class:active={activeTab == "planned"}
+                    on:click={() => (activeTab = "planned")}
+                >
+                    <Fa icon={faCalendar}/> Planned
+                </button>
+        </div>
+        <div class="p-2">
+            <div class="bg-light-one rounded p-2">
+                <div class:d-none={activeTab != "todo"}>
+                    <ProfileJobsTab jobs={jobsToDo} on:investigationStatusChange={handleInvestigationStatusChangeToDo} on:batchIgnoreDone={handleBatchIgnore}/>
+                </div>
+                <div class:d-none={activeTab != "done"}>
+                    <ProfileJobsTab jobs={jobsDone} on:investigationStatusChange={handleInvestigationStatusChangeDone} on:batchIgnoreDone={handleBatchIgnore}/>
+                </div>
+                <div class:d-none={activeTab != "planned"}>
+                    WIP
+                </div>
+            </div>
+        </div>
     </div>
 </div>
+
+
+<style>
+
+</style>

--- a/frontend/Profile/ProfileJobsTab.svelte
+++ b/frontend/Profile/ProfileJobsTab.svelte
@@ -1,0 +1,253 @@
+<script>
+    import { faCircle, faInfoCircle} from "@fortawesome/free-solid-svg-icons";
+    import ProfileJob from "./ProfileJob.svelte";
+    import Fa from "svelte-fa";
+    import { InvestigationStatusIcon, StatusCSSClassMap, TestInvestigationStatus, TestStatus } from "../Common/TestStatus";
+    import { titleCase } from "../Common/TextUtils";
+    import { createEventDispatcher } from "svelte";
+
+    export let jobs = [];
+    export let filterExpr = () => true;
+    const dispatch = createEventDispatcher();
+    let currentPage = 0;
+    let pagedData = [];
+    let filterString = "";
+    let testIdMap = {};
+    let releaseIdMap = {};
+    let allVersions = {};
+    
+    let enabledReleases = {};
+    let enabledVersions = {};
+    let stats = {};
+
+    const testIdResolved = function(e) {
+        let testInfo = e.detail.record;
+        let testId = e.detail.testId;
+        if (!testIdMap[testId]) {
+            testIdMap[testId] = testInfo.test.name;
+        }
+        
+        if (!releaseIdMap[testInfo.release.id]) {
+            releaseIdMap[testInfo.release.id] = testInfo.release.name;
+        }
+    };
+
+    /**
+     * 
+     * @param {string} filterString
+     * @param {string} testName
+     */
+    const shouldFilter = function (filterString, testName) {
+        if (!filterString) return false;
+        if (!testName) return false;
+        return testName.toLowerCase().search(filterString) == -1;
+    };
+
+    /**
+     * Filters by expr and aggregates jobs by job id
+     * @param {Object[]} jobs
+     * @param expr
+     */
+    const filterAndAggregateJobs = function (jobs, expr, filterString) {
+        const filteredJobs = jobs.filter(expr);
+        return filteredJobs.reduce((acc, job) => {
+            const resolvedName = testIdMap[job.test_id];
+            if (shouldFilter(filterString, resolvedName)) return acc;
+            if (!acc[job.test_id]) {
+                acc[job.test_id] = [];
+            }
+            acc[job.test_id].push(job);
+            return acc;
+        }, {});
+    };
+
+    /**
+     * Split an array into 2D array of "pages"
+     * @param {{ string: Object }} jobs
+     */
+    const paginateData = function (jobs) {
+        let allJobs = Object.entries(jobs).sort((a, b) => b[1].length - a[1].length);
+        const PAGE_SIZE = 10;
+        const steps = Math.max(parseInt(allJobs.length / PAGE_SIZE) + 1, 1);
+        const pages = Array
+            .from({length: steps}, () => [])
+            .map((_, pageIdx) => {
+                const sliceIdx = pageIdx * PAGE_SIZE;
+                const slice = allJobs.slice(sliceIdx, PAGE_SIZE + sliceIdx);
+                return [...slice];
+            });
+        return pages;
+    };
+
+    const selectPage = function(pagedData, page) {
+        let selectedPage = pagedData[page] ?? [];
+        return selectedPage;
+    };
+
+    const collectVersions = function (jobs) {
+        return jobs
+            .map(v => [v.release_id, v.scylla_version])
+            .reduce((acc, [releaseId, productVersion]) => {
+                let store = acc[releaseId] ?? [];
+                if (!store.includes(productVersion)) {
+                    store.push(productVersion);
+                    enabledVersions[productVersion] = enabledVersions[productVersion] ?? true;
+                }
+                acc[releaseId] = store;
+                return acc;
+            }, {});
+    };
+
+    const prepareFilters = function(jobs) {
+        allVersions = collectVersions(jobs);
+        enabledReleases = Object.fromEntries(jobs.map(v => [v.release_id, enabledReleases[v.release_id] ?? true]));
+    };
+
+    const filterJobsByBranchOrVersion = function(jobs) {
+        return jobs.filter(v => enabledReleases[v.release_id] && enabledVersions[v.scylla_version]);
+    };
+
+    const flattenVersions = function(versions, enabledReleases) {
+        let flattenedVersions = [];
+        Object.entries(versions).forEach(([releaseId, versions]) => {
+            if (enabledReleases[releaseId]) {
+                versions.forEach(v => {
+                    if (!flattenedVersions.includes(v)) {
+                        flattenedVersions.push(v);
+                    }
+                });
+            }
+        });
+
+        return flattenedVersions.sort((a, b) => a?.localeCompare(b) ?? 0);
+    };
+
+    const prepareStats = function(jobs, enabledReleases, enabledVersions) {
+        let stats = jobs.reduce((acc, v) => {
+            if (enabledReleases[v.release_id] && enabledVersions[v.scylla_version]) {
+                acc[v.status] = (acc[v.status] ?? 0) + 1;
+                acc[v.investigation_status] = (acc[v.investigation_status] ?? 0) + 1;
+            }
+            return acc;
+        }, {});
+        return stats;
+    };
+
+    const selectOneVersion = function(version) {
+        for (const key in enabledVersions) {
+            if (key != version) {
+                enabledVersions[key] = false;
+            }
+        }
+        enabledVersions[version] = true;
+    };
+
+    const selectOneRelease = function(releaseId) {
+        for (const key in enabledReleases) {
+            if (key != releaseId) {
+                enabledReleases[key] = false;
+            }
+        }
+        enabledReleases[releaseId] = true;
+    };
+
+    const onInvestigationStatusChange = function(e) {
+        let jobId = e.detail.runId;
+        let newStatus = e.detail.status;
+        let jobIdx = jobs.findIndex(v => v.id == jobId);
+        if (jobIdx >= 0) {
+            jobs[jobIdx].investigation_status = newStatus;
+            jobs = jobs;
+        }
+        stats = prepareStats(jobs, enabledReleases, enabledVersions);
+        dispatch("investigationStatusChange", e.detail);
+    };
+
+
+    $: prepareFilters(jobs);
+    $: pagedData = paginateData(filterAndAggregateJobs(filterJobsByBranchOrVersion(jobs, enabledReleases, enabledVersions), filterExpr, filterString));
+    $: stats = prepareStats(jobs, enabledReleases, enabledVersions);
+</script>
+
+<div class="mb-2 p-2">
+    <input type="text" bind:value={filterString} placeholder="Filter tests by name" class="form-control">
+</div>
+<div class="mb-2">
+    <div class="text-end">
+        <div class="d-inline-flex mb-2 align-items-center justify-content-end bg-white border rounded overflow-hidden p-2">
+            {#each Object.values(TestStatus) as status}
+                {#if stats[status]}
+                    <div title={titleCase(status)} class="d-flex align-items-center ms-1">
+                        <Fa icon={faCircle} class="{StatusCSSClassMap[status]} ms-1"/>
+                        <div class="ms-1">{stats[status] ?? 0}</div>
+                    </div>
+                {/if}
+            {/each}
+            {#each Object.values(TestInvestigationStatus) as status}
+                {#if stats[status]}
+                    <div title={titleCase(status)} class="d-flex align-items-center ms-1">
+                        <Fa icon={InvestigationStatusIcon[status]} class="{StatusCSSClassMap[status]} ms-1"/>
+                        <div class="ms-1">{stats[status] ?? 0}</div>
+                    </div>
+                {/if}
+            {/each}
+        </div>
+    </div>
+    <div title="Double click a release to select only that release">
+        <Fa icon={faInfoCircle}/>
+    </div>
+    <div class="d-flex flex-wrap mb-2">
+        {#each Object.keys(enabledReleases) as releaseId}
+            {@const releaseName = releaseIdMap[releaseId] ?? releaseId}
+            <button 
+                class="btn btn-{enabledReleases[releaseId] ? "success" : "light"} ms-2 mb-2 text-truncate"
+                title="Branch {releaseName}"
+                style="flex: 0 0 15%"
+                on:click={() => (enabledReleases[releaseId] = !enabledReleases[releaseId])}
+                on:dblclick={() => (selectOneRelease(releaseId))}
+            >
+                {releaseName}
+            </button>
+        {/each}
+    </div>
+    <div title="Double click a version to select only that version">
+        <Fa icon={faInfoCircle}/>
+    </div>
+    <div class="d-flex flex-wrap">
+        {#each flattenVersions(allVersions, enabledReleases) as version}
+            <button 
+                class="btn btn-{enabledVersions[version] ? "primary" : "light"} ms-2 mb-2" 
+                style="flex: 0 0 10%"
+                title="Product Version"
+                on:click={() => (enabledVersions[version] = !enabledVersions[version])}
+                on:dblclick={() => (selectOneVersion(version))}
+            >
+                {version ? version : "No version"}
+            </button>
+        {:else}
+            <div class="p-4 text-muted text-center">
+                No versions to display
+            </div>
+        {/each}
+    </div>
+</div>
+{#each selectPage(pagedData, currentPage) as [jobId, jobs] (jobId) }
+    <ProfileJob {jobId} {jobs} on:testIdResolved={testIdResolved} on:investigationStatusChange={onInvestigationStatusChange} on:batchIgnoreDone/>
+{:else}
+    <div class="text-muted text-center p-4">
+        Nothing to investigate.
+    </div>
+{/each}
+{#if pagedData.length > 1}
+    <div class="d-flex flex-wrap">
+        {#each pagedData as _, idx}
+            <button 
+                class="me-2 btn btn-sm btn-primary p-1 mb-1"
+                style="flex: 0 0 2.5%;"
+                on:click={() => (currentPage = idx)}
+            >
+                {idx + 1}
+            </button>
+        {/each}
+    </div>
+{/if}

--- a/frontend/ReleaseDashboard/TestDashboard.svelte
+++ b/frontend/ReleaseDashboard/TestDashboard.svelte
@@ -3,9 +3,6 @@
     import queryString from "query-string";
     import Fa from "svelte-fa";
     import {
-        faSearch,
-        faEyeSlash,
-        faEye,
         faBug,
         faComment,
         faArrowDown,
@@ -13,6 +10,7 @@
     } from "@fortawesome/free-solid-svg-icons";
 
     import {
+        InvestigationStatusIcon,
         StatusBackgroundCSSClassMap,
         TestInvestigationStatus,
         TestInvestigationStatusStrings,
@@ -38,12 +36,6 @@
         tests: {
 
         }
-    };
-
-    const investigationStatusIcon = {
-        in_progress: faSearch,
-        not_investigated: faEyeSlash,
-        investigated: faEye,
     };
 
     const dispatch = createEventDispatcher();
@@ -313,7 +305,7 @@
                                             >
                                                 <Fa
                                                     color="#000"
-                                                    icon={investigationStatusIcon[
+                                                    icon={InvestigationStatusIcon[
                                                         testStats.investigation_status
                                                     ]}
                                                 />

--- a/frontend/Stats/NumberStats.svelte
+++ b/frontend/Stats/NumberStats.svelte
@@ -1,8 +1,7 @@
 <script>
     import Fa from "svelte-fa";
-    import { TestStatus, StatusBackgroundCSSClassMap, TestInvestigationStatus, TestInvestigationStatusStrings, StatusCSSClassMap } from "../Common/TestStatus";
+    import { TestStatus, StatusBackgroundCSSClassMap, TestInvestigationStatus, TestInvestigationStatusStrings, StatusCSSClassMap, InvestigationStatusIcon } from "../Common/TestStatus";
     import { titleCase, subUnderscores } from "../Common/TextUtils";
-    import { faEye, faEyeSlash, faSearch } from "@fortawesome/free-solid-svg-icons";
     import { Collapse } from "bootstrap";
     export let displayNumber = false;
     export let displayInvestigations = false;
@@ -17,12 +16,6 @@
 
     let shortBlock;
     let extendedBlock;
-
-    const investigationStatusMapping = {
-        [TestInvestigationStatus.INVESTIGATED]: faEye,
-        [TestInvestigationStatus.NOT_INVESTIGATED]: faEyeSlash,
-        [TestInvestigationStatus.IN_PROGRESS]: faSearch,
-    };
 
     const normalize = function(val, max, min) {
         return (val - min) / (max - min);
@@ -70,7 +63,7 @@
                         class="flex-fill text-center {idx > 0 ? "border-start" : ""} px-3 py-2"
                         role="button"
                     >
-                        <Fa icon={investigationStatusMapping[investigationStatus]}/>
+                        <Fa icon={InvestigationStatusIcon[investigationStatus]}/>
                         {Object.values(stats?.[investigationStatus] ?? {}).reduce((acc, val) => acc + val, 0)}
                     </div>
                 {/each} 
@@ -82,7 +75,7 @@
                     {#each Object.values(TestInvestigationStatus) as investigationStatus, idx}
                         <div class="{idx > 0 ? "ms-2" : ""} rounded bg-white">
                             <h6 class="p-2 border-bottom">
-                                <Fa icon={investigationStatusMapping[investigationStatus]}/>
+                                <Fa icon={InvestigationStatusIcon[investigationStatus]}/>
                                 {TestInvestigationStatusStrings[investigationStatus]}
                                 <span class="d-inline-block ms-3 text-end">{Object.values(stats?.[investigationStatus] ?? {}).reduce((acc, val) => acc + val, 0)}</span>
                             </h6>

--- a/frontend/Teams/TeamMember.svelte
+++ b/frontend/Teams/TeamMember.svelte
@@ -144,7 +144,7 @@
 </div>
 <div id="showAllJobs-{member.id}" class="collapse">
     {#if requestedDetail && userJobs}
-        <ProfileJobs runs={userJobs} />
+        <ProfileJobs jobs={userJobs} userId={member.id} />
     {/if}
 </div>
 

--- a/frontend/TestRun/DriverMatrixTestRun.svelte
+++ b/frontend/TestRun/DriverMatrixTestRun.svelte
@@ -92,8 +92,9 @@
                         <RunStatusButton {testRun} on:statusUpdate={(e) => {
                             testRun.status = e.detail.status;
                         }} />
-                        <RunInvestigationStatusButton {testRun} on:statusUpdate={(e) => {
+                        <RunInvestigationStatusButton {testRun} on:investigationStatusChange={(e) => {
                             testRun.investigation_status = e.detail.status;
+                            dispatch("investigationStatusChange", e.detail);
                         }} />
                     </div>
                 </div>

--- a/frontend/TestRun/RunInvestigationStatusButton.svelte
+++ b/frontend/TestRun/RunInvestigationStatusButton.svelte
@@ -1,19 +1,12 @@
 <script>
-    import { faEye, faEyeSlash, faSearch } from "@fortawesome/free-solid-svg-icons";
     import { createEventDispatcher } from "svelte";
     import Fa from "svelte-fa";
-    import { InvestigationButtonCSSClassMap, TestInvestigationStatus, TestInvestigationStatusStrings } from "../Common/TestStatus";
+    import { InvestigationButtonCSSClassMap, InvestigationStatusIcon, TestInvestigationStatus, TestInvestigationStatusStrings } from "../Common/TestStatus";
     import { sendMessage } from "../Stores/AlertStore";
 
     export let testRun;
     const dispatch = createEventDispatcher();
     let disableButtons = false;
-
-    const investigationStatusIcon = {
-        in_progress: faSearch,
-        not_investigated: faEyeSlash,
-        investigated: faEye,
-    };
 
     const handleInvestigationStatus = async function (newInvestigationStatus) {
         disableButtons = true;
@@ -33,7 +26,7 @@
             let apiJson = await apiResponse.json();
             console.log(apiJson);
             if (apiJson.status === "ok") {
-                dispatch("statusUpdate", { status: newInvestigationStatus });
+                dispatch("investigationStatusChange", { runId: testRun.id, status: newInvestigationStatus });
             } else {
                 throw apiJson;
             }
@@ -64,7 +57,7 @@
         data-bs-toggle="dropdown"
     >
         <Fa
-            icon={investigationStatusIcon[
+            icon={InvestigationStatusIcon[
                 testRun.investigation_status
             ]}
         />

--- a/frontend/TestRun/Sirenada/SirenadaTestRun.svelte
+++ b/frontend/TestRun/Sirenada/SirenadaTestRun.svelte
@@ -92,9 +92,10 @@
                         <RunStatusButton {testRun} on:statusUpdate={(e) => {
                             testRun.status = e.detail.status;
                         }} />
-                        <RunInvestigationStatusButton {testRun} on:statusUpdate={(e) => {
+                        <RunInvestigationStatusButton {testRun} on:investigationStatusChange={(e) => {
                             testRun.investigation_status = e.detail.status;
-                        }} />
+                            dispatch("investigationStatusChange", e.detail);
+                        }}/>
                     </div>
                 </div>
                 <div class="col-6">

--- a/frontend/TestRun/TestRun.svelte
+++ b/frontend/TestRun/TestRun.svelte
@@ -99,8 +99,9 @@
                         <RunStatusButton {testRun} on:statusUpdate={(e) => {
                             testRun.status = e.detail.status;
                         }} />
-                        <RunInvestigationStatusButton {testRun} on:statusUpdate={(e) => {
+                        <RunInvestigationStatusButton {testRun} on:investigationStatusChange={(e) => {
                             testRun.investigation_status = e.detail.status;
+                            dispatch("investigationStatusChange", e.detail);
                         }} />
                     </div>
                 </div>

--- a/frontend/WorkArea/TestRunDispatcher.svelte
+++ b/frontend/WorkArea/TestRunDispatcher.svelte
@@ -7,4 +7,4 @@
 
 </script>
 
-<svelte:component this={AVAILABLE_PLUGINS?.[testInfo.test.plugin_name] ?? AVAILABLE_PLUGINS.unknown} {runId} {testInfo} {buildNumber} on:closeRun />
+<svelte:component this={AVAILABLE_PLUGINS?.[testInfo.test.plugin_name] ?? AVAILABLE_PLUGINS.unknown} {runId} {testInfo} {buildNumber} on:closeRun on:investigationStatusChange />

--- a/frontend/profile-jobs.js
+++ b/frontend/profile-jobs.js
@@ -2,7 +2,5 @@ import ProfileJobs from "./Profile/ProfileJobs.svelte";
 
 const app = new ProfileJobs({
     target: document.querySelector("#jobsContainer"),
-    props: {
-        runs: globalRuns
-    }
+    props: {}
 });

--- a/templates/profile_jobs.html.j2
+++ b/templates/profile_jobs.html.j2
@@ -5,16 +5,13 @@ My Jobs
 {% endblock %}
 
 {% block javascripts %}
-<script>
-    var globalRuns = {{ runs | tojson }};
-</script>
 {{super()}}
 <script defer src="/s/dist/profileJobs.bundle.js"></script>
 {% endblock javascripts %}
 
 {% block body %}
 {% if g.user %}
-<div class="container"  id="jobsContainer">
+<div id="jobsContainer">
 
 </div>
 {% else %}


### PR DESCRIPTION
This commit completely reworks "My Jobs", presenting only jobs that need
to be investigated and started in a tabbed interface. The runs are now
aggregated by the test, showing a short summary of items to be
investigated. Runs themselves are now only shown if they are at most 30
days old (configurable in the global config), and that's the only
condition, as the previous suite of conditions led to too many jobs
being shown to the user. The page now also includes set of filters to
filter jobs that are needed to be done - either by release branch or
product version. Finally, the "Done" tab shows runs that have been
marked as investigated in the current investigation session (shows
nothing by default, as that's no longer needed due to aggregation)

Additionally, a new "Ignore runs" feature has been added to TestRuns
selector - allowing user to mass ignore investigation status on runs
provided that they give a reason why.

Task: scylladb/qa-tasks#1152
