### PR TITLE
refactor(plugins/driver_matrix_tests): Multi-stage pipeline for Drivers

### DIFF
--- a/argus/backend/plugins/core.py
+++ b/argus/backend/plugins/core.py
@@ -30,7 +30,7 @@ class PluginModelBase(Model):
     _plugin_name = "unknown"
     # Metadata
     build_id = columns.Text(required=True, partition_key=True)
-    start_time = columns.DateTime(required=True, primary_key=True, clustering_order="DESC", default=datetime.now, custom_index=True)
+    start_time = columns.DateTime(required=True, primary_key=True, clustering_order="DESC", default=datetime.utcnow, custom_index=True)
     id = columns.UUID(index=True, required=True)
     release_id = columns.UUID(index=True)
     group_id = columns.UUID(index=True)

--- a/argus/backend/plugins/driver_matrix_tests/controller.py
+++ b/argus/backend/plugins/driver_matrix_tests/controller.py
@@ -1,8 +1,10 @@
 from flask import Blueprint, request
 
 from argus.backend.error_handlers import handle_api_exception
+from argus.backend.plugins.driver_matrix_tests.raw_types import DriverMatrixSubmitEnvRequest, DriverMatrixSubmitFailureRequest, DriverMatrixSubmitResultRequest
 from argus.backend.service.user import api_login_required
 from argus.backend.plugins.driver_matrix_tests.service import DriverMatrixService
+from argus.backend.util.common import get_payload
 
 bp = Blueprint("driver_matrix_api", __name__, url_prefix="/driver_matrix")
 bp.register_error_handler(Exception, handle_api_exception)
@@ -18,6 +20,43 @@ def driver_matrix_test_report():
     
 
     result = DriverMatrixService().tested_versions_report(build_id=build_id)
