### PR TITLE
improvement(plugins/sct): Add update cloud resource endpoint

### DIFF
--- a/argus/backend/plugins/sct/controller.py
+++ b/argus/backend/plugins/sct/controller.py
@@ -81,6 +81,17 @@ def sct_resource_update_shards(run_id: str, resource_name: str):
     }
 
 
+@bp.route("/<string:run_id>/resource/<string:resource_name>/update", methods=["POST"])
+@api_login_required
+def sct_resource_update(run_id: str, resource_name: str):
+    payload = get_payload(request)
+    result = SCTService.update_resource(run_id=run_id, resource_name=resource_name, update_data=payload["update_data"])
+    return {
+        "status": "ok",
+        "response": result
+    }
+
+
 @bp.route("/<string:run_id>/nemesis/submit", methods=["POST"])
 @api_login_required
 def sct_nemesis_submit(run_id: str):

--- a/argus/backend/plugins/sct/types.py
+++ b/argus/backend/plugins/sct/types.py
@@ -36,3 +36,21 @@ class PerformanceResultsRequest(TypedDict):
     perf_total_errors: str
 
     histograms: list[dict[str, RawHDRHistogram]] | None
+
+
+class InstanceInfoUpdateRequest(TypedDict):
+    provider: str
+    region: str
+    public_ip: str
+    private_ip: str
+    dc_name: str
+    rack_name: str
+    creation_time: int
+    termination_time: int
+    termination_reason: str
+    shards_amount: int
+
+
+class ResourceUpdateRequest(TypedDict):
+    state: str
+    instance_info: InstanceInfoUpdateRequest

--- a/argus/client/sct/client.py
+++ b/argus/client/sct/client.py
@@ -1,4 +1,5 @@
 import base64
+from typing import Any
 from uuid import UUID
 from dataclasses import asdict
 from argus.backend.plugins.sct.types import GeminiResultsRequest, PerformanceResultsRequest
@@ -16,6 +17,7 @@ class ArgusSCTClient(ArgusClient):
         SUBMIT_SCREENSHOTS = "/sct/$id/screenshots/submit"
         CREATE_RESOURCE = "/sct/$id/resource/create"
         TERMINATE_RESOURCE = "/sct/$id/resource/$name/terminate"
+        UPDATE_RESOURCE = "/sct/$id/resource/$name/update"
         SET_SCT_RUNNER  = "/sct/$id/sct_runner/set"
         UPDATE_SHARDS_FOR_RESOURCE = "/sct/$id/resource/$name/shards"
         SUBMIT_NEMESIS = "/sct/$id/nemesis/submit"
@@ -205,6 +207,22 @@ class ArgusSCTClient(ArgusClient):
             }
         )
         self.check_response(response)
+
+
+    def update_resource(self, name: str, update_data: dict[str, Any]) -> None:
+        """
+            Update fields of the resource.
+        """
+        response = self.post(
+            endpoint=self.Routes.UPDATE_RESOURCE,
+            location_params={"id": str(self.run_id), "name": name},
+            body={
+                **self.generic_body,
+                "update_data": update_data,
+            }
+        )
+        self.check_response(response)
+
 
     def submit_nemesis(self, name: str, class_name: str, start_time: int,
                        target_name: str, target_ip: str, target_shards: int) -> None:


### PR DESCRIPTION
This change adds a new endpoint for SCT controller that allows updating
almost all fields of a resource via a provided mapping (so that any
combination of valid fields is accepted server-side)

Task: scylladb/qa-tasks#1657
