### PR TITLE
feature(jenkins_service): Job cloning for Jenkins

### DIFF
--- a/argus/backend/controller/testrun_api.py
+++ b/argus/backend/controller/testrun_api.py
@@ -337,3 +337,103 @@ def get_queue_info():
             "queueItem": result
         }
     }
+
+
+@bp.route("/jenkins/clone/targets")
+@api_login_required
+def get_clone_targets():
+    test_id = request.args.get("testId")
+    if not test_id:
+        raise Exception("No testId provided")
+    service = JenkinsService()
+    result = service.get_releases_for_clone(test_id)
+
+    return {
+        "status": "ok",
+        "response": {
+            "targets": result
+        }
+    }
+
+
+@bp.route("/jenkins/clone/groups")
+@api_login_required
+def get_groups_for_target():
+    target_id = request.args.get("targetId")
+    if not target_id:
+        raise Exception("No targetId provided")
+    service = JenkinsService()
+    result = service.get_groups_for_release(target_id)
+
+    return {
+        "status": "ok",
+        "response": {
+            "groups": result
+        }
+    }
+
+
+@bp.route("/jenkins/clone/create", methods=["POST"])
+@api_login_required
+def clone_jenkins_job():
+
+    payload = get_payload(request)
+    service = JenkinsService()
+
+    result = service.clone_job(
+        current_test_id=payload["currentTestId"],
+        new_name=payload["newName"],
+        target=payload["target"],
+        group=payload["group"],
+        advanced_settings=payload["advancedSettings"],
+    )
+
+    return {
+        "status": "ok",
+        "response": result
+    }
+
+
+@bp.route("/jenkins/clone/build", methods=["POST"])
+@api_login_required
+def clone_build_jenkins_job():
+
+    payload = get_payload(request)
+    service = JenkinsService()
+
+    result = service.clone_build_job(build_id=payload["buildId"], params=payload["parameters"])
+
+    return {
+        "status": "ok",
+        "response": result
+    }
+
+
+@bp.route("/jenkins/clone/settings")
+@api_login_required
+def get_clone_job_advanced_settings():
+    build_id = request.args.get("buildId")
+    if not build_id:
+        raise Exception("No testId provided")
+    service = JenkinsService()
+    result = service.get_advanced_settings(build_id)
+
+    return {
+        "status": "ok",
+        "response": result
+    }
+
+
+@bp.route("/jenkins/clone/settings/validate", methods=["POST"])
+@api_login_required
+def clone_validate_new_settings():
+
+    payload = get_payload(request)
+    service = JenkinsService()
+
+    result = service.verify_job_settings(build_id=payload["buildId"], new_settings=payload["newSettings"])
+
+    return {
+        "status": "ok",
+        "response": result
+    }

--- a/argus/backend/service/jenkins_service.py
+++ b/argus/backend/service/jenkins_service.py
@@ -1,12 +1,17 @@
+import re
+import requests
 from typing import Any, TypedDict
+from uuid import UUID
 import xml.etree.ElementTree as ET
 import jenkins
 import logging
 
 from flask import current_app, g
 
-LOGGER = logging.getLogger(__name__)
+from argus.backend.models.web import ArgusGroup, ArgusRelease, ArgusTest, UserOauthToken
 
+LOGGER = logging.getLogger(__name__)
+GITHUB_REPO_RE = r"(?P<http>^https?:\/\/(www\.)?github\.com\/(?P<user>[\w\d\-]+)\/(?P<repo>[\w\d\-]+)(\.git)?$)|(?P<ssh>git@github\.com:(?P<ssh_user>[\w\d\-]+)\/(?P<ssh_repo>[\w\d\-]+)(\.git)?)"
 
 class Parameter(TypedDict):
     _class: str
@@ -15,8 +20,30 @@ class Parameter(TypedDict):
     value: Any
 
 
+class JenkinsServiceError(Exception):
+    pass
+
+
 class JenkinsService:
     RESERVED_PARAMETER_NAME = "requested_by_user"
