### PR TITLE
improvement(TestRuns.svelte): Add jenkins job url to system messages.

### DIFF
--- a/frontend/WorkArea/TestRuns.svelte
+++ b/frontend/WorkArea/TestRuns.svelte
@@ -359,7 +359,11 @@
                 {/each}
             </div>
         {:else}
-            <TestRunsMessage state={stateMap[currentState]} />
+            <TestRunsMessage state={stateMap[currentState]}>
+                <div>
+                    <a class="link link-primary" href="{testInfo.test.build_system_url}">Jenkins</a>
+                </div>
+            </TestRunsMessage>
         {/if}
     </div>
 {:else}


### PR DESCRIPTION
This change adds a jenkins url to the system messages view (any state
when there are no runs available to display), simplifying finding job in
the CI.

Fixes #307
