### PR TITLE
feature(plugins/core): Generic Results

### DIFF
--- a/argus/backend/controller/client_api.py
+++ b/argus/backend/controller/client_api.py
@@ -90,3 +90,14 @@ def run_finalize(run_type: str, run_id: str):
         "status": "ok",
         "response": result
     }
+
+
+@bp.route("/testrun/<string:run_type>/<string:run_id>/submit_results", methods=["POST"])
+@api_login_required
+def submit_results(run_type: str, run_id: str):
+    payload = get_payload(request)
+    result = ClientService().submit_results(run_type=run_type, run_id=run_id, results=payload)
+    return {
+        "status": "ok",
+        "response": result
+    }

--- a/argus/backend/controller/testrun_api.py
+++ b/argus/backend/controller/testrun_api.py
@@ -63,6 +63,17 @@ def test_run_activity(run_id: str):
     }
 
 
+
+@bp.route("/run/<string:test_id>/<string:run_id>/fetch_results", methods=["GET"])
+@api_login_required
+def fetch_results(test_id: str, run_id: str):
+    tables = TestRunService().fetch_results(test_id=UUID(test_id), run_id=UUID(run_id))
+    return {
+        "status": "ok",
+        "tables": tables
+    }
+
+
 @bp.route("/test/<string:test_id>/run/<string:run_id>/status/set", methods=["POST"])
 @api_login_required
 def set_testrun_status(test_id: str, run_id: str):

--- a/argus/backend/models/result.py
+++ b/argus/backend/models/result.py
@@ -1,0 +1,41 @@
+from cassandra.cqlengine import columns
+from cassandra.cqlengine.models import Model
+from cassandra.cqlengine.usertype import UserType
+from enum import Enum
+
+
+class Status(Enum):
+    PASS = 0
+    WARNING = 1
+    ERROR = 2
+
+
+class ColumnMetadata(UserType):
+    name = columns.Ascii()
+    unit = columns.Text()
+    type = columns.Ascii()
+
+
+class ArgusGenericResultMetadata(Model):
+    __table_name__ = "generic_result_metadata_v1"
+    test_id = columns.UUID(partition_key=True)
+    name = columns.Text(required=True, primary_key=True)
+    description = columns.Text()
+    columns_meta = columns.List(value_type=columns.UserDefinedType(ColumnMetadata))
+    rows_meta = columns.List(value_type=columns.Ascii())
+
+    def __init__(self, **kwargs):
+        kwargs["columns_meta"] = [ColumnMetadata(**col) for col in kwargs.pop('columns_meta', [])]
+        super().__init__(**kwargs)
+
+
+class ArgusGenericResultData(Model):
+    __table_name__ = "generic_result_data_v1"
+    test_id = columns.UUID(partition_key=True)
+    name = columns.Text(partition_key=True)
+    run_id = columns.UUID(primary_key=True)
+    column = columns.Ascii(primary_key=True, index=True)
+    row = columns.Ascii(primary_key=True, index=True)
+    sut_timestamp = columns.DateTime()  # for sorting
+    value = columns.Double()
+    status = columns.Ascii()

--- a/argus/backend/models/web.py
+++ b/argus/backend/models/web.py
@@ -6,6 +6,8 @@ from cassandra.cqlengine.usertype import UserType
 from cassandra.cqlengine import columns
 from cassandra.util import uuid_from_time, unix_time_from_uuid1  # pylint: disable=no-name-in-module
 
+from argus.backend.models.result import ArgusGenericResultMetadata, ArgusGenericResultData
+
 
 def uuid_now():
     return uuid_from_time(datetime.utcnow())
