### PR TITLE
improvement(auth): Redirect user to the requested page on login

### DIFF
--- a/argus/backend/controller/auth.py
+++ b/argus/backend/controller/auth.py
@@ -59,7 +59,7 @@ def generate_api_token():
 @bp.route('/logout', methods=("POST",))
 def logout():
     session.clear()
-    return redirect(url_for('main.home'))
+    return redirect(url_for('auth.login'))
 
 
 bp.before_app_request(load_logged_in_user)

--- a/argus/backend/controller/main.py
+++ b/argus/backend/controller/main.py
@@ -136,6 +136,8 @@ def profile_oauth_github_callback():
     if first_run_info:
         session["first_run_info"] = first_run_info
 
+    if path := session.pop("redirect_target"):
+        return redirect(path)
     return redirect(url_for("main.profile"))
 
 

--- a/argus/backend/service/user.py
+++ b/argus/backend/service/user.py
@@ -123,8 +123,10 @@ class UserService:
             github_token.token = oauth_data.get('access_token')
             github_token.save()
 
+        redirect_target = session.get("redirect_target")
         session.clear()
         session["user_id"] = str(user.id)
+        session["redirect_target"] = redirect_target
         if temp_password:
             return {
                 "password": temp_password,
@@ -191,6 +193,7 @@ def login_required(view: FlaskView):
     def wrapped_view(*args, **kwargs):
         if g.user is None and not getattr(view, "api_view", False):
             flash(message='Unauthorized, please login', category='error')
+            session["redirect_target"] = request.full_path
             return redirect(url_for('auth.login'))
         elif g.user is None and getattr(view, "api_view", True):
             return {


### PR DESCRIPTION
This commit improves UX when clicking on a link with an expired session -
previously user would get redirected to the login page and afterwards
would end up on their profile page. This is now fixed - the URL user was
going to is now preserved as a session variable and user gets redirected
to it on successful login (currently only on Github logins)
