### PR TITLE
feature(plugins/sct): Add support for Performance Subtest

### DIFF
--- a/argus/backend/plugins/sct/controller.py
+++ b/argus/backend/plugins/sct/controller.py
@@ -124,6 +124,25 @@ def sct_gemini_results_submit(run_id: str):
         "response": result
     }
 
+@bp.route("/<string:run_id>/performance/submit", methods=["POST"])
+@api_login_required
+def sct_performance_results_submit(run_id: str):
+    payload = get_payload(request)
+    result = SCTService.submit_performance_results(run_id=run_id, performance_results=payload["performance_results"])
+    return {
+        "status": "ok",
+        "response": result
+    }
+
+@bp.route("/<string:run_id>/performance/history", methods=["GET"])
+@api_login_required
+def sct_get_performance_history(run_id: str):
+    result = SCTService.get_performance_history_for_test(run_id=run_id)
+    return {
+        "status": "ok",
+        "response": result
+    }
+
 
 @bp.route("/release/<string:release_name>/kernels", methods=["GET"])
 @api_login_required

--- a/argus/backend/plugins/sct/plugin.py
+++ b/argus/backend/plugins/sct/plugin.py
@@ -12,6 +12,7 @@ from argus.backend.plugins.sct.udt import (
     NemesisRunInfo,
     NodeDescription,
     PackageVersion,
+    PerformanceHDRHistogram,
 )
 
 
@@ -31,5 +32,6 @@ class PluginInfo(PluginInfoBase):
         CloudSetupDetails,
         CloudNodesInfo,
         CloudInstanceDetails,
-        PackageVersion
+        PackageVersion,
+        PerformanceHDRHistogram,
     ]

--- a/argus/backend/plugins/sct/types.py
+++ b/argus/backend/plugins/sct/types.py
@@ -1,5 +1,16 @@
 from typing import TypedDict
 
+class RawHDRHistogram(TypedDict):
+    start_time: int
+    percentile_90: float
+    percentile_50: float
+    percentile_99_999: float
+    percentile_95: float
+    end_time: float
+    percentile_99_99: float
+    percentile_99: float
+    stddev: float
+    percentile_99_9: float
 
 class GeminiResultsRequest(TypedDict):
     oracle_nodes_count: int
@@ -14,3 +25,14 @@ class GeminiResultsRequest(TypedDict):
     gemini_write_errors: int
     gemini_read_ops: int
     gemini_read_errors: int
+
+class PerformanceResultsRequest(TypedDict):
+    test_name: str
+    stress_cmd: str
+    perf_op_rate_average: float
+    perf_op_rate_total: float
+    perf_avg_latency_99th: float
+    perf_avg_latency_mean: float
+    perf_total_errors: str
+
+    histograms: list[dict[str, RawHDRHistogram]] | None

--- a/argus/backend/plugins/sct/udt.py
+++ b/argus/backend/plugins/sct/udt.py
@@ -78,3 +78,16 @@ class NemesisRunInfo(UserType):
     start_time = columns.Integer()
     end_time = columns.Integer()
     stack_trace = columns.Text()
+
+
+class PerformanceHDRHistogram(UserType):
+    start_time = columns.Integer()
+    percentile_90 = columns.Float()
+    percentile_50 = columns.Float()
+    percentile_99_999 = columns.Float()
+    percentile_95 = columns.Float()
+    end_time = columns.Float()
+    percentile_99_99 = columns.Float()
+    percentile_99 = columns.Float()
+    stddev = columns.Float()
+    percentile_99_9 = columns.Float()

--- a/argus/backend/util/encoders.py
+++ b/argus/backend/util/encoders.py
@@ -1,10 +1,13 @@
 from datetime import datetime
+import logging
 from json.encoder import JSONEncoder
 from uuid import UUID
 
 import cassandra.cqlengine.usertype as ut
 import cassandra.cqlengine.models as m
 
+
+LOGGER = logging.getLogger(__name__)
 
 class ArgusJSONEncoder(JSONEncoder):
     def default(self, o):

--- a/argus/client/sct/client.py
+++ b/argus/client/sct/client.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 from dataclasses import asdict
-from argus.backend.plugins.sct.types import GeminiResultsRequest
+from argus.backend.plugins.sct.types import GeminiResultsRequest, PerformanceResultsRequest
 from argus.backend.util.enums import ResourceState, TestStatus
 from argus.client.base import ArgusClient
 from argus.client.sct.types import EventsInfo, LogLink, Package
@@ -19,6 +19,7 @@ class ArgusSCTClient(ArgusClient):
         UPDATE_SHARDS_FOR_RESOURCE = "/sct/$id/resource/$name/shards"
         SUBMIT_NEMESIS = "/sct/$id/nemesis/submit"
         SUBMIT_GEMINI_RESULTS = "/sct/$id/gemini/submit"