@@ -377,6 +379,8 @@ USED_MODELS: list[Model] = [
     ArgusScheduleAssignee,
     ArgusScheduleGroup,
     ArgusScheduleTest,
+    ArgusGenericResultMetadata,
+    ArgusGenericResultData,
 ]
 
 USED_TYPES: list[UserType] = [

--- a/argus/backend/plugins/core.py
+++ b/argus/backend/plugins/core.py
@@ -213,6 +213,8 @@ class PluginModelBase(Model):
     def finish_run(self, payload: dict = None):
         raise NotImplementedError()
 
+    def sut_timestamp(self) -> float:
+        raise NotImplementedError()
 
 class PluginInfoBase:
     # pylint: disable=too-few-public-methods

--- a/argus/backend/plugins/sct/testrun.py
+++ b/argus/backend/plugins/sct/testrun.py
@@ -249,6 +249,13 @@ class SCTTestRun(PluginModelBase):
 
         self._collect_event_message(event, event_message)
 
+    def sut_timestamp(self) -> float:
+        """converts scylla-server date to timestamp and adds revision in subseconds precision to diffirentiate
+        scylla versions from the same day. It's not perfect, but we don't know exact version time."""
+        scylla_package = [package for package in self.packages if package.name == "scylla-server"][0]
+        return (datetime.strptime(scylla_package.date, '%Y%m%d').timestamp()
+                + int(scylla_package.revision_id, 16) % 1000000 / 1000000)
+
 
 class SCTJunitReports(Model):
     test_id = columns.UUID(primary_key=True, partition_key=True, required=True)

--- a/argus/client/base.py
+++ b/argus/client/base.py
@@ -7,6 +7,7 @@ from uuid import UUID
 import requests
 
 from argus.backend.util.enums import TestStatus
+from argus.client.generic_result import GenericResultTable
 from argus.client.sct.types import LogLink
 
 JSON = dict[str, Any] | list[Any] | int | str | float | bool | Type[None]
@@ -28,6 +29,8 @@ class ArgusClient:
         SET_STATUS = "/testrun/$type/$id/set_status"
         SET_PRODUCT_VERSION = "/testrun/$type/$id/update_product_version"
         SUBMIT_LOGS = "/testrun/$type/$id/logs/submit"
+        SUBMIT_RESULTS = "/testrun/$type/$id/submit_results"
+        FETCH_RESULTS = "/testrun/$type/$id/fetch_results"
         FINALIZE = "/testrun/$type/$id/finalize"
 
     def __init__(self, auth_token: str, base_url: str, api_version="v1") -> None:
@@ -190,3 +193,16 @@ class ArgusClient:
             }
         )
         self.check_response(response)
+
+    def submit_results(self, result: GenericResultTable) -> None:
+        response = self.post(
+            endpoint=self.Routes.SUBMIT_RESULTS,
+            location_params={"type": self.test_type, "id": str(self.run_id)},
+            body={
+                **self.generic_body,
+                "run_id": str(self.run_id),
+                ** result.as_dict(),
+            }
+        )
+        self.check_response(response)
+

