### PR TITLE
fix(stats.py): Refactor row-fetching for stats.

### DIFF
--- a/argus/backend/plugins/driver_matrix_tests/model.py
+++ b/argus/backend/plugins/driver_matrix_tests/model.py
@@ -46,7 +46,7 @@ class DriverTestRun(PluginModelBase):
     @classmethod
     def _stats_query(cls) -> str:
         return ("SELECT id, test_id, group_id, release_id, status, start_time, build_job_url, build_id, "
-                f"assignee, end_time, investigation_status, heartbeat, scylla_version FROM {cls.table_name()} WHERE release_id = ?")
+                f"assignee, end_time, investigation_status, heartbeat, scylla_version FROM {cls.table_name()} WHERE build_id IN ? PER PARTITION LIMIT 15")
 
     @classmethod
     def get_distinct_product_versions(cls, release: ArgusRelease) -> list[str]:

--- a/argus/backend/plugins/generic/model.py
+++ b/argus/backend/plugins/generic/model.py
@@ -24,7 +24,7 @@ class GenericRun(PluginModelBase):
     @classmethod
     def _stats_query(cls) -> str:
         return ("SELECT id, test_id, group_id, release_id, status, start_time, build_job_url, build_id, "
-                f"assignee, end_time, investigation_status, heartbeat, scylla_version FROM {cls.table_name()} WHERE release_id = ?")
+                f"assignee, end_time, investigation_status, heartbeat, scylla_version FROM {cls.table_name()} WHERE build_id IN ? PER PARTITION LIMIT 15")
 
     @classmethod
     def get_distinct_product_versions(cls, release: ArgusRelease, cluster: ScyllaCluster = None) -> list[str]:

--- a/argus/backend/plugins/sct/testrun.py
+++ b/argus/backend/plugins/sct/testrun.py
@@ -113,7 +113,7 @@ class SCTTestRun(PluginModelBase):
     @classmethod
     def _stats_query(cls) -> str:
         return ("SELECT id, test_id, group_id, release_id, status, start_time, build_job_url, build_id, "
-                f"assignee, end_time, investigation_status, heartbeat, scylla_version FROM {cls.table_name()} WHERE release_id = ?")
+                f"assignee, end_time, investigation_status, heartbeat, scylla_version FROM {cls.table_name()} WHERE build_id IN ? PER PARTITION LIMIT 15")
 
     @classmethod
     def load_test_run(cls, run_id: UUID) -> 'SCTTestRun':

--- a/argus/backend/plugins/sirenada/model.py
+++ b/argus/backend/plugins/sirenada/model.py
@@ -47,7 +47,7 @@ class SirenadaRun(PluginModelBase):
     @classmethod
     def _stats_query(cls) -> str:
         return ("SELECT id, test_id, group_id, release_id, status, start_time, build_job_url, build_id, "
-                f"assignee, end_time, investigation_status, heartbeat, scylla_version FROM {cls.table_name()} WHERE release_id = ?")
+                f"assignee, end_time, investigation_status, heartbeat, scylla_version FROM {cls.table_name()} WHERE build_id IN ? PER PARTITION LIMIT 15")
 
     @classmethod
     def get_distinct_product_versions(cls, release: ArgusRelease, cluster: ScyllaCluster = None) -> list[str]:

--- a/frontend/ReleaseDashboard/TestDashboard.svelte
+++ b/frontend/ReleaseDashboard/TestDashboard.svelte
@@ -34,6 +34,7 @@
     export let productVersion;
     let stats;
     let statRefreshInterval;
+    let statsFetchedOnce = false;
     let versionsIncludeNoVersion = JSON.parse(window.localStorage.getItem(`releaseDashIncludeNoVersions-${releaseId}`)) ?? false;
     let versionsFilterExtraVersions = JSON.parse(window.localStorage.getItem(`releaseDashFilterExtraVersions-${releaseId}`)) ?? true;
     let users = {};
@@ -85,7 +86,7 @@
 
 
     const fetchStats = async function (force = false) {
-        if (!document.hasFocus()) return;
+        if (!document.hasFocus() && statsFetchedOnce) return;
         let params = queryString.stringify({
             release: releaseName,
             limited: new Number(false),
@@ -101,6 +102,7 @@
         }
         stats = json.response;
         dispatch("statsUpdate", stats);
+        statsFetchedOnce = true;
 
         if (stats.release.perpetual) {
             fetchGroupAssignees(releaseId);


### PR DESCRIPTION
This commit address performance bottlenecks in the stats fetching
module. Specifically it:
 - No longer uses release_id index, instead opting out to an IN query
   that includes relevant tests for the release
 - The 15 test limit is now achieved via PER PARTITION LIMIT clause in
   the stat query, instead of discarding indexed data
 - To avoid exceeding maximum cartesian product of an IN query a
   batching mechanism is introduced for reads, splitting stats query
   into N amount of 100 test queries
 - The queries themselves are using execute_async to execute in parallel
 - Most linear searches are now replaced with map lookups (trading
   multiple searches with an upfront map setup cost)
