### PR TITLE
fix(TestRuns.svelte): Ignore lack of focus on initial fetch

### DIFF
--- a/frontend/WorkArea/TestRuns.svelte
+++ b/frontend/WorkArea/TestRuns.svelte
@@ -143,7 +143,7 @@
     };
 
     const fetchTestRuns = async function () {
-        if (!document.hasFocus()) return;
+        if (!document.hasFocus() && !([states.INIT, states.INIT_RUNS].includes(currentState))) return;
         try {
             let params = queryString.stringify({
                 additionalRuns,


### PR DESCRIPTION
This change corrects an issue where TestRuns widget would not fetch runs
if it was open in a new tab - causing that tab to be instantly
backgrounded, preventing initial fetch from occuring.
