### PR TITLE
fix(driver_matrix_tests): Remove Z from timestamp if found

### DIFF
--- a/argus/backend/plugins/driver_matrix_tests/model.py
+++ b/argus/backend/plugins/driver_matrix_tests/model.py
@@ -106,7 +106,10 @@ class DriverTestRun(PluginModelBase):
             collection.passed = result.get("passed")
             collection.disabled = result.get("disabled")
             collection.time = result.get("time")
-            collection.timestamp = datetime.fromisoformat(result.get("timestamp"))
+            timestamp = result.get("timestamp")
+            # TODO: Not needed once python>=3.11
+            timestamp = timestamp[0:-1] if timestamp[-1] == "Z" else timestamp
+            collection.timestamp = datetime.fromisoformat(timestamp)
             for raw_suite in result.get("suites"):
                 suite = TestSuite()
                 suite.name = raw_suite.get("name")


### PR DESCRIPTION
This PR fixes an issue with Python's versions before 3.11 handling
of iso format strings, where they would reject isoformatted timestamp if
it contains "Z" at the end, which is used to indicate that the timestamp
in question is located at UTC-0.

Fixes: #261
