### PR TITLE
improvement(TestDashboard.svelte): Sort tests cards by status and name

### DIFF
--- a/frontend/ReleaseDashboard/TestDashboard.svelte
+++ b/frontend/ReleaseDashboard/TestDashboard.svelte
@@ -128,8 +128,9 @@
             unknown: -1,
 
         };
+        console.log(testStats);
         let tests = Object.values(testStats)
-            .sort((a, b) => testPriorities[b.status] - testPriorities[a.status])
+            .sort((a, b) => testPriorities[b.status] - testPriorities[a.status] || a.test.name.localeCompare(b.test.name))
             .reduce((tests, testStats) => {
                 tests[testStats.test.id] = testStats;
                 return tests;


### PR DESCRIPTION
This changes sort order of the tests on the TestDashboard to
instead first sort by status and then by name of the test.
