### PR TITLE
feature(plugins/sct): Store stress_duration in SCT runs

### DIFF
--- a/argus/backend/plugins/sct/testrun.py
+++ b/argus/backend/plugins/sct/testrun.py
@@ -60,6 +60,7 @@ class SCTTestRun(PluginModelBase):
 
     # Test Details
     test_name = columns.Text()
+    stress_duration = columns.Float()
     scm_revision_id = columns.Text()
     branch_name = columns.Text()
     origin_url = columns.Text()
@@ -181,6 +182,8 @@ class SCTTestRun(PluginModelBase):
 
         if req.sct_config:
             backend = req.sct_config.get("cluster_backend")
+            if duration_override := req.sct_config.get("stress_duration"):
+                run.stress_duration = float(duration_override)
             region_key = SCT_REGION_PROPERTY_MAP.get(backend, SCT_REGION_PROPERTY_MAP["default"])
             raw_regions = req.sct_config.get(region_key) or "undefined_region"
             regions = raw_regions.split() if isinstance(raw_regions, str) else raw_regions

--- a/frontend/TestRun/TestRunInfo.svelte
+++ b/frontend/TestRun/TestRunInfo.svelte
@@ -84,6 +84,12 @@
                         )}
                     </li>
                 {/if}
+                {#if test_run.stress_duration}
+                    <li>
+                        <span class="fw-bold">Custom Stress Duration:</span>
+                        {test_run.stress_duration}
+                    </li>
+                {/if}
                 <li>
                     <span class="fw-bold">Started by:</span>
                     {test_run.started_by ?? "Unknown, probably jenkins"}


### PR DESCRIPTION
This change adds a new field to SCT runs allowing to track
stress_duration field. The field is provided when a run had overriden
its default duration - for example a 3h longevity could be specified to
run for 6h instead. This change allows user to see the new duration to
better understand why a particular run ran for a certain period of time.

Fixes #279
