### PR TITLE
fix(driver_matrix_tests): Assign user to a job

### DIFF
--- a/argus/backend/plugins/driver_matrix_tests/model.py
+++ b/argus/backend/plugins/driver_matrix_tests/model.py
@@ -58,6 +58,10 @@ class DriverTestRun(PluginModelBase):
         run.build_id = req.job_name
         run.build_job_url = req.job_url
         run.assign_categories()
+        try:
+            run.assignee = run.get_scheduled_assignee()
+        except Exception:  # pylint: disable=broad-except
+            run.assignee = None
         for key, value in req.test_environment.items():
             env_info = EnvironmentInfo()
             env_info.key = key


### PR DESCRIPTION
This commit fixes an issue where a driver matrix run would never assign
a job to the scheduled user due to missing code
