### PR TITLE
fix(stats.py): Include unversioned runs in per-version filters

### DIFF
--- a/argus/backend/service/stats.py
+++ b/argus/backend/service/stats.py
@@ -354,7 +354,7 @@ class ReleaseStatsCollector:
 
         if self.release_version:
             self.release_rows = list(
-                filter(lambda row: row["scylla_version"] == self.release_version, self.release_rows))
+                filter(lambda row: row["scylla_version"] == self.release_version or not row["scylla_version"], self.release_rows))
 
         self.release_stats = ReleaseStats(release=self.release)
         self.release_stats.collect(rows=self.release_rows, limited=limited, force=force)


### PR DESCRIPTION
This adjusts behaviour as requested in scylladb/argus#273, making filter
also return jobs that have no version in case there was an issue with
retrieving that version during the run. The jobs are still sorted by
start time and only last 10 are presented

Closes #273

Task: scylladb/argus#273
