### PR TITLE
feature(ReleaseDashboard.svelte): Improved version filtering

### DIFF
--- a/argus/backend/controller/admin_api.py
+++ b/argus/backend/controller/admin_api.py
@@ -6,7 +6,7 @@ from flask import (
     Request,
 )
 from argus.backend.error_handlers import handle_api_exception
-from argus.backend.service.release_manager import ReleaseManagerService
+from argus.backend.service.release_manager import ReleaseEditPayload, ReleaseManagerService
 from argus.backend.service.user import api_login_required, check_roles
 from argus.backend.models.web import UserRoles
 
@@ -88,6 +88,36 @@ def set_release_dormancy():
         "status": "ok",
         "response": {
             "updated": result
+        }
+    }
+
+
+@bp.route("/release/edit", methods=["POST"])
+@check_roles(UserRoles.Admin)
+@api_login_required
+def edit_release():
+    payload: ReleaseEditPayload = get_payload(request)
+    result = ReleaseManagerService().edit_release(payload)
+
+    return {
+        "status": "ok",
+        "response": {
+            "updated": result
+        }
+    }
+
+
+@bp.route("/release/delete", methods=["POST"])
+@check_roles(UserRoles.Admin)
+@api_login_required
+def delete_release():
+    payload = get_payload(request)
+    result = ReleaseManagerService().delete_release(release_id=payload["releaseId"])
+
+    return {
+        "status": "ok",
+        "response": {
+            "deleted": result
         }
     }
 

--- a/argus/backend/controller/api.py
+++ b/argus/backend/controller/api.py
@@ -389,9 +389,10 @@ def release_stats_v2():
     release = request.args.get("release")
     limited = bool(int(request.args.get("limited")))
     version = request.args.get("productVersion", None)
