### PR TITLE
feature(argus): Job rebuild via Jenkins API 

### DIFF
--- a/argus/backend/controller/testrun_api.py
+++ b/argus/backend/controller/testrun_api.py
@@ -6,6 +6,7 @@ from flask import (
 )
 
 from argus.backend.error_handlers import handle_api_exception
+from argus.backend.service.jenkins_service import JenkinsService
 from argus.backend.service.testrun import TestRunService
 from argus.backend.service.user import api_login_required
 from argus.backend.util.common import get_payload
@@ -283,5 +284,56 @@ def ignore_jobs():
         "status": "ok",
         "response": {
             "affectedJobs": result
+        }
+    }
+
+
+@bp.route("/jenkins/params", methods=["POST"])
+@api_login_required
+def get_jenkins_job_params():
+
+    payload = get_payload(request)
+    service = JenkinsService()
+
+    result = service.retrieve_job_parameters(build_id=payload["buildId"], build_number=payload["buildNumber"])
+
+    return {
+        "status": "ok",
+        "response": {
+            "parameters": result
+        }
+    }
+
+
+@bp.route("/jenkins/build", methods=["POST"])
+@api_login_required
+def build_jenkins_job():
+
+    payload = get_payload(request)
+    service = JenkinsService()
+
+    result = service.build_job(build_id=payload["buildId"], params=payload["parameters"])
+
+    return {
+        "status": "ok",
+        "response": {
+            "queueItem": result
+        }
+    }
+
+
+@bp.route("/jenkins/queue_info")
+@api_login_required
+def get_queue_info():
+    queue_item = request.args.get("queueItem")
+    if not queue_item:
+        raise Exception("No queueItem provided")
+    service = JenkinsService()
+    result = service.get_queue_info(int(queue_item))
+
+    return {
+        "status": "ok",
+        "response": {
+            "queueItem": result
         }
     }

--- a/argus/backend/service/jenkins_service.py
+++ b/argus/backend/service/jenkins_service.py
@@ -30,7 +30,7 @@ class JenkinsService:
         parameter_defs = config.find("*//parameterDefinitions")
         if parameter_defs:
             descriptions = {
-                define.findtext("name"): f"{define.findtext('description')} (default: <span class=\"fw-bold\">{define.findtext('defaultValue')}</span>)" 
+                define.findtext("name"): f"{define.findtext('description', '')}" + f" (default: <span class=\"fw-bold\">{define.findtext('defaultValue')}</span>)" if define.findtext('defaultValue') else ""
                 for define in parameter_defs.iterfind("hudson.model.StringParameterDefinition")
             }
         else:

--- a/argus/backend/service/jenkins_service.py
+++ b/argus/backend/service/jenkins_service.py
@@ -1,0 +1,63 @@
+from typing import Any, TypedDict
+import xml.etree.ElementTree as ET
+import jenkins
+import logging
+
+from flask import current_app, g
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Parameter(TypedDict):
+    _class: str
+    name: str
+    description: str
+    value: Any
+
+
+class JenkinsService:
+    RESERVED_PARAMETER_NAME = "requested_by_user"
+
+    def __init__(self) -> None:
+        self._jenkins = jenkins.Jenkins(url=current_app.config["JENKINS_URL"],
+                                        username=current_app.config["JENKINS_USER"],
+                                        password=current_app.config["JENKINS_API_TOKEN"])
+
+    def retrieve_job_parameters(self, build_id: str, build_number: int) -> list[Parameter]:
+        job_info = self._jenkins.get_build_info(name=build_id, number=build_number)
+        raw_config = self._jenkins.get_job_config(name=build_id)
+        config = ET.fromstring(raw_config)
+        parameter_defs = config.find("*//parameterDefinitions")
+        if parameter_defs:
+            descriptions = {
+                define.findtext("name"): f"{define.findtext('description')} (default: <span class=\"fw-bold\">{define.findtext('defaultValue')}</span>)" 
+                for define in parameter_defs.iterfind("hudson.model.StringParameterDefinition")
+            }
+        else:
+            descriptions = {}
+        params = next(a for a in job_info["actions"] if a.get("_class", "#NONE") == "hudson.model.ParametersAction")["parameters"]
+        params = [param for param in params if param["name"] != self.RESERVED_PARAMETER_NAME]
+        for idx, param in enumerate(params):
+            params[idx]["description"] = descriptions.get(param["name"], "")
+
+        return params
+
+    def build_job(self, build_id: str, params: dict, user_override: str = None):
+        queue_number = self._jenkins.build_job(build_id, {
+            **params,
+            self.RESERVED_PARAMETER_NAME: g.user.username if not user_override else user_override
+        })
+        return queue_number
+
+    def get_queue_info(self, queue_item: int):
+        build_info = self._jenkins.get_queue_item(queue_item)
+        LOGGER.info("%s", build_info)
+        executable = build_info.get("executable")
+        if executable:
+            return executable
+        else:
+            return {
+                "why": build_info["why"],
+                "inQueueSince": build_info["inQueueSince"],
+                "taskUrl": build_info["task"]["url"],
+            }

--- a/frontend/TestRun/DriverMatrixRunInfo.svelte
+++ b/frontend/TestRun/DriverMatrixRunInfo.svelte
@@ -5,9 +5,11 @@
     import humanizeDuration from "humanize-duration";
     import Fa from "svelte-fa";
     import { timestampToISODate } from "../Common/DateUtils";
+    import { extractBuildNumber } from "../Common/RunUtils";
+    import JenkinsBuildModal from "./Jenkins/JenkinsBuildModal.svelte";
     export let testRun = {};
     export let testInfo;
-
+    let rebuildRequested = false;
     /**
      * @typedef {Object} EnvBlock
      * @property {string} scylla-product
@@ -95,10 +97,19 @@
         </div>
     </div>
     <div class="row">
+        {#if rebuildRequested}
+            <JenkinsBuildModal
+                buildId={testRun.build_id} 
+                buildNumber={extractBuildNumber(testRun)}
+                pluginName={testInfo.test.plugin_name}
+                on:rebuildCancel={() => (rebuildRequested = false)}
+                on:rebuildComplete={() => (rebuildRequested = false)}
+            />
+        {/if}
         <div class="col-6 p-2">
             <div class="btn-group">
-                <a class="btn btn-sm btn-outline-primary" href={`${testRun.build_job_url}rebuild/parameterized`} title="Rebuild"
-                    ><Fa icon={faPlay} /> Rebuild</a
+                <button class="btn btn-sm btn-outline-primary" on:click={() => (rebuildRequested = true)}
+                    ><Fa icon={faPlay} /> Rebuild</button
                 >
                 <a
                     href="/dashboard/{testInfo.release.name}"

--- a/frontend/TestRun/Jenkins/BuildStartPlaceholder.svelte
+++ b/frontend/TestRun/Jenkins/BuildStartPlaceholder.svelte
@@ -1,0 +1,10 @@
+<script>
+    /**
+     * @type {Object} args
+     */
+    export let args;
+</script>
+
+<div>
+    <span class="spinner-border spinner-border-sm"></span> Starting next build...
+</div>