--- a/argus/client/generic_result.py
+++ b/argus/client/generic_result.py
@@ -1,0 +1,99 @@
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Union
+
+
+class Status(Enum):
+    PASS = auto()
+    WARNING = auto()
+    ERROR = auto()
+
+    def __str__(self):
+        return self.name
+
+
+class ResultType(Enum):
+    INTEGER = auto()
+    FLOAT = auto()
+    DURATION = auto()
+
+    def __str__(self):
+        return self.name
+
+
+@dataclass
+class ColumnMetadata:
+    name: str
+    unit: str
+    type: ResultType
+
+    def as_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "unit": self.unit,
+            "type": str(self.type)
+        }
+
+
+class ResultTableMeta(type):
+    def __new__(cls, name, bases, dct):
+        cls_instance = super().__new__(cls, name, bases, dct)
+        meta = dct.get('Meta')
+
+        if meta:
+            cls_instance.name = meta.name
+            cls_instance.description = meta.description
+            cls_instance.columns = meta.Columns
+            cls_instance.column_names = {column.name for column in cls_instance.columns}
+            cls_instance.rows = []
+        return cls_instance
+
+
+@dataclass
+class Cell:
+    column: str
+    row: str
+    value: Union[int, float, str]
+    status: Status
+
+    def as_dict(self) -> dict:
+        return {
+            "column": self.column,
+            "row": self.row,
+            "value": self.value,
+            "status": str(self.status)
+        }
+
+
+@dataclass
+class GenericResultTable(metaclass=ResultTableMeta):
+    """
+    Base class for all Generic Result Tables in Argus. Use it as a base class for your result table.
+    """
+    sut_timestamp: int = 0  # automatic timestamp based on SUT version. Works only with SCT and refers to Scylla version.
+    sut_details: str = ""
+    results: list[Cell] = field(default_factory=list)
+
+    def as_dict(self) -> dict:
+        rows = []
+        for result in self.results:
+            if result.row not in rows:
+                rows.append(result.row)
+
+        meta_info = {
+            "name": self.name,
+            "description": self.description,
+            "columns_meta": [column.as_dict() for column in self.columns],
+            "rows_meta": rows
+        }
+        return {
+            "meta": meta_info,
+            "sut_timestamp": self.sut_timestamp,
+            "sut_details": self.sut_details,
+            "results": [result.as_dict() for result in self.results]
+        }
+
+    def add_result(self, column: str, row: str, value: Union[int, float, str], status: Status):
+        if column not in self.column_names:
+            raise ValueError(f"Column {column} not found in the table")
+        self.results.append(Cell(column=column, row=row, value=value, status=status))

--- a/dev-db/docker-compose.yaml
+++ b/dev-db/docker-compose.yaml
@@ -8,8 +8,8 @@ services:
           - argus-alpha
     command: --smp 1 --overprovisioned 1 --io-setup 0
     volumes:
-      - ./dev-db/alpha-data:/var/lib/scylla/data:rw
-      - ./dev-db/alpha-config:/etc/scylla:rw
+      - ./alpha-data:/var/lib/scylla/data:rw
+      - ./alpha-config:/etc/scylla:rw
 networks:
   scylla_bridge:
     driver: bridge

