### PR TITLE
improvement(TestRun.svelte): Rebuild link for Jenkins

### DIFF
--- a/frontend/TestRun/DriverMatrixRunInfo.svelte
+++ b/frontend/TestRun/DriverMatrixRunInfo.svelte
@@ -1,6 +1,6 @@
 <script>
     import {
-        faBusinessTime,
+        faBusinessTime, faPlay,
     } from "@fortawesome/free-solid-svg-icons";
     import humanizeDuration from "humanize-duration";
     import Fa from "svelte-fa";
@@ -97,6 +97,9 @@
     <div class="row">
         <div class="col-6 p-2">
             <div class="btn-group">
+                <a class="btn btn-sm btn-outline-primary" href={`${testRun.build_job_url}rebuild/parameterized`} title="Rebuild"
+                    ><Fa icon={faPlay} /> Rebuild</a
+                >
                 <a
                     href="/dashboard/{testInfo.release.name}"
                     class="btn btn-outline-success"

--- a/frontend/TestRun/Sirenada/SirenadaRunInfo.svelte
+++ b/frontend/TestRun/Sirenada/SirenadaRunInfo.svelte
@@ -1,6 +1,6 @@
 <script>
     import {
-        faBusinessTime,
+        faBusinessTime, faPlay,
     } from "@fortawesome/free-solid-svg-icons";
     import humanizeDuration from "humanize-duration";
     import Fa from "svelte-fa";
@@ -65,6 +65,9 @@
     <div class="row">
         <div class="col-6 p-2">
             <div class="btn-group">
+                <a class="btn btn-sm btn-outline-primary" href={`${testRun.build_job_url}rebuild/parameterized`} title="Rebuild"
+                    ><Fa icon={faPlay} /> Rebuild</a
+                >
                 <a
                     href="/dashboard/{testInfo.release.name}"
                     class="btn btn-outline-success"

--- a/frontend/TestRun/TestRunInfo.svelte
+++ b/frontend/TestRun/TestRunInfo.svelte
@@ -3,13 +3,14 @@
         faBusinessTime,
         faSearch,
         faCopy,
+        faPlay,
     } from "@fortawesome/free-solid-svg-icons";
     import humanizeDuration from "humanize-duration";
     import Fa from "svelte-fa";
     import { InProgressStatuses } from "../Common/TestStatus";
     import { timestampToISODate } from "../Common/DateUtils";
     import { getScyllaPackage, getKernelPackage, getUpgradedScyllaPackage,
-             getOperatorPackage, getOperatorHelmPackage, getOperatorHelmRepoPackage,
+        getOperatorPackage, getOperatorHelmPackage, getOperatorHelmRepoPackage,
     } from "../Common/RunUtils";
     export let test_run = {};
     export let release;
@@ -235,6 +236,9 @@
                         target="_blank"
                         aria-current="page"
                         ><Fa icon={faSearch} /> Restore Monitoring Stack</a
+                    >
+                    <a class="btn btn-sm btn-outline-primary" href={`${test_run.build_job_url}rebuild/parameterized`} title="Rebuild"
+                        ><Fa icon={faPlay} /> Rebuild</a
                     >
                     {#if navigator.clipboard}
                         <button


### PR DESCRIPTION
This change adds a link to Jenkins rebuild page for each of the
supported TestRun cards. This is initial part of the logic to eventually
have automatic rebuilds/clones of Jenkins jobs inside argus.

Task: scylladb/qa-tasks#1612
