### PR TITLE
fix(plugins/core): use .extend instead of .append

### DIFF
--- a/argus/backend/plugins/core.py
+++ b/argus/backend/plugins/core.py
@@ -105,7 +105,7 @@ class PluginModelBase(Model):
             assignees = ArgusScheduleAssignee.filter(
                 schedule_id=schedule.id
             ).all()
-            assignees_uuids.append(*[assignee.assignee for assignee in assignees])
+            assignees_uuids.extend([assignee.assignee for assignee in assignees])
 
         return assignees_uuids[0] if len(assignees_uuids) > 0 else None
 


### PR DESCRIPTION
This fixes an issue where a schedule contains either 0 or more than 1
assignee inside of a run. While we always expect only one assignee (and
only allow assigning one person), partial deletes of a schedule for any
reason might leave schedule without assignees and it could be retrieved
later.

Fixes #403
