### PR TITLE
improvement(frontend): Background stats fetching rework

### DIFF
--- a/frontend/ReleaseDashboard/ReleaseDashboard.svelte
+++ b/frontend/ReleaseDashboard/ReleaseDashboard.svelte
@@ -10,6 +10,7 @@
     export let releaseData = {};
     let clickedTests = {};
     let productVersion = queryString.parse(document.location.search)?.productVersion;
+    let stats;
 
     const handleTestClick = function (e) {
         console.log(e);
@@ -80,11 +81,10 @@
     <div class="row mb-2">
         <div class="col">
             <ReleaseStats
-                releaseName={releaseData.release.name}
                 horizontal={false}
                 displayExtendedStats={true}
                 hiddenStatuses={[TestStatus.NOT_PLANNED, TestStatus.NOT_RUN]}
-                {productVersion}
+                releaseStats={stats}
             />
         </div>
     </div>
@@ -97,6 +97,7 @@
                 bind:clickedTests={clickedTests}
                 on:testClick={handleTestClick}
                 on:versionChange={handleVersionChange}
+                on:statsUpdate={(e) => (stats = e.detail)}
             />
         </div>
         <div class="col-xs-10 col-sm-6 col-md-5">

--- a/frontend/ReleaseDashboard/TestDashboard.svelte
+++ b/frontend/ReleaseDashboard/TestDashboard.svelte
@@ -7,6 +7,7 @@
         faComment,
         faArrowDown,
         faArrowUp,
+        faRefresh,
     } from "@fortawesome/free-solid-svg-icons";
 
     import {
@@ -57,19 +58,22 @@
     let collapseState = loadCollapseState();
 
 
-    const fetchStats = async function () {
+    const fetchStats = async function (force = false) {
+        if (!document.hasFocus()) return;
         let params = queryString.stringify({
             release: releaseName,
             limited: new Number(false),
             force: new Number(true),
             productVersion: productVersion ?? "",
         });
-        let response = await fetch("/api/v1/release/stats/v2?" + params);
+        let opts = force ? {cache: "reload"} : {};
+        let response = await fetch("/api/v1/release/stats/v2?" + params, opts);
         let json = await response.json();
         if (json.status != "ok") {
             return false;
         }
         stats = json.response;
+        dispatch("statsUpdate", stats);
 
         if (stats.release.perpetual) {
             fetchGroupAssignees(releaseId);
@@ -80,6 +84,10 @@
                 }, 25 * idx);
             });
         }
