### PR TITLE
fix(driver_matrix_tests): Make some fields optional in JUnit testcases

### DIFF
--- a/argus/client/driver_matrix_tests/client.py
+++ b/argus/client/driver_matrix_tests/client.py
@@ -110,8 +110,8 @@ class ArgusDriverMatrixClient(ArgusClient):
             raw_cases.append({
                 "name": case.attrib["name"],
                 "status": status,
-                "time": float(case.attrib["time"]),
-                "classname": case.attrib["classname"],
+                "time": float(case.attrib.get("time", 0.0)),
+                "classname": case.attrib.get("classname", ""),
                 "message": message,
             })
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "argus-alm"
-version = "0.12.1"
+version = "0.12.2"
 description = "Argus"
 authors = ["Alexey Kartashov <alexey.kartashov@scylladb.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
This commit adjusts which fields are required from a testcase, since
certain frameworks do not report classname in certain cases (e.g. rust
driver matrix)
