### PR TITLE
fix(client_service.py): Mark Passed runs as Investigated automatically

### DIFF
--- a/argus/backend/plugins/driver_matrix_tests/model.py
+++ b/argus/backend/plugins/driver_matrix_tests/model.py
@@ -9,7 +9,7 @@ from argus.backend.models.web import ArgusRelease
 from argus.backend.plugins.core import PluginModelBase
 from argus.backend.plugins.driver_matrix_tests.udt import TestCollection, TestSuite, TestCase, EnvironmentInfo
 from argus.backend.plugins.driver_matrix_tests.raw_types import RawMatrixTestResult
-from argus.backend.util.enums import TestStatus
+from argus.backend.util.enums import TestInvestigationStatus, TestStatus
 
 
 class DriverMatrixPluginError(Exception):
@@ -134,6 +134,8 @@ class DriverTestRun(PluginModelBase):
             run.test_collection.append(collection)
 
         run.status = run._determine_run_status().value
+        if run.status == TestStatus.PASSED:
+            run.investigation_status = TestInvestigationStatus.INVESTIGATED.value
         run.save()
         return run
 
@@ -158,7 +160,7 @@ class DriverTestRun(PluginModelBase):
         return TestStatus.PASSED
 
     def change_status(self, new_status: TestStatus):
-        raise DriverMatrixPluginError("This method is obsolete. Status is now determined on submission.")
+        self.status = new_status.value
 
     def get_events(self) -> list:
         return []

--- a/argus/backend/plugins/sirenada/model.py
+++ b/argus/backend/plugins/sirenada/model.py
@@ -7,7 +7,7 @@ from argus.backend.db import ScyllaCluster
 from argus.backend.models.web import ArgusRelease
 from argus.backend.plugins.core import PluginModelBase
 from argus.backend.plugins.sirenada.types import RawSirenadaRequest, SirenadaPluginException
-from argus.backend.util.enums import TestStatus
+from argus.backend.util.enums import TestInvestigationStatus, TestStatus
 
 
 class SirenadaTest(UserType):
@@ -108,6 +108,8 @@ class SirenadaRun(PluginModelBase):
             if (case.s3_folder_id, case.sirenada_test_id) not in run.s3_folder_ids and case.s3_folder_id:
                 run.s3_folder_ids.append((case.s3_folder_id, case.sirenada_test_id))
 
+        if run.status == TestStatus.PASSED:
+            run.investigation_status = TestInvestigationStatus.INVESTIGATED.value
         run.save()
 
         return run

--- a/argus/backend/service/client_service.py
+++ b/argus/backend/service/client_service.py
@@ -2,7 +2,7 @@ from uuid import UUID
 from argus.backend.db import ScyllaCluster
 from argus.backend.plugins.core import PluginModelBase
 from argus.backend.plugins.loader import AVAILABLE_PLUGINS
-from argus.backend.util.enums import TestStatus
+from argus.backend.util.enums import TestInvestigationStatus, TestStatus
 
 
 class ClientException(Exception):
@@ -41,7 +41,10 @@ class ClientService:
     def update_run_status(self, run_type: str, run_id: str, new_status: str) -> str:
         model = self.get_model(run_type)
         run = model.load_test_run(UUID(run_id))
-        run.change_status(new_status=TestStatus(new_status))
+        status = TestStatus(new_status)
+        run.change_status(new_status=status)
+        if status == TestStatus.PASSED:
+            run.investigation_status = TestInvestigationStatus.INVESTIGATED.value
         run.save()
 
         return run.status


### PR DESCRIPTION
This change adjusts the run status logic to automatically mark any run
that passed as investigated, as there's nothing to investigate.

Fixes #317
