### PR TITLE
fix(encoders.py): Always provide ECMAScript datetime for dates

### DIFF
--- a/argus/backend/util/encoders.py
+++ b/argus/backend/util/encoders.py
@@ -19,6 +19,6 @@ class ArgusJSONEncoder(JSONEncoder):
             case m.Model():
                 return dict(o.items())
             case datetime():
-                return o.strftime("%Y-%m-%d %H:%M:%S UTC")
+                return o.strftime("%Y-%m-%dT%H:%M:%SZ")
             case _:
                 return super().default(o)

--- a/frontend/ReleaseDashboard/ReleaseActivity.svelte
+++ b/frontend/ReleaseDashboard/ReleaseActivity.svelte
@@ -43,7 +43,6 @@
             if (apiJson.status === "ok") {
                 activity = apiJson.response;
                 fetching = false;
-                console.log(activity);
             }
         } catch (error) {
             console.log(error);

--- a/frontend/ReleaseDashboard/TestDashboard.svelte
+++ b/frontend/ReleaseDashboard/TestDashboard.svelte
@@ -128,7 +128,6 @@
             unknown: -1,
 
         };
-        console.log(testStats);
         let tests = Object.values(testStats)
             .sort((a, b) => testPriorities[b.status] - testPriorities[a.status] || a.test.name.localeCompare(b.test.name))
             .reduce((tests, testStats) => {


### PR DESCRIPTION
This fixes an issue on certain browsers where dates would fail to parse,
crashing the application.

Fixes #298
Fixes #194
