### PR TITLE
improvement(GithubIssues.svelte): Pagination, filtering and ordering support

### DIFF
--- a/frontend/ReleaseDashboard/ReleaseDashboard.svelte
+++ b/frontend/ReleaseDashboard/ReleaseDashboard.svelte
@@ -9,6 +9,7 @@
     import { TestStatus } from "../Common/TestStatus";
     export let releaseData = {};
     let clickedTests = {};
+    let issuesClicked = false;
     let productVersion = queryString.parse(document.location.search)?.productVersion;
 
     const handleTestClick = function (e) {
@@ -56,6 +57,7 @@
                             type="button"
                             data-bs-toggle="collapse"
                             data-bs-target="#collapseIssues"
+                            on:click={() => issuesClicked = true}
                         >
                             All Issues
                         </button>
@@ -65,12 +67,14 @@
                         class="accordion-collapse collapse bg-light-one"
                     >
                         <div class="accordion-body">
+                            {#if issuesClicked}
                             <GithubIssues
                                 id={releaseData.release.id}
                                 filter_key="release_id"
                                 submitDisabled={true}
                                 aggregateByIssue={true}
                             />
+                            {/if}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
This change improves the way issues are presented in the issue view -
adding pagination for issue lists over 10 items, filtering bar to filter
issues by name, repo and number and ordering support - currently adding
Title, repo and Date (with ascending/descending orders)

Fixes #231