--- a/frontend/TestRun/Jenkins/BuildSuccessPlaceholder.svelte
+++ b/frontend/TestRun/Jenkins/BuildSuccessPlaceholder.svelte
@@ -1,0 +1,99 @@
+<script>
+    import queryString from "query-string";
+    import { sendMessage } from "../../Stores/AlertStore";
+    import { onDestroy, onMount } from "svelte";
+    import { timestampToISODate } from "../../Common/DateUtils";
+
+    /**
+     * @type {{queueItem: number}} args
+     */
+    export let args;
+
+    let fetching = true;
+    let retrySeconds = 30;
+    let buildInfo = {};
+    let resultRetryTimeout;
+
+    /**
+     * 
+     * @param {number} queueItem
+     * @returns {Promise<{_class: string, number: number, url: string}>}
+     */
+    const fetchBuildInfo = async function(queueItem) {
+        try {
+            let params = queryString.stringify({
+                queueItem: queueItem,
+            });
+            const response = await fetch("/api/v1/jenkins/queue_info?" + params);
+
+            const json = await response.json();
+            if (json.status != "ok") {
+                throw json;
+            }
+
+            let result = json.response.queueItem;
+            if (!result.number) {
+                resultRetryTimeout = setTimeout(async () => {
+                    buildInfo = await fetchBuildInfo(queueItem);
+                }, retrySeconds * 1000);
+            }
+            fetching = false;
+            return result;
+
+        } catch (error) {
+            if (error?.status === "error") {
+                sendMessage(
+                    "error",
+                    `API Error when fetching build parameters.\nMessage: ${error.response.arguments[0]}`
+                );
+            } else {
+                sendMessage(
+                    "error",
+                    "A backend error occurred during parameter fetch"
+                );
+                console.log(error);
+            }
+            return error;
+        }
+    };
+
+    onMount(async () => {
+        buildInfo = await fetchBuildInfo(args.queueItem);
+    });
+
+    onDestroy(() => {
+        if (resultRetryTimeout) {
+            clearTimeout(resultRetryTimeout);
+        }
+    });
+</script>
+
+<div class="text-center p-2">
+    {#if fetching}
+        <div>
+            <span class="spinner-border spinner-border-sm"></span> Receiving build info...
+        </div>
+    {:else}
+        {#if buildInfo?.number}
+            <div>
+                Build #{buildInfo.number} started!
+                <div>
+                    <a href="{buildInfo.url}">Jenkins</a>
+                </div>
+            </div>
+        {:else}
+        <div>
+            Build is not started yet.
+            <div>
+                Reason: {buildInfo.why} (since: {timestampToISODate(new Date(buildInfo.inQueueSince), true)})
+            </div>
+            <div>
+                Will re-check in {retrySeconds} seconds.
+            </div>
+            <div>
+                <a href="{buildInfo.taskUrl}">Jenkins</a>
+            </div>
+        </div>
+        {/if}
+    {/if}
+</div>

--- a/frontend/TestRun/Jenkins/CheckParam.svelte
+++ b/frontend/TestRun/Jenkins/CheckParam.svelte
@@ -1,0 +1,9 @@
+<script>
+    export let params;
+    export let definition = {};
+</script>
+
+<div class="form-check form-switch">
+    <input type="checkbox" class="form-check-input" on:change={(e) => definition.onChange(e, params)} checked={params[definition.internalName] === "true"}>
+    <label type="checkbox" class="form-check-label">{definition.checkLabel}</label>
+</div>

--- a/frontend/TestRun/Jenkins/DummyCheckParam.svelte
+++ b/frontend/TestRun/Jenkins/DummyCheckParam.svelte
@@ -1,0 +1,13 @@
+<script>
+    export let params;
+    export let definition = {};
+    export let wrapper;
+
+    if (definition.init) definition.init(params);
+
+</script>
+
+<div class="form-check form-switch">
+    <input type="checkbox" class="form-check-input" on:change={(e) => wrapper ? wrapper(e, definition, params) : definition.onChange(e, params)} checked={definition.value}>
+    <label type="checkbox" class="form-check-label">{definition.checkLabel}</label>
+</div>

--- a/frontend/TestRun/Jenkins/DummySelectParam.svelte
+++ b/frontend/TestRun/Jenkins/DummySelectParam.svelte
@@ -1,0 +1,13 @@
+<script>
+    export let params = {};
+    export let definition = {};
+    export let wrapper;
+</script>
+
+<div>
+    <select class="form-select" on:change={(e) => wrapper ? wrapper(e, definition, params) : definition.onChange(e, params)} value={definition.args.value ?? definition.values[0]}>
+        {#each definition.values as val, idx}
+            <option value="{val}">{(definition.labels ?? definition.values)[idx]}</option>
+        {/each}
+    </select>
+</div>

--- a/frontend/TestRun/Jenkins/JenkinsBuildModal.svelte
+++ b/frontend/TestRun/Jenkins/JenkinsBuildModal.svelte
@@ -1,0 +1,218 @@
+<script>
+    import { createEventDispatcher, onMount } from "svelte";
+    import { sendMessage } from "../../Stores/AlertStore";
+    import BuildStartPlaceholder from "./BuildStartPlaceholder.svelte";
+    import BuildSuccessPlaceholder from "./BuildSuccessPlaceholder.svelte";
+    import ParamFetchPlaceholder from "./ParamFetchPlaceholder.svelte";
+    import ParameterEditor from "./ParameterEditor.svelte";
+    import Fa from "svelte-fa";
+    import { faTimes } from "@fortawesome/free-solid-svg-icons";
+
+    export let buildId;
+    export let buildNumber;
+    let currentState = "none";
+    const dispatch = createEventDispatcher();
+
+    const STATES = {
+        PARAM_FETCH: "param_fetch",
+        PARAM_EDIT: "param_edit",
+        BUILD_START: "build_start",
+        BUILD_CONFIRMED: "build_confirmed",
+    };
+
+    const STATE_MACHINE = {
+        [STATES.PARAM_FETCH]: {
+            component: ParamFetchPlaceholder,
+            onEnter: async function () {
+                let res = await fetchLastBuildParams(this.args.buildId, this.args.buildNumber);
+                setState(STATES.PARAM_EDIT, {params: res});
+            },
+            /**
+             * @param {CustomEvent} event
+             */
+            onExit: async function (event) {
+                //empty
+            },
+            args: {
+                buildId: buildId,
+                buildNumber: buildNumber,
+            },
+        },
+        [STATES.PARAM_EDIT]: {
+            component: ParameterEditor,
+            onEnter: async function () {
+                //empty
+            },
+            /**
+             * @param {CustomEvent} event
+             */
+            onExit: async function (event) {
+                console.log(event.detail);
+                setState(STATES.BUILD_START, { buildParams: event.detail.buildParams });
+            },
+            args: {
+                params: {}
+            },
+        },
+        [STATES.BUILD_START]: {
+            component: BuildStartPlaceholder,
+            onEnter: async function () {
+                let queueItem = await startJobBuild(this.args.buildParams);
+                let event = new CustomEvent("exit", {detail: { queueItem }});
+                this.onExit(event);
+            },
+            /**
+             * @param {CustomEvent} event
+             */
+            onExit: async function (event) {
+                setState(STATES.BUILD_CONFIRMED, {queueItem: event.detail.queueItem});
+            },
+            args: {
+                buildParams: {},
+            },
+        },
+        [STATES.BUILD_CONFIRMED]: {
+            component: BuildSuccessPlaceholder,
+            onEnter: async function () {
+                //empty
+            },
+            /**
+             * @param {CustomEvent} event
+             */
+            onExit: async function (event) {
+                dispatch("rebuildComplete");
+            },
+            args: {
+                queueItem: -1,
+            },
+        },
+        none: {
+            component: undefined,
+            onEnter: () => {
+                //empty
+            },
+            onExit: () => {
+                //empty
+            },
+            args: {},
+        }
+    };
+
+    const setState = function(newState, init) {
+        currentState = newState;
+        STATE_MACHINE[currentState].args = {...STATE_MACHINE[currentState].args, ...init};
+        STATE_MACHINE[currentState].onEnter();
+    };
+
+    const fetchLastBuildParams = async function() {
+        try {
+            const params = {
+                buildId: buildId,
+                buildNumber: Number.parseInt(buildNumber),
+            };
+            const response = await fetch("/api/v1/jenkins/params", {
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                method: "POST",
+                body: JSON.stringify(params),
+            });
+
+            const json = await response.json();
+            if (json.status != "ok") {
+                throw json;
+            }
+
+            return json.response.parameters;
+
+        } catch (error) {
+            if (error?.status === "error") {
+                sendMessage(
+                    "error",
+                    `API Error when fetching build parameters.\nMessage: ${error.response.arguments[0]}`
+                );
+            } else {
+                sendMessage(
+                    "error",
+                    "A backend error occurred during parameter fetch"
+                );
+                console.log(error);
+            }
+        }
+    };
+
+    const startJobBuild = async function(buildParams) {
+        try {
+            const params = {
+                buildId: buildId,
+                parameters: buildParams,
+            };
+            const response = await fetch("/api/v1/jenkins/build", {
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                method: "POST",
+                body: JSON.stringify(params),
+            });
+
+            const json = await response.json();
+            if (json.status != "ok") {
+                throw json;
+            }
+
+            return json.response.queueItem;
+        } catch (error) {
+            if (error?.status === "error") {
+                sendMessage(
+                    "error",
+                    `API Error when starting build.\nMessage: ${error.response.arguments[0]}`
+                );
+            } else {
+                sendMessage(
+                    "error",
+                    "A backend error occurred attempting to start a build"
+                );
+                console.log(error);
+            }
+        }
+    };
+
+    onMount(() => {
+        setState(STATES.PARAM_FETCH, {});
+    });
+</script>
+
+<div class="build-modal">
+    <div class="d-flex align-items-center justify-content-center p-4">
+        <div class="rounded bg-white p-4 h-50">
+            <div class="mb-2 d-flex border-bottom pb-2">
+                <h5>Rebuilding <span class="fw-bold">{buildId}#{buildNumber}</span></h5>
+                <div class="ms-auto">
+                    <button 
+                        class="btn btn-close"
+                        on:click={() => {
+                            dispatch("rebuildCancel");
+                        }}
+                    ></button>
+                </div>
+            </div>
+            <svelte:component this={STATE_MACHINE[currentState].component} args={STATE_MACHINE[currentState].args} on:exit={STATE_MACHINE[currentState].onExit}/>
+        </div>
+    </div>
+</div>
+
+<style>
+    .h-50 {
+        width: 50%;
+    }
+    .build-modal {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        overflow-y: scroll;
+        background-color: rgba(0, 0, 0, 0.55);
+        z-index: 9999;
+    }
+</style>

--- a/frontend/TestRun/Jenkins/JenkinsBuildModal.svelte
+++ b/frontend/TestRun/Jenkins/JenkinsBuildModal.svelte
@@ -10,6 +10,7 @@
 
     export let buildId;
     export let buildNumber;
+    export let pluginName;
     let currentState = "none";
     const dispatch = createEventDispatcher();
 
@@ -51,6 +52,7 @@
                 setState(STATES.BUILD_START, { buildParams: event.detail.buildParams });
             },
             args: {
+                pluginName: pluginName,
                 params: {}
             },
         },

--- a/frontend/TestRun/Jenkins/ParamFetchPlaceholder.svelte
+++ b/frontend/TestRun/Jenkins/ParamFetchPlaceholder.svelte
@@ -1,0 +1,10 @@
+<script>
+    /**
+     * @type {{buildId: string, buildNumber: string}} args
+     */
+    export let args;
+</script>
+
+<div>
+    <span class="spinner-border spinner-border-sm"></span> Fetching parameters from {args.buildId}#{args.buildNumber}...
+</div>

--- a/frontend/TestRun/Jenkins/ParameterEditor.svelte
+++ b/frontend/TestRun/Jenkins/ParameterEditor.svelte
@@ -1,0 +1,54 @@
+<script>
+    import { createEventDispatcher } from "svelte";
+    import { sanitizeSelector } from "../../Common/TextUtils";
+
+    /**
+     * @type {{params: {_class: string, name: string, value: string, description: string}[]}}
+     */
+    export let args;
+    let showEmptyParams = false;
+    let buildParams = args.params.reduce((acc, val) => {
+        acc[val.name] = val.value;
+        return acc;
+    }, {});
+    const dispatch = createEventDispatcher();
+
+</script>
+
+<div>
+    <div class="mb-1">
+        <div class="btn-group btn-group-sm" role="group">
+            <button 
+                type="button"
+                class="btn"
+                class:btn-primary={!showEmptyParams}
+                class:btn-outline-primary={showEmptyParams}
+                on:click={() => (showEmptyParams = false)}
+            >This build parameters</button>
+            <button 
+                type="button"
+                class="btn"
+                class:btn-primary={showEmptyParams}
+                class:btn-outline-primary={!showEmptyParams}
+                on:click={() => (showEmptyParams = true)}
+            >All parameters</button>
+        </div>
+    </div>
+    <div class="mb-2">
+        {#each args.params as param}
+            {#if param.value || showEmptyParams}
+                <div class="mb-1">
+                    <label class="form-label fw-bold" for={param.name}>{param.name}</label>
+                    <input class="form-control" id={param.name} type="text" bind:value={buildParams[param.name]}>
+                    <div id="paramHelp{sanitizeSelector(param.name)}" class="form-text">{@html param.description}</div>
+                </div>
+            {/if}
+        {/each}
+    </div>
+    <div class="text-end">
+        <button
+            class="btn btn-success w-100 mb-1"
+            on:click={() => dispatch("exit", { buildParams: buildParams })}
+        >Build</button>
+    </div>
+</div>

--- a/frontend/TestRun/Jenkins/ParameterEditor.svelte
+++ b/frontend/TestRun/Jenkins/ParameterEditor.svelte
@@ -1,18 +1,40 @@
 <script>
     import { createEventDispatcher } from "svelte";
     import { sanitizeSelector } from "../../Common/TextUtils";
+    import SctParameterWizard from "./SCTParameterWizard.svelte";
+    import WizardUnavailable from "./WizardUnavailable.svelte";
+    import { sendMessage } from "../../Stores/AlertStore";
 
     /**
      * @type {{params: {_class: string, name: string, value: string, description: string}[]}}
      */
     export let args;
-    let showEmptyParams = false;
+
+    const WIZARDS = {
+        "scylla-cluster-tests": SctParameterWizard,
+        unsupported: WizardUnavailable,
+    };
+
+
+    let wizard;
+    let paramTab = 0;
     let buildParams = args.params.reduce((acc, val) => {
         acc[val.name] = val.value;
         return acc;
     }, {});
     const dispatch = createEventDispatcher();
 
+
+    const handleParameterSubmit = function (_) {
+        if (wizard && wizard.validate) {
+            let [validated, errors] = wizard.validate();
+            if (!validated) {
+                sendMessage("error", "Validation failed. Please verify the parameters");
+                return;
+            }
+        }
+        dispatch("exit", { buildParams: buildParams });
+    };
 </script>
 
 <div>
@@ -21,34 +43,45 @@
             <button 
                 type="button"
                 class="btn"
-                class:btn-primary={!showEmptyParams}
-                class:btn-outline-primary={showEmptyParams}
-                on:click={() => (showEmptyParams = false)}
+                class:btn-primary={paramTab == 0}
+                class:btn-outline-primary={paramTab != 0}
+                on:click={() => (paramTab = 0)}
+            >Wizard</button>
+            <button 
+                type="button"
+                class="btn"
+                class:btn-primary={paramTab == 1}
+                class:btn-outline-primary={paramTab != 1}
+                on:click={() => (paramTab = 1)}
             >This build parameters</button>
             <button 
                 type="button"
                 class="btn"
-                class:btn-primary={showEmptyParams}
-                class:btn-outline-primary={!showEmptyParams}
-                on:click={() => (showEmptyParams = true)}
+                class:btn-primary={paramTab == 2}
+                class:btn-outline-primary={paramTab != 2}
+                on:click={() => (paramTab = 2)}
             >All parameters</button>
         </div>
     </div>
     <div class="mb-2">
-        {#each args.params as param}
-            {#if param.value || showEmptyParams}
-                <div class="mb-1">
-                    <label class="form-label fw-bold" for={param.name}>{param.name}</label>
-                    <input class="form-control" id={param.name} type="text" bind:value={buildParams[param.name]}>
-                    <div id="paramHelp{sanitizeSelector(param.name)}" class="form-text">{@html param.description}</div>
-                </div>
-            {/if}
-        {/each}
+        {#if paramTab == 0}
+            <svelte:component bind:this={wizard} this={WIZARDS[args.pluginName] ?? WIZARDS.unsupported} params={buildParams} rawParams={args.params}/>
+        {:else}
+            {#each args.params as param}
+                {#if param.value || paramTab == 2}
+                    <div class="mb-1">
+                        <label class="form-label fw-bold" for={param.name}>{param.name}</label>
+                        <input class="form-control" id={param.name} type="text" bind:value={buildParams[param.name]}>
+                        <div id="paramHelp{sanitizeSelector(param.name)}" class="form-text">{@html param.description}</div>
+                    </div>
+                {/if}
+            {/each}
+        {/if}
     </div>
     <div class="text-end">
         <button
             class="btn btn-success w-100 mb-1"
-            on:click={() => dispatch("exit", { buildParams: buildParams })}
+            on:click={handleParameterSubmit}
         >Build</button>
     </div>
 </div>

--- a/frontend/TestRun/Jenkins/SCTParameterWizard.svelte
+++ b/frontend/TestRun/Jenkins/SCTParameterWizard.svelte
@@ -1,0 +1,549 @@
+<script>
+    import Fa from "svelte-fa";
+    import { sanitizeSelector } from "../../Common/TextUtils";
+    import { Collapse } from "bootstrap";
+    import DummySelectParam from "./DummySelectParam.svelte";
+    import SelectParam from "./SelectParam.svelte";
+    import StringParam from "./StringParam.svelte";
+    import { faExclamationCircle, faMinus, faPlus, faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
+    import DummyCheckParam from "./DummyCheckParam.svelte";
+
+    /**@type {{[string]: string}}*/
+    export let params = {};
+    export let rawParams = [];
+
+    const determineVersionSource = function(params) {
+        const keysToCheck = {
+            scylla_version: "scylla_version",
+            scylla_repo: "scylla_repo",
+            new_scylla_repo: "rolling_upgrade",
+            scylla_ami_id: "scylla_image",
+            gce_image_db: "scylla_image",
+            azure_image_db: "scylla_image",
+        };
+
+        for (const [key, type] of Object.entries(keysToCheck)) {
+            if (params[key]) {
+                return type;
+            }
+        }
+        return keysToCheck.scylla_version;
+    };
+
+    const conditionWrapper = function(definition, params, allDefs) {
+        if (!(definition.internalName in params) && !definition.formOnly) return false;
+        const result = definition.condition(params, allDefs);
+        if (result && definition.onShow) {
+            definition.onShow(params);
+        } else if (!result && definition.onHide) {
+            definition.onHide(params);
+        }
+        return result;
+    };
+
+    const onChangeWrapper = function(event, definition, params) {
+        if (definition.onChange) definition.onChange(event, params);
+        if (definition.requiresValidation) {
+            definition.validated = definition.validate(params);
+        }
+        paramDefinitions = paramDefinitions;
+    };
+
+    const ALL_BACKENDS = {
+        azure: "Microsoft Azure",
+        aws: "Amazon AWS", 
+        "aws-siren": "Amazon AWS (Siren-tests)", 
+        "k8s-local-kind-aws": "Kubernetes in Docker on AWS", 
+        "k8s-eks": "Kubernetes (Amazon EKS)",
+        gce: "Google Cloud",
+        "gce-siren": "Google Cloud (Siren-tests)",
+        "k8s-local-kind-gce": "Kubernetes in Docker on GCE", 
+        "k8s-gke": "Kubernetes (Google Kubernetes Engine)",
+    };
+
+    /**
+     * 
+     * @param {string} backend
+     * @param {string} group
+     */
+    const inBackendGroup = function (backend, group) {
+        const BACKEND_GROUPS = {
+            aws: ["aws", "aws-siren", "k8s-local-kind-aws", "k8s-eks"],
+            azure: ["azure"],
+            gce: ["gce", "gce-siren", "k8s-local-kind-gce", "k8s-gke"],
+            k8s: ["k8s-local-kind-aws", "k8s-eks", "k8s-gke"],
+        };
+        return (BACKEND_GROUPS[group] ?? []).includes(backend);
+    };
+
+    let paramDefinitions = {
+        environment: {
+            name: "Environment",
+            params: {
+                backend: {
+                    name: "Cloud Backend",
+                    description: "Cloud backend to use.",
+                    type: SelectParam,
+                    internalName: "backend",
+                    condition: (params, defs) => true,
+                    onChange: function (e, params) {
+                        //empty
+                    },
+                    values: Object.keys(ALL_BACKENDS),
+                    labels: Object.entries(ALL_BACKENDS).map(([k, v]) => `${v} (${k})`),
+                },
+                awsRegion: {
+                    name: "Cloud Region",
+                    description: "Only supported regions are displayed",
+                    type: SelectParam,
+                    internalName: "region",
+                    condition: (params, defs) => inBackendGroup(params.backend, "aws"),
+                    onShow: function (params) {
+                        if (!params[this.internalName]) {
+                            params[this.internalName] = this.values[0];
+                        }
+                    },
+                    onChange: function (e, params) {
+                        //empty
+                    },
+                    values: ["eu-west-1", "eu-west-2", "us-west-2", "us-east-1", "eu-north-1", "eu-central-1"],
+                },
+                azureRegion: {
+                    name: "Cloud Region",
+                    description: "Only supported regions are displayed",
+                    type: SelectParam,
+                    internalName: "azure_region_name",
+                    condition: (params, defs) => inBackendGroup(params.backend, "azure"),
+                    onShow: function (params) {
+                        if (!params[this.internalName]) {
+                            params[this.internalName] = this.values[0];
+                        }
+                    },
+                    onChange: function (e, params) {
+                        //empty
+                    },
+                    values: ["eastus"],
+                },
+                gceRegion: {
+                    name: "Cloud Region",
+                    description: "Only supported regions are displayed",
+                    type: SelectParam,
+                    internalName: "gce_datacenter",
+                    condition: (params, defs) => inBackendGroup(params.backend, "gce"),
+                    onShow: function (params) {
+                        if (!params[this.internalName]) {
+                            params[this.internalName] = this.values[0];
+                        }
+                    },
+                    onChange: function (e, params) {
+                        //empty
+                    },
+                    values: ["us-east1", "us-east4", "us-west1", "us-central1"],
+                },
+                availabilityZone: {
+                    name: "Availability Zone",
+                    description: "Availability zone for the region. Note that GCE only supports zones from a to d (with some exceptions)",
+                    type: StringParam,
+                    internalName: "availability_zone",
+                    condition: (params, defs) => (true),
+                    onChange: function (e, params) {
+                        //empty
+                    },
+                },
+                provisionType: {
+                    name: "Provision Type",
+                    type: SelectParam,
+                    internalName: "provision_type",
+                    condition: (params, defs) => true,
+                    onChange: function (e, params) {
+                        //empty
+                    },
+                    values: ["spot", "on_demand", "spot_fleet"],
+                    labels: ["Spot", "On Demand", "Spot Fleet"]
+                },
+            }
+        },
+        scyllaVersion: {
+            name: "Scylla Installation",
+            show: true,
+            currentSource: determineVersionSource(params),
+            requiresValidation: true,
+            validated: true,
+            validationHelpText: "",
+            validate: function (params) {
+                const PARAMS_TO_CHECK = {
+                    scylla_version: ["scyllaVersion"],
+                    scylla_repo: ["scyllaRepo"],
+                    scylla_image: ["scyllaImageAWS", "scyllaImageGCE", "scyllaImageAzure", ],
+                    rolling_upgrade: ["newScyllaRepo"],
+                };
+                let result = true;
+                console.log(this);
+                for (let paramName of PARAMS_TO_CHECK[this.currentSource]) {
+                    console.log(this.params.masterSelect.args.value);
+                    let param = this.params[paramName];
+                    console.log(param);
+                    if (param.requiresValidation && param.condition(params, paramDefinitions)) {
+                        param.validated = param.validate(params);
+                    }
+                    if (!param.validated) {
+                        result = false;
+                    }
+                }
+
+                return result;
+            },
+            params: {
+                masterSelect: {
+                    name: "",
+                    type: DummySelectParam,
+                    formOnly: true,
+                    args: {
+                        value: determineVersionSource(params),
+                    },
+                    internalName: undefined,
+                    condition: (params, defs) => true,
+                    onChange: function (e, params) {
+                        paramDefinitions.scyllaVersion.currentSource = e.target.value;
+                    },
+                    values: ["scylla_version", "scylla_repo", "scylla_image", "rolling_upgrade"],
+                    labels: ["Provide Scylla version directly", "Provide Scylla repo", "Specify Cloud Image", "Specify Rolling Upgrade Params"],
+                },
+                scyllaVersion: {
+                    name: "Scylla Version",
+                    description: "Short scylla version string, e.g. 5.2.9~rc0 or master:latest",
+                    type: StringParam,
+                    internalName: "scylla_version",
+                    requiresValidation: true,
+                    validated: true,
+                    validationHelpText: "Incorrect version string: Use branch:timestamp format (or branch:latest) OR short version string such as 5.3.0~rc0",
+                    validate: function (params) {
+                        const VERSION_RE = /^((?<branch>[\w\d\-.]+:((?<latest>latest)|(?<build_no>\d+)|(?<date>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)))$)|(?<version>(\d+\.\d+\.\d+))(?<rc>(~rc\d))?$/;
+                        return !!params[this.internalName] && VERSION_RE.test(params[this.internalName]);
+                    },
+                    condition: (params, defs) => (defs.scyllaVersion.currentSource == "scylla_version"),
+                    onChange: function (e, params) {
+                        params.scylla_repo = "";
+                        params.scylla_ami_id = "";
+                        params.gce_image_db = "";
+                        params.azure_image_db = "";
+                    }
+                },
+                scyllaRepo: {
+                    name: "Scylla Repository",
+                    description: "HTTP(s) link to the .repo/.list file",
+                    type: StringParam,
+                    internalName: "scylla_repo",
+                    requiresValidation: true,
+                    validated: true,
+                    validationHelpText: "Malformed repository file URL.",
+                    validate: function (params) {
+                        const URL_RE = /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)$/;
+                        return !!params[this.internalName] && URL_RE.test(params[this.internalName]);
+                    },
+                    condition: (params, defs) => (defs.scyllaVersion.currentSource == "scylla_repo"),
+                    onChange: function (e, params) {
+                        params.scylla_version = "";
+                        params.scylla_ami_id = "";
+                        params.gce_image_db = "";
+                        params.azure_image_db = "";
+                        this.validated = this.validate(params);
+                    }
+                },
+                scyllaImageAWS: {
+                    name: "Scylla AMI",
+                    description: "AWS Machine Image id",
+                    type: StringParam,
+                    internalName: "scylla_ami_id",
+                    requiresValidation: true,
+                    validated: true,
+                    validationHelpText: "AMI Id should be in the format of \"ami-hexid\"",
+                    validate: function (params) {
+                        const AMI_RE = /^ami-([abcdef\d]{4,17})$/;
+                        return !!params[this.internalName] && AMI_RE.test(params[this.internalName]);
+                    },
+                    condition: (params, defs) => (defs.scyllaVersion.currentSource == "scylla_image" && inBackendGroup(params.backend, "aws")),
+                    onChange: function (e, params) {
+                        params.scylla_version = "";
+                        params.scylla_repo = "";
+                    }
+                },
+                scyllaImageGCE: {
+                    name: "Scylla GCE Image",
+                    description: "GCE ImageId",
+                    type: StringParam,
+                    internalName: "gce_image_db",
+                    requiresValidation: true,
+                    validated: true,
+                    validationHelpText: "Malformed GCE Image Id\nFormat should be: https://www.googleapis.com/compute/v1/<imagePath>",
+                    validate: function (params) {
+                        const GCE_IMAGE_RE = /^https:\/\/www\.googleapis\.com\/compute\/v1\/(?<image_path>.+)$/;
+                        return !!params[this.internalName] && GCE_IMAGE_RE.test(params[this.internalName]);
+                    },
+                    condition: (params, defs) => (defs.scyllaVersion.currentSource == "scylla_image" && inBackendGroup(params.backend, "gce")),
+                    onChange: function (e, params) {
+                        params.scylla_version = "";
+                        params.scylla_repo = "";
+                    }
+                },
+                scyllaImageAzure: {
+                    name: "Scylla Azure ImageId",
+                    description: "Azure ImageId URI",
+                    type: StringParam,
+                    internalName: "azure_image_db",
+                    requiresValidation: true,
+                    validated: true,
+                    validationHelpText: "Malformed Azure Image URL\nFormat should be: /subscriptions/<projectPath>",
+                    validate: function (params) {
+                        const AZURE_RE = /^\/subscriptions\/(?<image_path>.+)$/;
+                        return !!params[this.internalName] && AZURE_RE.test(params[this.internalName]);
+                    },
+                    condition: (params, defs) => (defs.scyllaVersion.currentSource == "scylla_image" && inBackendGroup(params.backend, "azure")),
+                    onChange: function (e, params) {
+                        params.scylla_version = "";
+                        params.scylla_repo = "";
+                    }
+                },
+                newScyllaRepo: {
+                    name: "Repository to pull newest scylla version from",
+                    type: StringParam,
+                    internalName: "new_scylla_repo",
+                    requiresValidation: true,
+                    validated: true,
+                    validationHelpText: "Missing repo URL",
+                    validate: function (params) {
+                        const URL_RE = /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)$/;
+                        return !!params[this.internalName] && URL_RE.test(params[this.internalName]);
+                    },
+                    condition: (params, defs) => (defs.scyllaVersion.currentSource == "rolling_upgrade"),
+                    onChange: function (e, params) {
+                        //empty
+                    }
+                },
+                baseVersions: {
+                    name: "Base Versions to upgrade from",
+                    type: StringParam,
+                    internalName: "base_versions",
+                    condition: (params, defs) => (defs.scyllaVersion.currentSource == "rolling_upgrade"),
+                    onChange: function (e, params) {
+                        //empty
+                    }
+                },
+                updateDbPackagesCheck:  {
+                    name: "",
+                    checkLabel: "Update to private scylla packages",
+                    description: "",
+                    type: DummyCheckParam,
+                    formOnly: true,
+                    internalName: undefined,
+                    value: false,
+                    init: function (params) {
+                        this.value = !!params.update_db_packages;
+                    },
+                    condition: (params, defs) => (true),
+                    onChange: function (e, params) {
+                        paramDefinitions.scyllaVersion.params.updateDbPackagesCheck.value = e.target.checked;
+                        if (!e.target.checked) {
+                            params.update_db_packages = "";
+                        }
+                    }
+                },
+                updateDbPackages: {
+                    name: "S3 or Google Storage URL for private packages",
+                    description: "An s3:// or gs:// url is required to update scylla to specific packages",
+                    type: StringParam,
+                    internalName: "update_db_packages",
+                    condition: (params, defs) => (defs.scyllaVersion.params.updateDbPackagesCheck.value),
+                    onChange: function (e, params) {
+                        //empty
+                    }
+                },
+            }
+        },
+        testConfiguration: {
+            name: "Test Configuration",
+            params: {
+                testName: {
+                    name: "Test Name",
+                    type: StringParam,
+                    internalName: "test_name",
+                    condition: (params, defs) => true,
+                    onChange: function (e, params) {
+                        //empty
+                    }
+                },
+                testConfig: {
+                    name: "Configuration to use",
+                    type: StringParam,
+                    internalName: "test_config",
+                    condition: (params, defs) => true,
+                    onChange: function (e, params) {
+                        //empty
+                    }
+                },
+                stressDuration: {
+                    name: "Custom Stress Command Duration",
+                    type: StringParam,
+                    internalName: "stress_duration",
+                    condition: (params, defs) => true,
+                    onChange: function (e, params) {
+                        //empty
+                    }
+                },
+
+            }
+        },
+        clusterPostTestBehaviour: {
+            name: "Cluster Post-Test Behaviour",
+            params: {
+                dbNodes: {
+                    name: "Action for DB Cluster",
+                    type: SelectParam,
+                    internalName: "post_behavior_db_nodes",
+                    condition: (params, defs) => true,
+                    onChange: function (e, params) {
+                        //empty
+                    },
+                    values: ["keep", "keep-on-failure", "destroy"],
+                    labels: ["Keep", "Keep on Failure", "Destroy"],
+                },
+                loaderNodes: {
+                    name: "Action for Loader nodes",
+                    type: SelectParam,
+                    internalName: "post_behavior_loader_nodes",
+                    condition: (params, defs) => true,
+                    onChange: function (e, params) {
+                        //empty
+                    },
+                    values: ["keep", "keep-on-failure", "destroy"],
+                    labels: ["Keep", "Keep on Failure", "Destroy"],
+                },
+                monitorNodes: {
+                    name: "Action for Monitor nodes",
+                    type: SelectParam,
+                    internalName: "post_behavior_monitor_nodes",
+                    condition: (params, defs) => true,
+                    onChange: function (e, params) {
+                        //empty
+                    },
+                    values: ["keep", "keep-on-failure", "destroy"],
+                    labels: ["Keep", "Keep on Failure", "Destroy"],
+                },
+                k8sCluster: {
+                    name: "Action for Kubernetes Cluster",
+                    type: SelectParam,
+                    internalName: "post_behavior_k8s_cluster",
+                    condition: (params, defs) => inBackendGroup(params.backend, "k8s"),
+                    onChange: function (e, params) {
+                        //empty
+                    },
+                    values: ["keep", "keep-on-failure", "destroy"],
+                    labels: ["Keep", "Keep on Failure", "Destroy"],
+                }
+            }
+        },
+        reportSettings: {
+            name: "Reporting",
+            show: true,
+            requiresValidation: true,
+            validated: true,
+            validationHelpText: "",
+            validate: function (params) {
+                if (!params.email_recipients) {
+                    params.email_recipients = "qa@scylladb.com";
+                }
+                return true;
+            },
+            params: {
+                email_recipients: {
+                    name: "Email Report Recepients",
+                    description: "Comma separated list of email recipients",
+                    requiresValidation: true,
+                    validated: true,
+                    validationHelpText: "",
+                    validate: function (params) {
+                        return true;
+                    },
+                    type: StringParam,
+                    internalName: "email_recipients",
+                    condition: (params, defs) => true,
+                    onChange: function (e, params) {
+                        //empty
+                    }
+                },
+            }
+        }
+    };
+
+    export function validate() {
+        const errors = {};
+        let validated = true;
+        for (let [categoryName, category] of Object.entries(paramDefinitions)) {
+            if (category.requiresValidation) {
+                let res = category.validate(params);
+                if (!res) {
+                    validated = false;
+                    errors[categoryName] = category.validationHelpText;
+                }
+            }
+        }
+        paramDefinitions = paramDefinitions;
+        return [validated, errors];
+    }
+</script>
+
+
+<div class="bg-light-three rounded p-2">
+    {#each Object.entries(paramDefinitions) as [paramCategoryName, paramDef] (paramCategoryName)}
+        <div class="rounded bg-white shadow-sm p-2 mb-2">
+            <div class="fw-bold d-flex align-items-center">
+                <div class="ms-2">
+                    {paramDef.name}
+                </div>
+                <button 
+                    class="ms-auto btn btn-outline-dark" 
+                    type="button"
+                    on:click={() => {
+                        paramDef.show = !paramDef.show;
+                        new Collapse(`#collapse-${paramCategoryName}`).toggle();
+                    }}
+                >
+                    {#if paramDef.show}
+                        <Fa icon={faMinus}/>
+                    {:else}
+                        <Fa icon={faPlus}/>
+                    {/if}
+                </button>
+            </div>
+            <div class="mt-2 collapse" class:show={paramDef.show} id="collapse-{paramCategoryName}">
+                {#each Object.entries(paramDef.params) as [key, param] (param.internalName || key)}
+                    {#if conditionWrapper(param, params, paramDefinitions)}
+                        <div class="my-2 text-sm">
+                            <div class="form-label text-sm">
+                                {param.name}
+                                {#if param.internalName}
+                                    <span class="display-6 text-sm text-muted" title={param.internalName}>
+                                        <Fa icon={faQuestionCircle}/>
+                                    </span>
+                                {/if}
+                            </div>
+                            <svelte:component this={param.type} bind:definition={param} bind:params={params} wrapper={onChangeWrapper}/>
+                            <div id="paramHelp{sanitizeSelector(param.internalName ?? "")}" class="form-text">{@html param.description ?? rawParams.find(v => v.name == param.internalName)?.description ?? ""}</div>
+                            {#if !param.validated && param.requiresValidation}
+                                <div class="alert alert-danger">
+                                    <Fa icon={faExclamationCircle}/> {param.validationHelpText}
+                                </div>
+                            {/if}
+                        </div>
+                    {/if}
+                {/each}
+            </div>
+        </div>
+    {/each}
+</div>
+
+<style>
+    .text-sm {
+        font-size: 0.95em;
+    }
+</style>

--- a/frontend/TestRun/Jenkins/SelectParam.svelte
+++ b/frontend/TestRun/Jenkins/SelectParam.svelte
@@ -1,0 +1,18 @@
+<script>
+    export let params = {};
+    export let definition = {};
+    export let wrapper;
+</script>
+
+<div>
+    {#if params[definition.internalName] && !definition.values.includes(params[definition.internalName])}
+    <input class="form-control" type="text" disabled value="{params[definition.internalName]}">
+    {:else}
+        <select class="form-select" bind:value={params[definition.internalName]} on:change={(e) => wrapper ? wrapper(e, definition, params) : definition.onChange(e, params)}>
+
+            {#each definition.values as val, idx}
+                <option value="{val}">{(definition.labels ?? definition.values)[idx]}</option>
+            {/each}
+        </select>
+    {/if}
+</div>

--- a/frontend/TestRun/Jenkins/StringParam.svelte
+++ b/frontend/TestRun/Jenkins/StringParam.svelte
@@ -1,0 +1,7 @@
+<script>
+    export let params;
+    export let definition = {};
+    export let wrapper;
+</script>
+
+<input class="form-control" type="text" bind:value={params[definition.internalName]} on:change={(e) => wrapper ? wrapper(e, definition, params) : definition.onChange(e, params)}>

--- a/frontend/TestRun/Jenkins/WizardUnavailable.svelte
+++ b/frontend/TestRun/Jenkins/WizardUnavailable.svelte
@@ -1,0 +1,3 @@
+<div>
+    Wizard is not available for this test type.
+</div>

--- a/frontend/TestRun/Sirenada/SirenadaRunInfo.svelte
+++ b/frontend/TestRun/Sirenada/SirenadaRunInfo.svelte
@@ -5,8 +5,11 @@
     import humanizeDuration from "humanize-duration";
     import Fa from "svelte-fa";
     import { timestampToISODate } from "../../Common/DateUtils";
+    import { extractBuildNumber } from "../../Common/RunUtils";
+    import JenkinsBuildModal from "../Jenkins/JenkinsBuildModal.svelte";
     export let testRun = {};
     export let testInfo;
+    export let rebuildRequested = false;
 
 </script>
 
@@ -63,10 +66,19 @@
         </div>
     </div>
     <div class="row">
+        {#if rebuildRequested}
+            <JenkinsBuildModal
+                buildId={testRun.build_id} 
+                buildNumber={extractBuildNumber(testRun)}
+                pluginName={testInfo.test.plugin_name}
+                on:rebuildCancel={() => (rebuildRequested = false)}
+                on:rebuildComplete={() => (rebuildRequested = false)}
+            />
+        {/if}
         <div class="col-6 p-2">
             <div class="btn-group">
-                <a class="btn btn-sm btn-outline-primary" href={`${testRun.build_job_url}rebuild/parameterized`} title="Rebuild"
-                    ><Fa icon={faPlay} /> Rebuild</a
+                <button class="btn btn-sm btn-outline-primary" on:click={() => (rebuildRequested = true)}
+                    ><Fa icon={faPlay} /> Rebuild</button
                 >
                 <a
                     href="/dashboard/{testInfo.release.name}"

--- a/frontend/TestRun/TestRunInfo.svelte
+++ b/frontend/TestRun/TestRunInfo.svelte
@@ -226,7 +226,8 @@
             {#if rebuildRequested}
                 <JenkinsBuildModal 
                     buildId={test_run.build_id} 
-                    buildNumber={extractBuildNumber(test_run)} 
+                    buildNumber={extractBuildNumber(test_run)}
+                    pluginName={test.plugin_name}
                     on:rebuildCancel={() => (rebuildRequested = false)}
                     on:rebuildComplete={() => (rebuildRequested = false)}
                 />

--- a/frontend/TestRun/TestRunInfo.svelte
+++ b/frontend/TestRun/TestRunInfo.svelte
@@ -10,12 +10,14 @@
     import { InProgressStatuses } from "../Common/TestStatus";
     import { timestampToISODate } from "../Common/DateUtils";
     import { getScyllaPackage, getKernelPackage, getUpgradedScyllaPackage,
-        getOperatorPackage, getOperatorHelmPackage, getOperatorHelmRepoPackage,
+        getOperatorPackage, getOperatorHelmPackage, getOperatorHelmRepoPackage, extractBuildNumber,
     } from "../Common/RunUtils";
+    import JenkinsBuildModal from "./Jenkins/JenkinsBuildModal.svelte";
     export let test_run = {};
     export let release;
     export let group;
     export let test;
+    let rebuildRequested = false;
 
     let cmd_hydraInvestigateShowMonitor = `hydra investigate show-monitor ${test_run.id}`;
     let cmd_hydraInvestigateShowLogs = `hydra investigate show-logs ${test_run.id}`;
@@ -221,6 +223,14 @@
                     </div>
                 {/if}
             {/if}
+            {#if rebuildRequested}
+                <JenkinsBuildModal 
+                    buildId={test_run.build_id} 
+                    buildNumber={extractBuildNumber(test_run)} 
+                    on:rebuildCancel={() => (rebuildRequested = false)}
+                    on:rebuildComplete={() => (rebuildRequested = false)}
+                />
+            {/if}
             <div class="btn-group">
                 {#if InProgressStatuses.includes(test_run.status) && locateGrafanaNode()}
                     <a
@@ -237,8 +247,8 @@
                         aria-current="page"
                         ><Fa icon={faSearch} /> Restore Monitoring Stack</a
                     >
-                    <a class="btn btn-sm btn-outline-primary" href={`${test_run.build_job_url}rebuild/parameterized`} title="Rebuild"
-                        ><Fa icon={faPlay} /> Rebuild</a
+                    <button class="btn btn-sm btn-outline-primary" on:click={() => (rebuildRequested = true)}
+                        ><Fa icon={faPlay} /> Rebuild</button
                     >
                     {#if navigator.clipboard}
                         <button


### PR DESCRIPTION
This PR replaces Jenkins rebuild URL with a custom wizard that
allows user to execute a job rebuild from inside Argus. The process is
split into two distinct phases - fetching and editing job parameters and
starting and verifying the job. On the first phase the user is presented
with a simple editor (currently only supporting string values) which
shows all parameters used for the job (with a toggle to show all
parameters for the entire workflow, i.e. empty ones), allowing user to
make necessary changes before starting rebuild. On the second phase the
job is started and verified until jenkins provides a build number and a
job url - at this point the wizard is finished and user is notified of
success.

Closes https://github.com/scylladb/qa-tasks/issues/1612