### PR TITLE
feature(Notifications/Comment): Add inline reply to notifications

### DIFF
--- a/argus/backend/models/web.py
+++ b/argus/backend/models/web.py
@@ -180,6 +180,7 @@ class ArgusTestRunComment(Model):
     test_run_id = columns.UUID(required=True, index=True)
     user_id = columns.UUID(required=True, index=True)
     release_id = columns.UUID(required=True, index=True)
+    test_id = columns.UUID(required=True, index=True)
     posted_at = columns.Integer(
         required=True, clustering_order="desc", primary_key=True)
     message = columns.Text(min_length=1, max_length=65535)

--- a/argus/backend/service/testrun.py
+++ b/argus/backend/service/testrun.py
@@ -219,6 +219,7 @@ class TestRunService:
         plugin = self.get_plugin(test.plugin_name)
         release: ArgusRelease = ArgusRelease.get(id=test.release_id)
         comment = ArgusTestRunComment()
+        comment.test_id = test.id
         comment.message = message_stripped
         comment.reactions = reactions
         comment.mentions = [m.id for m in mentions]

--- a/frontend/Discussion/Comment.svelte
+++ b/frontend/Discussion/Comment.svelte
@@ -23,6 +23,7 @@
         posted_at: new Date(),
     };
     export let hideReplyButton = false;
+    export let hideUserActions = false;
     marked.use({
         extensions: [MarkdownUserMention]
     });
@@ -97,8 +98,8 @@
                 </button>
             </div>
         {/if}
-        {#if applicationCurrentUser.id == commentBody.user_id}
-            <div class="ms-1">
+        {#if applicationCurrentUser.id == commentBody.user_id && !hideUserActions}
+            <div class:ms-1={!hideReplyButton} class:ms-auto={hideReplyButton}>
                 <button
                     class="btn btn-light bg-editor"
                     title="Edit"

--- a/frontend/Profile/NotificationCommentWrapper.svelte
+++ b/frontend/Profile/NotificationCommentWrapper.svelte
@@ -1,8 +1,134 @@
 <script>
     import Comment from "../Discussion/Comment.svelte";
+    import CommentEditor from "../Discussion/CommentEditor.svelte";
+    import { sendMessage } from "../Stores/AlertStore";
     import { userList } from "../Stores/UserlistSubscriber";
     let users = $userList;
     export let supportData;
+    let replying = false;
+    let fetching = false;
+    let replyUser = "";
+
+    const newCommentTemplate = {
+        id: "",
+        message: "",
+        release: "",
+        reactions: {},
+        mentions: [],
+        user_id: "",
+        release_id: "",
+        test_run_id: supportData.test_run_id,
+        posted_at: new Date(),
+    };
+
+    let newCommentBody;
+
+    const handleReplyButton = function (e) {
+        newCommentBody = Object.assign({}, newCommentTemplate);
+        let authorId = e.detail.author;
+        let authorUsername = users?.[authorId]?.username;
+        replyUser = authorUsername;
+        let quotedMessage = e.detail.message
+            .trim()
+            .replaceAll("&gt;", ">")
+            .replaceAll("&lt;", "<")
+            .split("\n")
+            .map((val) => `> ${val}`)
+            .join("\n");
+        newCommentBody.message = `${authorUsername ? `@${authorUsername} posted:` : ""}${
+            newCommentBody.message
+        }\n${quotedMessage}\n`;
+        replying = true;
+    };
+
+    const handleCommentSubmit = async function (e) {
+        let commentBody = e.detail;
+        fetching = true;
+        try {
+            let apiResponse = await fetch(
+                `/api/v1/test/${supportData.test_id}/run/${supportData.test_run_id}/comments/submit`,
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        message: commentBody.message,
+                        reactions: commentBody.reactions,
+                        mentions: commentBody.mentions,
+                    }),
+                }
+            );
+            let apiJson = await apiResponse.json();
+            if (apiJson.status === "ok") {
+                fetching = false;
+                replying = false;
+                sendMessage("success", "Reply submitted!");
+            } else {
+                throw apiJson;
+            }
+        } catch (error) {
+            if (error?.status === "error") {
+                sendMessage("error", `API Error during comment submission.\nMessage: ${error.response.arguments[0]}`);
+            } else {
+                sendMessage("error", "A backend error occurred during comment submission");
+            }
+        } finally {
+            newCommentBody = Object.assign({}, newCommentTemplate);
+        }
+    };
 </script>
 
-<Comment commentBody={supportData} {users} />
+<Comment commentBody={supportData} {users} hideUserActions={true} hideReplyButton={!supportData.test_id} on:commentReply={handleReplyButton} />
+{#if replying}
+    <div class="reply-modal">
+        <div class="d-flex align-items-center justify-content-center p-4">
+            <div class="rounded bg-white p-4 h-50 position-relative">
+                {#if fetching}
+                    <div class="position-absolute d-flex align-items-center justify-content-center fetching-blocker">
+                        <span class="spinner-grow"></span>
+                        <div class="ms-1">Replying...</div>
+                    </div>
+                {/if}
+                <div class="mb-2 d-flex border-bottom pb-2">
+                    <h5>Replying to <span class="fw-bold">{replyUser}</span></h5>
+                    <div class="ms-auto">
+                        <button class="btn btn-close" on:click={() => (replying = false)} />
+                    </div>
+                </div>
+                <CommentEditor
+                    runId={supportData.test_run_id}
+                    mode="post"
+                    bind:commentBody={newCommentBody}
+                    on:submitComment={handleCommentSubmit}
+                />
+            </div>
+        </div>
+    </div>
+{/if}
+
+<style>
+    .h-50 {
+        width: 50%;
+    }
+    .reply-modal {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        overflow-y: scroll;
+        background-color: rgba(0, 0, 0, 0.55);
+        z-index: 9999;
+    }
+
+    .fetching-blocker {
+        left: 0px;
+        top: 0px;
+        height: 100%;
+        width: 100%;
+        background-color: rgba(0.3, 0.3, 0.3, 0.5);
+        z-index: 99999;
+        color: white;
+    }
+</style>

--- a/frontend/TestRun/TestRunComments.svelte
+++ b/frontend/TestRun/TestRunComments.svelte
@@ -132,7 +132,7 @@
     const handleCommentReply = function (e) {
         let author_id = e.detail.author;
         let author = users?.[author_id]?.username;
-        let quotedMessage = e.detail.message.trim().split("\n").map((val) => `> ${val}`).join("\n");
+        let quotedMessage = e.detail.message.trim().replaceAll("&gt;", ">").replaceAll("&lt;", "<").split("\n").map((val) => `> ${val}`).join("\n");
         newCommentBody.message = `${author ? `@${author} posted:` : ""}${newCommentBody.message}\n${quotedMessage}\n`;
     };
 


### PR DESCRIPTION
This commit adds functionality required to do replies inside
notification viewer, skipping the need for going into the main source
body and sending a comment there.
        
Fixes #203