+    include_no_version = bool(int(request.args.get("includeNoVersion", True)))
     force = bool(int(request.args.get("force")))
     stats = ReleaseStatsCollector(
-        release_name=release, release_version=version).collect(limited=limited, force=force)
+        release_name=release, release_version=version).collect(limited=limited, force=force, include_no_version=include_no_version)
 
     res = jsonify({
         "status": "ok",

--- a/argus/backend/models/web.py
+++ b/argus/backend/models/web.py
@@ -111,6 +111,7 @@ class ArgusRelease(Model):
     pretty_name = columns.Text()
     description = columns.Text()
     github_repo_url = columns.Text()
+    valid_version_regex = columns.Text()
     assignee = columns.List(value_type=columns.UUID)
     picture_id = columns.UUID()
     enabled = columns.Boolean(default=lambda: True)

--- a/frontend/AdminPanel/ReleaseDeletionConfirmationPopup.svelte
+++ b/frontend/AdminPanel/ReleaseDeletionConfirmationPopup.svelte
@@ -1,0 +1,64 @@
+<script>
+    import { createEventDispatcher } from "svelte";
+    import { sendMessage } from "../Stores/AlertStore";
+    const dispatch = createEventDispatcher();
+    export let releaseData;
+    let releaseNameForConfirmation = "";
+
+    const confirm = function() {
+        if (releaseNameForConfirmation != releaseData.name) {
+            sendMessage("error", "Release name doesn't match.");
+            return;
+        }
+        dispatch("deletionConfirmed");
+    };
+
+    const cancel = function() {
+        dispatch("deletionCanceled");
+    };
+
+</script>
+
+<div class="position-fixed popup-release-deletion">
+    <div class="row h-100 justify-content-center align-items-center">
+        <div class="col-5 rounded bg-white text-start shadow-sm p-2">
+            <h5 class="fw-bold">Deleting release: {releaseData.name} {releaseData.pretty_name ? `(${releaseData.pretty_name})` : ""}</h5>
+            <div>
+                This will delete the release and all its associated groups and tests. This operation is irreversible. Are you sure?
+
+                <p class="text-secondary">Note: Runs submitted for this release will be preserved, but will require manual intervention to work with again.</p>
+            </div>
+            <div>
+                <div class="form-group">
+                    <label for="" class="form-label">Type the release name to confirm:</label>
+                    <input
+                        type="text"
+                        class="form-control"
+                        bind:value={releaseNameForConfirmation}
+                    /> 
+                </div>
+            </div>
+            <div class="mt-2 mb-1">
+                <button class="btn btn-danger w-100" on:click={() => confirm()}>
+                    I understand. Delete the release.
+                </button>
+            </div>
+            <div>
+                <button class="btn btn-secondary w-100" on:click={() => cancel()}>
+                    Cancel
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<style>
+    .popup-release-deletion {
+        background-color: rgba(0, 0, 0, 0.5);
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: 1001;
+    }
+</style>

--- a/frontend/AdminPanel/ReleaseEditor.svelte
+++ b/frontend/AdminPanel/ReleaseEditor.svelte
@@ -1,0 +1,103 @@
+<script>
+    import { createEventDispatcher } from "svelte";
+    import ReleaseDeletionConfirmationPopup from "./ReleaseDeletionConfirmationPopup.svelte";
+    const dispatch = createEventDispatcher();
+    export let releaseData;
+
+    let awaitingConfirmation = false;
+
+    const handleReleaseEdit = function() {
+        dispatch("releaseEdit", releaseData);
+    };
+
+    const handleReleaseEditCancel = function() {
+        dispatch("releaseEditCancel");
+    };
+
+    const handleReleaseDelete = function() {
+        awaitingConfirmation = false;
+        dispatch("releaseDelete", {
+            releaseId: releaseData.id
+        });
+    };
+</script>
+
+<div class="position-fixed popup-release-editor">
+    <div class="row h-100 justify-content-center align-items-center">
+        <div class="col-5 rounded bg-white text-start shadow-sm p-2">
+            <h6 class="text-secondary"><span class="fw-bold">Release name:</span> {releaseData.name}</h6>
+            <div class="form-group">
+                <label for="" class="form-label">Friendly name</label>
+                <input
+                    type="text"
+                    class="form-control"
+                    placeholder="Example: ScyllaDB Enterprise 2024.1"
+                    bind:value={releaseData.pretty_name}
+                />                
+                <label for="" class="form-label">Version Regex</label>
+                <input
+                    type="text"
+                    class="form-control"
+                    placeholder="Example: 2024.1(.*)"
+                    bind:value={releaseData.valid_version_regex}
+                />
+            </div>
+            <div class="form-group">
+                <label for="" class="form-label mb-0">Weekly schedules</label>
+                <input
+                    type="checkbox"
+                    class="form-input-check"
+                    bind:checked={releaseData.perpetual}
+                />
+            </div>
+            
+            <div class="form-group">
+                <label for="" class="form-label mb-0">Disable stats fetching</label>
+                <input
+                    type="checkbox"
+                    class="form-input-check"
+                    bind:checked={releaseData.dormant}
+                />
+            </div>
+            <div class="form-group">
+                <label for="" class="form-label mb-0">Show release</label>
+                <input
+                    type="checkbox"
+                    class="form-input-check"
+                    bind:checked={releaseData.enabled}
+                />
+            </div>
+            <div class="mt-2 text-end">
+                <button
+                    class="btn btn-danger"
+                    on:click={() => (awaitingConfirmation = true)}
+                >
+                    Delete Release
+                </button>
+                {#if awaitingConfirmation}
+                    <ReleaseDeletionConfirmationPopup {releaseData} on:deletionConfirmed={handleReleaseDelete} on:deletionCanceled={() => (awaitingConfirmation = false)}/>
+                {/if}
+                <button
+                    class="btn btn-secondary"
+                    on:click={handleReleaseEditCancel}
+                >
+                    Cancel
+                </button>
+                <button class="btn btn-success" on:click={handleReleaseEdit}>
+                    Update
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<style>
+    .popup-release-editor {
+        background-color: rgba(0, 0, 0, 0.5);
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: 999;
+    }
+</style>

--- a/frontend/AdminPanel/ReleaseManager.svelte
+++ b/frontend/AdminPanel/ReleaseManager.svelte
@@ -13,12 +13,14 @@
     import ReleaseCreator from "./ReleaseCreator.svelte";
     import GroupCreator from "./GroupCreator.svelte";
     import TestCreator from "./TestCreator.svelte";
+    import ReleaseEditor from "./ReleaseEditor.svelte";
     let releases = [];
     let currentRelease;
     let currentReleaseId;
     let currentReleaseData;
     let currentGroup;
     let creatingRelease = false;
+    let editingRelease = false;
     let creatingGroup = false;
     let creatingTest = false;
     let moving = false;
@@ -38,7 +40,6 @@
                         currentRelease = releases[0];
                         currentReleaseId = currentRelease.id;
                     }
-                    ;
                 }
             } else {
                 throw apiJson;
@@ -138,7 +139,6 @@
         currentRelease = releases.find(
             (release) => release.id == currentReleaseId
         );
-        ;
     };
 
     const handleGroupChange = function (group) {
@@ -243,6 +243,33 @@
     const handleReleaseCreateCancel = function (e) {
         creatingRelease = false;
     };
+
+
+    const handleReleaseEdit = async function (e) {
+        editingRelease = false;
+        let result = await apiMethodCall(
+            "/admin/api/v1/release/edit",
+            e.detail
+        );
+        if (result.status === "ok") {
+            fetchReleases();
+        }
+    };
+
+    const handleReleaseDelete = async function (e) {
+        editingRelease = false;
+        currentRelease = undefined;
+        let result = await apiMethodCall("/admin/api/v1/release/delete", e.detail);
+        if (result.status === "ok") {
+            fetchReleases();
+        }
+    };
+
+    const handleReleaseEditCancel = function (e) {
+        editingRelease = false;
+    };
+
+
 
     const handleReleaseStateChange = async function (e) {
         let result = await apiMethodCall("/admin/api/v1/release/set_state", {
@@ -349,7 +376,25 @@
                 </div>
             {/if}
         </div>
-        <div class="col-2 text-end">
+        <div class="col-2 text-end d-flex align-items-center justify-content-end">
+            {#if currentRelease}
+                <div class="mx-2">
+                    <button
+                        class="btn btn-primary" 
+                        on:click={() => (editingRelease = true)}
+                    >
+                        Edit
+                    </button>
+                </div>
+            {/if}
+            {#if editingRelease}
+                <ReleaseEditor 
+                    releaseData={currentRelease}
+                    on:releaseEdit={handleReleaseEdit}
+                    on:releaseEditCancel={handleReleaseEditCancel}
+                    on:releaseDelete={handleReleaseDelete}
+                />
+            {/if}
             <button
                 class="btn btn-success"
                 on:click={() => (creatingRelease = true)}


### PR DESCRIPTION
This change allows administrators to define release's version regular
expression, which filters out versions displayed on the Release
Dashboard. For this purpose, a new menu was introduced in admin panel to
edit the release - setting the version regex makes the version bar on
the dashboard only display matching versions, for example: setting it to
"5.4(.*)" would only display versions starting with "5.4". This is
useful to filter out dev builds, erroneous submissions, missing versions
and rolling upgrades. Additionally, the behaviour of fetching "No
Version" runs was changed - a new checkbox was added to the dashboard
allowing user to set preference whether or not to fetch runs containing
no version alongside any versioned run. In case the checkbox is not
checked, there is a filter option to filter down to "No Version". The
regex behaviour also receives its own checkbox, allowing user to set
preference whether or not to filter out extra versions from his
dashboard. Lastly, a button to delete a release was added alongside
general release editing window.

Fixes #315
