### PR TITLE
fix(driver_matrix_tests): Resolve Enum value manually

### DIFF
--- a/argus/backend/plugins/driver_matrix_tests/model.py
+++ b/argus/backend/plugins/driver_matrix_tests/model.py
@@ -102,7 +102,7 @@ class DriverTestRun(PluginModelBase):
                 collection.suites.append(suite)
             run.test_collection.append(collection)
 
-        run.status = run._determine_run_status()
+        run.status = run._determine_run_status().value
         run.save()
         return run
 


### PR DESCRIPTION
This change fixes an issue where CQL engine would stringify string Enum
as '<Enum.VALUE>' instead of casting it to string, causing CQL query to
error out.

Fixes: scylladb/argus#256
