### PR TITLE
fix(models/web): Make default release non-perpetual

### DIFF
--- a/argus/backend/models/web.py
+++ b/argus/backend/models/web.py
@@ -114,7 +114,7 @@ class ArgusRelease(Model):
     assignee = columns.List(value_type=columns.UUID)
     picture_id = columns.UUID()
     enabled = columns.Boolean(default=lambda: True)
-    perpetual = columns.Boolean(default=lambda: True)
+    perpetual = columns.Boolean(default=lambda: False)
     dormant = columns.Boolean(default=lambda: False)
 
     def __eq__(self, other):


### PR DESCRIPTION
This change changes default release type to "Static", which is used for
scheduling purposes to determine if release needs weekly schedules (like
scylla-master for example) or endless static schedules like point
releases.
