### PR TITLE
Cleanup test resources button

### DIFF
--- a/frontend/TestRun/ResourcesInfo.svelte
+++ b/frontend/TestRun/ResourcesInfo.svelte
@@ -1,7 +1,14 @@
 <script>
     export let resources;
+    export let backend;
+    export let run_id;
     import { timestampToISODate } from "../Common/DateUtils";
     import { titleCase } from "../Common/TextUtils";
+    import Fa from "svelte-fa";
+    import {
+        faCopy,
+        faPlay,
+    } from "@fortawesome/free-solid-svg-icons";
     let sortHeaders = {
         creationTime: ["instance_info", "creation_time"],
         terminationTime: ["instance_info", "termination_time"],
@@ -71,8 +78,28 @@
         });
     };
 </script>
-
-
+<div class="row">
+    <div class="p-1 m-2 d-flex align-items-center">
+        <button
+            type="button"
+            class="btn btn-outline-success me-2"
+            on:click={() => {
+                let regions = "SCT_REGION_NAME= SCT_GCE_DATACENTER= SCT_AZURE_REGION_NAME= ";
+                navigator.clipboard.writeText(
+                    `${regions} hydra clean-resources --backend ${backend} --test-id ${run_id}`
+                );
+            }}>
+            <Fa icon={faCopy} /> Hydra Clean Resources
+        </button>
+        <a
+            href="https://jenkins.scylladb.com/view/QA/job/QA-tools/job/hydra-clean-test-resources/parambuild/?test_id={run_id}&backend={backend}"
+            class="btn btn-outline-primary"
+            target="_blank"
+            aria-current="page">
+            <Fa icon={faPlay} /> Clean with jenkins
+        </a>
+    </div>
+</div>
 <div class="form-group mb-2">
     <input
         class="form-control"

--- a/frontend/TestRun/TestRun.svelte
+++ b/frontend/TestRun/TestRun.svelte
@@ -310,6 +310,8 @@
                     <div class="p-2">
                         <ResourcesInfo
                             resources={testRun.allocated_resources}
+                            backend={testRun.cloud_setup?.backend}
+                            run_id="{testRun.id}"
                         />
                     </div>
                 </div>


### PR DESCRIPTION
Users need an easy way to clean resources left alive for given test id.

Added 2 buttons in resource tab:
1. By providing hydra clean-resources command to clipboard
2. By linking to jenkins cleanup job with parameters filled

Closes: https://github.com/scylladb/qa-tasks/issues/323

![image](https://github.com/user-attachments/assets/0d207ce8-899f-4870-9b6f-ae6b38409d3b)