+    };
+
+    const handleDashboardRefreshClick = function() {
+        fetchStats(true);
     };
 
     const fetchVersions = async function() {
@@ -196,6 +204,11 @@
 
 </script>
 <div class="rounded bg-light-one shadow-sm p-2">
+    <div class="text-end mb-2">
+        <button title="Refresh" class="btn btn-sm btn-outline-dark" on:click={handleDashboardRefreshClick}>
+            <Fa icon={faRefresh}/>
+        </button>
+    </div>
     {#await fetchVersions()}
         <div>Loading versions...</div>
     {:then versions}

--- a/frontend/Stats/ReleaseStats.svelte
+++ b/frontend/Stats/ReleaseStats.svelte
@@ -1,30 +1,11 @@
 <script>
     import NumberStats from "./NumberStats.svelte";
-    import { createEventDispatcher, onDestroy, onMount } from "svelte";
-    export let releaseName = "";
-    export let productVersion = "";
     export let DisplayItem = NumberStats;
     export let showTestMap = false;
     export let showReleaseStats = true;
     export let horizontal = false;
     export let hiddenStatuses = [];
     export let displayExtendedStats = false;
-    const dispatch = createEventDispatcher();
-    const fetchStats = async function () {
-        let params = new URLSearchParams({
-            release: releaseName,
-            limited: new Number(false),
-            force: new Number(false),
-            productVersion: productVersion,
-        });
-        let response = await fetch("/api/v1/release/stats/v2?" + params);
-        let json = await response.json();
-        if (json.status != "ok") {
-            return false;
-        }
-        releaseStats = json.response;
-        dispatch("statsUpdate", { stats: releaseStats });
-    };
 
     const releaseStatsDefault = {
         created: 0,
@@ -39,24 +20,7 @@
         tests: {},
         total: -1,
     };
-
-    let statRefreshInterval;
-    let releaseStats = releaseStatsDefault;
-    $: fetchStats(productVersion);
-
-    onMount(() => {
-        fetchStats();
-        let refreshInterval = 300 + 15 + Math.round((Math.random() * 10));
-        statRefreshInterval = setInterval(() => {
-            fetchStats();
-        }, refreshInterval * 1000);
-    });
-
-    onDestroy(() => {
-        if (statRefreshInterval) {
-            clearInterval(statRefreshInterval);
-        }
-    });
+    export let releaseStats = releaseStatsDefault;
 
 </script>
 

--- a/frontend/Stats/StatsFetcher.svelte
+++ b/frontend/Stats/StatsFetcher.svelte
@@ -1,0 +1,35 @@
+<script>
+    import queryString from "query-string";
+    import ReleaseStats from "./ReleaseStats.svelte";
+    export let releaseName;
+    export let productVersion;
+
+    const fetchStats = async function (force = false) {
+        if (!document.hasFocus()) return Promise.reject(new Error("#noFocus"));
+        let params = queryString.stringify({
+            release: releaseName,
+            limited: new Number(false),
+            force: new Number(true),
+            productVersion: productVersion ?? "",
+        });
+        let opts = force ? {cache: "reload"} : {};
+        let response = await fetch("/api/v1/release/stats/v2?" + params, opts);
+        let json = await response.json();
+        if (json.status != "ok") {
+            return false;
+        }
+        return json.response;
+    };
+</script>
+
+{#await fetchStats()}
+    <span class="spinner-border spinner-border-sm" /> Loading statistics...
+{:then releaseStats}
+    <ReleaseStats {releaseStats}/>
+{:catch err}
+    {#if err.message == "#noFocus"}
+        <!-- blank -->
+    {:else}
+        {err.message}
+    {/if}
+{/await}

--- a/frontend/TestRun/DriverMatrixTestRun.svelte
+++ b/frontend/TestRun/DriverMatrixTestRun.svelte
@@ -2,6 +2,7 @@
     import { onMount, onDestroy, createEventDispatcher } from "svelte";
     import Fa from "svelte-fa";
     import {
+        faRefresh,
         faTimes,
     } from "@fortawesome/free-solid-svg-icons";
     import ActivityTab from "./ActivityTab.svelte";
@@ -27,6 +28,7 @@
     let failedToLoad = false;
 
     const fetchTestRunData = async function () {
+        if (!document.hasFocus()) return;
         try {
             let run = await fetchRun(testInfo.test.plugin_name, runId);
             testRun = run;
@@ -59,7 +61,7 @@
 
         runRefreshInterval = setInterval(() => {
             fetchTestRunData();
-        }, 1000 * 30);
+        }, 1000 * 300);
     });
 
     onDestroy(() => {
@@ -77,6 +79,13 @@
             {/if}
         </div>
         <div class="ms-auto text-end">
+            <button class="btn btn-sm btn-outline-dark" title="Refresh" on:click={() => {
+                fetchTestRunData();
+            }}
+                ><Fa icon={faRefresh} /></button
+            >
+        </div>
+        <div class="ms-2 text-end">
             <button class="btn btn-sm btn-outline-dark" title="Close" on:click={() => {
                 dispatch("closeRun", { id: runId });
             }}
@@ -91,6 +100,7 @@
                     <div class="d-flex align-items-center">
                         <RunStatusButton {testRun} on:statusUpdate={(e) => {
                             testRun.status = e.detail.status;
+                            dispatch("runStatusChange");
                         }} />
                         <RunInvestigationStatusButton {testRun} on:investigationStatusChange={(e) => {
                             testRun.investigation_status = e.detail.status;

--- a/frontend/TestRun/Sirenada/SirenadaTestRun.svelte
+++ b/frontend/TestRun/Sirenada/SirenadaTestRun.svelte
@@ -2,6 +2,7 @@
     import { onMount, onDestroy, createEventDispatcher } from "svelte";
     import Fa from "svelte-fa";
     import {
+        faRefresh,
         faTimes,
     } from "@fortawesome/free-solid-svg-icons";
     import ActivityTab from "../ActivityTab.svelte";
@@ -28,6 +29,7 @@
     let failedToLoad = false;
 
     const fetchTestRunData = async function () {
+        if (!document.hasFocus()) return;
         try {
             let run = await fetchRun(testInfo.test.plugin_name, runId);
             testRun = run;
@@ -60,7 +62,7 @@
 
         runRefreshInterval = setInterval(() => {
             fetchTestRunData();
-        }, 1000 * 30);
+        }, 1000 * 300);
     });
 
     onDestroy(() => {
@@ -78,6 +80,13 @@
             {/if}
         </div>
         <div class="ms-auto text-end">
+            <button class="btn btn-sm btn-outline-dark" title="Refresh" on:click={() => {
+                fetchTestRunData();
+            }}
+                ><Fa icon={faRefresh} /></button
+            >
+        </div>
+        <div class="ms-2 text-end">
             <button class="btn btn-sm btn-outline-dark" title="Close" on:click={() => {
                 dispatch("closeRun", { id: runId });
             }}
@@ -92,6 +101,7 @@
                     <div class="d-flex align-items-center">
                         <RunStatusButton {testRun} on:statusUpdate={(e) => {
                             testRun.status = e.detail.status;
+                            dispatch("runStatusChange");
                         }} />
                         <RunInvestigationStatusButton {testRun} on:investigationStatusChange={(e) => {
                             testRun.investigation_status = e.detail.status;

--- a/frontend/TestRun/TestRun.svelte
+++ b/frontend/TestRun/TestRun.svelte
@@ -2,6 +2,7 @@
     import { onMount, onDestroy, createEventDispatcher } from "svelte";
     import Fa from "svelte-fa";
     import {
+        faRefresh,
         faTimes,
     } from "@fortawesome/free-solid-svg-icons";
     import ResourcesInfo from "./ResourcesInfo.svelte";
@@ -35,6 +36,7 @@
     let failedToLoad = false;
 
     const fetchTestRunData = async function () {
+        if (!document.hasFocus()) return;
         try {
             let run = await fetchRun(testInfo.test.plugin_name, runId);
             testRun = run;
@@ -86,6 +88,13 @@
             {/if}
         </div>
         <div class="ms-auto text-end">
+            <button class="btn btn-sm btn-outline-dark" title="Refresh" on:click={() => {
+                fetchTestRunData();
+            }}
+                ><Fa icon={faRefresh} /></button
+            >
+        </div>
+        <div class="ms-2 text-end">
             <button class="btn btn-sm btn-outline-dark" title="Close" on:click={() => {
                 dispatch("closeRun", { id: runId });
             }}
@@ -100,6 +109,7 @@
                     <div class="d-flex align-items-center">
                         <RunStatusButton {testRun} on:statusUpdate={(e) => {
                             testRun.status = e.detail.status;
+                            dispatch("runStatusChange");
                         }} />
                         <RunInvestigationStatusButton {testRun} on:investigationStatusChange={(e) => {
                             testRun.investigation_status = e.detail.status;

--- a/frontend/WorkArea/TestRunDispatcher.svelte
+++ b/frontend/WorkArea/TestRunDispatcher.svelte
@@ -7,4 +7,4 @@
 
 </script>
 
-<svelte:component this={AVAILABLE_PLUGINS?.[testInfo.test.plugin_name] ?? AVAILABLE_PLUGINS.unknown} {runId} {testInfo} {buildNumber} on:closeRun on:investigationStatusChange />
+<svelte:component this={AVAILABLE_PLUGINS?.[testInfo.test.plugin_name] ?? AVAILABLE_PLUGINS.unknown} {runId} {testInfo} {buildNumber} on:closeRun on:investigationStatusChange on:runStatusChange />

--- a/frontend/WorkArea/TestRuns.svelte
+++ b/frontend/WorkArea/TestRuns.svelte
@@ -12,6 +12,8 @@
     import { AVAILABLE_PLUGINS } from "../Common/PluginDispatch";
     import { sendMessage } from "../Stores/AlertStore";
     import TestRunsMessage from "./TestRunsMessage.svelte";
+    import { faRefresh } from "@fortawesome/free-solid-svg-icons";
+    import Fa from "svelte-fa";
 
     export let testId;
     export let listId = uuidv4();
@@ -141,6 +143,7 @@
     };
 
     const fetchTestRuns = async function () {
+        if (!document.hasFocus()) return;
         try {
             let params = queryString.stringify({
                 additionalRuns,
@@ -257,7 +260,7 @@
             fetchTestRuns();
             runRefreshInterval = setInterval(async () => {
                 fetchTestRuns();
-            }, 120 * 1000);
+            }, 1200 * 1000);
         }
     });
 
@@ -341,6 +344,7 @@
                     on:closeRun={handleTestRunClose}
                     on:increaseLimit={handleIncreaseLimit}
                     on:ignoreRuns={handleIgnoreRuns}
+                    on:fetchNewRuns={fetchTestRuns}
                 />
                 {#each runs as run (run.id)}
                     <div class:show={clickedTestRuns[run.id]} class="collapse mb-2" id="collapse{run.id}">
@@ -352,6 +356,7 @@
                                     buildNumber={extractBuildNumber(run)}
                                     on:closeRun={handleTestRunClose}
                                     on:investigationStatusChange
+                                    on:runStatusChange={fetchTestRuns}
                                 />
                             {/if}
                         </div>

--- a/frontend/WorkArea/TestRunsSelector.svelte
+++ b/frontend/WorkArea/TestRunsSelector.svelte
@@ -1,7 +1,7 @@
 <script>
     import { createEventDispatcher, onMount } from "svelte";
     import Fa from "svelte-fa";
-    import { faBan, faPlus, faTimes } from "@fortawesome/free-solid-svg-icons";
+    import { faBan, faPlus, faRefresh, faTimes } from "@fortawesome/free-solid-svg-icons";
     import { extractBuildNumber } from "../Common/RunUtils";
     import { StatusButtonCSSClassMap } from "../Common/TestStatus";
     import { Modal } from "bootstrap";
@@ -75,7 +75,7 @@
         >
             <Fa icon={faPlus}/>
         </button>
-    </div>    
+    </div>
     <div class="me-2 mb-2 d-inline-block">
         <button
             class="btn btn-light"
@@ -86,6 +86,15 @@
             }}
         >
             <Fa icon={faBan}/>
+        </button>
+    </div>
+    <div class="d-inline-block">
+        <button 
+            class="btn btn-light"
+            on:click={() => dispatch("fetchNewRuns")}
+            title="Fetch Runs"
+        >
+            <Fa icon={faRefresh}/>
         </button>
     </div>
 </div>

--- a/frontend/release-page.js
+++ b/frontend/release-page.js
@@ -1,14 +1,14 @@
-import ReleaseStats from "./Stats/ReleaseStats.svelte";
+
+import StatsFetcher from "./Stats/StatsFetcher.svelte";
 
 const registeredApps = [];
 const releaseElements = document.querySelectorAll("div.release-card");
 
 releaseElements.forEach(el => {
-    let app = new ReleaseStats({
+    let app = new StatsFetcher({
         target: el.querySelector("div.release-stats"),
         props: {
-            releaseName: el.dataset.argusReleaseName,
-            showTestMap: false
+            releaseName: el.dataset.argusReleaseName
         }
     });
     registeredApps.push(app);


### PR DESCRIPTION
This commit changes the way Argus fetches release statistics in
background. Primary changes include:

* Workarea no longer fetches all release stats, instead only fetching
  release once when it is clicked. A button was added to refresh those
  stats manually to the release dropdown.

* Release Dashboard was optimized to only make 1 stats request per state
  change (version, background update) and now also contains a manual
  refresh button.

* Auto-refresh timers, where still applicable, were increased to 15-20
  minutes

* Background stats request will not fire now if the tab the request is
  being made from is not in focus

* Updating test run status now also updates the run selector.

* Both TestRun and TestRunSelector now contain a manual refresh button.
  Timers were increased for certain test types (with non-realtime data),
  SCT stays at 30 second refresh interval. Both also no longer fetch if
  tab is in the background.

Part of #293
Fixes #313
