### PR TITLE
feature(argus): Custom Views

### DIFF
--- a/argus/backend/controller/api.py
+++ b/argus/backend/controller/api.py
@@ -12,6 +12,7 @@ from argus.backend.controller.notification_api import bp as notifications_bp
 from argus.backend.controller.client_api import bp as client_bp
 from argus.backend.controller.testrun_api import bp as testrun_bp
 from argus.backend.controller.team import bp as team_bp
+from argus.backend.controller.view_api import bp as view_bp
 from argus.backend.service.argus_service import ArgusService
 from argus.backend.service.user import UserService, api_login_required
 from argus.backend.service.stats import ReleaseStatsCollector
@@ -23,6 +24,7 @@ bp.register_blueprint(notifications_bp)
 bp.register_blueprint(client_bp)
 bp.register_blueprint(testrun_bp)
 bp.register_blueprint(team_bp)
+bp.register_blueprint(view_bp)
 bp.register_error_handler(Exception, handle_api_exception)
 LOGGER = logging.getLogger(__name__)
 

--- a/argus/backend/controller/main.py
+++ b/argus/backend/controller/main.py
@@ -1,3 +1,5 @@
+import datetime
+import json
 import logging
 from uuid import UUID
 from flask import (
@@ -8,6 +10,7 @@ from argus.backend.controller.team_ui import bp as teams_bp
 from argus.backend.service.argus_service import ArgusService
 from argus.backend.models.web import WebFileStorage
 from argus.backend.service.user import UserService, login_required
+from argus.backend.service.views import UserViewService
 
 LOGGER = logging.getLogger(__name__)
 
@@ -53,6 +56,24 @@ def releases():
     service = ArgusService()
     all_releases = service.get_releases()
     return render_template("releases.html.j2", releases=all_releases)
+
+
+@bp.route("/views")
+@login_required
+def views():
+    service = UserViewService()
+    all_views = service.get_all_views()
+    return render_template("views.html.j2", views=sorted(all_views, key=lambda view: view.created or datetime.datetime.fromtimestamp(0), reverse=True))
+
+
+@bp.route("/view/<string:view_name>")
+@login_required
+def view_dashboard(view_name: str):
+    service = UserViewService()
+    view = service.get_view_by_name(view_name=view_name)
+    data_json = view
+    view["widget_settings"] = json.loads(view["widget_settings"])
+    return render_template("view_dashboard.html.j2", data=data_json)
 
 
 @bp.route("/alert_debug")

--- a/argus/backend/controller/view_api.py
+++ b/argus/backend/controller/view_api.py
@@ -1,0 +1,162 @@
+import logging
+from uuid import UUID
+from flask import (
+    Blueprint,
+    jsonify,
+    request,
+)
+from argus.backend.error_handlers import handle_api_exception
+from argus.backend.models.web import User
+from argus.backend.service.stats import ViewStatsCollector
+from argus.backend.service.user import api_login_required
+from argus.backend.service.views import UserViewService
+from argus.backend.util.common import get_payload
+
+bp = Blueprint('view_api', __name__, url_prefix='/views')
+LOGGER = logging.getLogger(__name__)
+bp.register_error_handler(Exception, handle_api_exception)
+
+
+class ViewApiException(Exception):
+    pass
+
+
+@bp.route("/", methods=["GET"])
+@api_login_required
+def index():
+    return {
+        "status": "ok",
+        "response": {
+            "version": "v1",
+        }
+    }
+
+
+@bp.route("/create", methods=["POST"])
+@api_login_required
+def create_view():
+    payload = get_payload(request)
+    service = UserViewService()
+    view = service.create_view(
+        name=payload["name"], 
+        items=payload["items"],
+        widget_settings=payload["settings"],
+        description=payload.get("description"),
+        display_name=payload.get("displayName")
+    )
+    return {
+        "status": "ok",
+        "response": view
+    }
+
+
+@bp.route("/get", methods=["GET"])
+@api_login_required
+def get_view():
+    view_id = request.args.get("viewId")
+    if not view_id:
+        raise ViewApiException("No viewId provided.")
+    service = UserViewService()
+    view = service.get_view(UUID(view_id))
+    return {
+        "status": "ok",
+        "response": view
+    }
+
+
+@bp.route("/all", methods=["GET"])
+@api_login_required
+def get_all_views():
+    user_id = request.args.get("userId")
+    if user_id:
+        user = User.get(id=user_id)
+    else:
+        user = None
+    service = UserViewService()
+    views = service.get_all_views(user)
+    return {
+        "status": "ok",
+        "response": views
+    }
+
+
+@bp.route("/update", methods=["POST"])
+@api_login_required
+def update_view():
+    payload = get_payload(request)
+    service = UserViewService()
+    res = service.update_view(view_id=payload["viewId"], update_data=payload["updateData"])
+    return {
+        "status": "ok",
+        "response": res
+    }
+
+
+@bp.route("/delete", methods=["POST"])
+@api_login_required
+def delete_view():
+    payload = get_payload(request)
+    service = UserViewService()
+    res = service.delete_view(payload["viewId"])
+    return {
+        "status": "ok",
+        "response": res
+    }
+
+
+@bp.route("/search", methods=["GET"])
+@api_login_required
+def search_tests():
+    query = request.args.get("query")
+    service = UserViewService()
+    if query:
+        res = service.test_lookup(query)
+    else:
+        res = []
+    return {
+        "status": "ok",
+        "response": {
+            "hits": res,
+            "total": len(res)
+        }
+    }
+
+@bp.route("/stats", methods=["GET"])
+@api_login_required
+def view_stats():
+    view_id = request.args.get("viewId")
+    if not view_id:
+        raise ViewApiException("No view id provided.")
+    limited = bool(int(request.args.get("limited", 0)))
+    version = request.args.get("productVersion", None)
+    include_no_version = bool(int(request.args.get("includeNoVersion", True)))
+    force = bool(int(request.args.get("force",  0)))
+    collector = ViewStatsCollector(view_id=view_id, filter=version)
+    stats = collector.collect(limited=limited, force=force, include_no_version=include_no_version)
+
+    res = jsonify({
+        "status": "ok",
+        "response": stats
+    })
+    res.cache_control.max_age = 300
+    return res
+
+@bp.route("/<string:view_id>/versions", methods=["GET"])
+@api_login_required
+def view_versions(view_id: str):
+    service = UserViewService()
+    res = service.get_versions_for_view(view_id)
+    return {
+        "status": "ok",
+        "response": res
+    }
+
+@bp.route("/<string:view_id>/resolve", methods=["GET"])
+@api_login_required
+def view_resolve(view_id: str):
+    service = UserViewService()
+    res = service.resolve_view_for_edit(view_id)
+    return {
+        "status": "ok",
+        "response": res
+    }

--- a/argus/backend/models/web.py
+++ b/argus/backend/models/web.py
@@ -146,6 +146,20 @@ class ArgusGroup(Model):
             return super().__eq__(other)
 
 
+class ArgusUserView(Model):
+    id = columns.UUID(primary_key=True, partition_key=True, default=uuid4)
+    name = columns.Text(required=True, index=True)
+    display_name = columns.Text()
+    description = columns.Text()
+    user_id = columns.UUID(required=True, index=True)
+    tests = columns.List(value_type=columns.UUID, default=lambda: [])
+    release_ids = columns.List(value_type=columns.UUID, default=lambda: [])
+    group_ids = columns.List(value_type=columns.UUID, default=lambda: [])
+    created = columns.DateTime(default=datetime.utcnow)
+    last_updated = columns.DateTime(default=datetime.utcnow)
+    widget_settings = columns.Text(required=True)
+
+
 class ArgusTest(Model):
     __table_name__ = "argus_test_v2"
     id = columns.UUID(primary_key=True, default=uuid4)
@@ -350,6 +364,7 @@ USED_MODELS: list[Model] = [
     Team,
     WebFileStorage,
     ArgusRelease,
+    ArgusUserView,
     ArgusGroup,
     ArgusTest,
     ArgusTestRunComment,

--- a/argus/backend/service/views.py
+++ b/argus/backend/service/views.py
@@ -1,0 +1,243 @@
+import datetime
+import logging
+import re
+from functools import partial, reduce
+from typing import Any, Callable, TypedDict
+from urllib.parse import unquote
+from uuid import UUID
+
+from cassandra.cqlengine.models import Model
+from argus.backend.models.web import ArgusGroup, ArgusRelease, ArgusTest, ArgusUserView, User
+from argus.backend.plugins.loader import all_plugin_models
+from argus.backend.util.common import chunk, current_user
+
+LOGGER = logging.getLogger(__name__)
+
+
+class UserViewException(Exception):
+    pass
+
+
+class ViewUpdateRequest(TypedDict):
+    name: str
+    description: str
+    display_name: str
+    tests: list[str]
+    widget_settings: str
+
+
+class UserViewService:
+    ADD_ALL_ID = UUID("db6f33b2-660b-4639-ba7f-79725ef96616")
+    def create_view(self, name: str, items: list[str], widget_settings: str, description: str = None, display_name: str = None) -> ArgusUserView:
+        try:
+            name_check = ArgusUserView.get(name=name)
+            raise UserViewException(f"View with name {name} already exists: {name_check.id}", name, name_check, name_check.id)
+        except ArgusUserView.DoesNotExist:
+            pass
+        view = ArgusUserView()
+        view.name = name
+        view.display_name = display_name or name
+        view.description = description
+        view.widget_settings = widget_settings
+        view.tests = []
+        for entity in items:
+            entity_type, entity_id = entity.split(":")
+            match (entity_type):
+                case "release": 
+                    view.tests.extend(t.id for t in ArgusTest.filter(release_id=entity_id).all())
+                    view.release_ids.append(entity_id)
+                case "group": 
+                    view.tests.extend(t.id for t in ArgusTest.filter(group_id=entity_id).all())
+                    view.group_ids.append(entity_id)
+                case "test": 
+                    view.tests.append(entity_id)
+        view.user_id = current_user().id
+
+        view.save()
+        return view
+
+    @staticmethod
+    def index_mapper(item: Model, type = "test"):
+        mapped = dict(item)
+        mapped["type"] = type
+        return mapped
+
+    def test_lookup(self, query: str):
+        def facet_extraction(query: str) -> str:
+            extractor = re.compile(r"(?:(?P<name>(?:release|group)):(?P<value>\"?[\w\d\.\-]*\"?))")
+            facets = re.findall(extractor, query)
+
+            return (re.sub(extractor, "", query).strip(), facets)
+
+        def facet_filter(item: dict, key: str, facet_query: str):
+            if entity := item.get(key):
+                name: str = entity.get("pretty_name") or entity.get("name")
+                return facet_query.lower() in name.lower() if name else False
+            return False
+
+        def facet_wrapper(query_func: Callable[[dict], bool], facet_query: str, facet_type: str) -> bool:
+            def inner(item: dict, query: str):
+                return query_func(item, query) and facet_filter(item, facet_type, facet_query)
+            return inner
+
+
+        def index_searcher(item, query: str):
+            name: str = item["pretty_name"] or item["name"]
+            return unquote(query).lower() in name.lower() if query else True
+
+
+        supported_facets = ["release", "group"]
+
+        text_query, facets = facet_extraction(query)
+        search_func = index_searcher
+        for facet, value in facets:
+            if facet in supported_facets:
+                search_func = facet_wrapper(query_func=search_func, facet_query=value, facet_type=facet)
+
+
+        all_tests = ArgusTest.all()
+        all_releases = ArgusRelease.all()
+        all_groups = ArgusGroup.all()
+        release_by_id = {release.id: partial(self.index_mapper, type="release")(release) for release in all_releases}
+        group_by_id = {group.id: partial(self.index_mapper, type="group")(group) for group in all_groups}
+        index = [self.index_mapper(t) for t in all_tests]
+        index = [*release_by_id.values(), *group_by_id.values(), *index]
+        for item in index:
+            item["group"] = group_by_id.get(item.get("group_id"))
+            item["release"] = release_by_id.get(item.get("release_id"))
+
+        results = filter(partial(search_func, query=text_query), index)
+
+        return [{ "id": self.ADD_ALL_ID, "name": "Add all...", "type": "special" }, *list(results)]
+
+    def update_view(self, view_id: str | UUID, update_data: ViewUpdateRequest) -> bool:
+        view: ArgusUserView = ArgusUserView.get(id=view_id)
+        if view.user_id != current_user().id and not current_user().is_admin():
+            raise UserViewException("Unable to modify other users' views")
+        for key in ["user_id", "id"]:
+            update_data.pop(key, None)
+        items = update_data.pop("items")
+        for k, value in update_data.items():
+            view[k] = value
+        view.tests = []
+        view.release_ids = []
+        view.group_ids = []
+        for entity in items:
+            entity_type, entity_id = entity.split(":")
+            match (entity_type):
+                case "release": 
+                    view.tests.extend(t.id for t in ArgusTest.filter(release_id=entity_id).all())
+                    view.release_ids.append(entity_id)
+                case "group": 
+                    view.tests.extend(t.id for t in ArgusTest.filter(group_id=entity_id).all())
+                    view.group_ids.append(entity_id)
+                case "test": 
+                    view.tests.append(entity_id)
+        view.last_updated = datetime.datetime.now(datetime.UTC)
+        view.save()
+        return True
+
+    def delete_view(self, view_id: str | UUID) -> bool:
+        view = ArgusUserView.get(id=view_id)
+        if view.user_id != current_user().id and not current_user().is_admin():
+            raise UserViewException("Unable to modify other users' views")
+        view.delete()
+
+        return True
+
+    def get_view(self, view_id: str | UUID) -> ArgusUserView:
+        view: ArgusUserView = ArgusUserView.get(id=view_id)
+        if datetime.datetime.utcnow() - (view.last_updated or datetime.datetime.fromtimestamp(0)) > datetime.timedelta(hours=1):
+            self.refresh_stale_view(view)
+        return view
+
+    def get_view_by_name(self, view_name: str) -> ArgusUserView:
+        view: ArgusUserView = ArgusUserView.get(name=view_name)
+        if datetime.datetime.utcnow() - (view.last_updated or datetime.datetime.fromtimestamp(0)) > datetime.timedelta(hours=1):
+            self.refresh_stale_view(view)
+        return view
+
+    def get_all_views(self, user: User | None = None) -> list[ArgusUserView]:
+        if user:
+            return list(ArgusUserView.filter(user_id=user.id).all())
+        return list(ArgusUserView.filter().all())
+
+    def resolve_view_tests(self, view_id: str | UUID) -> list[ArgusTest]:
+        view = ArgusUserView.get(id=view_id)
+        return self.resolve_tests_by_id(view.tests)
+
+    def resolve_tests_by_id(self, test_ids: list[str | UUID]) -> list[ArgusTest]:
+        tests = []
+        for batch in chunk(test_ids):
+            tests.extend(ArgusTest.filter(id__in=batch).all())
+
+        return tests
+
+    def batch_resolve_entity(self, entity: Model, param_name: str, entity_ids: list[UUID]) -> list[Model]:
+        result = []
+        for batch in chunk(entity_ids):
+            result.extend(entity.filter(**{f"{param_name}__in": batch}).allow_filtering().all())
+        return result
+
+    def refresh_stale_view(self, view: ArgusUserView):
+        view.tests = [test.id for test in self.resolve_view_tests(view.id)]
+        all_tests = set(view.tests)
+        all_tests.update(test.id for test in self.batch_resolve_entity(ArgusTest, "group_id", view.group_ids))
+        all_tests.update(test.id for test in self.batch_resolve_entity(ArgusTest, "release_id", view.release_ids))
+        view.tests = list(all_tests)
+        view.last_updated = datetime.datetime.now(datetime.UTC)
+        view.save()
+
+        return view
+
+    def resolve_releases_for_tests(self, tests: list[ArgusTest]):
+        releases = []
+        unique_release_ids = reduce(lambda releases, test: releases.add(test.release_id) or releases, tests, set())
+        for batch in chunk(unique_release_ids):
+            releases.extend(ArgusRelease.filter(id__in=batch).all())
+
+        return releases
+
+    def resolve_groups_for_tests(self, tests: list[ArgusTest]):
+        releases = []
+        unique_release_ids = reduce(lambda groups, test: groups.add(test.group_id) or groups, tests, set())
+        for batch in chunk(unique_release_ids):
+            releases.extend(ArgusGroup.filter(id__in=batch).all())
+
+        return releases
+
+    def get_versions_for_view(self, view_id: str | UUID) -> list[str]:
+        tests = self.resolve_view_tests(view_id)
+        unique_versions = {ver for plugin in all_plugin_models()
+                           for ver in plugin.get_distinct_versions_for_view(tests=tests)}
+
+        return sorted(list(unique_versions), reverse=True)
+
+    def resolve_view_for_edit(self, view_id: str | UUID) -> dict:
+        view: ArgusUserView = ArgusUserView.get(id=view_id)
+        resolved = dict(view)
+        view_groups = self.batch_resolve_entity(ArgusGroup, "id", view.group_ids)
+        view_releases = self.batch_resolve_entity(ArgusRelease, "id", view.release_ids)
+        view_tests = self.resolve_view_tests(view.id)
+        all_groups = { group.id: partial(self.index_mapper, type="group")(group) for group in self.resolve_releases_for_tests(view_tests) }
+        all_releases ={ release.id: partial(self.index_mapper, type="release")(release) for release in self.resolve_releases_for_tests(view_tests) }
+        entities_by_id = {
+            entity.id: partial(self.index_mapper, type="release" if isinstance(entity, ArgusRelease) else "group")(entity)
+            for container in [view_releases, view_groups]
+            for entity in container
+        }
+
+        items = []
+        for test in view_tests:
+            if not (entities_by_id.get(test.group_id) or entities_by_id.get(test.release_id)):
+                item = dict(test)
+                item["type"] = "test"
+                items.append(item)
+
+        items = [*entities_by_id.values(), *items]
+        for entity in items:
+            entity["group"] = all_groups.get(entity.get("group_id"), {}).get("pretty_name") or all_groups.get(entity.get("group_id"), {}).get("name")
+            entity["release"] = all_releases.get(entity.get("release_id"), {}).get("pretty_name") or all_releases.get(entity.get("release_id"), {}).get("name")
+
+        resolved["items"] = items
+        return resolved

--- a/argus/backend/template_filters.py
+++ b/argus/backend/template_filters.py
@@ -18,3 +18,10 @@ def safe_user(user: User):
     user_dict = dict(user.items())
     del user_dict["password"]
     return user_dict
+
+
+@is_filter("formatted_date")
+def formatted_date(date: datetime | None):
+    if date:
+        return date.strftime("%d/%m/%Y %H:%M:%S")
+    return "#unknown"

--- a/argus/backend/util/common.py
+++ b/argus/backend/util/common.py
@@ -1,8 +1,11 @@
+from itertools import islice
 import logging
-from typing import Callable
+from typing import Callable, Iterable
 from uuid import UUID
 
-from flask import Request, Response
+from flask import Request, Response, g
+
+from argus.backend.models.web import User
 
 
 LOGGER = logging.getLogger(__name__)
@@ -18,6 +21,11 @@ def first(iterable, value, key: Callable = None, predicate: Callable = None):
         elif elem == value:
             return elem
     return None
+
+
+def chunk(iterable: Iterable, slice_size = 90):
+    it = iter(iterable)
+    return iter(lambda: list(islice(it, slice_size)), [])
 
 
 def check_scheduled_test(test, group, testname):
@@ -41,6 +49,10 @@ def get_payload(client_request: Request) -> dict:
     request_payload = client_request.get_json()
 
     return request_payload
+
+
+def current_user() -> User:
+    return g.user
 
 
 def get_build_number(build_job_url: str) -> int | None:

--- a/frontend/AdminPanel/AdminPanel.svelte
+++ b/frontend/AdminPanel/AdminPanel.svelte
@@ -4,6 +4,7 @@
     import AdminPanelWelcome from "./AdminPanelWelcome.svelte";
     import UserManager from "./UserManager.svelte";
     import ReleaseManager from "./ReleaseManager.svelte";
+    import ViewsManager from "./ViewsManager.svelte";
 
     export let currentRoute;
 
@@ -11,6 +12,7 @@
         index: AdminPanelWelcome,
         users: UserManager,
         releases: ReleaseManager,
+        views: ViewsManager,
     };
 
     const handleRouteClick = function(route, event) {
@@ -57,6 +59,16 @@
                         on:click={(e) => handleRouteClick("releases", e)}
                     >
                         Releases
+                    </button>
+                </li>
+                <li class="list-group-item">
+                    <button
+                        class:btn-primary={currentRoute == "views"}
+                        class:btn-outline-primary={currentRoute != "views"}
+                        class="btn h-100 w-100"
+                        on:click={(e) => handleRouteClick("views", e)}
+                    >
+                        Views
                     </button>
                 </li>
             </ul>

--- a/frontend/AdminPanel/ViewListItem.svelte
+++ b/frontend/AdminPanel/ViewListItem.svelte
@@ -1,0 +1,81 @@
+<script>
+    import { faEdit, faTrash } from "@fortawesome/free-solid-svg-icons";
+    import { createEventDispatcher } from "svelte";
+    import Fa from "svelte-fa";
+
+    export let view;
+    let deleting = false;
+    const dispatch = createEventDispatcher();
+
+    const resolveViewForUpdating = async function () {
+        try {
+            const response = await fetch(`/api/v1/views/${view.id}/resolve`);
+
+            const json = await response.json();
+            if (json.status != "ok") {
+                throw json;
+            }
+            console.log(json.response);
+
+            dispatch("viewUpdateRequested", json.response);
+        } catch (error) {
+            console.log(error);
+        }
+    };
+</script>
+
+<div class="d-flex align-items-center rounded bg-white p-2 border shadow-sm mb-2">
+    <div>
+        <div class="fw-bold">{view.display_name || view.name}</div>
+        <div>Contains {view.tests.length} tests.</div>
+        <div class="text-muted">
+            {view.description || "No description provided."}
+        </div>
+    </div>
+    <div class="ms-auto"><button class="btn btn-primary" on:click={resolveViewForUpdating}><Fa icon={faEdit}/></button></div>
+    <div class="ms-2"><button class="btn btn-danger" on:click={() => (deleting = true)}><Fa icon={faTrash}/></button></div>
+</div>
+
+{#if deleting}
+    <div class="delete-view-modal">
+        <div class="d-flex align-items-center justify-content-center p-4">
+            <div class="rounded bg-white p-4 h-50">
+                <div class="mb-2 d-flex border-bottom pb-2">
+                    <h5>Deleting <span class="fw-bold">{view.display_name || view.name}</span></h5>
+                    <div class="ms-auto">
+                        <button 
+                            class="btn btn-close"
+                            on:click={() => {
+                                deleting = false;
+                            }}
+                        ></button>
+                    </div>
+                </div>
+                <div>
+                    <div>Are you sure you want to delete this view?</div>
+                    <div class="d-flex justify-content-end">
+                        <div><button class="btn btn-danger" on:click={() => dispatch("delete", view.id)}>Confirm</button></div>
+                        <div class="ms-1"><button class="btn btn-secondary" on:click={() => (deleting = false)}>Cancel</button></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{/if}
+
+
+<style>
+    .h-50 {
+        width: 50%;
+    }
+    .delete-view-modal {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        overflow-y: scroll;
+        background-color: rgba(0, 0, 0, 0.55);
+        z-index: 9999;
+    }
+</style>

--- a/frontend/AdminPanel/ViewSelectItem.svelte
+++ b/frontend/AdminPanel/ViewSelectItem.svelte
@@ -1,0 +1,48 @@
+<script>
+    export let item = undefined;
+    export let isActive = false;
+    export let isFirst = false;
+    export let isHover = false;
+
+    const ITEM_TYPES = {
+        test: "T",
+        group: "G",
+        release: "R",
+        special: "S"
+    };
+</script>
+
+
+<div 
+    class="p-2 border-bottom border-top"
+    class:rounded-top={isFirst}
+    class:bg-primary={isHover}
+    class:hover={isHover}
+>
+    <div class="d-flex">
+        <div class="me-2"><span class="fw-bold">{ITEM_TYPES[item.type]}</span></div>
+        <div>{item.pretty_name || item.name}</div>
+        <div class="ms-auto d-flex justify-content-end align-items-center text-sm">
+            {#if item.release}
+                <div>
+                    <span class="fw-bold">{item.release?.name}</span>
+                </div>
+            {/if}
+            {#if item.group}
+                <div class="ms-2">
+                    {item.group?.pretty_name || item.group?.name}
+                </div>
+            {/if}
+        </div>
+    </div>
+</div>
+
+<style>
+    .hover {
+        cursor: pointer;
+    }
+
+    .text-sm {
+        font-size: 0.8em;
+    }
+</style>

--- a/frontend/AdminPanel/ViewWidget.svelte
+++ b/frontend/AdminPanel/ViewWidget.svelte
@@ -1,0 +1,95 @@
+<script>
+    import Fa from "svelte-fa";
+    import { WIDGET_TYPES, Widget } from "../Common/ViewTypes";
+    import { faEdit, faList, faTrash } from "@fortawesome/free-solid-svg-icons";
+    import { createEventDispatcher, onMount } from "svelte";
+
+
+    /**
+     * @type {Widget}
+     */
+    export let widgetSettings = {};
+
+    let editingSettings = false;
+    const dispatch = createEventDispatcher();
+    let WIDGET_DEF = WIDGET_TYPES[widgetSettings.type];
+    $: WIDGET_DEF = WIDGET_TYPES[widgetSettings.type];
+    
+
+    const populateWidgetSettings = function() {
+        Object
+            .entries(WIDGET_DEF.settingDefinitions)
+            .forEach(([setting, definition]) => { 
+                if (!widgetSettings.settings[setting]) widgetSettings.settings[setting] = definition.default;
+            });
+    };
+
+    onMount(() => populateWidgetSettings());
+</script>
+
+<div class="mb-2 rounded bg-white p-2">
+    <div class="d-flex align-items-center">
+        <div class="me-2"><Fa icon={faList}/> <span class="fw-bold">{widgetSettings.position}</span></div>
+        <div class="flex-fill">
+            <select class="form-select" bind:value={widgetSettings.type} on:change={() => populateWidgetSettings()}>
+                {#each Object.entries(WIDGET_TYPES) as [type, spec] (type)}
+                    <option value="{type}">{spec.friendlyName}</option>
+                {/each}
+            </select>
+        </div>
+        <div class="ms-2">
+            <button class="btn btn-primary" on:click={() => (editingSettings = true)}><Fa icon={faEdit} /></button>
+        </div>
+        <div class="ms-2">
+            <button class="btn btn-danger" on:click={() => dispatch("removeWidget", widgetSettings)}><Fa icon={faTrash} /></button>
+        </div>
+    </div>
+</div>
+
+{#if editingSettings}
+    <div class="widget-settings-modal">
+        <div class="d-flex align-items-center justify-content-center p-4">
+            <div class="rounded bg-white p-4 h-50">
+                <div class="mb-2 d-flex border-bottom pb-2">
+                    <h5>Editing <span class="fw-bold">{WIDGET_DEF.friendlyName}</span></h5>
+                    <div class="ms-auto">
+                        <button 
+                            class="btn btn-close"
+                            on:click={() => {
+                                editingSettings = false;
+                            }}
+                        ></button>
+                    </div>
+                </div>
+                <div>
+                    {#each Object.entries(WIDGET_DEF.settingDefinitions) as [settingName, definition] (settingName)}
+                        {#if typeof definition.type !== "string"}
+                            <svelte:component this={definition.type} bind:settings={widgetSettings.settings} {definition} {settingName} />
+                        {:else}
+                            <div>
+                                {JSON.stringify(definition)}
+                            </div>
+                        {/if}
+                    {:else}
+                        <div class="text-muted text-center">No settings to configure.</div>
+                    {/each}
+                </div>
+            </div>
+        </div>
+    </div>
+{/if}
+<style>
+    .h-50 {
+        width: 50%;
+    }
+    .widget-settings-modal {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        overflow-y: scroll;
+        background-color: rgba(0, 0, 0, 0.55);
+        z-index: 9999;
+    }
+</style>

--- a/frontend/Common/ViewTypes.js
+++ b/frontend/Common/ViewTypes.js
@@ -1,0 +1,73 @@
+import ViewGithubIssues from "../Views/Widgets/ViewGithubIssues.svelte";
+import ViewReleaseStats from "../Views/Widgets/ViewReleaseStats.svelte";
+import ViewTestDashboard from "../Views/Widgets/ViewTestDashboard.svelte";
+import CheckValue from "../Views/WidgetSettingTypes/CheckValue.svelte";
+import MultiSelectValue from "../Views/WidgetSettingTypes/MultiSelectValue.svelte";
+import { TestStatus } from "./TestStatus";
+import { subUnderscores, titleCase } from "./TextUtils";
+
+export class Widget {
+    constructor(position = -1, type = "testDashboard", settings = {}) {
+        this.position = position;
+        this.type = type;
+        this.settings = settings;
+    }
+}
+
+
+export const WIDGET_TYPES = {
+    testDashboard: {
+        type: ViewTestDashboard,
+        friendlyName: "Test Dashboard",
+        settingDefinitions: {
+
+        },
+    },
+    releaseStats: {
+        type: ViewReleaseStats,
+        friendlyName: "Stat bar",
+        settingDefinitions: {
+            horizontal: {
+                type: CheckValue,
+                default: false,
+                help: "Display Stats bar horizontally (EXPERIMENTAL)",
+                displayName: "Horizontal Stats"
+            },
+            displayExtendedStats: {
+                type: CheckValue,
+                default: false,
+                help: "Display investigation stats widget under stats bar",
+                displayName: "Enable Per-Investigation Stats"
+            },
+            hiddenStatuses: {
+                type: MultiSelectValue,
+                default: [],
+                values: Object.values(TestStatus),
+                labels: Object.keys(TestStatus).map(s => subUnderscores(s).split(" ").map(s => titleCase(s)).join(" ")),
+                help: "Select which statuses to exclude from investigation widget",
+                displayName: "Statuses to exclude from extended stats"
+            }
+        }
+    },
+    githubIssues: {
+        type: ViewGithubIssues,
+        friendlyName: "Github Scoped Issue View",
+        settingDefinitions: {
+            submitDisabled: {
+                type: CheckValue,
+                default: true,
+                help: "Disable user ability to attach issues",
+                displayName: "Disable Issue Submit"
+            },
+            aggregateByIssue: {
+                type: CheckValue,
+                default: true,
+                help: "Aggregate runs that have the same issue under same issue",
+                displayName: "Aggregate Runs by Issue"
+            }
+        }
+    }
+};
+
+
+export const ADD_ALL_ID = "db6f33b2-660b-4639-ba7f-79725ef96616";

--- a/frontend/Github/GithubIssue.svelte
+++ b/frontend/Github/GithubIssue.svelte
@@ -41,6 +41,7 @@
         type: "issues",
         url: "https://github.com/",
         user_id: "",
+        state: undefined,
         added_on: "Mon, 1 Jan 1970 9:00:00 GMT",
     };
 
@@ -48,6 +49,7 @@
     export let aggregated = false;
 
     let deleting = false;
+    let issueState = issue.state;
 
     const fetchGithubToken = async function() {
         let tokenRequest = await apiMethodCall("/api/v1/profile/github/token", undefined, "GET");
@@ -59,6 +61,7 @@
     };
 
     const fetchIssueState = async function() {
+        if (issueState) return issueState;
         if (!githubToken) {
             try {
                 githubToken = await fetchGithubToken();
@@ -81,7 +84,12 @@
         if (parseInt(issueStateResponse.headers.get("x-ratelimit-remaining")) === 0) {
             return Promise.reject(new Error("Rate limit exceeded"));
         }
-        return issueStateResponse.json();
+        issueState = await issueStateResponse.json();
+        dispatch("issueStateUpdate", {
+            issueId: issue.id,
+            state: issueState,
+        });
+        return issueState;
     };
 
 

--- a/frontend/Profile/ViewUserResolver.svelte
+++ b/frontend/Profile/ViewUserResolver.svelte
@@ -1,0 +1,14 @@
+<script>
+    import { userList } from "../Stores/UserlistSubscriber";
+    import AssigneeList from "../WorkArea/AssigneeList.svelte";
+
+    /**
+     * @type {Element}
+     */
+    export let element;
+    let creatorId = element.dataset.argusViewCreator;
+</script>
+
+<div class="d-inline-block">
+    <AssigneeList assignees={[creatorId]} />
+</div>

--- a/frontend/ReleaseDashboard/ReleaseDashboard.svelte
+++ b/frontend/ReleaseDashboard/ReleaseDashboard.svelte
@@ -111,8 +111,7 @@
     <div class="row mb-2">
         <div class="col-xs-2 col-sm-6 col-md-7">
             <TestDashboard
-                releaseName={releaseData.release.name}
-                releaseId={releaseData.release.id}
+                dashboardObject={releaseData.release}
                 {productVersion}
                 bind:clickedTests={clickedTests}
                 on:testClick={(e) => handleTestClick(e.detail)}

--- a/frontend/Views/ViewDashboard.svelte
+++ b/frontend/Views/ViewDashboard.svelte
@@ -1,0 +1,76 @@
+<script>
+    import { WIDGET_TYPES } from "../Common/ViewTypes";
+    import { sendMessage } from "../Stores/AlertStore";
+    export let view;
+    let stats = undefined;
+    let productVersion;
+    let clickedTests = {};
+
+    const handleTestClick = function (detail) {
+        if (detail.start_time == 0) {
+            sendMessage("info", `The test "${detail.name}" hasn't been run yet!"`);
+            return;
+        }
+        let key = detail.id;
+        if (!clickedTests[key]) {
+            clickedTests[key] = detail;
+        } else {
+            delete clickedTests[key];
+            clickedTests = clickedTests;
+        }
+    };
+
+    const handleDeleteRequest = function(e) {
+        let key = e.detail.id;
+        if (clickedTests[key]) {
+            delete clickedTests[key];
+            clickedTests = clickedTests;
+        }
+    };
+
+    const handleQuickSelect = function (e) {
+        let tests = e.detail.tests;
+        tests.forEach((v) => {
+            let group = stats.groups[v.test.group_id];
+            handleTestClick({
+                name: v.test.name,
+                id: v.test.id,
+                assignees: [],
+                group: group.group.name,
+                status: v.status,
+                start_time: v.start_time,
+                last_runs: v.last_runs,
+                build_system_id: v.test.build_system_id,
+            });
+        });
+    };
+
+</script>
+
+<div class="rounded bg-white m-2 shadow-sm p-2">
+    <div>
+        <h4>{view.display_name || view.name}</h4>
+    </div>
+    <div class="mb-2">
+        {#each view.widget_settings as widget}
+            <div class="mb-2">
+                <svelte:component
+                    this={WIDGET_TYPES[widget.type].type}
+                    dashboardObject={view}
+                    dashboardObjectType="view"
+                    settings={widget.settings}
+                    bind:stats={stats}
+                    bind:productVersion={productVersion}
+                    bind:clickedTests={clickedTests}
+                    on:statsUpdate
+                    on:testClick={(e) => handleTestClick(e.detail)}
+                    on:versionChange
+                    on:quickSelect={handleQuickSelect}
+                    on:deleteRequest={handleDeleteRequest}
+                />
+            </div>
+        {:else}
+            <div class="alert alert-danger">No widgets defined for view!</div>
+        {/each}
+    </div>
+</div>

--- a/frontend/Views/WidgetSettingTypes/CheckValue.svelte
+++ b/frontend/Views/WidgetSettingTypes/CheckValue.svelte
@@ -1,0 +1,21 @@
+<script>
+    import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
+    import Fa from "svelte-fa";
+
+    /**
+     * @type {{
+     *  default: boolean,
+     *  help: string,
+     *  displayName: string,
+     *  type: Object
+     * }}
+     */
+    export let settingName;
+    export let definition;
+    export let settings;
+</script>
+
+<div class="form-check form-switch">
+    <input type="checkbox" class="form-check-input" bind:checked={settings[settingName]}>
+    <label type="checkbox" class="form-check-label">{definition.displayName}</label> <span title="{definition.help}"><Fa icon={faQuestionCircle}/></span>
+</div>

--- a/frontend/Views/WidgetSettingTypes/MultiSelectValue.svelte
+++ b/frontend/Views/WidgetSettingTypes/MultiSelectValue.svelte
@@ -1,0 +1,27 @@
+<script>
+    import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
+    import Fa from "svelte-fa";
+
+    /**
+     * @type {{
+     *  default: any[],
+     *  help: string,
+     *  displayName: string,
+     *  type: Object,
+     *  values: string[],
+     *  labels: string[],
+     * }}
+     */
+    export let settingName;
+    export let definition;
+    export let settings;
+</script>
+
+<div>
+    <div>{definition.displayName} <span title="{definition.help}"><Fa icon={faQuestionCircle}/></span></div>
+    <select class="form-select" multiple size=10 bind:value={settings[settingName]}>
+        {#each definition.values as value, idx}
+            <option value="{value}">{(definition.labels ?? definition.values)[idx]}</option>
+        {/each}
+    </select>
+</div>

--- a/frontend/Views/Widgets/ViewGithubIssues.svelte
+++ b/frontend/Views/Widgets/ViewGithubIssues.svelte
@@ -1,0 +1,43 @@
+<script>
+    import GithubIssues from "../../Github/GithubIssues.svelte";
+    export let dashboardObject;
+    export let dashboardObjectType;
+    export let stats;
+    export let settings;
+    export let productVersion;
+    export let clickedTests;
+
+
+    let issuesClicked = false;
+</script>
+
+<div class="accordion">
+    <div class="accordion-item">
+        <h2 class="accordion-header">
+            <button
+                class="accordion-button collapsed"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#collapseIssues"
+                on:click={() => issuesClicked = true}
+            >
+                All Issues
+            </button>
+        </h2>
+        <div
+            id="collapseIssues"
+            class="accordion-collapse collapse bg-light-one"
+        >
+            <div class="accordion-body">
+                {#if issuesClicked}
+                    <GithubIssues
+                        id={dashboardObject.id}
+                        filter_key="view_id"
+                        submitDisabled={settings.submitDisabled}
+                        aggregateByIssue={settings.aggregateByIssue}
+                    />
+                {/if}
+            </div>
+        </div>
+    </div>
+</div>

--- a/frontend/Views/Widgets/ViewReleaseStats.svelte
+++ b/frontend/Views/Widgets/ViewReleaseStats.svelte
@@ -1,0 +1,18 @@
+<script>
+    import ReleaseStats from "../../Stats/ReleaseStats.svelte";
+    export let settings;
+    export let stats;
+
+</script>
+
+<div class="row mb-2">
+    <div class="col">
+        <ReleaseStats
+            horizontal={settings.horizontal}
+            displayExtendedStats={settings.displayExtendedStats}
+            hiddenStatuses={settings.hiddenStatuses}
+            bind:releaseStats={stats}
+            on:quickSelect
+        />
+    </div>
+</div>

--- a/frontend/Views/Widgets/ViewTestDashboard.svelte
+++ b/frontend/Views/Widgets/ViewTestDashboard.svelte
@@ -1,0 +1,33 @@
+<script>
+    export let dashboardObject;
+    export let dashboardObjectType;
+    export let stats;
+    export let settings;
+    export let productVersion;
+    export let clickedTests;
+
+    import TestDashboard from "../../ReleaseDashboard/TestDashboard.svelte";
+    import TestPopoutSelector from "../../ReleaseDashboard/TestPopoutSelector.svelte";
+
+</script>
+<div class="row mb-2">
+    <div class="col-xs-2 col-sm-6 col-md-7">
+        <TestDashboard
+            dashboardObject={dashboardObject}
+            {dashboardObjectType}
+            {settings}
+            bind:productVersion={productVersion}
+            bind:stats={stats}
+            bind:clickedTests={clickedTests}
+            on:testClick
+            on:versionChange
+            on:statsUpdate
+        />
+    </div>
+    <div class="col-xs-10 col-sm-6 col-md-5">
+        <TestPopoutSelector
+            bind:tests={clickedTests}
+            on:deleteRequest
+        />
+    </div>
+</div>

--- a/frontend/view-dashboard.js
+++ b/frontend/view-dashboard.js
@@ -1,0 +1,8 @@
+import ViewDashboard from "./Views/ViewDashboard.svelte";
+
+const app = new ViewDashboard({
+    target: document.querySelector("div#viewDashboard"),
+    props: {
+        view: globalThis.ARGUS_VIEW_DATA,
+    }
+});

--- a/frontend/view-user-resolver.js
+++ b/frontend/view-user-resolver.js
@@ -1,0 +1,11 @@
+import { element } from "svelte/internal";
+import ViewUserResolver from "./Profile/ViewUserResolver.svelte";
+
+document.querySelectorAll("span.view-creator").forEach(elem => {
+    const app = new ViewUserResolver({
+        target: elem,
+        props: {
+            element: elem,
+        }
+    });
+});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "bootstrap": "^5.1.3",
     "chart.js": "^3.6.0",
     "chrono-node": "^2.3.4",
+    "color": "^4.2.3",
     "css-loader": "^5.2.6",
     "dayjs": "^1.10.7",
     "dompurify": "^2.4.1",

--- a/templates/partials/nav_bar.html.j2
+++ b/templates/partials/nav_bar.html.j2
@@ -7,6 +7,7 @@
         <div class="navbar-nav">
             <a class="{% if request.path == url_for('main.run_dashboard')%}active{%endif%} nav-link" aria-current="page" href="{{ url_for('main.run_dashboard')}}"><i class="fas fa-tasks"></i> Workspace</a>
             <a class="{% if request.path == url_for('main.releases')%}active{%endif%} nav-link" href="{{ url_for('main.releases')}}"><i class="fas fa-business-time"></i> Releases</a>
+            <a class="{% if request.path == url_for('main.views')%}active{%endif%} nav-link" href="{{ url_for('main.views')}}"><i class="far fa-object-group"></i> Views</a>
             {% if g.user %}
             <a class="{% if request.path == url_for('main.profile_jobs')%}active{%endif%} nav-link" href="{{ url_for('main.profile_jobs')}}"><i class="fas fa-archive"></i> My Jobs</a>
             <a class="{% if request.path == url_for('main.profile_schedules')%}active{%endif%} nav-link" href="{{ url_for('main.profile_schedules')}}"><i class="fas fa-calendar-week"></i> My Schedule</a>

--- a/templates/view_dashboard.html.j2
+++ b/templates/view_dashboard.html.j2
@@ -1,0 +1,19 @@
+{% extends "base.html.j2" %}
+
+{% block title %}
+{{ data.display_name or data.name }}
+{% endblock %}
+
+{% block javascripts %}
+{{ super() }}
+<script>
+    globalThis.ARGUS_VIEW_DATA = JSON.parse('{{ data | tojson | safe }}');
+</script>
+<script defer src="/s/dist/viewDashboard.bundle.js"></script>
+{% endblock javascripts %}
+
+{% block body %}
+    <div class="container-fluid my-4">
+        <div id="viewDashboard"></div>
+    </div>
+{% endblock %}

--- a/templates/views.html.j2
+++ b/templates/views.html.j2
@@ -1,0 +1,40 @@
+{% extends "base.html.j2" %}
+
+{% block title %}
+Views
+{% endblock %}
+
+{% block javascripts %}
+{{ super() }}
+<script defer src="/s/dist/viewUserResolver.bundle.js"></script>
+{% endblock javascripts %}
+
+{% block body %}
+    <div class="container my-2 rounded overflow-hidden shadow-sm bg-light-three p-4">
+        {% for view in views %}
+            <div class="row rounded overflow-hidden shadow-sm bg-white p-1 mb-2">
+                <div class="col-10 view-card" data-argus-view-id="{{ view.id }}">
+                    <div class="card-body">
+                            <h3 class="card-title">{{ view.name if not view.display_name else view.display_name }}</h3>
+                            <p class="card-subtitle text-muted">{{ view.description if view.description else "No description provided" }}</p>
+                    </div>
+                </div>
+                <div class="col-2">
+                    <div class="d-flex align-items-center h-100">
+                        <div class="btn-group">
+                            <a href="{{ url_for('main.view_dashboard', view_name=view.name) }}" class="btn btn-primary"><i class="fas fa-tachometer-alt"></i> View Dashboard</a>
+                        </div>
+                    </div>
+                </div>
+                <div class="d-flex align-items-center justify-content-end text-end" style="font-size: 0.8em">
+                    <div class="me-2">
+                        Created at <span class="fw-bold">{{ view.created | formatted_date }}</span> by
+                    </div>
+                    <div>
+                        <span class="view-creator" data-argus-view-creator="{{ view.user_id }}"></span>
+                    </div>
+                </div>
+            </div>
+        {% endfor %}
+    </div>
+{% endblock %}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,6 +54,14 @@ module.exports = {
             import: "./frontend/release-dashboard.js",
             dependOn: "globalAlert"
         },
+        viewDashboard: {
+            import: "./frontend/view-dashboard.js",
+            dependOn: "globalAlert"
+        },
+        viewUserResolver: {
+            import: "./frontend/view-user-resolver.js",
+            dependOn: "globalAlert"
+        },
         releaseScheduler: {
             import: "./frontend/release-scheduler.js",
             dependOn: "globalAlert"

--- a/yarn.lock
+++ b/yarn.lock
@@ -620,10 +620,26 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name@~1.1.4:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
+  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
+color@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/color/-/color-4.2.3.tgz#d781ecb5e57224ee43ea9627560107c0e0c6463a"
+  integrity sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==
+  dependencies:
+    color-convert "^2.0.1"
+    color-string "^1.9.0"
 
 colorette@^2.0.14:
   version "2.0.16"
@@ -1168,6 +1184,11 @@ interpret@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
+
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-binary-path@~2.1.0:
   version "2.1.0"
@@ -1796,6 +1817,13 @@ signal-exit@^3.0.3:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
+
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==
+  dependencies:
+    is-arrayish "^0.3.1"
 
 slash@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This commit adds a new way to present tests inside argus - Views. Built
by users, they allow scoping tests, issues and statistics into a more
focused view. The View Manager allows users to build view from existing
tests, groups and releases, along with a new widget builder allowing
users to select what their view should contain widget wise (Currently
contains 3 widgets, copying the release dashboard structure).
Additionally, the Issue View was improved to allow filtering by issue
state and labels, as well as caching issue state to prevent extraneous
fetches.

Fixes https://github.com/scylladb/argus/issues/352