### PR TITLE
fix(stats.py): Fix worst-case collection

### DIFF
--- a/argus/backend/service/stats.py
+++ b/argus/backend/service/stats.py
@@ -126,7 +126,7 @@ def generate_field_status_map(
         field_name = "status",
         container_class = TestStatus,
         cmp_class = ComparableTestStatus
-    ) -> dict[int, str]:
+    ) -> dict[int, tuple[str, TestRunStatRow]]:
 
     status_map = {}
     for run in last_runs:
@@ -136,7 +136,7 @@ def generate_field_status_map(
                 if cmp_class(container_class(status)) < cmp_class(container_class(run[field_name])):
                     status_map[run_number] = run[field_name]
             case _:
-                status_map[run_number] = run[field_name]
+                status_map[run_number] = (run[field_name], run)
     return status_map
 
 
@@ -305,11 +305,10 @@ class TestStats:
             self.parent_group.increment_status(status=self.status)
             return
         status_map = generate_field_status_map(last_runs)
-        investigation_status_map = generate_field_status_map(
-            last_runs, "investigation_status", TestInvestigationStatus, ComparableTestInvestigationStatus)
 
-        self.status = status_map.get(get_build_number(last_run["build_job_url"]))
-        self.investigation_status = investigation_status_map.get(get_build_number(last_run["build_job_url"]))
+        worst_case = status_map.get(get_build_number(last_run["build_job_url"]))
+        self.status = worst_case[0]
+        self.investigation_status = worst_case[1]["investigation_status"]
         self.start_time = last_run["start_time"]
 
         self.parent_group.increment_status(status=self.status)
@@ -318,6 +317,7 @@ class TestStats:
 
         self.last_runs = [
             {
+                "id": run["id"],
                 "status": run["status"],
                 "build_number": get_build_number(run["build_job_url"]),
                 "build_job_name": run["build_id"],
@@ -327,10 +327,17 @@ class TestStats:
                 "comments": [dict(i.items()) for i in self.parent_group.parent_release.comments if i.test_run_id == run["id"]],
             }
             for run in last_runs
-        ][:5]
-        self.has_bug_report = len(self.last_runs[0]["issues"]) > 0
+        ]
+        try:
+            target_run = next(run for run in self.last_runs if run["id"] == worst_case[1]["id"])
+        except StopIteration:
+            target_run = worst_case[1]
+            target_run["issues"] = [dict(i.items()) for i in self.parent_group.parent_release.issues if i.run_id == target_run["id"]]
+            target_run["comments"] = [dict(i.items()) for i in self.parent_group.parent_release.comments if i.test_run_id == target_run["id"]]
+        self.has_bug_report = len(target_run["issues"]) > 0
         self.parent_group.parent_release.has_bug_report = self.has_bug_report or self.parent_group.parent_release.has_bug_report
-        self.has_comments = len(self.last_runs[0]["comments"]) > 0
+        self.has_comments = len(target_run["comments"]) > 0
+        self.last_runs = self.last_runs[:5]
 
 
 class ReleaseStatsCollector:


### PR DESCRIPTION
Due to an issue in #336 there was a problem arranging information with
worst case if worst case was not one of the last 5 runs. This is now
fixed by slicing the array later and in case we are unable to find the
run still in the filtered out runs we reconstruct the required entity.
