### PR TITLE
fix(siren-tests):  Add the number of failures info

### DIFF
--- a/frontend/Common/TestStatus.js
+++ b/frontend/Common/TestStatus.js
@@ -64,7 +64,8 @@ export const StatusBackgroundCSSClassMap = {
     "aborted": "bg-dark",
     "not_run": "bg-secondary",
     "not_planned": "bg-not-planned",
-    "unknown": "bg-dark"
+    "unknown": "bg-dark",
+    "skipped": "bg-dark"
 };
 
 export const StatusTableBackgroundCSSClassMap = {


### PR DESCRIPTION
For siren-tests plugin was added the number of failures of the job and the total results info 

fixes: https://github.com/scylladb/argus/issues/266