### PR TITLE
fix(stats.py): Always show worst case status and investigation status

### DIFF
--- a/argus/backend/service/testrun.py
+++ b/argus/backend/service/testrun.py
@@ -31,6 +31,7 @@ from argus.backend.plugins.core import PluginInfoBase, PluginModelBase
 from argus.backend.plugins.loader import AVAILABLE_PLUGINS
 from argus.backend.events.event_processors import EVENT_PROCESSORS
 from argus.backend.service.notification_manager import NotificationManagerService
+from argus.backend.service.stats import ComparableTestStatus
 from argus.backend.util.common import get_build_number, strip_html_tags
 from argus.backend.util.enums import TestInvestigationStatus, TestStatus
 
@@ -79,6 +80,8 @@ class TestRunService:
 
         for row in last_runs:
             row["build_number"] = get_build_number(build_job_url=row["build_job_url"])
+
+        last_runs = sorted(last_runs, reverse=True, key=lambda run: (run["build_number"], ComparableTestStatus(TestStatus(run["status"]))))
 
         return last_runs
 


### PR DESCRIPTION
This change addresses an issue where release dashboard would show failed
run, but not that failed run's investigation status (because of sorting
differences) and also makes sure to show the worst case investigation
status for aggregated runs. Additionally, this makes testrun endpoint to
sort runs by both build number and status, making aggregated runs show
the worst case status here too.

Task: scylladb/qa-tasks#1216
