### PR TITLE
improvement(TestDashboard): Display per-group status bars

### DIFF
--- a/frontend/ReleaseDashboard/TestDashboard.svelte
+++ b/frontend/ReleaseDashboard/TestDashboard.svelte
@@ -21,6 +21,7 @@
     import AssigneeList from "../WorkArea/AssigneeList.svelte";
     import { userList } from "../Stores/UserlistSubscriber";
     import { getPicture } from "../Common/UserUtils";
+    import NumberStats from "../Stats/NumberStats.svelte";
     export let releaseName = "";
     export let releaseId = "";
     export let clickedTests = {};
@@ -218,8 +219,11 @@
             {#if !groupStats.disabled}
                 <div class="p-2 shadow mb-2 rounded bg-main">
                     <h5 class="mb-2 d-flex">
-                        <div>
+                        <div class="flex-fill">
                             <div class="mb-2">{groupStats.group.pretty_name || groupStats.group.name}</div>
+                            <div class="mb-2">
+                                <NumberStats displayInvestigations={true} stats={groupStats} displayPercentage={true}/>
+                            </div>
                             {#if Object.keys(assigneeList.groups).length > 0 && Object.keys(users).length > 0}
                                 <div class="shadow-sm bg-main rounded d-inline-block p-2">
                                     <div class="d-flex align-items-center">

--- a/frontend/Stats/NumberStats.svelte
+++ b/frontend/Stats/NumberStats.svelte
@@ -4,6 +4,7 @@
     import { titleCase, subUnderscores } from "../Common/TextUtils";
     import { Collapse } from "bootstrap";
     export let displayNumber = false;
+    export let displayPercentage = false;
     export let displayInvestigations = false;
     export let hiddenStatuses = [];
     export let stats = {
@@ -25,6 +26,16 @@
     const toggleExtendedInvestigations = function () {
         new Collapse(shortBlock, { toggle: true });
         new Collapse(extendedBlock, {toggle: true });
+    };
+
+    const calcPercentageForStatus = function(status, stats) {
+        const allowedStatuses = Object.values(TestStatus).filter(v => !hiddenStatuses.includes(v));
+        const filteredTotal = Object
+            .entries(stats)
+            .filter(v => allowedStatuses.includes(v[0]) && typeof v[1] === "number")
+            .reduce((acc, v) => acc + v[1], 0);
+        const statusCount = stats?.[status] ?? 0;
+        return (statusCount / filteredTotal * 100).toFixed(1);
     };
 
     const calculateStatusStats = function(stats, investigationStatus, allowedStatuses) {
@@ -65,16 +76,19 @@
                     style="width: {Math.max(Math.round(normalize(stats[status], stats.total, 0) * 100), 10)}%"
                     title="{subUnderscores(titleCase(status))} ({stats[status]})"
                 >
-                    <div class="p-1 text-small text-light text-outline">
+                    <div class="p-1 text-small text-light text-center text-outline">
                         {#if displayNumber}
                             {stats[status]}
+                        {/if}
+                        {#if displayPercentage}
+                            {displayNumber ? "(" : ""}{calcPercentageForStatus(status, stats)}%{displayNumber ? ")" : ""}
                         {/if}
                     </div>
                 </div>
             {/if}
         {/each}
     </div>
-    {#if stats.release && displayInvestigations}
+    {#if stats.total != -1 && displayInvestigations}
         {@const allowedStatuses = Object.values(TestStatus).filter(v => !hiddenStatuses.includes(v))}
         <div 
             class="mt-2 collapse show"


### PR DESCRIPTION
This adds a status bar to release dashboard groups, similar to the
global job status bar visible on the release dashboard.

Fixes #301
