### PR TITLE
feature(driver_matrix_tests): Endpoint for querying per-test driver results

### DIFF
--- a/argus/backend/plugins/driver_matrix_tests/controller.py
+++ b/argus/backend/plugins/driver_matrix_tests/controller.py
@@ -1,0 +1,24 @@
+from flask import Blueprint, request
+
+from argus.backend.error_handlers import handle_api_exception
+from argus.backend.service.user import api_login_required
+from argus.backend.plugins.driver_matrix_tests.service import DriverMatrixService
+
+bp = Blueprint("driver_matrix_api", __name__, url_prefix="/driver_matrix")
+bp.register_error_handler(Exception, handle_api_exception)
+
+
+@bp.route("/test_report", methods=["GET"])
+@api_login_required
+def driver_matrix_test_report():
+
+    build_id = request.args.get("buildId")
+    if not build_id:
+        raise Exception("No build id provided")
+    
+
+    result = DriverMatrixService().tested_versions_report(build_id=build_id)
+    return {
+        "status": "ok",
+        "response": result
+    }

--- a/argus/backend/plugins/driver_matrix_tests/plugin.py
+++ b/argus/backend/plugins/driver_matrix_tests/plugin.py
@@ -2,6 +2,7 @@ from flask import Blueprint
 
 from argus.backend.plugins.core import PluginInfoBase, PluginModelBase
 from argus.backend.plugins.driver_matrix_tests.model import DriverTestRun
+from argus.backend.plugins.driver_matrix_tests.controller import bp as driver_matrix_api_bp
 from argus.backend.plugins.driver_matrix_tests.udt import TestCollection, EnvironmentInfo, TestCase, TestSuite
 
 
@@ -9,7 +10,7 @@ class PluginInfo(PluginInfoBase):
     # pylint: disable=too-few-public-methods
     name: str = "driver-matrix-tests"
     model: PluginModelBase = DriverTestRun
-    controller: Blueprint = None
+    controller: Blueprint = driver_matrix_api_bp
     all_models = [
         DriverTestRun,
     ]

--- a/argus/backend/plugins/driver_matrix_tests/service.py
+++ b/argus/backend/plugins/driver_matrix_tests/service.py
@@ -1,0 +1,42 @@
+from argus.backend.db import ScyllaCluster
+from argus.backend.models.web import ArgusRelease, ArgusTest
+from argus.backend.plugins.driver_matrix_tests.model import DriverTestRun
+
+
+class DriverMatrixService:
+    def tested_versions_report(self, build_id: str) -> dict:
+        db = ScyllaCluster.get()
+        all_runs_for_test_query = db.prepare(f"SELECT * FROM {DriverTestRun.table_name()} WHERE build_id = ?")
+
+        rows = list(db.session.execute(all_runs_for_test_query, parameters=(build_id,)).all())
+
+        if len(rows) == 0:
+            raise Exception(f"No results for build_id {build_id}", build_id)
+
+        latest = rows[0]
+        try:
+            test: ArgusTest = ArgusTest.get(id=latest["test_id"])
+            release: ArgusRelease = ArgusRelease.get(id=latest["release_id"])
+        except (ArgusTest.DoesNotExist, ArgusRelease.DoesNotExist):
+            raise Exception(f"Unable to find release and test information for build_id {build_id} and run_id {latest['id']}", build_id, latest["id"])
+        
+
+        version_map = {}
+
+        for row in rows:
+            driver_versions = [(col["name"], col["driver"]) for col in row["test_collection"]]
+            for version, driver_type in driver_versions:
+                driver_type = driver_type if driver_type else "Unknown"
+                versions: list = version_map.get(driver_type, [])
+                if version not in versions:
+                    versions.append(version)
+                    versions.sort()
+                version_map[driver_type] = versions
+
+        response = {
+            "release": release.name,
+            "test": test.name,
+            "build_id": build_id,
+            "versions": version_map,
+        }
+        return response

--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -1,0 +1,46 @@
+# Argus API
+
+To use argus API the user first should generate an API token. To do so, proceed to the Profile Page inside the application and locate the button to generate the token. WARNING: The token will be shown only once, so be sure to save it after copying. For each API call, the token should be provided as part of Authorization header, example:
+
+```sh
+curl --request GET \
+ --url https://argus.scylladb.com/api/v1/client/driver_matrix/test_report?buildId=example/driver-matrix/test \
+ --header "Authorization: token YourTokenHere"
+```
+
+## Current endpoints
+
+```http
+GET /api/v1/client/driver_matrix/test_report
+```
+
+Accepts following parameters:
+
+| Parameter | Type | Description |
+| --------- | ---- | ------------|
+| buildId          | string     | build id of the test to query            |
+
+```json
+{
+  "response": {
+    "build_id": "example/driver-matrix/test", 
+    "release": "xxxxxxxx", 
+    "test": "testing-driver-matrix", 
+    "versions": {
+      "datastax": [
+        "pytest.datastax.v3.3.24.0", 
+        "pytest.datastax.v3.3.25.0", 
+        "pytest.datastax.v4.3.24.0", 
+        "pytest.datastax.v4.3.25.0"
+      ], 
+      "scylla": [
+        "pytest.scylla.v3.3.24.8", 
+        "pytest.scylla.v3.3.25.5", 
+        "pytest.scylla.v4.3.24.8", 
+        "pytest.scylla.v4.3.25.5"
+      ]
+    }
+  }, 
+  "status": "ok"
+}
+```


### PR DESCRIPTION
feature(driver_matrix_tests): Endpoint for querying per-test driver results

This commit adds an endpoint to query driver matrix results per test (so
per driver type), by providing build_id we get a report that contains
all tested driver versions for this particular build id.

Closes #296