+        SUBMIT_PERFORMANCE_RESULTS = "/sct/$id/performance/submit"
         FINALIZE_NEMESIS = "/sct/$id/nemesis/finalize"
         SUBMIT_EVENTS = "/sct/$id/events/submit"
 
@@ -125,6 +126,20 @@ class ArgusSCTClient(ArgusClient):
             body={
                 **self.generic_body,
                 "gemini_data": gemini_data,
+            }
+        )
+        self.check_response(response)
+
+    def submit_performance_results(self, performance_results: PerformanceResultsRequest) -> None:
+        """
+            Submits results of a performance run. Things such as throughput stats, overall and per op
+        """
+        response = self.post(
+            endpoint=self.Routes.SUBMIT_PERFORMANCE_RESULTS,
+            location_params={"id": str(self.run_id)},
+            body={
+                **self.generic_body,
+                "performance_results": performance_results,
             }
         )
         self.check_response(response)

--- a/frontend/TestRun/ActivityTab.svelte
+++ b/frontend/TestRun/ActivityTab.svelte
@@ -59,7 +59,7 @@
                         class="img-profile"
                         src={getPictureForId(event.user_id)}
                         alt=""
-                    /> {activity.events[event.id]}
+                    /> {@html activity.events[event.id]}
                     <small class="text-muted"
                         >{new Date(
                             event.created_at

--- a/frontend/TestRun/SCTSubTests/Performance/PerformanceTabBodyComponent.svelte
+++ b/frontend/TestRun/SCTSubTests/Performance/PerformanceTabBodyComponent.svelte
@@ -1,0 +1,152 @@
+<script>
+    import { onMount } from "svelte";
+    import { sendMessage } from "../../../Stores/AlertStore";
+    import { getScyllaPackage } from "../../../Common/RunUtils";
+
+    export let testRun;
+    let performanceResults;
+    let performanceHistory = [];
+    let resultsByVersion;
+
+    const MONITORED_METRICS = [
+        "perf_op_rate_total",
+        "perf_avg_latency_mean",
+        "perf_avg_latency_99th",
+    ];
+
+    const asc = (a, b) => a - b;
+    const desc = (a, b) => b - a;
+
+    const METRIC_ORDER = {
+        perf_op_rate_total: desc,
+        perf_avg_latency_mean: asc,
+        perf_avg_latency_99th: asc,
+    };
+
+    const fetchPerformanceHistory = async function () {
+        try {
+            let response = await fetch(`/api/v1/client/sct/${testRun.id}/performance/history`);
+            let json = await response.json();
+            if (json.status == "ok") {
+                performanceHistory = json.response;
+                resultsByVersion = sortResultsByVersion(performanceHistory);
+            }
+        } catch (error) {
+            if (error?.status === "error") {
+                sendMessage(
+                    "error",
+                    `API Error when fetching test run data.\nMessage: ${error.response.arguments[0]}`
+                );
+            } else {
+                sendMessage(
+                    "error",
+                    "A backend error occurred during test run data fetch"
+                );
+                console.log(error);
+            }
+        }
+    };
+
+    /**
+     * 
+     * @param {Object[]} historicalData
+     */
+    const sortResultsByVersion = function(historicalData) {
+        return historicalData.reduce((acc, run) => {
+            if (!run.scylla_version) return acc;
+            if (!acc[run.scylla_version]) acc[run.scylla_version] = [];
+            acc[run.scylla_version].push(run);
+            acc[run.scylla_version].sort((a, b) => Date.parse(b.start_time) - Date.parse(a.start_time));
+            return acc;
+        }, {});
+    };
+
+    const cmp = function(lhs, rhs) {
+        const delta = rhs - lhs;
+        const change = (Math.abs(delta) * 100 / rhs).toFixed(0);
+
+        return delta >= 0 ? change : change * -1;
+    };
+
+    /**
+     * 
+     * @param {{[key: string]: Object[]}} sortedHistoricalData
+     * @param {string} metricName
+     */
+    const findBestAndLastResult = function(sortedHistoricalData, metricName) {
+        let resultPerKey = {};
+        for (let key in sortedHistoricalData) {
+            let bestResult = Array.from(sortedHistoricalData[key]).sort((a, b) => METRIC_ORDER[metricName](a[metricName], b[metricName])).at(0);
+            let lastResult = sortedHistoricalData[key].at(0);
+            resultPerKey[key] = {
+                "best": bestResult,
+                "last": lastResult,
+            };
+        }
+
+        return resultPerKey;
+    };
+
+    onMount(() => {
+        fetchPerformanceHistory();
+    });
+</script>
+
+<div
+    class="tab-pane fade"
+    id="nav-performance-{testRun.id}"
+    role="tabpanel"
+>
+    <div class="p-2">
+        <div class="mb-2 p-2">
+            <h5>Performance</h5>
+            <ul class="border-start list-unstyled p-2">
+                <li><span class="fw-bold">Test name: </span>{testRun.test_name}</li>
+                <li><span class="fw-bold">Stress command: </span>{testRun.stress_cmd}</li>
+                <li><span class="fw-bold">Operation Rate: </span>{testRun.perf_op_rate_total}</li>
+                <li><span class="fw-bold">Average Operation Rate: </span>{testRun.perf_op_rate_average}</li>
+                <li><span class="fw-bold">Latency 99th Percentile: </span>{testRun.perf_avg_latency_99th}</li>
+                <li><span class="fw-bold">Mean Latency: </span>{testRun.perf_avg_latency_mean}</li>
+                <li><span class="fw-bold">Total Errors: </span>{testRun.perf_total_errors}</li>
+            </ul>
+        </div>
+        <div class="p-2">
+            {#each MONITORED_METRICS as metricName}
+                {@const resultsByMetric = findBestAndLastResult(resultsByVersion, metricName)}
+                <h2>{metricName.slice("perf_".length)}</h2>
+                <div class="mb-2">
+                    <table class="table table-bordered">
+                        <thead>
+                            <th>Current Result</th>
+                            <th>Compared Version</th>
+                            <th>Best</th>
+                            <th>Diff</th>
+                            <th>Commit, Date</th>
+                            <th>last</th>
+                            <th>Diff</th>
+                            <th>Commit, Date</th>
+                        </thead>
+                        <tbody>
+                            {#each Object.entries(resultsByMetric) as [versionName, results] (versionName)}
+                                {@const bestPackage = getScyllaPackage(results.best.packages)}
+                                {@const lastPackage = getScyllaPackage(results.last.packages)}
+                                {@const cmpToBest = cmp(testRun[metricName], results.best[metricName])}
+                                {@const cmpToLast = cmp(testRun[metricName], results.last[metricName])}
+                                <tr>
+                                    <td>{testRun[metricName].toFixed(1)}</td>
+                                    <td>{versionName}</td>
+                                    <td>{results.best[metricName].toFixed(1)}</td>
+                                    <td class="table-{cmpToBest > 5 ? "success" : cmpToBest < -5 ? "danger" : "dark"}">{cmpToBest}%</td>
+                                    <td>#{bestPackage.revision_id}, {bestPackage.date}</td>
+                                    <td>{results.last[metricName].toFixed(1)}</td>
+                                    <td class="table-{cmpToLast > 5 ? "success" : cmpToBest < -5 ? "danger" : "dark"}">{cmpToLast}%</td>
+                                    <td>#{lastPackage.revision_id}, {lastPackage.date}</td>
+                                </tr>
+                            {/each}
+                        </tbody>
+                    </table>
+                </div>
+            {/each}
+        </div>
+    </div>
+</div>

--- a/frontend/TestRun/SCTSubTests/Performance/PerformanceTabComponent.svelte
+++ b/frontend/TestRun/SCTSubTests/Performance/PerformanceTabComponent.svelte
@@ -1,0 +1,13 @@
+<script>
+    export let testRun;
+</script>
+
+<button
+    class="nav-link"
+    id="nav-performance-tab-{testRun.id}"
+    data-bs-toggle="tab"
+    data-bs-target="#nav-performance-{testRun.id}"
+    type="button"
+    role="tab"
+    ><i class="fas fa-chart-simple" /> Performance</button
+>

--- a/frontend/TestRun/SCTSubTests/Subtest.js
+++ b/frontend/TestRun/SCTSubTests/Subtest.js
@@ -1,14 +1,19 @@
 import GeminiTabBodyComponent from "./Gemini/GeminiTabBodyComponent.svelte";
 import GeminiTabComponent from "./Gemini/GeminiTabComponent.svelte";
+import PerformanceTabBodyComponent from "./Performance/PerformanceTabBodyComponent.svelte";
+import PerformanceTabComponent from "./Performance/PerformanceTabComponent.svelte";
 
 export const Subtests = {
     GEMINI: "gemini",
+    PERFORMANCE: "performance",
 };
 
 export const SubtestTabComponents = {
     [Subtests.GEMINI]: GeminiTabComponent,
+    [Subtests.PERFORMANCE]: PerformanceTabComponent,
 };
 
 export const SubtestTabBodyComponents = {
     [Subtests.GEMINI]: GeminiTabBodyComponent,
+    [Subtests.PERFORMANCE]: PerformanceTabBodyComponent,
 };

--- a/frontend/TestRun/TestRun.svelte
+++ b/frontend/TestRun/TestRun.svelte
@@ -58,6 +58,7 @@
                     "error",
                     "A backend error occurred during test run data fetch"
                 );
+                console.log(error);
             }
         }
     };


### PR DESCRIPTION
This commit adds a support and frontend components for performance
regression jobs (throughput and latency). Initial frontend components
mimic the current email format for those jobs and regression finder
mimics the way sct finds a regression - A regression will be looked for
across all available version on which this job has been ran, until it
either finds the regression between best or last run. In this scenario,
SCT Plugin will set the job as failed and will create an event explaining
the cause for the failure and run the comparison failed against.

Task: scylladb/qa-tasks#1243
