### PR TITLE
improvement(*TestRun): Allow viewing all issues relevant to the test

### DIFF
--- a/frontend/TestRun/DriverMatrixTestRun.svelte
+++ b/frontend/TestRun/DriverMatrixTestRun.svelte
@@ -6,7 +6,6 @@
     } from "@fortawesome/free-solid-svg-icons";
     import ActivityTab from "./ActivityTab.svelte";
     import TestRunComments from "./TestRunComments.svelte";
-    import GithubIssues from "../Github/GithubIssues.svelte";
     import { sendMessage } from "../Stores/AlertStore";
     import { fetchRun } from "../Common/RunUtils";
     import RunStatusButton from "./RunStatusButton.svelte";
@@ -14,6 +13,7 @@
     import RunAssigneeSelector from "./RunAssigneeSelector.svelte";
     import DriverMatrixRunInfo from "./DriverMatrixRunInfo.svelte";
     import DriverMatrixTestCollection from "./DriverMatrixTestCollection.svelte";
+    import IssueTab from "./IssueTab.svelte";
 
     export let runId = "";
     export let buildNumber = -1;
@@ -185,7 +185,7 @@
                 <div class="tab-pane fade" id="nav-issues-{runId}" role="tabpanel">
                     <div class="py-2 bg-white">
                         {#if issuesOpen}
-                            <GithubIssues id={runId} testId={testInfo.test.id} />
+                            <IssueTab {testInfo} {runId} />
                         {/if}
                     </div>
                 </div>

--- a/frontend/TestRun/IssueTab.svelte
+++ b/frontend/TestRun/IssueTab.svelte
@@ -1,0 +1,22 @@
+<script>
+    import GithubIssues from "../Github/GithubIssues.svelte";
+
+    export let runId;
+    export let testInfo;
+</script>
+
+<GithubIssues id={runId} testId={testInfo.test.id} />
+<div class="accordion accordion-flush border-top" id="allIssuesContainer-{testInfo.test.id}-{runId}">
+    <div class="accordion-item">
+        <h2 class="accordion-header">
+        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#allIssues-{testInfo.test.id}-{runId}">
+            All issues for this test
+        </button>
+        </h2>
+        <div id="allIssues-{testInfo.test.id}-{runId}" class="accordion-collapse collapse" data-bs-parent="#allIssuesContainer-{testInfo.test.id}-{runId}">
+        <div class="accordion-body overflow-scroll" style="max-height: 768px">
+            <GithubIssues id={testInfo.test.id} testId={testInfo.test.id} filter_key="test_id" aggregateByIssue={true} submitDisabled={true}/>
+        </div>
+        </div>
+    </div>
+</div>

--- a/frontend/TestRun/Sirenada/SirenadaTestRun.svelte
+++ b/frontend/TestRun/Sirenada/SirenadaTestRun.svelte
@@ -6,7 +6,6 @@
     } from "@fortawesome/free-solid-svg-icons";
     import ActivityTab from "../ActivityTab.svelte";
     import TestRunComments from "../TestRunComments.svelte";
-    import GithubIssues from "../../Github/GithubIssues.svelte";
     import { sendMessage } from "../../Stores/AlertStore";
     import { fetchRun } from "../../Common/RunUtils";
     import RunStatusButton from "../RunStatusButton.svelte";
@@ -14,6 +13,7 @@
     import RunAssigneeSelector from "../RunAssigneeSelector.svelte";
     import SirenadaRunInfo from "./SirenadaRunInfo.svelte";
     import SirenadaTestBreakdown from "./SirenadaTestBreakdown.svelte";
+    import IssueTab from "../IssueTab.svelte";
 
     export let runId = "";
     export let buildNumber = -1;
@@ -185,7 +185,7 @@
                 <div class="tab-pane fade" id="nav-issues-{runId}" role="tabpanel">
                     <div class="py-2 bg-white">
                         {#if issuesOpen}
-                            <GithubIssues id={runId} testId={testInfo.test.id} />
+                            <IssueTab {testInfo} {runId} />
                         {/if}
                     </div>
                 </div>

--- a/frontend/TestRun/TestRun.svelte
+++ b/frontend/TestRun/TestRun.svelte
@@ -10,7 +10,6 @@
     import TestRunInfo from "./TestRunInfo.svelte";
     import Screenshots from "./Screenshots.svelte";
     import TestRunComments from "./TestRunComments.svelte";
-    import GithubIssues from "../Github/GithubIssues.svelte";
     import IssueTemplate from "./IssueTemplate.svelte";
     import { sendMessage } from "../Stores/AlertStore";
     import { fetchRun } from "../Common/RunUtils";
@@ -20,6 +19,7 @@
     import HeartbeatIndicator from "./HeartbeatIndicator.svelte";
     import EventsTab from "./EventsTab.svelte";
     import ArtifactTab from "./ArtifactTab.svelte";
+    import IssueTab from "./IssueTab.svelte";
     export let runId = "";
     export let buildNumber = -1;
     export let testInfo = {};
@@ -259,7 +259,7 @@
                 <div class="tab-pane fade" id="nav-issues-{runId}" role="tabpanel">
                     <IssueTemplate test_run={testRun} test={testInfo.test} />
                     {#if issuesOpen}
-                        <GithubIssues id={runId} testId={testInfo.test.id} />
+                        <IssueTab {testInfo} {runId} />
                     {/if}
                 </div>
                 <div


### PR DESCRIPTION
This change adjust the Issues tab to display both issues attached to
this particular run and a collapse of all issues associated with the
run's test.

Task: scylladb/qa-tasks#288
