### PR TITLE
fix(ResourcesInfo.svelte): Incorrect column name

### DIFF
--- a/frontend/TestRun/ResourcesInfo.svelte
+++ b/frontend/TestRun/ResourcesInfo.svelte
@@ -141,7 +141,7 @@
                     &#x25B2;
                 </span>
             {/if}
-            Provider
+            Region
         </th>
         <th
             role="button"


### PR DESCRIPTION
Changes duplicate "Provider" column header to "Region"