+
+    SETTINGS_CONFIG_MAP = {
+        "scylla-cluster-tests": {
+            "gitRepo": "*//scm/userRemoteConfigs/hudson.plugins.git.UserRemoteConfig/url",
+            "gitBranch": "*//scm/branches/hudson.plugins.git.BranchSpec/name",
+            "pipelineFile": "*//scriptPath",
+        },
+        "driver-matrix-tests": {
+            "gitRepo": "*//scm/userRemoteConfigs/hudson.plugins.git.UserRemoteConfig/url",
+            "gitBranch": "*//scm/branches/hudson.plugins.git.BranchSpec/name",
+            "pipelineFile": "*//scriptPath",
+        },
+        "sirenada": {
+            "gitRepo": "*//scm/userRemoteConfigs/hudson.plugins.git.UserRemoteConfig/url",
+            "gitBranch": "*//scm/branches/hudson.plugins.git.BranchSpec/name",
+            "pipelineFile": "*//scriptPath",
+        }
+    }
 
     def __init__(self) -> None:
         self._jenkins = jenkins.Jenkins(url=current_app.config["JENKINS_URL"],
@@ -41,6 +68,153 @@ class JenkinsService:
             params[idx]["description"] = descriptions.get(param["name"], "")
 
         return params
+
+    def get_releases_for_clone(self, test_id: str):
+        test_id = UUID(test_id)
+        # TODO: Filtering based on origin location / user preferences
+        _: ArgusTest = ArgusTest.get(id=test_id)
+
+        releases = list(ArgusRelease.all())
+
+        return sorted(releases, key=lambda r: r.pretty_name if r.pretty_name else r.name)
+
+    def get_groups_for_release(self, release_id: str):
+        groups = list(ArgusGroup.filter(release_id=release_id).all())
+
+        return sorted(groups, key=lambda g: g.pretty_name if g.pretty_name else g.name)
+
+    def _verify_sct_settings(self, new_settings: dict[str, str]) -> tuple[bool, str]:
+        if not (match := re.match(GITHUB_REPO_RE, new_settings["gitRepo"])):
+            return (False, "Repository doesn't conform to GitHub schema")
+
+        git_info = match.groupdict()
+        if git_info.get("ssh"):
+            repo = git_info["ssh_repo"]
+            user = git_info["ssh_user"]
+        else:
+            repo = git_info["repo"]
+            user = git_info["user"]
+
+        user_tokens = UserOauthToken.filter(user_id=g.user.id).all()
+        token = None
+        for tok in user_tokens:
+            if tok.kind == "github":
+                token = tok.token
+                break
+        if not token:
+            raise JenkinsServiceError("Github token not found")
+
+        response = requests.get(
+            url=f"https://api.github.com/repos/{user}/{repo}/contents/{new_settings['pipelineFile']}?ref={new_settings['gitBranch']}",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+            }
+            )
+        
+        if response.status_code == 404:
+            return (False, f"Pipeline file not found in the <a href=\"https://github.com/{user}/{repo}/tree/{new_settings['gitBranch']}\"> target repository</a>, please check the repository before continuing")
+
+        if response.status_code == 403:
+            return (True, "No access to this repository using your token. The pipeline file cannot be verified.")
+
+        if response.status_code == 200:
+            return (True, "")
+
+        return (False, "Generic Error")
+
+    def verify_job_settings(self, build_id: str, new_settings: dict[str, str]) -> tuple[bool, str]:
+        PLUGIN_MAP = {
+            "scylla-cluster-tests": self._verify_sct_settings,
+            # for now they match
+            "sirenada": self._verify_sct_settings,
+            "driver-matrix-tests": self._verify_sct_settings,
+        }
+        test: ArgusTest = ArgusTest.get(build_system_id=build_id)
+        plugin_name = test.plugin_name
+
+        validated, message = PLUGIN_MAP.get(plugin_name, lambda _: (True, ""))(new_settings)
+
+        return {
+            "validated": validated,
+            "message": message,
+        }
+
+    def get_advanced_settings(self, build_id: str):
+        test: ArgusTest = ArgusTest.get(build_system_id=build_id)
+        plugin_name = test.plugin_name
+
+        if not (plugin_settings := self.SETTINGS_CONFIG_MAP.get(plugin_name)):
+            return {}
+
+        settings = {}
+        raw_config = self._jenkins.get_job_config(name=build_id)
+        config = ET.fromstring(raw_config)
+
+        for setting, xpath in plugin_settings.items():
+            value = config.find(xpath)
+            settings[setting] = value.text
+
+        return settings
+
+    def adjust_job_settings(self, build_id: str, plugin_name: str, settings: dict[str, str]):
+        xpath_map = self.SETTINGS_CONFIG_MAP.get(plugin_name)
+        if not xpath_map:
+            return
+        
+        config = self._jenkins.get_job_config(name=build_id)
+        xml = ET.fromstring(config)
+        for setting, value in settings.items():
+            element = xml.find(xpath_map[setting])
+            element.text = value
+
+        adjusted_config = ET.tostring(xml, encoding="unicode")
+        self._jenkins.reconfig_job(name=build_id, config_xml=adjusted_config)
+
+    def clone_job(self, current_test_id: str, new_name: str, target: str, group: str, advanced_settings: bool | dict[str, str]):
+        cloned_test: ArgusTest = ArgusTest.get(id=current_test_id)
+        target_release: ArgusRelease = ArgusRelease.get(id=target)
+        target_group: ArgusGroup = ArgusGroup.get(id=group)
+
+        if target_group.id == cloned_test.id and new_name == cloned_test.name:
+            raise JenkinsServiceError("Unable to clone: source and destination are the same")
+
+        if not target_group.build_system_id:
+            raise JenkinsServiceError("Unable to clone: target group is missing jenkins folder path")
+
+        jenkins_new_build_id = f"{target_group.build_system_id}/{new_name}"
+
+        new_test = ArgusTest()
+        new_test.name = new_name
+        new_test.build_system_id = jenkins_new_build_id
+        new_test.group_id = target_group.id
+        new_test.release_id = target_release.id
+        new_test.plugin_name = cloned_test.plugin_name
+
+        old_config = self._jenkins.get_job_config(name=cloned_test.build_system_id)
+        LOGGER.info(old_config)
+        xml = ET.fromstring(old_config)
+        display_name = xml.find("displayName")
+        display_name.text = new_name
+        new_config = ET.tostring(xml, encoding="unicode")
+        self._jenkins.create_job(name=jenkins_new_build_id, config_xml=new_config)
+        new_job_info = self._jenkins.get_job_info(name=jenkins_new_build_id)
+        new_test.build_system_url = new_job_info["url"]
+        new_test.save()
+
+        if advanced_settings:
+            self.adjust_job_settings(build_id=jenkins_new_build_id, plugin_name=new_test.plugin_name, settings=advanced_settings)
+
+        return {
+            "new_job": new_job_info,
+            "new_entity": new_test,
+        }
+
+    def clone_build_job(self, build_id: str, params: dict[str, str]):
+        queue_item = self.build_job(build_id=build_id, params=params)
+        return {
+            "queueItem": queue_item,
+        }
 
     def build_job(self, build_id: str, params: dict, user_override: str = None):
         queue_number = self._jenkins.build_job(build_id, {

--- a/frontend/Common/JenkinsSettingsHelp.js
+++ b/frontend/Common/JenkinsSettingsHelp.js
@@ -1,0 +1,14 @@
+export const JENKINS_ADVANCED_SETTINGS = {
+    gitRepo: {
+        label: "Git Repository",
+        help: "Repository link to a Github repo."
+    },
+    gitBranch: {
+        label: "Git Branch",
+        help: "Branch to build the job from."
+    },
+    pipelineFile: {
+        label: "Pipeline file",
+        help: "Path inside repository to the pipeline (.jenkinsfile) of the job."
+    }
+};

--- a/frontend/TestRun/DriverMatrixRunInfo.svelte
+++ b/frontend/TestRun/DriverMatrixRunInfo.svelte
@@ -1,15 +1,17 @@
 <script>
     import {
-        faBusinessTime, faPlay,
+        faBusinessTime, faCopy, faPlay,
     } from "@fortawesome/free-solid-svg-icons";
     import humanizeDuration from "humanize-duration";
     import Fa from "svelte-fa";
     import { timestampToISODate } from "../Common/DateUtils";
     import { extractBuildNumber } from "../Common/RunUtils";
     import JenkinsBuildModal from "./Jenkins/JenkinsBuildModal.svelte";
+    import JenkinsCloneModal from "./Jenkins/JenkinsCloneModal.svelte";
     export let testRun = {};
     export let testInfo;
     let rebuildRequested = false;
+    let cloneRequested = false;
     /**
      * @typedef {Object} EnvBlock
      * @property {string} scylla-product
@@ -106,10 +108,26 @@
                 on:rebuildComplete={() => (rebuildRequested = false)}
             />
         {/if}
+        {#if cloneRequested}
+            <JenkinsCloneModal 
+                buildId={testRun.build_id} 
+                buildNumber={extractBuildNumber(testRun)}
+                pluginName={testInfo.test.plugin_name}
+                testId={testInfo.test.id}
+                releaseId={testInfo.release.id}
+                groupId={testInfo.group.id}
+                oldTestName={testInfo.test.name}
+                on:cloneCancel={() => (cloneRequested = false)}
+                on:cloneComplete={() => (cloneRequested = false)}
+            />
+        {/if}
         <div class="col-6 p-2">
             <div class="btn-group">
                 <button class="btn btn-sm btn-outline-primary" on:click={() => (rebuildRequested = true)}
                     ><Fa icon={faPlay} /> Rebuild</button
+                >
+                <button class="btn btn-sm btn-outline-primary" on:click={() => (cloneRequested = true)}
+                    ><Fa icon={faCopy} /> Clone</button
                 >
                 <a
                     href="/dashboard/{testInfo.release.name}"

--- a/frontend/TestRun/Jenkins/Build.js
+++ b/frontend/TestRun/Jenkins/Build.js
@@ -1,0 +1,38 @@
+import { sendMessage } from "../../Stores/AlertStore";
+
+export const startJobBuild = async function(buildId, buildParams) {
+    try {
+        const params = {
+            buildId: buildId,
+            parameters: buildParams,
+        };
+        const response = await fetch("/api/v1/jenkins/clone/build", {
+            headers: {
+                "Content-Type": "application/json",
+            },
+            method: "POST",
+            body: JSON.stringify(params),
+        });
+
+        const json = await response.json();
+        if (json.status != "ok") {
+            throw json;
+        }
+
+        return json.response.queueItem;
+    } catch (error) {
+        if (error?.status === "error") {
+            sendMessage(
+                "error",
+                `API Error when starting build.\nMessage: ${error.response.arguments[0]}`
+            );
+        } else {
+            sendMessage(
+                "error",
+                "A backend error occurred attempting to start a build"
+            );
+            console.log(error);
+        }
+    }
+};
+

--- a/frontend/TestRun/Jenkins/BuildSuccessPlaceholder.svelte
+++ b/frontend/TestRun/Jenkins/BuildSuccessPlaceholder.svelte
@@ -1,16 +1,23 @@
 <script>
     import queryString from "query-string";
     import { sendMessage } from "../../Stores/AlertStore";
-    import { onDestroy, onMount } from "svelte";
+    import { createEventDispatcher, onDestroy, onMount } from "svelte";
     import { timestampToISODate } from "../../Common/DateUtils";
+    import Fa from "svelte-fa";
+    import { faArrowCircleRight } from "@fortawesome/free-solid-svg-icons";
 
     /**
-     * @type {{queueItem: number}} args
+     * @type {{
+     *  queueItem: number,
+     *  isFirst: boolean,
+     *  plugin: string,
+     * }}
      */
     export let args;
+    const dispatch = createEventDispatcher();
 
     let fetching = true;
-    let retrySeconds = 30;
+    let retrySeconds = 5;
     let buildInfo = {};
     let resultRetryTimeout;
 
@@ -77,9 +84,19 @@
         {#if buildInfo?.number}
             <div>
                 Build #{buildInfo.number} started!
-                <div>
+                <div class="mb-2">
                     <a href="{buildInfo.url}">Jenkins</a>
                 </div>
+                {#if args.isFirst}
+                    <div>
+                        This is a first build, which will require a re-run to actually start.
+                        <div class="my-2 p-2">
+                            <button class="w-100 btn btn-success" on:click={() => dispatch("exit", { firstBuildRestart: true })}>
+                                <Fa icon={faArrowCircleRight} /> Start build #2
+                            </button>
+                        </div>
+                    </div>
+                {/if}
             </div>
         {:else}
         <div>

--- a/frontend/TestRun/Jenkins/CloneCreatePlaceholder.svelte
+++ b/frontend/TestRun/Jenkins/CloneCreatePlaceholder.svelte
@@ -1,0 +1,76 @@
+<script>
+    import { createEventDispatcher, onMount } from "svelte";
+    import { sendMessage } from "../../Stores/AlertStore";
+
+    /**
+     * @type {{
+     * currentTestId: string,
+     * newName: string,
+     * target: string,
+     * group: string,
+     * advancedSettings: boolean | { [string]: string },
+     * }} args
+     */
+    export let args;
+    const dispatch = createEventDispatcher();
+
+    let result;
+
+    const cloneJob = async function() {
+        try {
+            const response = await fetch("/api/v1/jenkins/clone/create", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify(args),
+            });
+
+            const json = await response.json();
+            if (json.status != "ok") {
+                throw json;
+            }
+
+            console.log(json.response);
+            result = json.response;
+
+        } catch (error) {
+            if (error?.status === "error") {
+                sendMessage(
+                    "error",
+                    `API Error during job clone.\nMessage: ${error.response.arguments[0]}`
+                );
+            } else {
+                sendMessage(
+                    "error",
+                    "A backend error occurred during job clone"
+                );
+                console.log(error);
+            }
+        }
+    };
+
+    onMount(async () => {
+        cloneJob();
+    });
+</script>
+
+<div>
+    {#if result}
+        <div class="mb-6">
+            <h6>Clone successful!</h6>
+            <div>
+                Created <a href="{result.new_job.url}">{result.new_entity.build_system_id}</a>.
+            </div>
+        </div>
+        <div>
+            <button class="btn btn-success w-100" on:click={() => {
+                dispatch("exit", {
+                    newBuildId: result.new_entity.build_system_id
+                });
+            }}>Next</button>
+        </div>
+    {:else}
+        <span class="spinner-border spinner-border-sm"></span> Cloning...
+    {/if}
+</div>

--- a/frontend/TestRun/Jenkins/CloneTargetSelector.svelte
+++ b/frontend/TestRun/Jenkins/CloneTargetSelector.svelte
@@ -1,0 +1,284 @@
+<script>
+    import queryString from "query-string";
+    import Select from "svelte-select";
+    import { sendMessage } from "../../Stores/AlertStore";
+    import { createEventDispatcher, onMount } from "svelte";
+    import Fa from "svelte-fa";
+    import { faCheck, faTimes } from "@fortawesome/free-solid-svg-icons";
+    import { JENKINS_ADVANCED_SETTINGS } from "../../Common/JenkinsSettingsHelp";
+    /**
+     * @type {{
+     * pluginName: string,
+     * releaseId: string,
+     * groupId: string,
+     * oldTestName: string,
+     * buildId: string,
+     * targets: {
+     *  name: string,
+     *  id: string,
+     *  pretty_name: string,
+     * }[]}} args
+     */
+    export let args;
+    const dispatch = createEventDispatcher();
+    let advancedSettings = false;
+    let advancedSettingsBody = {};
+    let newTestName = args.oldTestName;
+    let groups;
+    let target = args.releaseId;
+    let targetRelease = "";
+    let group = args.groupId;
+
+    let groupState = "targetSelect";
+    let validationState = "validationCompleted";
+    let validated = false;
+    let validationMessage = "";
+    let stateMessages = {
+        targetSelect: {
+            shown: false,
+        },
+        groupFetch: {
+            shown: true,
+            message: "Fetching groups...",
+            spinner: true,
+
+        },
+        groupsReady: {
+            shown: false,
+        },
+        validationCompleted: {
+            shown: false,
+        },
+        validationProgress: {
+            shown: true,
+            spinner: true,
+            message: "Validating job parameters...",
+        }
+    };
+
+    const itemizeGroupsForSelect = function (groups) {
+        return groups
+            .filter(v => v.build_system_id && v.enabled)
+            .filter(v => (targetRelease.name || "").toLowerCase().includes("staging") ? true : v.name.toLowerCase().includes("repro"))
+            .map((v) => { 
+                return {
+                    value: v.id,
+                    label: v.pretty_name ? `${v.pretty_name} [Jenkins path: ${v.build_system_id}]`: `${v.name} [Jenkins path: ${v.build_system_id}]`,
+                };
+            });
+    };
+
+    const fetchCategoriesForTarget = async function(e) {
+        try {
+            groupState = "groupFetch";
+            group = undefined;
+            groups = undefined;
+            targetRelease = args.targets.find(v => v.id == target); 
+            const params = {
+                targetId: target,
+            };
+            const qs = queryString.stringify(params);
+            const response = await fetch("/api/v1/jenkins/clone/groups?" + qs);
+
+            const json = await response.json();
+            if (json.status != "ok") {
+                throw json;
+            }
+
+            groups = json.response.groups;
+            groupState = "groupsReady";
+
+        } catch (error) {
+            if (error?.status === "error") {
+                sendMessage(
+                    "error",
+                    `API Error when fetching groups.\nMessage: ${error.response.arguments[0]}`
+                );
+            } else {
+                sendMessage(
+                    "error",
+                    "A backend error occurred during group fetch"
+                );
+                console.log(error);
+            }
+        }
+    };
+
+    const fetchOldJobSettings = async function() {
+        try {
+            const params = {
+                buildId: args.buildId,
+            };
+            const qs = queryString.stringify(params);
+            const response = await fetch("/api/v1/jenkins/clone/settings?" + qs);
+
+            const json = await response.json();
+            if (json.status != "ok") {
+                throw json;
+            }
+            advancedSettingsBody = json.response;
+
+            return json.response;
+        } catch (error) {
+            if (error?.status === "error") {
+                sendMessage(
+                    "error",
+                    `API Error when fetching settings.\nMessage: ${error.response.arguments[0]}`
+                );
+            } else {
+                sendMessage(
+                    "error",
+                    "A backend error occurred during settings fetch"
+                );
+                console.log(error);
+            }
+        }
+    };
+
+    const handleValidation = async function(_) {
+        try {
+            const params = {
+                buildId: args.buildId,
+                newSettings: advancedSettingsBody,
+            };
+            validationState = "validationProgress";
+            const response = await fetch("/api/v1/jenkins/clone/settings/validate", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify(params, undefined, 1)
+            });
+
+            const json = await response.json();
+            if (json.status != "ok") {
+                throw json;
+            }
+
+            validated = json.response.validated;
+            validationMessage = json.response.message;
+
+        } catch (error) {
+            if (error?.status === "error") {
+                sendMessage(
+                    "error",
+                    `API Error when validating settings.\nMessage: ${error.response.arguments[0]}`
+                );
+            } else {
+                sendMessage(
+                    "error",
+                    "A backend error occurred during settings validation"
+                );
+                console.log(error);
+            }
+        } finally {
+            validationState = "validationCompleted";
+        }
+    };
+
+    const handleClone = function(_) {
+        dispatch("exit", {
+            newName: newTestName,
+            target: target,
+            group: group,
+            advancedSettings: advancedSettings ? advancedSettingsBody : false,
+        });
+    };
+
+    onMount(() => {
+        if (args.releaseId && args.groupId) {
+            fetchCategoriesForTarget();
+        }
+    });
+
+</script>
+
+<div>
+    <div class="mb-2">
+        <label class="form-label">Test Name</label>
+        <input type="text" class="form-control" bind:value={newTestName}>
+    </div>
+    <div class="mb-2">
+        <label for="" class="form-label">Release</label>
+        <select class="form-select" bind:value={target} on:change={fetchCategoriesForTarget}>
+            {#each args.targets as release (release.id)}
+                {#if release.enabled}
+                    <option value="{release.id}">{release.pretty_name ? release.pretty_name: release.name}</option>
+                {/if}
+            {/each}
+        </select>
+        <div class="form-text">Specify Argus Release for the cloned test. Usually same release or scylla-staging.</div>
+    </div>
+    {#if groupState == "groupsReady"}
+        <div class="mb-2">
+            <label for="" class="form-label">Target group</label>
+            <Select items={itemizeGroupsForSelect(groups)} on:select={(e) => group = e.detail.value}/>
+            <div class="form-text">Specify Argus Group to store the new test in. [] denotes mapped Jenkins path.</div>
+        </div>
+    {:else}
+        {#if stateMessages[groupState].shown}
+            <div>
+                {#if stateMessages[groupState].spinner}
+                    <span class="spinner-border spinner-border-sm"></span>
+                {/if}
+                {stateMessages[groupState].message}
+            </div>
+        {/if}
+    {/if}
+    <div class="mb-2">
+        <div class="form-check form-switch">
+            <input type="checkbox" class="form-check-input" bind:checked={advancedSettings}>
+            <label type="checkbox" class="form-check-label">Adjust job configuration</label>
+        </div>
+        {#if validationMessage}
+            <div class="alert alert-danger my-2">
+                {@html validationMessage}
+            </div>
+        {/if}
+        {#if advancedSettings}
+            {#await fetchOldJobSettings()}
+                <span class="spinner-border spinner-border-sm"></span> Loading job config...
+            {:then settings}
+                <div class="mb-1">
+                    {#each Object.entries(settings) as [name, _]}
+                        <div>
+                            <label class="form-label" for="">{JENKINS_ADVANCED_SETTINGS[name]?.label ?? name}</label>
+                            <input class="form-control" type="text" name="" id="" bind:value={advancedSettingsBody[name]}>
+                        </div>
+                        <div class="form-text">{JENKINS_ADVANCED_SETTINGS[name]?.help}</div>
+                    {:else}
+                        <div>
+                            <span class="text-muted">No additional settings to configure.</span>
+                        </div>
+                    {/each}
+                </div>
+            {/await}
+        {/if}
+    </div>
+    {#if advancedSettings}
+        {#if stateMessages[validationState].shown}
+            <div class="mb-2 text-center p-2">
+                {#if stateMessages[validationState].spinner}
+                    <span class="spinner-border spinner-border-sm"></span>
+                {/if}
+                {stateMessages[validationState].message}
+            </div>
+        {/if}
+        <div class="mb-2">
+            <button 
+            class="btn btn-primary w-100" 
+                on:click={handleValidation}
+            >
+                {#if validated}
+                    <Fa icon={faCheck}/>
+                {:else if !validated && validationMessage}
+                    <Fa icon={faTimes}/>
+                {/if}
+                Validate
+            </button>
+        </div>
+    {/if}
+    <div>
+        <button class="btn btn-success w-100" on:click={handleClone} disabled={!(group && target) || (advancedSettings && !validated)}>Next</button>
+    </div>
+</div>

--- a/frontend/TestRun/Jenkins/LoadTargetsPlaceholder.svelte
+++ b/frontend/TestRun/Jenkins/LoadTargetsPlaceholder.svelte
@@ -1,0 +1,10 @@
+<script>
+    /**
+     * @type {{testId: string}} args
+     */
+    export let args;
+</script>
+
+<div>
+    <span class="spinner-border spinner-border-sm"></span> Loading targets...
+</div>

--- a/frontend/TestRun/Sirenada/SirenadaRunInfo.svelte
+++ b/frontend/TestRun/Sirenada/SirenadaRunInfo.svelte
@@ -1,15 +1,17 @@
 <script>
     import {
-        faBusinessTime, faPlay,
+        faBusinessTime, faCopy, faPlay,
     } from "@fortawesome/free-solid-svg-icons";
     import humanizeDuration from "humanize-duration";
     import Fa from "svelte-fa";
     import { timestampToISODate } from "../../Common/DateUtils";
     import { extractBuildNumber } from "../../Common/RunUtils";
     import JenkinsBuildModal from "../Jenkins/JenkinsBuildModal.svelte";
+    import JenkinsCloneModal from "../Jenkins/JenkinsCloneModal.svelte";
     export let testRun = {};
     export let testInfo;
     export let rebuildRequested = false;
+    let cloneRequested = false;
 
 </script>
 
@@ -75,10 +77,26 @@
                 on:rebuildComplete={() => (rebuildRequested = false)}
             />
         {/if}
+        {#if cloneRequested}
+            <JenkinsCloneModal 
+                buildId={testRun.build_id} 
+                buildNumber={extractBuildNumber(testRun)}
+                pluginName={testInfo.test.plugin_name}
+                testId={testInfo.test.id}
+                releaseId={testInfo.release.id}
+                groupId={testInfo.group.id}
+                oldTestName={testInfo.test.name}
+                on:cloneCancel={() => (cloneRequested = false)}
+                on:cloneComplete={() => (cloneRequested = false)}
+            />
+        {/if}
         <div class="col-6 p-2">
             <div class="btn-group">
                 <button class="btn btn-sm btn-outline-primary" on:click={() => (rebuildRequested = true)}
                     ><Fa icon={faPlay} /> Rebuild</button
+                >
+                <button class="btn btn-sm btn-outline-primary" on:click={() => (cloneRequested = true)}
+                    ><Fa icon={faCopy} /> Clone</button
                 >
                 <a
                     href="/dashboard/{testInfo.release.name}"

--- a/frontend/TestRun/TestRunInfo.svelte
+++ b/frontend/TestRun/TestRunInfo.svelte
@@ -13,11 +13,13 @@
         getOperatorPackage, getOperatorHelmPackage, getOperatorHelmRepoPackage, extractBuildNumber,
     } from "../Common/RunUtils";
     import JenkinsBuildModal from "./Jenkins/JenkinsBuildModal.svelte";
+    import JenkinsCloneModal from "./Jenkins/JenkinsCloneModal.svelte";
     export let test_run = {};
     export let release;
     export let group;
     export let test;
     let rebuildRequested = false;
+    let cloneRequested = false;
 
     let cmd_hydraInvestigateShowMonitor = `hydra investigate show-monitor ${test_run.id}`;
     let cmd_hydraInvestigateShowLogs = `hydra investigate show-logs ${test_run.id}`;
@@ -195,7 +197,7 @@
         </div>
     </div>
     <div class="row">
-        <div class="col-6 p-2">
+        <div class="col-12 p-2">
             {#if InProgressStatuses.includes(test_run.status)}
                 {#if test_run.sct_runner_host}
                     <div class="mb-1">
@@ -232,6 +234,19 @@
                     on:rebuildComplete={() => (rebuildRequested = false)}
                 />
             {/if}
+            {#if cloneRequested}
+                <JenkinsCloneModal 
+                    buildId={test_run.build_id} 
+                    buildNumber={extractBuildNumber(test_run)}
+                    pluginName={test.plugin_name}
+                    testId={test.id}
+                    releaseId={release.id}
+                    groupId={group.id}
+                    oldTestName={test.name}
+                    on:cloneCancel={() => (cloneRequested = false)}
+                    on:cloneComplete={() => (cloneRequested = false)}
+                />
+            {/if}
             <div class="btn-group">
                 {#if InProgressStatuses.includes(test_run.status) && locateGrafanaNode()}
                     <a
@@ -250,6 +265,9 @@
                     >
                     <button class="btn btn-sm btn-outline-primary" on:click={() => (rebuildRequested = true)}
                         ><Fa icon={faPlay} /> Rebuild</button
+                    >
+                    <button class="btn btn-sm btn-outline-primary" on:click={() => (cloneRequested = true)}
+                        ><Fa icon={faCopy} /> Clone</button
                     >
                     {#if navigator.clipboard}
                         <button


### PR DESCRIPTION
This commits adds logic and frontend components to clone a job inside
jenkins. The main difference between rebuild and clone being
the target release and group selector, in addition to "Advanced Settings"
menu, which differs between job types. All 3 main jobs types are
supported.

Task: scylladb/qa-tasks#1653
