### PR TITLE
refactor(ReleaseScheduler.svelte): Release Assignee Planner rework

### DIFF
--- a/argus/backend/controller/api.py
+++ b/argus/backend/controller/api.py
@@ -13,7 +13,7 @@ from argus.backend.controller.client_api import bp as client_bp
 from argus.backend.controller.testrun_api import bp as testrun_bp
 from argus.backend.controller.team import bp as team_bp
 from argus.backend.controller.view_api import bp as view_bp
-from argus.backend.service.argus_service import ArgusService
+from argus.backend.service.argus_service import ArgusService, ScheduleUpdateRequest
 from argus.backend.service.user import UserService, api_login_required
 from argus.backend.service.stats import ReleaseStatsCollector
 from argus.backend.models.web import ArgusRelease, ArgusGroup, ArgusTest, User, UserOauthToken
@@ -229,6 +229,8 @@ def release_schedules_submit():
         groups=payload["groups"],
         assignees=payload["assignees"],
         tag=payload["tag"],
+        comments=payload.get("comments"),
+        group_ids=payload.get("groupIds"),
     )
 
     return jsonify({
@@ -250,6 +252,27 @@ def release_schedules_delete():
     return jsonify({
         "status": "ok",
         "response": schedule_delete_result
+    })
+
+
+@bp.route("/release/schedules/update", methods=["POST"])
+@api_login_required
+def release_schedule_update():
+    payload = get_payload(request)
+    req = ScheduleUpdateRequest(**payload)
+    service = ArgusService()
+    update_result = service.update_schedule(
+        release_id=req.release_id,
+        schedule_id=req.schedule_id,
+        old_tests=req.old_tests,
+        new_tests=req.new_tests,
+        comments=req.comments,
+        assignee=req.assignee
+    )
+
+    return jsonify({
+        "status": "ok",
+        "response": update_result
     })
 
 

--- a/frontend/Common/ModalWindow.svelte
+++ b/frontend/Common/ModalWindow.svelte
@@ -1,0 +1,44 @@
+<script>
+    import { createEventDispatcher } from "svelte";
+
+    const dispatch = createEventDispatcher();
+</script>
+
+<div class="modal-window">
+    <div class="d-flex align-items-center justify-content-center p-4">
+        <div class="rounded bg-white p-4 h-50">
+            <div class="mb-2 d-flex border-bottom pb-2">
+                <h5>
+                    <slot name="title"><!-- optional fallback --></slot>
+                </h5>
+                <div class="ms-auto">
+                    <button 
+                        class="btn btn-close"
+                        on:click={() => {
+                            dispatch("modalClose");
+                        }}
+                    ></button>
+                </div>
+            </div>
+            <div>
+                <slot name="body"><!-- optional fallback --></slot>
+            </div>
+        </div>
+    </div>
+</div>
+
+<style>
+    .h-50 {
+        width: 50%;
+    }
+    .modal-window {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        overflow-y: scroll;
+        background-color: rgba(0, 0, 0, 0.55);
+        z-index: 9999;
+    }
+</style>

--- a/frontend/Common/SelectUtils.js
+++ b/frontend/Common/SelectUtils.js
@@ -1,3 +1,3 @@
 export const filterUser = function (label, filterText, user) {
     return `${label ?? ""}${user?.full_name ?? ""}`.toLowerCase().includes(filterText.toLowerCase());
-}
+};

--- a/frontend/Profile/User.svelte
+++ b/frontend/Profile/User.svelte
@@ -19,12 +19,12 @@
             <div
                 class="img-profile"
                 style="background-image: url({getPicture(item.picture_id)});"
-                title={item.label}
+                title={item.label || item.username}
             />
         </div>
         <div class="ms-2 text-start">
             <div>{item.full_name ?? item.label}</div>
-            <div class="text-muted user-label">{item.label}</div>
+            <div class="text-muted user-label">{item.label || item.username}</div>
         </div>
     </div>
 </div>

--- a/frontend/ReleasePlanner/ReleasePlanEditor.svelte
+++ b/frontend/ReleasePlanner/ReleasePlanEditor.svelte
@@ -1,0 +1,373 @@
+<script>
+    import { createEventDispatcher, onMount } from "svelte";
+    import Select from "svelte-select";
+    import { endDate, startDate, timestampToISODate } from "../Common/DateUtils";
+    import User from "../Profile/User.svelte";
+    import { faArrowAltCircleRight, faFlagCheckered, faTimes, faTrash } from "@fortawesome/free-solid-svg-icons";
+    import Fa from "svelte-fa";
+    import { sendMessage } from "../Stores/AlertStore";
+    import { filterUser } from "../Common/SelectUtils";
+    import ModalWindow from "../Common/ModalWindow.svelte";
+
+    export let selectedTests = [];
+    export let clickedTests = {};
+    export let selectedAssignee;
+    export let releaseData = {};
+    export let plannerData = {};
+    export let users = {};
+    let oldSchedule;
+
+    export const enterEditMode = function (schedule) {
+        newSchedule = Object.assign({}, schedule);
+        oldSchedule = schedule;
+        users = users;
+        mode = "edit";
+    };
+
+    export const exitEditMode = function () {
+        newSchedule = Object.assign({}, PayloadTemplate);
+        selectedTests = [];
+        selectedAssignee = undefined;
+        oldSchedule = undefined;
+        clickedTests = {};
+        mode = "create";
+    };
+
+    export const getCurrentMode = () => mode;
+    export const getCurrentScheduleId = () => newSchedule.id;
+
+    let mode = "create"; // create, edit
+    let deleting = false;
+    let lockButtons = false;
+
+    const getAllComments = function () {
+        return plannerData.tests
+            .map((test) => {
+                return test.comment;
+            })
+            .filter((comment) => comment);
+    };
+
+    const fetchVersions = async function() {
+        let response = await fetch(`/api/v1/release/${plannerData.release.id}/versions`);
+        if (response.status != 200) {
+            return Promise.reject("API Error");
+        }
+        let json = await response.json();
+        if (json.status !== "ok") {
+            return Promise.reject(json.exception);
+        }
+
+        autocompleteVersions = json.response;
+    };
+
+    /**
+     *
+     * @param {Array<string>} autocompleteList
+     */
+    const uniqueAutocompleteTokens = function(autocompleteList) {
+        return autocompleteList.reduce((acc, val) => {
+            if (!acc.includes(val)) {
+                acc.push(val);
+            }
+            return acc;
+        }, []);
+    };
+
+    let autocompleteVersions = [];
+    let autocompleteComments = getAllComments();
+
+    const dispatch = createEventDispatcher();
+
+    const PayloadTemplate = {
+        releaseId: releaseData.release.id,
+        groups: [],
+        tests: [],
+        start: startDate(releaseData.release),
+        end: endDate(releaseData.release, startDate(releaseData.release)),
+        assignees: [],
+        tag: "",
+    };
+
+    let newSchedule = Object.assign(PayloadTemplate);
+
+    const submitNewSchedule = async function () {
+        try {
+            lockButtons = true;
+            let payload = Object.assign({}, newSchedule);
+            payload.start = timestampToISODate(payload.start.getTime());
+            payload.end = timestampToISODate(payload.end.getTime());
+            payload.assignees = [selectedAssignee?.id || undefined];
+            payload.tests = selectedTests.map(v => v.id);
+            payload.comments = selectedTests.reduce((acc, val) => {(acc[val.id] = val.comment); return acc;}, {});
+            payload.groupIds = selectedTests.reduce((acc, val) => {(acc[val.id] = val.group_id); return acc;}, {});
+
+            let apiResponse = await fetch("/api/v1/release/schedules/submit", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify(payload),
+            });
+            let apiJson = await apiResponse.json();
+            if (apiJson.status === "ok") {
+                dispatch("fetchSchedules", true);
+                dispatch("fetchPlannerData", true);
+                handleTestsClear();
+                selectedAssignee = undefined;
+            } else {
+                throw apiJson;
+            }
+            newSchedule = Object.assign(PayloadTemplate);
+        } catch (error) {
+            if (error?.status === "error") {
+                sendMessage(
+                    "error",
+                    `Unable to submit schedule.\nAPI Response: ${error.response.arguments[0]}`,
+                    "ReleasePlanner::submitNewSchedule"
+                );
+            } else {
+                sendMessage(
+                    "error",
+                    "A backend error occurred during schedule submission",
+                    "ReleasePlanner::submitNewSchedule"
+                );
+                console.log(error);
+                console.trace();
+            }
+        } finally {
+            lockButtons = false;
+        }
+    };
+
+    const updateSchedule = async function() {
+        try {
+            lockButtons = true;
+            let apiResponse = await fetch("/api/v1/release/schedules/update", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    release_id: releaseData.release.id,
+                    schedule_id: newSchedule.id,
+                    assignee: selectedAssignee.id,
+                    new_tests: selectedTests.map(v => v.id),
+                    old_tests: oldSchedule.tests,
+                    comments: selectedTests.reduce((acc, val) => {(acc[val.id] = val.comment); return acc;}, {}),
+                }),
+            });
+            let apiJson = await apiResponse.json();
+            if (apiJson.status === "ok") {
+                dispatch("fetchSchedules", true);
+                dispatch("fetchPlannerData", true);
+                exitEditMode();
+            } else {
+                throw apiJson;
+            }
+        } catch (error) {
+            if (error?.status === "error") {
+                sendMessage(
+                    "error",
+                    `Unable to update schedule.\nAPI Response: ${error.response.arguments[0]}`,
+                    "ReleasePlanner::deleteSchedule"
+                );
+            } else {
+                sendMessage(
+                    "error",
+                    "A backend error occurred during schedule update",
+                    "ReleasePlanner::deleteSchedule"
+                );
+                console.log(error);
+                console.trace();
+            }
+        } finally {
+            lockButtons = false;
+        }
+    };
+
+    const deleteSchedule = async function (scheduleId) {
+        try {
+            lockButtons = true;
+            let apiResponse = await fetch("/api/v1/release/schedules/delete", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    releaseId: releaseData.release.id,
+                    scheduleId: scheduleId,
+                    deleteComments: true,
+                }),
+            });
+            let apiJson = await apiResponse.json();
+            if (apiJson.status === "ok") {
+                dispatch("fetchSchedules", true);
+                dispatch("fetchPlannerData", true);
+                exitEditMode();
+            } else {
+                throw apiJson;
+            }
+        } catch (error) {
+            if (error?.status === "error") {
+                sendMessage(
+                    "error",
+                    `Unable to delete schedule.\nAPI Response: ${error.response.arguments[0]}`,
+                    "ReleasePlanner::deleteSchedule"
+                );
+            } else {
+                sendMessage(
+                    "error",
+                    "A backend error occurred during schedule deletion",
+                    "ReleasePlanner::deleteSchedule"
+                );
+            }
+        } finally {
+            deleting = false;
+            lockButtons = false;
+        }
+    };
+
+    const handleTestsClear = function () {
+        clickedTests = {};
+        selectedTests = [];
+    };
+
+    onMount(() => {
+        fetchVersions();
+    });
+</script>
+{#if deleting}
+    <ModalWindow on:modalClose={() => deleting = false}>
+        <span slot="title">Deleting schedule</span>
+        <div slot="body">
+            <div>Are you sure you want to delete this schedule?</div>
+            {#if lockButtons}
+                <div><span class="spinner-border spinner-border-sm"></span> Working...</div>
+            {/if}
+            <div class="text-end">
+                <button class="btn btn-danger" disabled={lockButtons} on:click={() => deleteSchedule(newSchedule.id)}>Confirm</button>
+                <button class="btn btn-secondary" disabled={lockButtons} on:click={() => deleting = false}>Cancel</button>
+            </div>
+        </div>
+    </ModalWindow>
+{/if}
+<div class="my-2 bg-light-one p-2 rounded shadow-sm">
+    {#if releaseData.release.perpetual}
+        <div>
+            <div class="rounded p-2 border-warning border bg-warning bg-opacity-50">
+                <b>Important:</b> Test schedules are only valid for this week!
+            </div>
+        </div>
+    {/if}
+    {#if Object.values(users).length > 0}
+        {#if mode == "create"}
+            <div class="mb-2 w-100">
+                <button class="btn btn-success w-100" on:click={submitNewSchedule} disabled={lockButtons}>{#if lockButtons}
+                    <span class="spinner-border spinner-border-sm"></span>
+                {/if} Create</button>
+            </div>
+        {:else if mode == "edit"}
+            <div class="mb-2 btn-group w-100">
+                <button class="btn btn-warning" disabled={lockButtons} on:click={() => updateSchedule()}>{#if lockButtons}
+                    <span class="spinner-border spinner-border-sm"></span>
+                {/if} Update</button>
+                <button class="btn btn-secondary" disabled={lockButtons} on:click={() => exitEditMode()}>Cancel</button>
+                <button class="btn btn-danger" disabled={lockButtons} on:click={() => deleting = true}>Delete</button>
+            </div>
+        {/if}
+        <div class="d-flex mb-1">
+            <div class="mb-1 w-100 flex-fill">
+                <label for="newScheduleComment" class="form-label">Plan Comment</label>
+                <textarea
+                    class="form-control w-100"
+                    id="newScheduleComment"
+                    style="resize: none;"
+                    bind:value={newSchedule.tag}
+                />
+            </div>
+        </div>
+        <div class="mb-2">
+            {#if releaseData.release.perpetual}
+                <div>
+                    <div class="mb-1">Timing</div>
+                    <div class="mb-1 p-1 text-muted rounded shadow-sm d-inline-block">
+                        <Fa icon={faArrowAltCircleRight} /> Will start on {timestampToISODate(
+                            newSchedule.start.getTime()
+                        )}
+                    </div>
+                    <div class="mb-1 p-1 text-muted rounded shadow-sm d-inline-block">
+                        <Fa icon={faFlagCheckered} /> Will end on {timestampToISODate(
+                            newSchedule.end.getTime()
+                        )}
+                    </div>
+                </div>
+            {/if}
+        </div>
+        <div>
+            <div class="mb-3">
+                <div class="form-label">Assignee</div>
+                <Select
+                    Item={User}
+                    items={Object.values(users)}
+                    optionIdentifier="id"
+                    labelIdentifier="full_name"
+                    itemFilter={filterUser}
+                    placeholder="Select assignee"
+                    bind:value={selectedAssignee}
+                />
+            </div>
+        </div>
+        <div>
+            <div class="mb-3">
+                <datalist id="comment-autocomplete">
+                    {#each uniqueAutocompleteTokens([...autocompleteVersions, ...autocompleteComments]) as val}
+                        <option value="{val}"></option>
+                    {/each}
+                </datalist>
+                {#if selectedTests.length > 0}
+                        <div class="w-100 mb-1">
+                            <button class="w-100 btn btn-danger" disabled={lockButtons} on:click={() => handleTestsClear()}><Fa icon={faTrash}/> Clear All</button>
+                        </div>
+                {/if}
+                <ul class="list-group">
+                    {#each selectedTests as test (test.id)}
+                        <li class="list-group-item">
+                            <div class="d-flex align-items-center mb-1">
+                                <div>{test.name}</div>
+                                <div class="ms-auto">
+                                    <button
+                                        class="btn btn-dark btn-sm"
+                                        disabled={lockButtons}
+                                        on:click={() => {
+                                            selectedTests = selectedTests.filter(v => v.id != test.id);
+                                            clickedTests[test.id] = false;
+                                        }}
+                                    >
+                                        <Fa icon={faTimes}/>
+                                    </button>
+                                </div>
+                            </div>
+                            <div>
+                                <div class="input-group">
+                                    <input type="text" class="form-control" placeholder="Comment" list="comment-autocomplete" bind:value={test.comment}>
+                                    <button class="btn btn-secondary" disabled={lockButtons} on:click={() => selectedTests.forEach(v => {
+                                        v.comment = test.comment;
+                                        selectedTests = selectedTests;
+                                    })}>All</button>
+                                </div>
+                            </div>
+                        </li>
+                    {:else}
+                        <div class="text-muted p-2 text-center">Select tests by clicking on them on the left</div>
+                    {/each}
+                </ul>
+            </div>
+        </div>
+    {:else}
+        <div class="col d-flex align-items-center justify-content-center">
+            <div class="spinner-border me-3 text-muted" />
+            <div class="display-6 text-muted">Fetching users...</div>
+        </div>
+    {/if}
+</div>

--- a/frontend/ReleasePlanner/ReleaseScheduler.svelte
+++ b/frontend/ReleasePlanner/ReleaseScheduler.svelte
@@ -1,43 +1,28 @@
 <script>
     import { onMount } from "svelte";
-    import Select from "svelte-select";
     import Fa from "svelte-fa";
-    import { faArrowAltCircleRight, faArrowDown, faCalendar, faFlagCheckered } from "@fortawesome/free-solid-svg-icons";
-    import User from "../Profile/User.svelte";
+    import { faCalendar, faDashboard} from "@fortawesome/free-solid-svg-icons";
     import ReleasePlanTable from "./ReleasePlanTable.svelte";
     import { userList } from "../Stores/UserlistSubscriber";
     import { sendMessage } from "../Stores/AlertStore";
-    import {
-        startDate,
-        endDate,
-        timestampToISODate
-    } from "../Common/DateUtils";
-    import { filterUser } from "../Common/SelectUtils";
+    import ReleasePlanEditor from "./ReleasePlanEditor.svelte";
+
     export let releaseData = {};
     export let schedules = [];
     let users = {};
     $: users = $userList;
     let selectedTests = [];
-    let selectedAssignee;
     let clickedTests = {};
     let plannerData = {};
+    let editorMode = "create";
+    let selectedAssignee;
 
-    const PayloadTemplate = {
-        releaseId: releaseData.release.id,
-        groups: [],
-        tests: [],
-        start: startDate(releaseData.release),
-        end: endDate(releaseData.release, startDate(releaseData.release)),
-        assignees: [],
-        tag: "",
-    };
-
-    let newSchedule = Object.assign(PayloadTemplate);
+    let releasePlanEditorComponent;
 
     const fetchPlannerData = async function () {
         try {
             let params = new URLSearchParams({
-                releaseId: releaseData.release.id
+                releaseId: releaseData.release.id,
             }).toString();
             let apiResponse = await fetch("/api/v1/release/planner/data?" + params, {
                 method: "GET",
@@ -68,7 +53,7 @@
     const fetchSchedules = async function () {
         try {
             let params = new URLSearchParams({
-                releaseId: releaseData.release.id
+                releaseId: releaseData.release.id,
             });
 
             let apiResponse = await fetch("/api/v1/release/schedules?" + params, {
@@ -98,172 +83,38 @@
         }
     };
 
-    const submitNewSchedule = async function () {
-        try {
-            let payload = Object.assign({}, newSchedule);
-            payload.start = timestampToISODate(payload.start.getTime());
-            payload.end = timestampToISODate(payload.end.getTime());
-
-            let apiResponse = await fetch("/api/v1/release/schedules/submit", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify(payload),
-            });
-            let apiJson = await apiResponse.json();
-            if (apiJson.status === "ok") {
-                fetchSchedules();
-                handleTestsClear();
-                selectedAssignee = undefined;
-            } else {
-                throw apiJson;
-            }
-            newSchedule = Object.assign(PayloadTemplate);
-        } catch (error) {
-            if (error?.status === "error") {
-                sendMessage(
-                    "error",
-                    `Unable to submit schedule.\nAPI Response: ${error.response.arguments[0]}`,
-                    "ReleasePlanner::submitNewSchedule"
-                );
-            } else {
-                sendMessage(
-                    "error",
-                    "A backend error occurred during schedule submission",
-                    "ReleasePlanner::submitNewSchedule"
-                );
-            }
-        }
-    };
-
-    const deleteSchedule = async function (event) {
-        let scheduleId = event.detail.id;
-        try {
-            let apiResponse = await fetch("/api/v1/release/schedules/delete", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    releaseId: releaseData.release.id,
-                    scheduleId: scheduleId,
-                }),
-            });
-            let apiJson = await apiResponse.json();
-            if (apiJson.status === "ok") {
-                fetchSchedules();
-            } else {
-                throw apiJson;
-            }
-            newSchedule = Object.assign(PayloadTemplate);
-        } catch (error) {
-            if (error?.status === "error") {
-                sendMessage(
-                    "error",
-                    `Unable to delete schedule.\nAPI Response: ${error.response.arguments[0]}`,
-                    "ReleasePlanner::deleteSchedule"
-                );
-            } else {
-                sendMessage(
-                    "error",
-                    "A backend error occurred during schedule deletion",
-                    "ReleasePlanner::deleteSchedule"
-                );
-            }
-        }
-    };
-
-    const prepareUsers = function (users) {
-        return Object.values(users)
-            .map((val) => {
-                return {
-                    label: val.username,
-                    value: val.id,
-                    picture_id: val.picture_id,
-                    full_name: val.full_name,
-                };
-            })
-            .sort((a, b) => {
-                if (a.value > b.value) {
-                    return 1;
-                } else if (b.value > a.value) {
-                    return -1;
-                }
-                return 0;
-            });
-    };
-
-    const extractTests = function (plannerData) {
-        if (!plannerData.release) return;
-        return Object.values(plannerData.tests)
-            .map((val) => {
-                return {
-                    label: `${val.group_name}/${val.name}`,
-                    value: val.id,
-                    test: val,
-                };
-            })
-            .sort((a, b) => {
-                if (a.label > b.label) {
-                    return 1;
-                } else if (b.label > a.label) {
-                    return -1;
-                }
-                return 0;
-            });
-    };
-
-    const handleCellClick = function (e) {
-        let data = e.detail;
-        let testLabel = `${data.group}/${data.test.name}`;
-        if (!selectedTests) {
-            selectedTests = [];
-        }
-
-        if (selectedTests.findIndex((test) => test.label == testLabel) == -1) {
-            selectedTests.push({
-                label: testLabel,
-                value: data.test.id,
-            });
+    const handleTestClick = function (test) {
+        if (selectedTests.findIndex((t) => t.id == test.id) == -1) {
+            selectedTests.push(test);
             selectedTests = selectedTests;
-            clickedTests[testLabel] = true;
+            clickedTests[test.id] = true;
             clickedTests = clickedTests;
-            console.log(clickedTests);
-            handleTestSelect({
-                detail: selectedTests,
-            });
         } else {
-            clickedTests[testLabel] = false;
+            clickedTests[test.id] = false;
             clickedTests = clickedTests;
-            selectedTests = selectedTests.filter(
-                (test) => test.label != testLabel
-            );
-            handleTestSelect({
-                detail: selectedTests,
-            });
+            selectedTests = selectedTests.filter((t) => t.id != test.id);
         }
     };
 
-    const handleTestsClear = function (e) {
-        clickedTests = {};
-        selectedTests = [];
-        handleTestSelect({
-            detail: [],
-        });
+    const handleScheduledTestClick = function(e) {
+        let schedule = e.detail.schedule;
+        let test = e.detail.test;
+        let testEntities = plannerData.tests.filter(v => schedule.tests.includes(v.id));
+        if (releasePlanEditorComponent.getCurrentMode() != "edit" || releasePlanEditorComponent.getCurrentScheduleId() != schedule.id) {
+            releasePlanEditorComponent.enterEditMode(schedule);
+            selectedTests = testEntities;
+            selectedAssignee = users[schedule.assignees[0]];
+            clickedTests = {};
+            selectedTests.forEach(v => clickedTests[v.id] = true);
+        } else {
+            handleTestClick(test);
+        }
     };
 
-    const handleTestSelect = function (e) {
-        newSchedule.tests =
-            e.detail?.map((val) => {
-                return val.value;
-            }) ?? [];
-        newSchedule = newSchedule;
-    };
-
-    const handleAssigneeSelect = function (e) {
-        newSchedule.assignees = [e.detail.value];
-        newSchedule = newSchedule;
+    const handleSelectAll = function(e) {
+        let testsToIgnore = schedules.map(v => v.tests).reduce((acc, val) => [...acc, ...val], []);
+        let selectedTests = e.detail.tests.filter(v => !testsToIgnore.includes(v.id));
+        selectedTests.forEach(v => handleTestClick(v));
     };
 
     onMount(() => {
@@ -274,143 +125,50 @@
 
 <div class="container-fluid border rounded bg-white my-3 min-vh-100 shadow-sm">
     <div class="row">
-        <div class="p-2 display-6">{releaseData.release.name}</div>
-        <div>
-            <a class="btn btn-primary" href="/release/{releaseData.release.name}/duty"><Fa icon={faCalendar}/> Group Planner</a>
+        <h1 class="display-1">{releaseData.release.name}</h1>
+        <div class="btn-group mb-2">
+            <a class="btn btn-outline-primary" href="/release/{releaseData.release.name}/duty"
+                ><Fa icon={faCalendar} /> Group Planner</a
+            >
+            <a class="btn btn-outline-primary" href="/dashboard/{releaseData.release.name}"
+                ><Fa icon={faDashboard} /> Release Dashboard</a
+            >
         </div>
     </div>
     <div class="row">
-        {#if Object.values(users).length > 0 && plannerData.release}
-            <ReleasePlanTable
-                {releaseData}
-                {users}
-                {schedules}
-                {plannerData}
-                bind:clickedTests
-                on:cellClick={handleCellClick}
-                on:deleteSchedule={deleteSchedule}
-                on:refreshSchedules={() => fetchSchedules()}
-            />
-        {/if}
-    </div>
-    {#if releaseData.release.perpetual}
-        <div class="row">
-            <div class="col p-2">
-                <div class="rounded p-2 border-warning border bg-warning bg-opacity-50">
-                    <b>Important:</b> Test schedules are only valid for this week!
-                </div>
-            </div>
+        <div class="col-xs-2 col-sm-6 col-md-7">
+            {#if Object.values(users).length > 0 && plannerData.release}
+                <ReleasePlanTable
+                    {releaseData}
+                    {users}
+                    {schedules}
+                    {plannerData}
+                    bind:clickedTests
+                    on:testClick={(e) => handleTestClick(e.detail.test)}
+                    on:selectAllClick={handleSelectAll}
+                    on:scheduledTestClick={handleScheduledTestClick}
+                />
+            {/if}
         </div>
-    {/if}
-    <div class="row">
-        {#if Object.values(users).length > 0}
-            <div class="col border rounded m-3 p-3">
-                <h4 class="mb-3">New plan</h4>
-                <div class="d-flex align-items-start justify-content-start">
-                    <div class="me-3 w-25">
-                        <div class="mb-3">
-                            <label
-                                for="newScheduleReleaseName"
-                                class="form-label">Release</label
-                            >
-                            <input
-                                id="newScheduleReleaseName"
-                                class="form-control"
-                                type="text"
-                                value={releaseData.release.name}
-                                disabled
-                            />
-                        </div>
-                        <div class="mb-3">
-                            <label for="newScheduleComment" class="form-label">Comment</label>
-                            <textarea
-                                class="form-control"
-                                id="newScheduleComment"
-                                cols="30"
-                                rows="5"
-                                style="resize: none;"
-                                on:keyup={(e) => {newSchedule.tag = e.target.value; newSchedule = newSchedule;}}
-                            ></textarea>
-                        </div>
-                    </div>
-                    <div class="me-3 w-50">
-                        <div class="mb-3">
-                            <div class="form-label">Tests</div>
-                            <Select
-                                items={extractTests(plannerData)}
-                                isMulti={true}
-                                placeholder="Select tests"
-                                bind:value={selectedTests}
-                                on:select={handleTestSelect}
-                                on:clear={handleTestsClear}
-                            />
-                        </div>
-                        {#if releaseData.release.perpetual}
-                            <div>
-                                <div class="mb-1">Timing</div>
-                                <div class="mb-1 p-1 text-muted rounded shadow-sm d-inline-block">
-                                    <Fa icon={faArrowAltCircleRight} /> Will start on {timestampToISODate(newSchedule.start.getTime())}
-                                </div>
-                                <div class="mb-1 p-1 text-muted rounded shadow-sm d-inline-block">
-                                    <Fa icon={faFlagCheckered} /> Will end on {timestampToISODate(newSchedule.end.getTime())}
-                                </div>
-                            </div>
-                        {/if}
-                    </div>
-                    <div class="me-3 w-25">
-                        <div class="mb-3">
-                            <div class="form-label">Assignee</div>
-                            <Select
-                                Item={User}
-                                items={prepareUsers(users)}
-                                itemFilter={filterUser}
-                                placeholder="Select assignee"
-                                bind:value={selectedAssignee}
-                                on:select={handleAssigneeSelect}
-                            />
-                        </div>
-                    </div>
-                </div>
-                <div class="mb-3 w-100">
-                    <button
-                        class="btn btn-success w-100"
-                        on:click={submitNewSchedule}>Create</button
-                    >
-                </div>
-            </div>
-        {:else}
-            <div class="col d-flex align-items-center justify-content-center">
-                <div class="spinner-border me-3 text-muted" />
-                <div class="display-6 text-muted">Fetching users...</div>
-            </div>
-        {/if}
+        <div class="col-xs-10 col-sm-6 col-md-5">
+            {#if Object.values(users).length > 0 && plannerData.release}
+                <ReleasePlanEditor
+                    bind:this={releasePlanEditorComponent}
+                    {plannerData}
+                    {users}
+                    {releaseData}
+                    mode={editorMode}
+                    bind:selectedTests
+                    bind:clickedTests
+                    bind:selectedAssignee
+                    on:fetchSchedules={fetchSchedules}
+                    on:fetchPlannerData={fetchPlannerData}
+                />
+            {/if}
+        </div>
     </div>
-</div>
-
-<div
-    class:d-none={Object.keys(clickedTests).length == 0}
-    class="anchor-down"
->
-    <button
-        class="btn btn-success"
-        on:click={() => {
-            window.scrollTo({behavior: "smooth", top: document.body.clientHeight }); 
-        }}
-    >
-        <Fa icon={faArrowDown}/>
-    </button>
 </div>
 
 <style>
-    .anchor-down {
-        position: fixed;
-        left: 90%;
-        top: 90%;
 
-    }
-    .anchor-down>button {
-        border-radius: 50%;
-        width: 64px;
-        height: 64px;
-    }
 </style>


### PR DESCRIPTION
This commit reworks Release Planner wholesale, completely redoing the
way the table is structured. It is now similar in structure to the
TestDashboard used by Release Dashboard page and includes several new
features:

* Ability to select a whole group
* Collapseable groups that can be hidden when not needed
* Ability to batch edit a comment
* Ability to edit individual tests on a schedule
* Ability to reassign whole schedule to a different assignee
* Backlinks to the release dashboard
