### PR TITLE
fix(argus_service): Split assignee queries for large amount of groups

### DIFF
--- a/frontend/WorkArea/RunGroup.svelte
+++ b/frontend/WorkArea/RunGroup.svelte
@@ -15,6 +15,7 @@
     export let assigneeList = [];
     export let runs = [];
     export let groupStats;
+    export let releaseObject;
 
     let groupClicked = false;
     let testAssignees = {};
@@ -104,6 +105,8 @@
                         {:else if groupStats?.disabled ?? false}
                             <!-- svelte-ignore empty-block -->
                         {:else if groupStats?.total == 0}
+                            <!-- svelte-ignore empty-block -->
+                        {:else if !releaseObject.enabled || releaseObject.dormant}
                             <!-- svelte-ignore empty-block -->
                         {:else}
                             <span class="spinner-border spinner-border-sm" />

--- a/frontend/WorkArea/RunRelease.svelte
+++ b/frontend/WorkArea/RunRelease.svelte
@@ -154,6 +154,7 @@
                     {#each releaseGroups ?? [] as group (group.id)}
                         <RunGroup
                             release={release.name}
+                            releaseObject={release}
                             {group}
                             filtered={isFiltered(group.pretty_name || group.name)}
                             parent="#accordionGroups{release.name}"


### PR DESCRIPTION
This commit fixes an issue where retrieving assignees for large releases
would not be possible due to exceeding max cartesian product defined for
IN queries. The queries are now split into 60 item batches (default
max cartesian product is 100 for scylla) to always be under this limit
and retrieve the schedules in batches, preventing issues like this from
occuring.

Fixes #350
