### PR TITLE
fix(argus_service.py): Do not use IN query for querying unassigned runs

### DIFF
--- a/argus/backend/plugins/core.py
+++ b/argus/backend/plugins/core.py
@@ -27,7 +27,7 @@ class PluginModelBase(Model):
     _plugin_name = "unknown"
     # Metadata
     build_id = columns.Text(required=True, partition_key=True)
-    start_time = columns.DateTime(required=True, primary_key=True, clustering_order="DESC", default=datetime.now)
+    start_time = columns.DateTime(required=True, primary_key=True, clustering_order="DESC", default=datetime.now, custom_index=True)
     id = columns.UUID(index=True, required=True)
     release_id = columns.UUID(index=True)
     group_id = columns.UUID(index=True)

--- a/frontend/ReleasePlanner/ScheduleTable.svelte
+++ b/frontend/ReleasePlanner/ScheduleTable.svelte
@@ -140,7 +140,7 @@
                             on:click={() => {onAssigneeCellClick(group.schedules[date.dateKey], group, date)}}
                         >
                             {#if group.schedules[date.dateKey]}
-                                {users[group.schedules[date.dateKey].assignees[0]]?.full_name}
+                                {users[group.schedules[date.dateKey].assignees[0]]?.full_name ?? "#EMPTY"}
                             {/if}
                             {#if clickedCell == `${group.name}/${date.dateKey}`}
                             <Schedule


### PR DESCRIPTION
This fix corrects an issue where a large group of tests would cause a
query error due to exceeding the size of available cartesian product for
the query. Additionally this corrects an issue where deleting a schedule
without an assignee would be impossible.
