### PR TITLE
improvement(ReleaseDashboard): UX adjustments for Quick Selector

### DIFF
--- a/frontend/ReleaseDashboard/TestPopoutSelector.svelte
+++ b/frontend/ReleaseDashboard/TestPopoutSelector.svelte
@@ -10,13 +10,29 @@
         faTimes,
         faAngleDoubleDown,
         faBug,
-        faHammer,
         faExternalLinkSquareAlt,
+        faTrash,
+        faComment,
+        faArrowUp,
     } from "@fortawesome/free-solid-svg-icons";
     import { faGithub } from "@fortawesome/free-brands-svg-icons";
     export let tests = {};
     export let releaseName = "";
     let encodedState = "e30";
+    let top;
+    let sticky = false;
+    let observer = new IntersectionObserver((entries) => {
+        let entry = entries[0];
+        if (!entry) return;
+        if (entry.intersectionRatio == 0 && !entry.isIntersecting) {
+            sticky = true;
+        } else {
+            sticky = false;
+        }
+    }, {
+        threshold: [0, 0.25, 0.5, 0.75, 1]
+    });
+
     $: encodedState = stateEncoder(
         Object.values(tests).map(v => v.id)
     );
@@ -27,12 +43,33 @@
             id: id
         });
     };
+
+    $: top ? observer.observe(top) : observer.disconnect();
+
 </script>
 
-<div class="sticky">
+<div class="position-fixed" style="top: 95%; left: 98%" class:d-none={!sticky}>
+    <button class="btn btn-primary" on:click={() => window.scrollTo({behavior: "smooth", top: 0 })}><Fa icon={faArrowUp}/></button>
+</div>
+<div class="">
+    <div bind:this={top}></div>
     {#if Object.values(tests).length > 0}
         <div class="d-flex flex-column">
-            <ul class="list-group popout-tests">
+            <div class:sticky={sticky}>
+                <div class="d-flex align-items center mb-2">
+                    <a
+                        href="/workspace?state={encodedState}"
+                        class="btn btn-primary w-75 me-1"
+                        >Investigate selected <Fa icon={faExternalLinkSquareAlt} /></a
+                    >
+                    <button
+                        class="btn btn-danger w-25"
+                        on:click={() => tests = {}}
+                        ><Fa icon={faTrash} /> Remove All</button
+                    >
+                </div>
+            </div>
+            <ul class="list-group">
                 {#each Object.values(tests) as test (test.id)}
                     <li class="list-group-item">
                         <div class="d-flex align-items-center">
@@ -79,24 +116,34 @@
                                             </div>
                                             <div class="ms-2">
                                                 <a
-                                                    target="_blank"
-                                                    href={run.build_job_url}
+                                                    href="/test/{test.id}/runs?additionalRuns[]={run.id}"
                                                     class="link-dark"
                                                 >
                                                     #{run.build_number}
                                                 </a>
                                             </div>
-                                            <div class="ms-auto me-1">
-                                                {#if run.assignee}
+                                            <div class="ms-auto"></div>
+                                            {#if run.issues.length > 0}
+                                                <div class="ms-2" title="Has Issues">
+                                                    <Fa icon={faBug} />
+                                                </div>
+                                            {/if}
+                                            {#if run.comments.length > 0}
+                                                <div class="ms-2" title="Has Comments">
+                                                    <Fa icon={faComment} />
+                                                </div>
+                                            {/if}
+                                            {#if run.assignee}
+                                                <div class="ms-2">
                                                     <AssigneeList
                                                         assignees={[
                                                             run.assignee,
                                                         ]}
                                                         smallImage={true}
                                                     />
-                                                {/if}
-                                            </div>
-                                            <div class="text-muted small-text">
+                                                </div>
+                                            {/if}
+                                            <div class="ms-2 text-muted small-text">
                                                 {timestampToISODate(
                                                     run.start_time
                                                 )}
@@ -137,11 +184,7 @@
                     </li>
                 {/each}
             </ul>
-            <a
-                href="/workspace?state={encodedState}"
-                class="btn btn-primary"
-                >Investigate selected <Fa icon={faExternalLinkSquareAlt} /></a
-            >
+            <div style="height: 8em"></div>
         </div>
     {/if}
 </div>
@@ -154,36 +197,7 @@
     .sticky {
         position: sticky;
         top: 1em;
+        z-index: 10;
     }
 
-    .popout-tests {
-        height: 1100px;
-        overflow-y: scroll;
-    }
-
-    @media screen and (max-height: 1080px) {
-        .popout-tests {
-            height: 900px;
-        }
-    }
-
-    @media screen and (max-height: 720px) {
-        .popout-tests {
-            height: 500px;
-        }
-    }
-
-    @media screen and (max-height: 480px) {
-        .popout-tests {
-            height: 320px;
-        }
-
-    }
-
-    @media screen and (max-height: 320px) {
-
-        .popout-tests {
-            height: 200px;
-        }
-    }
 </style>

--- a/frontend/Stats/NumberStats.svelte
+++ b/frontend/Stats/NumberStats.svelte
@@ -4,6 +4,7 @@
     import { titleCase, subUnderscores } from "../Common/TextUtils";
     import { Collapse } from "bootstrap";
     import { createEventDispatcher } from "svelte";
+    import { faChevronRight } from "@fortawesome/free-solid-svg-icons";
     export let displayNumber = false;
     export let displayPercentage = false;
     export let displayInvestigations = false;
@@ -138,11 +139,12 @@
                                         <div class="flex-fill d-flex align-items-center">
                                             <div class="me-4">
                                                 <button 
-                                                    class="btn btn-sm btn-light"
+                                                    class="btn btn-sm btn-light mb-1"
                                                     on:click={() => {
                                                         dispatch("quickSelect", { tests: getTestsForStatus(stats, investigationStatus, status) });
                                                     }}
                                                 >
+                                                    <Fa icon={faChevronRight} />
                                                     {subUnderscores(titleCase(status))}
                                                 </button>
                                             </div>


### PR DESCRIPTION
This commit fixes and improves some of the usability issues related to
TestPopoutSelector.

* The button group now starts on top and follows cursor
* Double scroll has been removed
* A button to scroll to the top of the window has been added
* A "Remove All" button is now present alongside "Investigate Selected" button
* Quick filters are now explained better and contain additional buttons,
  such as: Select all failed and not investigated, Select all
  investigated without additional info.
* Version container has been adjusted slightly to contain its elements
  better and also highlighted from the background
* The quick select buttons inside the investigation breakdown are now
  indicated that are buttons better, using a chevron icon on each of
  them.
* The build number on quick investigate selector is now clickable and
  leads to the run page.
* Each row in quick investigate now shows if there's a comment or issue
  on the run.
