### PR TITLE
fix(*RunInfo.svelte): Fix release dashboard link

### DIFF
--- a/frontend/TestRun/DriverMatrixRunInfo.svelte
+++ b/frontend/TestRun/DriverMatrixRunInfo.svelte
@@ -98,7 +98,7 @@
         <div class="col-6 p-2">
             <div class="btn-group">
                 <a
-                    href="/dashboard/{testRun.release_name}"
+                    href="/dashboard/{testInfo.release.name}"
                     class="btn btn-outline-success"
                     ><Fa icon={faBusinessTime} /> Release Dashboard</a
                 >

--- a/frontend/TestRun/Sirenada/SirenadaRunInfo.svelte
+++ b/frontend/TestRun/Sirenada/SirenadaRunInfo.svelte
@@ -66,7 +66,7 @@
         <div class="col-6 p-2">
             <div class="btn-group">
                 <a
-                    href="/dashboard/{testRun.release_name}"
+                    href="/dashboard/{testInfo.release.name}"
                     class="btn btn-outline-success"
                     ><Fa icon={faBusinessTime} /> Release Dashboard</a
                 >

--- a/frontend/TestRun/TestRunInfo.svelte
+++ b/frontend/TestRun/TestRunInfo.svelte
@@ -238,7 +238,7 @@
                     {/if}
                 {/if}
                 <a
-                    href="/dashboard/{test_run.release_name}"
+                    href="/dashboard/{release.name}"
                     class="btn btn-outline-success"
                     ><Fa icon={faBusinessTime} /> Release Dashboard</a
                 >


### PR DESCRIPTION
This fixes an issue where release dashboard link wasn't working due to
the structure of test run record changing and removing the release name
field (it has since been delegated to ArgusRelease entity)
