### PR TITLE
feature(ArtifactTab.svelte): Add Log Link widget

### DIFF
--- a/frontend/TestRun/ArtifactTab.svelte
+++ b/frontend/TestRun/ArtifactTab.svelte
@@ -1,10 +1,88 @@
 <script>
+    import { faPlus } from "@fortawesome/free-solid-svg-icons";
     import ArtifactRow from "./ArtifactRow.svelte";
-
+    import { sendMessage } from "../Stores/AlertStore";
+    import { createEventDispatcher } from "svelte";
+    import Fa from "svelte-fa";
 
     export let testRun;
+
+    let logName = "";
+    let logLink = "";
+    const dispatch = createEventDispatcher();
+
+    const addLogLink = async function() {
+        try {
+            let res = await fetch(`/api/v1/client/testrun/scylla-cluster-tests/${testRun.id}/logs/submit`, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    logs: [
+                        {
+                            "log_name": logName,
+                            "log_link": logLink,
+                        }
+                    ]
+                })
+            });
+
+            let result = await res.json();
+            if (result.status === "ok") {
+                sendMessage("success", "Log link added to run!");
+                dispatch("refreshRequest");
+            } else {
+                throw result;
+            }
+        } catch (error) {
+            if (error?.status === "error") {
+                sendMessage(
+                    "error",
+                    `API Error when fetching test run data.\nMessage: ${error.response.arguments[0]}`
+                );
+            } else {
+                sendMessage(
+                    "error",
+                    "A backend error occurred during test run data fetch"
+                );
+                console.log(error);
+            }
+        }
+    };
 </script>
 
+<div>
+    <div class="p-2 mb-2">
+        <button
+            class="btn btn-success"
+            data-bs-toggle="collapse"
+            data-bs-target="#collapseAddLink-{testRun.id}"
+        >
+            <Fa icon={faPlus}/>
+            Add Log Link
+        </button>
+    </div>
+    <div class="m-2 collapse border rounded p-2" id="collapseAddLink-{testRun.id}">
+        <div class="mb-2">
+            <label class="form-label">Log Name</label>
+            <input class="form-control" type="text" placeholder="Friendly Log Name" bind:value={logName}>
+        </div>
+        <div class="mb-2">
+            <label class="form-label">Log URL</label>
+            <input class="form-control" type="text" placeholder="URL for the Log File" bind:value={logLink}>
+        </div>
+        <div>
+            <button
+                class="btn btn-sm btn-primary"
+                data-bs-toggle="collapse"
+                data-bs-target="#collapseAddLink-{testRun.id}"
+                on:click={addLogLink}>
+                Submit
+            </button>
+        </div>
+    </div>
+</div>
 
 {#if testRun.logs.length > 0}
 <table

--- a/frontend/TestRun/TestRun.svelte
+++ b/frontend/TestRun/TestRun.svelte
@@ -290,7 +290,7 @@
                 </div>
                 <div class="tab-pane fade" id="nav-logs-{runId}" role="tabpanel">
                     {#if artifactTabOpened}
-                        <ArtifactTab {testRun} />
+                        <ArtifactTab {testRun} on:refreshRequest={fetchTestRunData}/>
                     {/if}
                 </div>
                 <div


### PR DESCRIPTION
This commit adds a form to the Logs tab of SCT TestRun component,
allowing user to submit a custom URL for a log (e.g. coredump url).

Task: scylladb/qa-tasks#330
