### PR TITLE
fix(TestRuns.svelte): Re-enable background refresh for Workspace Runs

### DIFF
--- a/frontend/TestRun/DriverMatrixTestRun.svelte
+++ b/frontend/TestRun/DriverMatrixTestRun.svelte
@@ -28,7 +28,6 @@
     let failedToLoad = false;
 
     const fetchTestRunData = async function () {
-        if (!document.hasFocus()) return;
         try {
             let run = await fetchRun(testInfo.test.plugin_name, runId);
             testRun = run;

--- a/frontend/TestRun/Sirenada/SirenadaTestRun.svelte
+++ b/frontend/TestRun/Sirenada/SirenadaTestRun.svelte
@@ -29,7 +29,6 @@
     let failedToLoad = false;
 
     const fetchTestRunData = async function () {
-        if (!document.hasFocus()) return;
         try {
             let run = await fetchRun(testInfo.test.plugin_name, runId);
             testRun = run;

--- a/frontend/TestRun/TestRun.svelte
+++ b/frontend/TestRun/TestRun.svelte
@@ -37,7 +37,6 @@
     let failedToLoad = false;
 
     const fetchTestRunData = async function () {
-        if (!document.hasFocus()) return;
         try {
             let run = await fetchRun(testInfo.test.plugin_name, runId);
             testRun = run;

--- a/frontend/WorkArea/TestRuns.svelte
+++ b/frontend/WorkArea/TestRuns.svelte
@@ -143,7 +143,6 @@
     };
 
     const fetchTestRuns = async function () {
-        if (!document.hasFocus() && !([states.INIT, states.INIT_RUNS].includes(currentState))) return;
         try {
             let params = queryString.stringify({
                 additionalRuns,
@@ -260,7 +259,7 @@
             fetchTestRuns();
             runRefreshInterval = setInterval(async () => {
                 fetchTestRuns();
-            }, 1200 * 1000);
+            }, 120 * 1000);
         }
     });
 


### PR DESCRIPTION
This commit reverts the behaviour of TestRuns component where it will
now again refresh without tab being in focus

Fixes #343
