### PR TITLE
improvement(GithubIssues.svelte): Modal window for viewing attached runs

### DIFF
--- a/argus/backend/controller/testrun_api.py
+++ b/argus/backend/controller/testrun_api.py
@@ -289,6 +289,22 @@ def ignore_jobs():
     }
 
 
+@bp.route("/get_runs_by_test_id_run_id", methods=["POST"])
+@api_login_required
+def get_runs_by_test_id_run_id():
+    payload: list[tuple[UUID, UUID]] = get_payload(request)
+    service = TestRunService()
+
+    result = service.resolve_run_build_id_and_number_multiple(payload)
+
+    return {
+        "status": "ok",
+        "response": {
+            "runs": result
+        }
+    }
+
+
 @bp.route("/jenkins/params", methods=["POST"])
 @api_login_required
 def get_jenkins_job_params():

--- a/argus/backend/service/testrun.py
+++ b/argus/backend/service/testrun.py
@@ -1,4 +1,6 @@
+from collections import defaultdict
 from datetime import datetime, timedelta
+from functools import reduce
 import json
 import logging
 import re
@@ -408,6 +410,25 @@ class TestRunService:
         else:
             response = [dict(issue.items()) for issue in all_issues]
         return response
+
+    def resolve_run_build_id_and_number_multiple(self, runs: list[tuple[UUID, UUID]]) -> dict[UUID, dict[str, Any]]:
+        test_ids = [r[0] for r in runs]
+        all_tests: list = []
+        for id_slice in chunk(test_ids):
+            all_tests.extend(ArgusTest.filter(id__in=id_slice).all())
+
+        tests: dict[str, ArgusTest] = {str(t.id): t for t in all_tests}
+        runs_by_plugin = reduce(lambda acc, val: acc[tests[val[0]].plugin_name].append(val[1]) or acc, runs, defaultdict(list))
+        all_runs = {}
+        for plugin, run_ids in runs_by_plugin.items():
+            model = AVAILABLE_PLUGINS.get(plugin).model
+            model_runs = []
+            for run_id in run_ids:
+                model_runs.append(model.filter(id=run_id).only(["build_id", "start_time", "build_job_url", "id", "test_id"]).get())
+            all_runs.update({ str(run["id"]): {**run, "build_number": get_build_number(run["build_job_url"])} for run in model_runs })
+
+        return all_runs
+
 
     def delete_github_issue(self, issue_id: UUID) -> dict:
         issue: ArgusGithubIssue = ArgusGithubIssue.get(id=issue_id)

--- a/frontend/Github/GithubIssues.svelte
+++ b/frontend/Github/GithubIssues.svelte
@@ -4,7 +4,7 @@
     import { newIssueDestinations } from "../Common/IssueDestinations";
     import GithubIssue from "./GithubIssue.svelte";
     import { sendMessage } from "../Stores/AlertStore";
-    import { faCopy } from "@fortawesome/free-solid-svg-icons";
+    import { faChevronDown, faChevronUp, faCopy } from "@fortawesome/free-solid-svg-icons";
     import Fa from "svelte-fa";
     import Color from "color";
     export let id = "";
@@ -16,6 +16,7 @@
     let newIssueUrl = "";
     let issues = [];
     let fetching = false;
+    let showAllLabels = false;
     const fetchIssues = async function () {
         issues = [];
         fetching = true;
@@ -296,21 +297,26 @@
                 </div>
             </div>
             <div class="row">
-                <div class="d-flex p-2 bg-dark rounded shadow-sm flex-wrap">
-                    {#each availableLabels as label}
-                        <button 
-                            class="ms-2 btn btn-sm btn-secondary m-1" 
-                            style="border-color: #{label.color}; color: #{label.color}; background-color: {labelActive(label.id, selectedLabels) ? Color(`#${label.color}`).darken(0.75) : "rgba(1,1,1,0)"}"
-                            on:click={() => handleLabelClick(label)}
-                        >
-                            {label.name}
-                        </button>
-                    {/each}
+                <div class="rounded border p-2 bg-light-one">
+                    <div role="button" tabindex="0" class="mb-1 w-100" on:keypress={() => (showAllLabels = !showAllLabels)} on:click={() => (showAllLabels = !showAllLabels)}>All Labels <Fa icon={showAllLabels ? faChevronUp : faChevronDown}/></div>
+                    <div class="collapse" class:show={showAllLabels}>
+                        <div class="d-flex p-2 bg-dark rounded shadow-sm flex-wrap">
+                            {#each availableLabels as label}
+                                <button 
+                                    class="ms-2 btn btn-sm btn-secondary m-1" 
+                                    style="border-color: #{label.color}; color: #{label.color}; background-color: {labelActive(label.id, selectedLabels) ? Color(`#${label.color}`).darken(0.75) : "rgba(1,1,1,0)"}"
+                                    on:click={() => handleLabelClick(label)}
+                                >
+                                    {label.name}
+                                </button>
+                            {/each}
+                        </div>
+                    </div>
                 </div>
             </div>
             <div class="row">
                 {#each sortedIssues[currentPage] ?? [] as issue (issue.id)}
-                    <GithubIssue bind:issue={issue} aggregated={aggregateByIssue} deleteEnabled={!submitDisabled} on:issueDeleted={fetchIssues} on:issueStateUpdate={onStateUpdate}/>
+                    <GithubIssue bind:issue={issue} aggregated={aggregateByIssue} deleteEnabled={!submitDisabled} on:issueDeleted={fetchIssues} on:issueStateUpdate={onStateUpdate} on:labelClick={(e) => handleLabelClick(e.detail)}/>
                 {/each}
             </div>
             <div class="d-flex ">

--- a/frontend/WorkArea/TestRunsPanel.svelte
+++ b/frontend/WorkArea/TestRunsPanel.svelte
@@ -15,7 +15,7 @@
 </script>
 
 {#if Object.keys(testRuns).length > 0}
-<div class="p-2 mb-1 text-end"><a href="/test_runs?{serializedState}" class="btn btn-secondary btn-sm">Share</a></div>
+<div class="p-2 mb-1 text-end"><a href="/test_runs?state={serializedState}" class="btn btn-secondary btn-sm">Share</a></div>
 <div class="p-2">
     <input class="form-control" type="text" placeholder="Filter runs" bind:value={filterStringRuns} on:input={() => { testRuns = testRuns; }}>
 </div>

--- a/frontend/test-runs-breakout.js
+++ b/frontend/test-runs-breakout.js
@@ -9,6 +9,6 @@ let decodedState = state ? Base64.decode(state) : "{}";
 const app = new TestRunsPanel({
     target: document.querySelector("div#testRunsBreakout"),
     props: {
-        test_runs: JSON.parse(decodedState)
+        testRuns: JSON.parse(decodedState)
     }
 });


### PR DESCRIPTION
This commit adds new button to the aggregated issue (an issue that
contains multiple runs, e.g. on release dashboard) that allows viewing
all the runs attached to it as a list. It also adds an endpoint to
resolve those runs into human readable strings to provide an overview.
Additionally, a new "Investigate selected" button is added on each modal
window to jump to workspace with **test** in question (each run is
clickable to get to the test+run page. Additionally, "Share" button on
workspace page is now fixed, Labels on issues are now individually
clickable (replicating "All labels" functionality) and the labels strip
is now hidden by default and is revealed by a button.

Fixes #157 
