### PR TITLE
fix(jenkins_service.py): Skip changing display name if not present

### DIFF
--- a/argus/backend/service/jenkins_service.py
+++ b/argus/backend/service/jenkins_service.py
@@ -195,7 +195,8 @@ class JenkinsService:
         LOGGER.info(old_config)
         xml = ET.fromstring(old_config)
         display_name = xml.find("displayName")
-        display_name.text = new_name
+        if display_name:
+            display_name.text = new_name
         new_config = ET.tostring(xml, encoding="unicode")
         self._jenkins.create_job(name=jenkins_new_build_id, config_xml=new_config)
         new_job_info = self._jenkins.get_job_info(name=jenkins_new_build_id)


### PR DESCRIPTION
This fixes an issue where some jenkins jobs might not contain a display
name, leading to an error during clone.

Fixes #381
