### PR TITLE
feature(AdminPanel): Quick toggles for Groups/Tests

### DIFF
--- a/argus/backend/controller/admin_api.py
+++ b/argus/backend/controller/admin_api.py
@@ -261,3 +261,29 @@ def get_tests_for_group():
         "status": "ok",
         "response": tests
     }
+
+
+@bp.route("/release/test/state/toggle", methods=["POST"])
+@check_roles(UserRoles.Admin)
+@api_login_required
+def quick_toggle_test_enabled():
+    
+    payload = get_payload(request)
+    res = ReleaseManagerService().toggle_test_enabled(test_id=payload["entityId"], new_state=payload["state"])
+    return {
+        "status": "ok",
+        "response": res
+    }
+
+
+@bp.route("/release/group/state/toggle", methods=["POST"])
+@check_roles(UserRoles.Admin)
+@api_login_required
+def quick_toggle_group_enabled():
+    
+    payload = get_payload(request)
+    res = ReleaseManagerService().toggle_group_enabled(group_id=payload["entityId"], new_state=payload["state"])
+    return {
+        "status": "ok",
+        "response": res
+    }

--- a/argus/backend/service/release_manager.py
+++ b/argus/backend/service/release_manager.py
@@ -44,6 +44,20 @@ class ReleaseManagerService:
     def get_tests(self, group_id: UUID) -> list[ArgusTest]:
         return list(ArgusTest.filter(group_id=group_id).all())
 
+    def toggle_test_enabled(self, test_id: UUID, new_state: bool) -> bool:
+        test: ArgusTest = ArgusTest.get(id=test_id)
+        test.enabled = new_state
+        test.save()
+
+        return test
+
+    def toggle_group_enabled(self, group_id: UUID, new_state: bool) -> bool:
+        test: ArgusGroup = ArgusGroup.get(id=group_id)
+        test.enabled = new_state
+        test.save()
+
+        return test
+
     def create_release(self, release_name: str, pretty_name: str, perpetual: bool) -> ArgusRelease:
         try:
             release = ArgusRelease.get(name=release_name)

--- a/frontend/AdminPanel/ReleaseManager.svelte
+++ b/frontend/AdminPanel/ReleaseManager.svelte
@@ -26,6 +26,9 @@
     let moving = false;
     let fetching = false;
 
+    let groups = [];
+    let tests = [];
+
     const fetchReleases = async function () {
         try {
             fetching = true;
@@ -73,6 +76,7 @@
             );
             let apiJson = await apiResponse.json();
             if (apiJson.status === "ok") {
+                groups = apiJson.response;
                 return Promise.resolve(apiJson.response);
             } else {
                 return Promise.reject(new Error(apiJson.message));
@@ -93,6 +97,7 @@
             );
             let apiJson = await apiResponse.json();
             if (apiJson.status === "ok") {
+                tests = apiJson.response;
                 return Promise.resolve(apiJson.response);
             } else {
                 return Promise.reject(new Error(apiJson.message));
@@ -297,6 +302,16 @@
         }
     };
 
+    const handleVisibilityToggle = async function(entity, type, state) {
+        let result = await apiMethodCall(
+            `/admin/api/v1/release/${type}/state/toggle`,
+            {
+                entityId: entity,
+                state: state,
+            }
+        );
+    };
+
     const handleReleasePerpetualityChange = async function (e) {
         let result = await apiMethodCall(
             "/admin/api/v1/release/set_perpetual",
@@ -466,6 +481,9 @@
                                     groups={releaseGroups}
                                     on:groupDelete={handleGroupDelete}
                                     on:groupUpdate={handleGroupUpdate}
+                                    on:visibilityToggleGroup={(e) => {
+                                        handleVisibilityToggle(e.detail.groupId, "group", e.detail.enabled);
+                                    }}
                                 />
                             </li>
                         {/each}
@@ -519,6 +537,9 @@
                                         groups={releaseGroups}
                                         on:testUpdate={handleTestUpdate}
                                         on:testDelete={handleTestDelete}
+                                        on:visibilityToggleTest={(e) => {
+                                            handleVisibilityToggle(e.detail.testId, "test", e.detail.enabled);
+                                        }}
                                     />
                                 {/each}
                             </ul>

--- a/frontend/AdminPanel/ReleaseManagerGroup.svelte
+++ b/frontend/AdminPanel/ReleaseManagerGroup.svelte
@@ -32,6 +32,14 @@
         });
     };
 
+    const handleVisibilityToggle = function(e) {
+        e.stopPropagation();
+        dispatch("visibilityToggleGroup", {
+            groupId: group.id,
+            enabled: !group.enabled,
+        });
+    };
+
     onMount(() => {
         newGroupId = groups?.[0]?.id ?? "";
     });
@@ -44,6 +52,11 @@
         {/if}
     </div>
     <div class="ms-auto">
+        <div class="form-check form-switch">
+            <input class="form-check-input" type="checkbox" role="switch" on:click={handleVisibilityToggle} bind:checked={group.enabled}>
+        </div>
+    </div>
+    <div class="ms-2">
         <button
             class="btn btn-light"
             title="Edit"

--- a/frontend/AdminPanel/ReleaseManagerTest.svelte
+++ b/frontend/AdminPanel/ReleaseManagerTest.svelte
@@ -26,6 +26,14 @@
         });
     };
 
+    const handleVisibilityToggle = function(e) {
+        e.stopPropagation();
+        dispatch("visibilityToggleTest", {
+            testId: test.id,
+            enabled: !test.enabled,
+        });
+    };
+
     const handleTestDelete = function () {
         editing = false;
         dispatch("testDelete", {
@@ -45,6 +53,11 @@
         <div class="text-muted text-small">{test.build_system_id}</div>
     </div>
     <div class="ms-auto">
+        <div class="form-check form-switch">
+            <input class="form-check-input" type="checkbox" role="switch" bind:checked={test.enabled} on:click={handleVisibilityToggle}>
+        </div>
+    </div>
+    <div class="ms-2">
         <button
             class="btn btn-light"
             title="Edit"


### PR DESCRIPTION
This commits adds quick switches to enable/disable groups and tests
inside admin management panel

Fixes #392 