### PR TITLE
improvement(NumberStats): Filtering for statuses and Percentages

### DIFF
--- a/frontend/ReleaseDashboard/ReleaseDashboard.svelte
+++ b/frontend/ReleaseDashboard/ReleaseDashboard.svelte
@@ -6,6 +6,7 @@
     import TestPopoutSelector from "./TestPopoutSelector.svelte";
     import { sendMessage } from "../Stores/AlertStore";
     import TestDashboard from "./TestDashboard.svelte";
+    import { TestStatus } from "../Common/TestStatus";
     export let releaseData = {};
     let clickedTests = {};
     let productVersion = queryString.parse(document.location.search)?.productVersion;
@@ -82,6 +83,7 @@
                 releaseName={releaseData.release.name}
                 horizontal={false}
                 displayExtendedStats={true}
+                hiddenStatuses={[TestStatus.NOT_PLANNED, TestStatus.NOT_RUN]}
                 {productVersion}
             />
         </div>

--- a/frontend/Stats/ReleaseStats.svelte
+++ b/frontend/Stats/ReleaseStats.svelte
@@ -7,6 +7,7 @@
     export let showTestMap = false;
     export let showReleaseStats = true;
     export let horizontal = false;
+    export let hiddenStatuses = [];
     export let displayExtendedStats = false;
     const dispatch = createEventDispatcher();
     const fetchStats = async function () {
@@ -63,7 +64,7 @@
     {#if releaseStats?.total > 0}
         {#if showReleaseStats}
             <div class="w-100 mb-2">
-                <svelte:component this={DisplayItem} stats={releaseStats} displayNumber={displayExtendedStats} displayInvestigations={displayExtendedStats}/>
+                <svelte:component this={DisplayItem} stats={releaseStats} displayNumber={displayExtendedStats} displayInvestigations={displayExtendedStats} {hiddenStatuses}/>
             </div>
         {/if}
     {:else if releaseStats?.total == -1}


### PR DESCRIPTION
This change adds a paramater to adjust displayed statuses inside the
widget (filtering out unneeded ones). Additionally it adds percentage
display to each status.

Fixes #295
