### PR TITLE
feature(Login.svelte): Allow disabling `repo` scope for Github login

### DIFF
--- a/argus/backend/service/testrun.py
+++ b/argus/backend/service/testrun.py
@@ -341,7 +341,7 @@ class TestRunService:
             }
         )
         if issue_request.status_code != 200:
-            raise Exception(f"Error getting issue state: Response: HTTP {issue_request.status_code}", issue_request)
+            raise Exception(f"Error getting issue state: Response: HTTP {issue_request.status_code}", issue_request.json())
 
         issue_state: dict[str, Any] = issue_request.json()
 

--- a/frontend/Profile/Login.svelte
+++ b/frontend/Profile/Login.svelte
@@ -1,0 +1,70 @@
+<script>
+    export let csrfToken;
+    export let githubCid;
+    export let githubScopes;
+
+    /**
+     * @type {boolean}
+     */
+    let disableRepoAccess = JSON.parse(localStorage.getItem("loginPageDisableFullRepoAccess")) ?? false;
+
+    /**
+     * @param {string} rawScopes
+     * @param {boolean} fullAccess
+     * @returns {string}
+     */
+    const parseScopes = function(rawScopes, fullAccess) {
+        /**
+         * @type {{ string: boolean }} Scopes
+         */
+        let scopes = rawScopes
+            .split(/\s/)
+            .reduce((acc, scope) => {
+                acc[scope] = scope == "repo" ? !fullAccess : true;
+                return acc;
+            }, {});
+
+        return Object
+            .entries(scopes)
+            .filter(([_, enabled]) => enabled)
+            .map(([scope, _]) => scope)
+            .join(" ");
+    };
+
+</script>
+
+<div class="row justify-content-center">
+    <div class="col-4 text-end">
+        <form method="post">
+            <div class="mb-3">
+                <label class="form-label" for="username">Username</label>
+                <input class="form-control" name="username" id="username" required />
+            </div>
+            <div class="mb-3">
+                <label class="form-label" for="password">Password</label>
+                <input class="form-control" type="password" name="password" id="password" required />
+            </div>
+            <div class="mb-3">
+                <input class="btn btn-primary" type="submit" value="Log In" />
+            </div>
+        </form>
+        <form action="https://github.com/login/oauth/authorize" method="get">
+            <input type="hidden" name="scope" value={parseScopes(githubScopes, disableRepoAccess)} />
+            <input type="hidden" name="client_id" value={githubCid} />
+            <input type="hidden" name="state" value={csrfToken} />
+            <button class="btn btn-dark" type="submit"><i class="fab fa-github" /> Sign In with GitHub</button>
+        </form>
+        <div class="mb-3">
+            <label for="disableRepoAccess" class="form-check-label">Disable full repo access</label>
+            <input
+                id="disableRepoAccess"
+                type="checkbox"
+                class="form-check-input"
+                bind:checked={disableRepoAccess}
+                on:change={() => {
+                    localStorage.setItem("loginPageDisableFullRepoAccess", `${disableRepoAccess}`);
+                }}
+            >
+        </div>
+    </div>
+</div>

--- a/frontend/login.js
+++ b/frontend/login.js
@@ -1,0 +1,12 @@
+import Login from "./Profile/Login.svelte";
+
+
+const app = new Login({
+    target: document.querySelector("div#loginContainer"),
+    props: {
+        csrfToken: CSRF_TOKEN,
+        githubCid: GITHUB_CLIENT_ID,
+        githubScopes: GITHUB_SCOPES,
+    }
+});
+

--- a/templates/auth/login.html.j2
+++ b/templates/auth/login.html.j2
@@ -4,34 +4,21 @@
   Login
 {% endblock %}
 
+{% block javascripts %}
+{{ super() }}
+<script defer src="/s/dist/login.bundle.js"></script>
+<script>
+  const GITHUB_SCOPES = "{{ github_scopes }}";
+  const GITHUB_CLIENT_ID = "{{ github_cid }}";
+  const CSRF_TOKEN = "{{ csrf_token }}";
+</script>
+{% endblock javascripts %}
+
 {% block user_header %}
 <a href="{{ url_for('main.home') }}">Home</a>
 {% endblock user_header %}
 
 {% block body %}
-<div class="container">
-  <div class="row justify-content-center">
-    <div class="col-4 text-end">
-      <form method="post">
-        <div class="mb-3">
-          <label class="form-label" for="username">Username</label>
-          <input class="form-control" name="username" id="username" required>
-        </div>
-        <div class="mb-3">
-          <label class="form-label" for="password">Password</label>
-          <input class="form-control" type="password" name="password" id="password" required>
-        </div>
-        <div class="mb-3">
-          <input class="btn btn-primary" type="submit" value="Log In">
-        </div>
-      </form>
-      <form action="https://github.com/login/oauth/authorize" method="get">
-        <input type="hidden" name="scope" value="{{ github_scopes }}">
-        <input type="hidden" name="client_id" value="{{ github_cid }}">
-        <input type="hidden" name="state" value="{{ csrf_token }}">
-        <button class="btn btn-dark" type="submit"><i class="fab fa-github"></i> Sign In with GitHub</button>
-      </form>
-    </div>
-  </div>
+<div id="loginContainer">
 </div>
 {% endblock %}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,6 +22,10 @@ module.exports = {
             import: "./frontend/flashDebug.js",
             dependOn: "globalAlert"
         },
+        login: {
+            import: "./frontend/login.js",
+            dependOn: "globalAlert"
+        },
         workArea: {
             import: "./frontend/work-area.js",
             dependOn: "globalAlert"


### PR DESCRIPTION
This change allows user to decline giving full repository read/write
permissions (as this is needed to read issue states inside organization
private repositories) via a checkbox on the login page. The state of the
checkbox is saved into local storage to prevent user from having to
constantly check it. Additionally, this commit moves the login page out
of a Jinja template and into a Svelte component.

Task: #297