+    return {
+        "status": "ok",
+        "response": result
+    }
+
+@bp.route("/result/submit", methods=["POST"])
+@api_login_required
+def submit_result():
+    payload = get_payload(request)
+    request_data = DriverMatrixSubmitResultRequest(**payload)
+
+    result = DriverMatrixService().submit_driver_result(driver_name=request_data.driver_name, driver_type=request_data.driver_type, run_id=request_data.run_id, raw_xml=request_data.raw_xml)
+    return {
+        "status": "ok",
+        "response": result
+    }
+
+
+@bp.route("/result/fail", methods=["POST"])
+@api_login_required
+def submit_failure():
+    payload = get_payload(request)
+    request_data = DriverMatrixSubmitFailureRequest(**payload)
+
+    result = DriverMatrixService().submit_driver_failure(driver_name=request_data.driver_name, driver_type=request_data.driver_type, run_id=request_data.run_id, failure_reason=request_data.failure_reason)
+    return {
+        "status": "ok",
+        "response": result
+    }
+
+@bp.route("/env/submit", methods=["POST"])
+@api_login_required
+def submit_env():
+    payload = get_payload(request)
+    request_data = DriverMatrixSubmitEnvRequest(**payload)
+
+    result = DriverMatrixService().submit_env_info(run_id=request_data.run_id, raw_env=request_data.raw_env)
     return {
         "status": "ok",
         "response": result

--- a/argus/backend/plugins/driver_matrix_tests/model.py
+++ b/argus/backend/plugins/driver_matrix_tests/model.py
@@ -1,8 +1,12 @@
 from dataclasses import dataclass
 from datetime import datetime
 from functools import reduce
+import logging
+from pprint import pformat
 import re
+from typing import Literal, TypedDict
 from uuid import UUID
+from xml.etree import ElementTree
 from cassandra.cqlengine import columns
 from argus.backend.db import ScyllaCluster
 from argus.backend.models.web import ArgusRelease
@@ -11,6 +15,8 @@ from argus.backend.plugins.driver_matrix_tests.udt import TestCollection, TestSu
 from argus.backend.plugins.driver_matrix_tests.raw_types import RawMatrixTestResult
 from argus.backend.util.enums import TestStatus
 
+
+LOGGER = logging.getLogger(__name__)
 
 class DriverMatrixPluginError(Exception):
     pass
@@ -26,6 +32,65 @@ class DriverMatrixRunSubmissionRequest():
     matrix_results: list[RawMatrixTestResult]
 
 
+@dataclass(init=True, repr=True, frozen=True)
+class DriverMatrixRunSubmissionRequestV2():
+    schema_version: str
+    run_id: str
+    job_name: str
+    job_url: str
+
+
+TestTypeType = Literal['java', 'cpp', 'python', 'gocql']
+
+
+class AdaptedXUnitData(TypedDict):
+    timestamp: str
+
+
+def python_driver_matrix_adapter(xml: ElementTree.ElementTree) -> AdaptedXUnitData:
+    testsuites = list(xml.getroot().iter("testsuite"))
+
+    return {
+        "timestamp": testsuites[0].attrib.get("timestamp"),
+    }
+
+
+def java_driver_matrix_adapter(xml: ElementTree.ElementTree) -> AdaptedXUnitData:
+    testsuites = xml.getroot()
+    ts_now = datetime.utcnow().timestamp()
+    try:
+        time_taken = float(testsuites.attrib.get("time"))
+    except ValueError:
+        time_taken = 0.0
+
+    timestamp = datetime.utcfromtimestamp(ts_now - time_taken).isoformat()
+
+    return {
+        "timestamp": timestamp,
+    }
+
+
+def cpp_driver_matrix_adapter(xml: ElementTree.ElementTree) -> AdaptedXUnitData:
+    testsuites = xml.getroot()
+
+    return {
+        "timestamp": testsuites.attrib.get("timestamp"),
+    }
+
+
+def gocql_driver_matrix_adapter(xml: ElementTree.ElementTree) -> AdaptedXUnitData:
+    testsuites = list(xml.getroot().iter("testsuite"))
+
+    return {
+        "timestamp": testsuites[0].attrib.get("timestamp"),
+    }
+
+
+def generic_adapter(xml: ElementTree.ElementTree) -> AdaptedXUnitData:
+    return {
+        "timestamp": datetime.utcnow().isoformat()
+    }
+
 class DriverTestRun(PluginModelBase):
     _plugin_name = "driver-matrix-tests"
     __table_name__ = "driver_test_run"
@@ -34,6 +99,14 @@ class DriverTestRun(PluginModelBase):
     environment_info = columns.List(value_type=columns.UserDefinedType(user_type=EnvironmentInfo))
 
     _no_upstream = ["rust"]
+
+    _TEST_ADAPTERS = {
+        "java": java_driver_matrix_adapter,
+        "cpp": cpp_driver_matrix_adapter,
+        "python": python_driver_matrix_adapter,
+        "gocql": gocql_driver_matrix_adapter,
+    }
+
 
     _artifact_fnames = {
         "cpp": r"TEST-(?P<driver_name>[\w]*)-(?P<version>[\d\.-]*)",
@@ -78,6 +151,173 @@ class DriverTestRun(PluginModelBase):
 
     @classmethod
     def submit_run(cls, request_data: dict) -> 'DriverTestRun':
+        if request_data["schema_version"] == "v2":
+            req = DriverMatrixRunSubmissionRequestV2(**request_data)
+        else:
+            return cls.submit_matrix_run(request_data)
+
+        run = cls()
+        run.id = req.run_id
+        run.build_id = req.job_name
+        run.build_job_url = req.job_url
+        run.start_time = datetime.utcnow()
+        run.assign_categories()
+        try:
+            run.assignee = run.get_scheduled_assignee()
+        except Exception:  # pylint: disable=broad-except
+            run.assignee = None
+
+        run.status = TestStatus.CREATED.value
+        run.save()
+        return run
+
+    @classmethod
+    def submit_driver_result(cls, run_id: UUID, driver_name: str, driver_type: TestTypeType, xml_data: str):
+        run: DriverTestRun = cls.get(id=run_id)
+
+        collection = run.parse_result_xml(driver_name, xml_data, driver_type)
+        run.test_collection.append(collection)
+
+        if run.status == TestStatus.CREATED:
+            run.status = TestStatus.RUNNING.value
+
+        run.save()
+        return run
+
+
+    @classmethod
+    def submit_driver_failure(cls, run_id: UUID, driver_name: str, driver_type: TestTypeType, fail_message: str):
+        run: DriverTestRun = cls.get(id=run_id)
+
+        collection = TestCollection()
+        collection.failures = 1
+        collection.failure_message = fail_message
+        collection.name = driver_name
+        driver_info = run.get_driver_info(driver_name, driver_type)
+        collection.driver = driver_info.get("driver_name")
+        collection.tests_total = 1
+        run.test_collection.append(collection)
+
+        if run.status == TestStatus.CREATED:
+            run.status = TestStatus.RUNNING.value
+
+        run.save()
+        return run
+
+    @classmethod
+    def submit_env_info(cls, run_id: UUID, env_data: str):
+        run: DriverTestRun = cls.get(id=run_id)
+        env = run.parse_build_environment(env_data)
+
+        for key, value in env.items():
+            env_info = EnvironmentInfo()
+            env_info.key = key
+            env_info.value = value
+            run.environment_info.append(env_info)
+
+        run.scylla_version = env.get("scylla-version")
+
+        run.save()
+        return run
+
+    def parse_build_environment(self, raw_env: str) -> dict[str, str]:
+        result = {}
+        for line in raw_env.split("\n"):
+            if not line:
+                continue
+            LOGGER.debug("ENV: %s", line)
+            key, val = line.split(": ")
+            result[key] = val.strip()
+
+        return result
+
+    def get_test_cases(self, cases: list[ElementTree.Element]) -> list[TestCase]:
+        result = []
+        for raw_case in cases:
+            children = list(raw_case.findall("./*"))
+            if len(children) > 0:
+                status = children[0].tag
+                message = f"{children[0].attrib.get('message', 'no-message')} ({children[0].attrib.get('type', 'no-type')})"
+            else:
+                status = "passed"
+                message = ""
+
+            case = TestCase()
+            case.name = raw_case.attrib["name"]
+            case.status = status
+            case.time = float(raw_case.attrib.get("time", 0.0))
+            case.classname = raw_case.attrib.get("classname", "")
+            case.message = message
+            result.append(case)
+
+        return result
+
+    def get_driver_info(self, xml_name: str, test_type: TestTypeType) -> dict[str, str]:
+        if test_type == "cpp":
+            filename_re = r"TEST-(?P<driver_name>[\w]*)-(?P<version>[\d\.]*)(\.xml)?"
+        else:
+            filename_re = r"(?P<name>[\w]*)\.(?P<driver_name>[\w]*)\.(?P<proto>v\d)\.(?P<version>[\d\.]*)(\.xml)?"
+
+        match = re.match(filename_re, xml_name)
+
+        return match.groupdict() if match else {}
+
+    def get_passed_count(self, suite_attribs: dict[str, str]) -> int:
+        if (pass_count := suite_attribs.get("passed")):
+            return int(pass_count)
+        total = int(suite_attribs.get("tests", 0))
+        errors = int(suite_attribs.get("errors", 0))
+        skipped = int(suite_attribs.get("skipped", 0))
+        failures = int(suite_attribs.get("failures", 0))
+
+        return total - errors - skipped - failures
+
+    def parse_result_xml(self, name: str, xml_data: str, test_type: TestTypeType) -> TestCollection:
+        xml: ElementTree.ElementTree = ElementTree.ElementTree(ElementTree.fromstring(xml_data))
+        LOGGER.debug("%s", pformat(xml))
+        testsuites = xml.getroot()
+        adapted_data = self._TEST_ADAPTERS.get(test_type, generic_adapter)(xml)
+
+        driver_info = self.get_driver_info(name, test_type)
+        test_collection = TestCollection()
+        test_collection.timestamp = datetime.fromisoformat(adapted_data["timestamp"][0:-1] if adapted_data["timestamp"][-1] == "Z" else adapted_data["timestamp"])
+        test_collection.name = name
+        test_collection.driver = driver_info.get("driver_name")
+        test_collection.tests_total = 0
+        test_collection.failures = 0
+        test_collection.errors = 0
+        test_collection.disabled = 0
+        test_collection.skipped = 0
+        test_collection.passed = 0
+        test_collection.time = 0.0
+        test_collection.suites = []
+
+        for xml_suite in testsuites.iter("testsuite"):
+            suite = TestSuite()
+            suite.name = xml_suite.attrib["name"]
+            suite.tests_total = int(xml_suite.attrib.get("tests", 0))
+            suite.failures = int(xml_suite.attrib.get("failures", 0))
+            suite.disabled = int(0)
+            suite.passed = self.get_passed_count(xml_suite.attrib)
+            suite.skipped = int(xml_suite.attrib.get("skipped", 0))
+            suite.errors = int(xml_suite.attrib.get("errors", 0))
+            suite.time = float(xml_suite.attrib["time"])
+            suite.cases = self.get_test_cases(xml_suite.findall("testcase"))
+
+            test_collection.suites.append(suite)
+            test_collection.tests_total += suite.tests_total
+            test_collection.failures += suite.failures
+            test_collection.errors += suite.errors
+            test_collection.disabled += suite.disabled
+            test_collection.skipped += suite.skipped
+            test_collection.passed += suite.passed
+            test_collection.time += suite.time
+
+        return test_collection
+
+    @classmethod
+    def submit_matrix_run(cls, request_data):
+        # Legacy method
         req = DriverMatrixRunSubmissionRequest(**request_data)
         run = cls()
         run.id = req.run_id  # pylint: disable=invalid-name
@@ -146,6 +386,11 @@ class DriverTestRun(PluginModelBase):
         return []
 
     def _determine_run_status(self):
+        for collection in self.test_collection:
+            # patch failure
+            if collection.failure_message:
+                return TestStatus.FAILED
+
         if len(self.test_collection) < 2:
             return TestStatus.FAILED
 
@@ -153,14 +398,14 @@ class DriverTestRun(PluginModelBase):
         if len(driver_types) <= 1 and not any(driver for driver in self._no_upstream if driver in driver_types):
             return TestStatus.FAILED
 
-        failure_count = reduce(lambda acc, val: acc + (val.failures + val.errors), self.test_collection, 0)
+        failure_count = reduce(lambda acc, val: acc + (val.failures or 0 + val.errors or 0), self.test_collection, 0)
         if failure_count > 0:
             return TestStatus.FAILED
 
         return TestStatus.PASSED
 
     def change_status(self, new_status: TestStatus):
-        raise DriverMatrixPluginError("This method is obsolete. Status is now determined on submission.")
+        self.status = new_status
 
     def get_events(self) -> list:
         return []
@@ -170,6 +415,7 @@ class DriverTestRun(PluginModelBase):
 
     def finish_run(self, payload: dict = None):
         self.end_time = datetime.utcnow()
+        self.status = self._determine_run_status().value
 
     def submit_logs(self, logs: list[dict]):
         pass

--- a/argus/backend/plugins/driver_matrix_tests/raw_types.py
+++ b/argus/backend/plugins/driver_matrix_tests/raw_types.py
@@ -1,4 +1,6 @@
+from dataclasses import dataclass
 from typing import TypedDict
+from uuid import UUID
 
 
 class RawMatrixTestCase(TypedDict):
@@ -33,3 +35,28 @@ class RawMatrixTestResult(TypedDict):
     time: float
     timestamp: str
     suites: list[RawMatrixTestSuite]
+
+
+@dataclass(init=True, frozen=True)
+class DriverMatrixSubmitResultRequest():
+    schema_version: str
+    run_id: UUID
+    driver_type: str
+    driver_name: str
+    raw_xml: str
+
+
+@dataclass(init=True, frozen=True)
+class DriverMatrixSubmitFailureRequest():
+    schema_version: str
+    run_id: UUID
+    driver_type: str
+    driver_name: str
+    failure_reason: str
+
+
+@dataclass(init=True, frozen=True)
+class DriverMatrixSubmitEnvRequest():
+    schema_version: str
+    run_id: UUID
+    raw_env: str

--- a/argus/backend/plugins/driver_matrix_tests/service.py
+++ b/argus/backend/plugins/driver_matrix_tests/service.py
@@ -1,7 +1,12 @@
+import base64
+import logging
+from uuid import UUID
 from argus.backend.db import ScyllaCluster
 from argus.backend.models.web import ArgusRelease, ArgusTest
 from argus.backend.plugins.driver_matrix_tests.model import DriverTestRun
 
+
+LOGGER = logging.getLogger(__name__)
 
 class DriverMatrixService:
     def tested_versions_report(self, build_id: str) -> dict:
@@ -40,3 +45,16 @@ class DriverMatrixService:
             "versions": version_map,
         }
         return response
+
+    def submit_driver_result(self, run_id: UUID | str, driver_name: str, driver_type: str, raw_xml: str) -> bool:
+        xml_data = base64.decodebytes(bytes(raw_xml, encoding="utf-8"))
+        DriverTestRun.submit_driver_result(UUID(run_id), driver_name, driver_type, xml_data)
+        return True
+
+    def submit_driver_failure(self, run_id: UUID | str, driver_name: str, driver_type: str, failure_reason: str) -> bool:
+        DriverTestRun.submit_driver_failure(UUID(run_id), driver_name, driver_type, failure_reason)
+        return True
+
+    def submit_env_info(self, run_id: UUID | str, raw_env: str) -> bool:
+        DriverTestRun.submit_env_info(UUID(run_id), raw_env)
+        return True

--- a/argus/backend/plugins/driver_matrix_tests/udt.py
+++ b/argus/backend/plugins/driver_matrix_tests/udt.py
@@ -12,12 +12,12 @@ class TestCase(UserType):
 
 class TestSuite(UserType):
     name = columns.Text()
-    tests_total = columns.Integer()
-    failures = columns.Integer()
-    disabled = columns.Integer()
-    skipped = columns.Integer()
-    passed = columns.Integer()
-    errors = columns.Integer()
+    tests_total = columns.Integer(default=lambda: 0)
+    failures = columns.Integer(default=lambda: 0)
+    disabled = columns.Integer(default=lambda: 0)
+    skipped = columns.Integer(default=lambda: 0)
+    passed = columns.Integer(default=lambda: 0)
+    errors = columns.Integer(default=lambda: 0)
     time = columns.Float()
     cases = columns.List(value_type=columns.UserDefinedType(user_type=TestCase))
 
@@ -25,14 +25,15 @@ class TestSuite(UserType):
 class TestCollection(UserType):
     name = columns.Text()
     driver = columns.Text()
-    tests_total = columns.Integer()
-    failures = columns.Integer()
-    disabled = columns.Integer()
-    skipped = columns.Integer()
-    passed = columns.Integer()
-    errors = columns.Integer()
+    tests_total = columns.Integer(default=lambda: 0)
+    failure_message = columns.Text()
+    failures = columns.Integer(default=lambda: 0)
+    disabled = columns.Integer(default=lambda: 0)
+    skipped = columns.Integer(default=lambda: 0)
+    passed = columns.Integer(default=lambda: 0)
+    errors = columns.Integer(default=lambda: 0)
     timestamp = columns.DateTime()
-    time = columns.Float()
+    time = columns.Float(default=lambda: 0.0)
     suites = columns.List(value_type=columns.UserDefinedType(user_type=TestSuite))
 
 

--- a/argus/client/driver_matrix_tests/cli.py
+++ b/argus/client/driver_matrix_tests/cli.py
@@ -1,0 +1,110 @@
+import base64
+import json
+from pathlib import Path
+import click
+import logging
+from argus.backend.util.enums import TestStatus
+
+from argus.client.driver_matrix_tests.client import ArgusDriverMatrixClient
+
+LOGGER = logging.getLogger(__name__)
+
+
+@click.group
+def cli():
+    pass
+
+
+def _submit_driver_result_internal(api_key: str, base_url: str, run_id: str, metadata_path: str):
+    metadata = json.loads(Path(metadata_path).read_text(encoding="utf-8"))
+    LOGGER.info("Submitting results for %s [%s/%s] to Argus...", run_id, metadata["driver_name"], metadata["driver_type"])
+    raw_xml = (Path(metadata_path).parent / metadata["junit_result"]).read_bytes()
+    client = ArgusDriverMatrixClient(run_id=run_id, auth_token=api_key, base_url=base_url)
+    client.submit_driver_result(driver_name=metadata["driver_name"], driver_type=metadata["driver_type"], raw_junit_data=base64.encodebytes(raw_xml))
+    LOGGER.info("Done.")
+
+def _submit_driver_failure_internal(api_key: str, base_url: str, run_id: str, metadata_path: str):
+    metadata = json.loads(Path(metadata_path).read_text(encoding="utf-8"))
+    LOGGER.info("Submitting failure for %s [%s/%s] to Argus...", run_id, metadata["driver_name"], metadata["driver_type"])
+    client = ArgusDriverMatrixClient(run_id=run_id, auth_token=api_key, base_url=base_url)
+    client.submit_driver_failure(driver_name=metadata["driver_name"], driver_type=metadata["driver_type"], failure_reason=metadata["failure_reason"])
+    LOGGER.info("Done.")
+
+
+@click.command("submit-run")
+@click.option("--api-key", help="Argus API key for authorization", required=True)
+@click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
+@click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
+@click.option("--build-id", required=True, help="Unique job identifier in the build system, e.g. scylla-master/group/job for jenkins (The full path)")
+@click.option("--build-url", required=True, help="Job URL in the build system")
+def submit_driver_matrix_run(api_key: str, base_url: str, run_id: str, build_id: str, build_url: str):
+    LOGGER.info("Submitting %s (%s) to Argus...", build_id, run_id)
+    client = ArgusDriverMatrixClient(run_id=run_id, auth_token=api_key, base_url=base_url)
+    client.submit_driver_matrix_run(job_name=build_id, job_url=build_url)
+    LOGGER.info("Done.")
+
+
+@click.command("submit-driver")
+@click.option("--api-key", help="Argus API key for authorization", required=True)
+@click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
+@click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
+@click.option("--metadata-path", required=True, help="Path to the metadata .json file that contains path to junit xml and other required information")
+def submit_driver_result(api_key: str, base_url: str, run_id: str, metadata_path: str):
+    _submit_driver_result_internal(api_key=api_key, base_url=base_url, run_id=run_id, metadata_path=metadata_path)
+
+
+@click.command("fail-driver")
+@click.option("--api-key", help="Argus API key for authorization", required=True)
+@click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
+@click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
+@click.option("--metadata-path", required=True, help="Path to the metadata .json file that contains path to junit xml and other required information")
+def submit_driver_failure(api_key: str, base_url: str, run_id: str, metadata_path: str):
+    _submit_driver_failure_internal(api_key=api_key, base_url=base_url, run_id=run_id, metadata_path=metadata_path)
+
+
+@click.command("submit-or-fail-driver")
+@click.option("--api-key", help="Argus API key for authorization", required=True)
+@click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
+@click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
+@click.option("--metadata-path", required=True, help="Path to the metadata .json file that contains path to junit xml and other required information")
+def submit_or_fail_driver(api_key: str, base_url: str, run_id: str, metadata_path: str):
+    metadata = json.loads(Path(metadata_path).read_text(encoding="utf-8"))
+    if metadata.get("failure_reason"):
+        _submit_driver_failure_internal(api_key=api_key, base_url=base_url, run_id=run_id, metadata_path=metadata_path)
+    else:
+        _submit_driver_result_internal(api_key=api_key, base_url=base_url, run_id=run_id, metadata_path=metadata_path)
+
+
+@click.command("submit-env")
+@click.option("--api-key", help="Argus API key for authorization", required=True)
+@click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
+@click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
+@click.option("--env-path", required=True, help="Path to the Build-00.txt file that contains environment information about Scylla")
+def submit_driver_env(api_key: str, base_url: str, run_id: str, env_path: str):
+    LOGGER.info("Submitting environment for run %s to Argus...", run_id)
+    raw_env = Path(env_path).read_text()
+    client = ArgusDriverMatrixClient(run_id=run_id, auth_token=api_key, base_url=base_url)
+    client.submit_env(raw_env)
+    LOGGER.info("Done.")
+
+
+@click.command("finish-run")
+@click.option("--api-key", help="Argus API key for authorization", required=True)
+@click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
+@click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
+@click.option("--status", required=True, help="Resulting job status")
+def finish_driver_matrix_run(api_key: str, base_url: str, run_id: str, status: str):
+    client = ArgusDriverMatrixClient(run_id=run_id, auth_token=api_key, base_url=base_url)
+    client.finalize_run(run_type=ArgusDriverMatrixClient.test_type, run_id=run_id, body={"status": TestStatus(status)})
+
+
+cli.add_command(submit_driver_matrix_run)
+cli.add_command(submit_driver_result)
+cli.add_command(submit_or_fail_driver)
+cli.add_command(submit_driver_failure)
+cli.add_command(submit_driver_env)
+cli.add_command(finish_driver_matrix_run)
+
+
+if __name__ == "__main__":
+    cli()

--- a/argus/client/driver_matrix_tests/client.py
+++ b/argus/client/driver_matrix_tests/client.py
@@ -1,214 +1,77 @@
-from functools import reduce
-from datetime import datetime
-from typing import TypedDict, Literal
-import re
-import logging
 from uuid import UUID
-from pathlib import Path
-from pprint import pformat
-from glob import glob
-from xml.etree import ElementTree
-
 from argus.backend.util.enums import TestStatus
 from argus.client.base import ArgusClient
-from argus.backend.plugins.driver_matrix_tests.raw_types import RawMatrixTestResult, RawMatrixTestCase
-
-
-LOGGER = logging.getLogger(__name__)
-
-TestTypeType = Literal['java', 'cpp', 'python', 'gocql']
-
-class AdaptedXUnitData(TypedDict):
-    timestamp: str
-
-
-def python_driver_matrix_adapter(xml: ElementTree.ElementTree) -> AdaptedXUnitData:
-    testsuites = list(xml.getroot().iter("testsuite"))
-
-    return {
-        "timestamp": testsuites[0].attrib.get("timestamp"),
-    }
-
-
-def java_driver_matrix_adapter(xml: ElementTree.ElementTree) -> AdaptedXUnitData:
-    testsuites = xml.getroot()
-    ts_now = datetime.utcnow().timestamp()
-    try:
-        time_taken = float(testsuites.attrib.get("time"))
-    except ValueError:
-        time_taken = 0.0
-
-    timestamp = datetime.utcfromtimestamp(ts_now - time_taken).isoformat()
-
-    return {
-        "timestamp": timestamp,
-    }
-
-
-def cpp_driver_matrix_adapter(xml: ElementTree.ElementTree) -> AdaptedXUnitData:
-    testsuites = xml.getroot()
-
-    return {
-        "timestamp": testsuites.attrib.get("timestamp"),
-    }
-
-
-def gocql_driver_matrix_adapter(xml: ElementTree.ElementTree) -> AdaptedXUnitData:
-    testsuites = list(xml.getroot().iter("testsuite"))
-
-    return {
-        "timestamp": testsuites[0].attrib.get("timestamp"),
-    }
-
-
-def generic_adapter(xml: ElementTree.ElementTree) -> AdaptedXUnitData:
-    return {
-        "timestamp": datetime.utcnow().isoformat()
-    }
 
 
 class ArgusDriverMatrixClient(ArgusClient):
     test_type = "driver-matrix-tests"
-    schema_version: None = "v1"
+    schema_version: None = "v2"
 
-    TEST_ADAPTERS = {
-        "java": java_driver_matrix_adapter,
-        "cpp": cpp_driver_matrix_adapter,
-        "python": python_driver_matrix_adapter,
-        "gocql": gocql_driver_matrix_adapter,
-    }
+    class Routes(ArgusClient.Routes):
+        SUBMIT_DRIVER_RESULT = "/driver_matrix/result/submit"
+        SUBMIT_DRIVER_FAILURE = "/driver_matrix/result/fail"
+        SUBMIT_ENV = "/driver_matrix/env/submit"
 
     def __init__(self, run_id: UUID, auth_token: str, base_url: str, api_version="v1") -> None:
         super().__init__(auth_token, base_url, api_version)
         self.run_id = run_id
 
-    def parse_build_environment(self, env_path: str) -> dict[str, str]:
-        with open(Path(env_path), mode="rt", encoding="utf-8") as env_file:
-            raw_env = env_file.read()
-
-        result = {}
-        for line in raw_env.split("\n"):
-            if not line:
-                continue
-            LOGGER.debug("ENV: %s", line)
-            key, val = line.split(": ")
-            result[key] = val.strip()
-
-        return result
-
-    def get_test_cases(self, cases: list[ElementTree.Element]) -> list[RawMatrixTestCase]:
-        raw_cases = []
-        for case in cases:
-            children = list(case.findall("./*"))
-            if len(children) > 0:
-                status = children[0].tag
-                message = f"{children[0].attrib.get('message', 'no-message')} ({children[0].attrib.get('type', 'no-type')})"
-            else:
-                status = "passed"
-                message = ""
-
-            raw_cases.append({
-                "name": case.attrib["name"],
-                "status": status,
-                "time": float(case.attrib.get("time", 0.0)),
-                "classname": case.attrib.get("classname", ""),
-                "message": message,
-            })
-
-        return raw_cases
-
-    def get_driver_info(self, xml_name: str, test_type: TestTypeType) -> dict[str, str]:
-        if test_type == "cpp":
-            filename_re = r"TEST-(?P<driver_name>[\w]*)-(?P<version>[\d\.]*)\.xml"
-        else:
-            filename_re = r"(?P<name>[\w]*)\.(?P<driver_name>[\w]*)\.(?P<proto>v\d)\.(?P<version>[\d\.]*)\.xml"
-
-        match = re.match(filename_re, xml_name)
-
-        return match.groupdict() if match else {}
-
-    def get_passed_count(self, suite_attribs: dict[str, str]) -> int:
-        if (pass_count := suite_attribs.get("passed")):
-            return int(pass_count)
-        total = int(suite_attribs.get("tests", 0))
-        errors = int(suite_attribs.get("errors", 0))
-        skipped = int(suite_attribs.get("skipped", 0))
-        failures = int(suite_attribs.get("failures", 0))
-
-        return total - errors - skipped - failures
-
-    def parse_result_xml(self, xml_path: Path, test_type:  TestTypeType) -> RawMatrixTestResult:
-        with xml_path.open(mode="rt", encoding="utf-8") as xml_file:
-            xml = ElementTree.parse(source=xml_file)
-            LOGGER.info("%s", pformat(xml))
-        testsuites = xml.getroot()
-        adapted_data = self.TEST_ADAPTERS.get(test_type, generic_adapter)(xml)
-
-        driver_info = self.get_driver_info(xml_path.name, test_type)
-        test_collection = {
-            "timestamp": adapted_data["timestamp"],
-            "name": xml_path.stem,
-            "driver_name": driver_info.get("driver_name"),
-            "tests": 0,
-            "failures": 0,
-            "errors": 0,
-            "disabled": 0,
-            "skipped": 0,
-            "passed": 0,
-            "time": 0.0,
-        }
-        all_suites = []
-        for suite in testsuites.iter("testsuite"):
-            raw_suite = {
-                "name": suite.attrib["name"],
-                "tests": int(suite.attrib.get("tests", 0)),
-                "failures": int(suite.attrib.get("failures", 0)),
-                "disabled": int(0),
-                "passed": self.get_passed_count(suite.attrib),
-                "skipped": int(suite.attrib.get("skipped", 0)),
-                "errors": int(suite.attrib.get("errors", 0)),
-                "time": float(suite.attrib["time"]),
-                "cases": self.get_test_cases(list(suite.iter("testcase")))
-            }
-            all_suites.append(raw_suite)
-            test_collection["tests"] += raw_suite["tests"]
-            test_collection["failures"] += raw_suite["failures"]
-            test_collection["errors"] += raw_suite["errors"]
-            test_collection["disabled"] += raw_suite["disabled"]
-            test_collection["skipped"] += raw_suite["skipped"]
-            test_collection["passed"] += raw_suite["passed"]
-            test_collection["time"] += raw_suite["time"]
-
-        return {
-            **test_collection,
-            "suites": all_suites
-        }
-
-    def get_results(self, result_path: str, test_type: TestTypeType) -> list[RawMatrixTestResult]:
-        xmls = glob(f"{result_path}/**/*.xml", recursive=True)
-        LOGGER.info("Will use following XMLs: %s", pformat(xmls))
-        results = []
-        for xml in xmls:
-            result = self.parse_result_xml(Path(xml), test_type)
-            results.append(result)
-        return results
-
-    def submit(self, build_id: str, build_url: str, env_path: str, result_path: str, test_type: TestTypeType):
-        env = self.parse_build_environment(env_path)
-        results = self.get_results(result_path, test_type)
-
-        self.submit_driver_matrix_run(job_name=build_id, job_url=build_url, test_environment=env, results=results)
-
-    def submit_driver_matrix_run(self, job_name: str, job_url: str,
-                                 results: list[RawMatrixTestResult], test_environment: dict[str, str]) -> None:
+    def submit_driver_matrix_run(self, job_name: str, job_url: str) -> None:
         response = super().submit_run(run_type=self.test_type, run_body={
             "run_id": str(self.run_id),
             "job_name": job_name,
-            "job_url": job_url,
-            "test_environment": test_environment,
-            "matrix_results": results
+            "job_url": job_url
         })
 
+        self.check_response(response)
+
+    def submit_driver_result(self, driver_name: str, driver_type: str, raw_junit_data: bytes):
+        """
+            Submit results of a single driver run
+        """
+        response = self.post(
+            endpoint=self.Routes.SUBMIT_DRIVER_RESULT,
+            location_params={},
+            body={
+                **self.generic_body,
+                "run_id": str(self.run_id),
+                "driver_name": driver_name,
+                "driver_type": driver_type,
+                "raw_xml": str(raw_junit_data, encoding="utf-8"),
+            }
+        )
+        self.check_response(response)
+
+    def submit_driver_failure(self, driver_name: str, driver_type: str, failure_reason: str):
+        """
+            Submit a failure to run of a specific driver test
+        """
+        response = self.post(
+            endpoint=self.Routes.SUBMIT_DRIVER_FAILURE,
+            location_params={},
+            body={
+                **self.generic_body,
+                "run_id": str(self.run_id),
+                "driver_name": driver_name,
+                "driver_type": driver_type,
+                "failure_reason": failure_reason,
+            }
+        )
+        self.check_response(response)
+
+    def submit_env(self, env_info: str):
+        """
+            Submit env-info file (Build-00.txt)
+        """
+        response = self.post(
+            endpoint=self.Routes.SUBMIT_ENV,
+            location_params={},
+            body={
+                **self.generic_body,
+                "run_id": str(self.run_id),
+                "raw_env": env_info,
+            }
+        )
         self.check_response(response)
 
     def set_matrix_status(self, status: TestStatus):

--- a/frontend/Common/DriverMatrixTypes.ts
+++ b/frontend/Common/DriverMatrixTypes.ts
@@ -21,6 +21,7 @@ export interface TestSuite {
 export interface TestCollection {
     name: string;
     driver: string;
+    failure_message: string;
     tests_total: number;
     failures: number;
     disabled: number;

--- a/frontend/TestRun/DriverMatrixTestCollection.svelte
+++ b/frontend/TestRun/DriverMatrixTestCollection.svelte
@@ -41,7 +41,13 @@
             </h2>
             <div id="collapseTestCollection-{testId}-{idx}" class="accordion-collapse collapse">
                 <div class="accordion-body" >
-                    <DriverMatrixBreakdown suites={collection.suites}/>
+                    {#if collection.failure_message}
+                        <div>
+                            <pre class="rounded p-2 bg-light-one" style="white-space: pre-wrap;">{collection.failure_message}</pre>
+                        </div>
+                    {:else}
+                        <DriverMatrixBreakdown suites={collection.suites}/>
+                    {/if}
                 </div>
             </div>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "argus-alm"
-version = "0.12.5"
+version = "0.12.4b3"
 description = "Argus"
 authors = ["Alexey Kartashov <alexey.kartashov@scylladb.com>"]
 license = "Apache-2.0"
@@ -21,6 +21,7 @@ click = "^8.1.3"
 
 [tool.poetry.scripts]
 argus-client-generic = 'argus.client.generic.cli:cli'
+argus-driver-matrix-client = 'argus.client.driver_matrix_tests.cli:cli'
 
 [tool.poetry.group.web-backend.dependencies]
 PyYAML = "^6.0.0"


### PR DESCRIPTION
This commit reworks the way Driver Matrix Runs are submitted to Argus,
replacing previously one-shot architecture with a multi-stage pipeline
akin to SCT, where driver matrix run first submits itself, and then
submits results sequentially (either a pass or failure), finalizing with
a call that makes backend determine status based on resulting payload.
Patch failures are now supported. Entire logic was moved from the client
to the backend, removing the need to update the client in case of large
changes to the API / submitted data.

Fixes #289