### PR TITLE
fix(plugins/generic): Parse submitted scylla version

### DIFF
--- a/argus/backend/plugins/core.py
+++ b/argus/backend/plugins/core.py
@@ -187,7 +187,7 @@ class PluginModelBase(Model):
     def submit_product_version(self, version: str):
         raise NotImplementedError()
 
-    def set_product_version(self, version: str):
+    def set_full_version(self, version: str):
         self.product_version = version
 
     def submit_logs(self, logs: list[dict]):

--- a/argus/backend/plugins/generic/model.py
+++ b/argus/backend/plugins/generic/model.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import re
 from uuid import UUID
 from cassandra.cqlengine import columns
 from cassandra.cqlengine.models import Model
@@ -37,8 +38,10 @@ class GenericRun(PluginModelBase):
         return sorted(list(unique_versions), reverse=True)
 
     def submit_product_version(self, version: str):
-        self.scylla_version = version
-        self.set_product_version(version)
+        pattern = re.compile(r"((?P<short>[\w.~]+)-(?P<build>(0\.)?(?P<date>[0-9]{8,8})\.(?P<commit>\w+).*))")
+        if match := pattern.search(version):
+            self.scylla_version = match.group("short")
+            self.set_full_version(version)
 
     @classmethod
     def load_test_run(cls, run_id: UUID) -> 'GenericRun':


### PR DESCRIPTION
This change fixes an issue where a submitted scylla version from generic
plugin would save it as is, leading to cluttering the short version
selector. The full version is still saved to a separate field for
additional filtering
