### PR TITLE
fix(TestRun.svelte): Use svelte-fa instead of <i> tag

### DIFF
--- a/frontend/Profile/Login.svelte
+++ b/frontend/Profile/Login.svelte
@@ -1,4 +1,7 @@
 <script>
+    import { faGithub } from "@fortawesome/free-brands-svg-icons";
+    import Fa from "svelte-fa";
+
     export let csrfToken;
     export let githubCid;
     export let githubScopes;
@@ -52,7 +55,7 @@
             <input type="hidden" name="scope" value={parseScopes(githubScopes, disableRepoAccess)} />
             <input type="hidden" name="client_id" value={githubCid} />
             <input type="hidden" name="state" value={csrfToken} />
-            <button class="btn btn-dark" type="submit"><i class="fab fa-github" /> Sign In with GitHub</button>
+            <button class="btn btn-dark" type="submit"><Fa icon={faGithub}/> Sign In with GitHub</button>
         </form>
         <div class="mb-3">
             <label for="disableRepoAccess" class="form-check-label">Disable full repo access</label>

--- a/frontend/TestRun/DriverMatrixTestRun.svelte
+++ b/frontend/TestRun/DriverMatrixTestRun.svelte
@@ -2,6 +2,11 @@
     import { onMount, onDestroy, createEventDispatcher } from "svelte";
     import Fa from "svelte-fa";
     import {
+        faBoxes,
+        faCodeBranch,
+        faComments,
+        faExclamationTriangle,
+        faInfoCircle,
         faRefresh,
         faTimes,
     } from "@fortawesome/free-solid-svg-icons";
@@ -123,7 +128,7 @@
                         data-bs-target="#nav-details-{runId}"
                         type="button"
                         role="tab"
-                        ><i class="fas fa-info-circle" /> Details</button
+                        ><Fa icon={faInfoCircle}/> Details</button
                     >
                     <button
                         class="nav-link"
@@ -132,7 +137,7 @@
                         data-bs-target="#nav-tests-{runId}"
                         type="button"
                         role="tab"
-                        ><i class="fas fa-boxes" /> Tests</button
+                        ><Fa icon={faBoxes}/> Tests</button
                     >
                     <button
                         class="nav-link"
@@ -142,7 +147,7 @@
                         type="button"
                         on:click={() => (commentsOpen = true)}
                         role="tab"
-                        ><i class="fas fa-comments" /> Discussion</button
+                        ><Fa icon={faComments}/> Discussion</button
                     >
                     <button
                         class="nav-link"
@@ -152,7 +157,7 @@
                         type="button"
                         role="tab"
                         on:click={() => (issuesOpen = true)}
-                        ><i class="fas fa-code-branch" /> Issues</button
+                        ><Fa icon={faCodeBranch}/> Issues</button
                     >
                     <button
                         class="nav-link"
@@ -162,7 +167,7 @@
                         type="button"
                         on:click={() => (activityOpen = true)}
                         role="tab"
-                        ><i class="fas fa-exclamation-triangle" /> Activity</button
+                        ><Fa icon={faExclamationTriangle}/> Activity</button
                     >
                 </div>
             </nav>

--- a/frontend/TestRun/SCTSubTests/Gemini/GeminiTabComponent.svelte
+++ b/frontend/TestRun/SCTSubTests/Gemini/GeminiTabComponent.svelte
@@ -1,4 +1,7 @@
 <script>
+    import { faEye } from "@fortawesome/free-solid-svg-icons";
+    import Fa from "svelte-fa";
+
     export let testRun;
 </script>
 
@@ -9,5 +12,5 @@
     data-bs-target="#nav-gemini-{testRun.id}"
     type="button"
     role="tab"
-    ><i class="fas fa-eye" /> Gemini</button
+    ><Fa icon={faEye}/> Gemini</button
 >

--- a/frontend/TestRun/SCTSubTests/Performance/PerformanceTabComponent.svelte
+++ b/frontend/TestRun/SCTSubTests/Performance/PerformanceTabComponent.svelte
@@ -1,4 +1,7 @@
 <script>
+    import { faChartSimple } from "@fortawesome/free-solid-svg-icons";
+    import Fa from "svelte-fa";
+
     export let testRun;
 </script>
 
@@ -9,5 +12,5 @@
     data-bs-target="#nav-performance-{testRun.id}"
     type="button"
     role="tab"
-    ><i class="fas fa-chart-simple" /> Performance</button
+    ><Fa icon={faChartSimple}/> Performance</button
 >

--- a/frontend/TestRun/Sirenada/SirenadaTestRun.svelte
+++ b/frontend/TestRun/Sirenada/SirenadaTestRun.svelte
@@ -2,6 +2,11 @@
     import { onMount, onDestroy, createEventDispatcher } from "svelte";
     import Fa from "svelte-fa";
     import {
+        faClipboard,
+        faCodeBranch,
+        faComments,
+        faExclamationTriangle,
+        faInfoCircle,
         faRefresh,
         faTimes,
     } from "@fortawesome/free-solid-svg-icons";
@@ -124,7 +129,7 @@
                         data-bs-target="#nav-details-{runId}"
                         type="button"
                         role="tab"
-                        ><i class="fas fa-info-circle" /> Details</button
+                        ><Fa icon={faInfoCircle}/> Details</button
                     >
                     <button
                         class="nav-link"