--- a/docs/generic_results.md
+++ b/docs/generic_results.md
@@ -1,0 +1,64 @@
+# Generic results
+Generic results is Argus feature that allows receiving and storing arbitrary table data from tests. 
+Generic Result in terms of Argus is a table with columns and rows (like a spreadsheet). Each result has a name, description and belongs to given test (Jenkins job).
+
+## How it works
+Generic results are stored in 2 tables: ArgusGenericResultMetadata ArgusGenericResultData.
+
+### ArgusGenericResultMetadata
+This table stores information what results are available for given `test_id` (Jenkins job). Contain information about each result: name, description, columns, and rows.
+
+### ArgusGenericResultData
+This table stores actual data for each result. Each row in this table is a cell in the result table. Its location is defined by `column` and `row` fields.
+Besides the value, each cell contains information about value status (PASS, WARNING, ERROR) and `sut_timestamp` which corresponds to SUT version (e.g. calculated from binaries build date for ScyllaDB). SUT version is not shown in the result table, but it is used for sorting purposes (needed when graphing results in time - time refers to SUT version).
+
+## Usage
+Generic results are stored in Argus database and can be accessed via Argus API and displayed in Argus UI in `Results` tab for given run.
+
+To send generic results to Argus, you need to create `ResultTable` class basing on `GenericResultTable` available in Argus Client library and send it using `ArgusClient` class (or it's child class like `ArgusSCTClient`). 
+
+Child class of `GenericResultTable` needs to define `Meta` class with `name` and `description` fields. It also needs to define `Columns` field that will describe available columns details for given result: as a list of `ColumnMetadata` objects. Each `ColumnMetadata` object needs to have `name`, `unit` and `type` fields. `type` field can be one of `ResultType` enum values.
+
+See example:
+
+```python
+from uuid import UUID
+
+from argus.client.sct.client import ArgusSCTClient
+from argus.client.generic_result import GenericResultTable, ColumnMetadata, ResultType, Status
+
+
+class LatencyResultTable(GenericResultTable):
+    class Meta:
+        name = "Write Latency"
+        description = "Latency for write operations"
+        Columns = [ColumnMetadata(name="latency", unit="ms", type=ResultType.FLOAT),
+                   ColumnMetadata(name="op_rate", unit="ops", type=ResultType.INTEGER),
+                   ColumnMetadata(name="duration", unit="HH:MM:SS", type=ResultType.DURATION)]
+
+
+result_table = LatencyResultTable()
+
+result_table.add_result(column="latency", row="mean", value=1.1, status=Status.WARNING)
+result_table.add_result(column="op_rate", row="mean", value=59988, status=Status.ERROR)
+result_table.add_result(column="latency", row="p99", value=2.7, status=Status.PASS)
+result_table.add_result(column="op_rate", row="p99", value=59988, status=Status.WARNING)
+result_table.add_result(column="duration", row="p99", value=8888, status=Status.ERROR)
+result_table.add_result(column="duration", row="mean", value=332, status=Status.PASS)
+
+# when testing locally, otherwise just use ArgusClient instance in your test.
+run_id = UUID("24e09748-bba4-47fd-a615-bf7ea2c425eb")
+client = ArgusSCTClient(run_id, auth_token="<token>",
+                        base_url="http://localhost:5000")
+client.submit_results(result_table)
+```
+
+If using different SUT than ScyllaDB (or need to adjust dynamically) you can set `sut_timestamp` field in table constructor. `sut_timestamp` should always correspond to SUT build timestamp. Like this:
+```python
+result_table = LatencyResultTable(sut_timestamp=1629302400)
+```
+This will assure proper sorting of results in Argus UI when comparing to different versions in time based graphs.
+
+# Limitations
+* Only 3 types of values are supported: FLOAT, INTEGER, DURATION
+* automatic SUT timestamp supported only by SCT: it calculates based on the Scylla Version date and commit id (builds from the same date are not the same, but timestamp does not reflect which one was earlier).

--- a/frontend/TestRun/ResultsTab.svelte
+++ b/frontend/TestRun/ResultsTab.svelte
@@ -1,0 +1,121 @@
+<script>
+    import {onMount} from "svelte";
+
+    let fetching = true;
+    export let id = "";
+    export let test_id = "";
+    let results = [];
+
+
+    const fetchResults = async function () {
+        fetching = true;
+        try {
+            let apiResponse = await fetch(`/api/v1/run/${test_id}/${id}/fetch_results`);
+            let apiJson = await apiResponse.json();
+            if (apiJson.status === "ok") {
+
+                fetching = false;
+                results = apiJson.tables;
+                console.log(results);
+            }
+        } catch (error) {
+            console.log(error);
+        }
+    };
+
+    const durationToStr = (seconds) => {
+        const hours = Math.floor(seconds / 3600);
+        const minutes = Math.floor((seconds % 3600) / 60);
+        const secs = seconds % 60;
+        return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}:${secs.toString().padStart(2, '0')}`;
+    };
+
+    const formatValue = (value, type) => {
+        switch (type) {
+        case "FLOAT":
+            return value.toFixed(2);
+        case "INTEGER":
+            return value.toLocaleString();
+        case "DURATION":
+            return durationToStr(value);
+        default:
+            return value;
+        }
+    };
+
+    const getColumnType = (result, columnName) => {
+        return result.meta.columns_meta.find((col) => col.name === columnName).type;
+    };
+
+    onMount(() => {
+        fetchResults();
+    });
+
+    const styleMap = {
+        "PASS": "table-success",
+        "ERROR": "table-danger",
+        "WARNING": "table-warning"
+    };
+
+</script>
+
+<style>
+    th, td {
+        text-align: center;
+    }
+
+    table {
+        width: auto;
+        table-layout: auto;
+    }
+
+    .unit {
+        font-size: 0.8em;
+        color: gray;
+        vertical-align: top;
+    }
+</style>
+
+{#if !fetching}
+    <div class="p-2">
+        {#each results as result}
+            <div class="">
+                <h3>{result.meta.name}</h3>
+                <span>{result.meta.description}</span>
+                <table class="table table-bordered">
+                    <thead class="thead-dark">
+                    <tr>
+                        <th></th>
+                        {#each result.meta.columns_meta as col}
+                            <th>{col.name} <span class="unit">[{col.unit}]</span></th>
+                        {/each}
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {#each result.meta.rows_meta as row}
+                        <tr>
+                            <td>{row}</td>
+                            {#each result.meta.columns_meta as col}
+                                {#each result.cells as cell}
+                                    {#if cell.column === col.name && cell.row === row}
+                                        <td class="{styleMap[cell.status]}">{formatValue(cell.value, getColumnType(result, cell.column))}</td>
+                                    {/if}
+                                {/each}
+                            {/each}
+                        </tr>
+                    {/each}
+                    </tbody>
+                </table>
+            </div>
+        {:else}
+            <div class="row">
+                <div class="col text-center p-1 text-muted">No results for this run.</div>
+            </div>
+        {/each}
+    </div>
+{:else}
+    <div class="mb-2 text-center p-2">
+        <span class="spinner-border spinner-border-sm"></span> Loading results...
+    </div>
+{/if}
+

--- a/frontend/TestRun/TestRun.svelte
+++ b/frontend/TestRun/TestRun.svelte
@@ -13,6 +13,7 @@
         faRefresh,
         faRssSquare,
         faSpider,
+        faTable,
         faTimes,
     } from "@fortawesome/free-solid-svg-icons";
     import ResourcesInfo from "./ResourcesInfo.svelte";
@@ -35,6 +36,7 @@
     import PackagesInfo from "./PackagesInfo.svelte";
     import queryString from "query-string";
     import JUnitResults from "./jUnitResults.svelte";
+    import ResultsTab from "./ResultsTab.svelte";
     export let runId = "";
     export let buildNumber = -1;
     export let testInfo = {};
@@ -42,6 +44,7 @@
     let testRun = undefined;
     let runRefreshInterval;
     let activityOpen = false;
+    let resultsOpen = false;
     let eventsOpen = false;
     let commentsOpen = false;
     let issuesOpen = false;
@@ -224,6 +227,16 @@
                     {/if}
                     <button
                         class="nav-link"
+                        id="nav-results-tab-{runId}"
+                        data-bs-toggle="tab"
+                        data-bs-target="#nav-results-{runId}"
+                        type="button"
+                        on:click={() => (resultsOpen = true)}
+                        role="tab"
+                        ><Fa icon={faTable}/> Results</button
+                    >
+                    <button
+                        class="nav-link"
                         id="nav-events-tab-{runId}"
                         data-bs-toggle="tab"
                         data-bs-target="#nav-events-{runId}"
@@ -370,6 +383,15 @@
                 >
                     {#if activityOpen}
                         <ActivityTab id={runId} />
+                    {/if}
+                </div>
+                <div
+                    class="tab-pane fade"
+                    id="nav-results-{runId}"
+                    role="tabpanel"
+                >
+                    {#if resultsOpen}
+                        <ResultsTab id={runId} test_id={testInfo.test.id} />
                     {/if}
                 </div>
             </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "argus-alm"
-version = "0.12.3"
+version = "0.12.5"
 description = "Argus"
 authors = ["Alexey Kartashov <alexey.kartashov@scylladb.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Introduced generic results: allows clients to send arbitrary tabular
data to Argus and show it in `Results` tab in run view.
See [docs/generic_results.md](./docs/generic_results.md) for more details.

refs: https://github.com/scylladb/qa-tasks/issues/1244