@@ -133,7 +138,7 @@
                         data-bs-target="#nav-results-{runId}"
                         type="button"
                         role="tab"
-                        ><i class="fas fa-clipboard" /> Results</button
+                        ><Fa icon={faClipboard}/> Results</button
                     >
                     <button
                         class="nav-link"
@@ -143,7 +148,7 @@
                         type="button"
                         on:click={() => (commentsOpen = true)}
                         role="tab"
-                        ><i class="fas fa-comments" /> Discussion</button
+                        ><Fa icon={faComments}/> Discussion</button
                     >
                     <button
                         class="nav-link"
@@ -153,7 +158,7 @@
                         type="button"
                         role="tab"
                         on:click={() => (issuesOpen = true)}
-                        ><i class="fas fa-code-branch" /> Issues</button
+                        ><Fa icon={faCodeBranch}/> Issues</button
                     >
                     <button
                         class="nav-link"
@@ -163,7 +168,7 @@
                         type="button"
                         on:click={() => (activityOpen = true)}
                         role="tab"
-                        ><i class="fas fa-exclamation-triangle" /> Activity</button
+                        ><Fa icon={faExclamationTriangle}/> Activity</button
                     >
                 </div>
             </nav>

--- a/frontend/TestRun/TestRun.svelte
+++ b/frontend/TestRun/TestRun.svelte
@@ -2,7 +2,16 @@
     import { onMount, onDestroy, createEventDispatcher } from "svelte";
     import Fa from "svelte-fa";
     import {
+        faBox,
+        faCloud,
+        faCodeBranch,
+        faComments,
+        faExclamationTriangle,
+        faImages,
+        faInfoCircle,
         faRefresh,
+        faRssSquare,
+        faSpider,
         faTimes,
     } from "@fortawesome/free-solid-svg-icons";
     import ResourcesInfo from "./ResourcesInfo.svelte";
@@ -134,7 +143,7 @@
                         data-bs-target="#nav-details-{runId}"
                         type="button"
                         role="tab"
-                        ><i class="fas fa-info-circle" /> Details</button
+                        ><Fa icon={faInfoCircle}/> Details</button
                     >
                     {#if testRun.subtest_name && Object.values(Subtests).includes(testRun.subtest_name)}
                         <svelte:component this={SubtestTabComponents[testRun.subtest_name]} {testRun}/>
@@ -146,7 +155,7 @@
                         data-bs-target="#nav-screenshots-{runId}"
                         type="button"
                         role="tab"
-                        ><i class="fas fa-images" /> Screenshots</button
+                        ><Fa icon={faImages}/> Screenshots</button
                     >
                     <button
                         class="nav-link"
@@ -154,7 +163,7 @@
                         data-bs-toggle="tab"
                         data-bs-target="#nav-resources-{runId}"
                         type="button"
-                        role="tab"><i class="fas fa-cloud" /> Resources</button
+                        role="tab"><Fa icon={faCloud}/> Resources</button
                     >
                     <button
                         class="nav-link"
@@ -162,7 +171,7 @@
                         data-bs-toggle="tab"
                         data-bs-target="#nav-packages-{runId}"
                         type="button"
-                        role="tab"><i class="fas fa-box" /> Packages</button
+                        role="tab"><Fa icon={faBox}/> Packages</button
                     >
                     <button
                         class="nav-link"
@@ -172,7 +181,7 @@
                         type="button"
                         role="tab"
                         on:click={() => (eventsOpen = true)}
-                        ><i class="fas fa-rss-square" /> Events</button
+                        ><Fa icon={faRssSquare}/> Events</button
                     >
                     <button
                         class="nav-link"
@@ -180,7 +189,7 @@
                         data-bs-toggle="tab"
                         data-bs-target="#nav-nemesis-{runId}"
                         type="button"
-                        role="tab"><i class="fas fa-spider" /> Nemesis</button
+                        role="tab"><Fa icon={faSpider}/> Nemesis</button
                     >
                     <button
                         class="nav-link"
@@ -189,7 +198,7 @@
                         data-bs-target="#nav-logs-{runId}"
                         type="button"
                         on:click={() => (artifactTabOpened = true)}
-                        role="tab"><i class="fas fa-box" /> Logs</button
+                        role="tab"><Fa icon={faBox}/> Logs</button
                     >
                     <button
                         class="nav-link"
@@ -199,7 +208,7 @@
                         type="button"
                         on:click={() => (commentsOpen = true)}
                         role="tab"
-                        ><i class="fas fa-comments" /> Discussion</button
+                        ><Fa icon={faComments}/> Discussion</button
                     >
                     <button
                         class="nav-link"
@@ -209,7 +218,7 @@
                         type="button"
                         role="tab"
                         on:click={() => (issuesOpen = true)}
-                        ><i class="fas fa-code-branch" /> Issues</button
+                        ><Fa icon={faCodeBranch}/> Issues</button
                     >
                     <button
                         class="nav-link"
@@ -219,7 +228,7 @@
                         type="button"
                         on:click={() => (activityOpen = true)}
                         role="tab"
-                        ><i class="fas fa-exclamation-triangle" /> Activity</button
+                        ><Fa icon={faExclamationTriangle}/> Activity</button
                     >
                 </div>
             </nav>


### PR DESCRIPTION
This fixes an issue where repeated mount/dismount of component would
duplicate Font-Awesome icons in the markup, as they don't have same
cleanup procedures as svelte does.

Task: #341
