### PR TITLE
fix(frontend): Provide a placeholder status if stats are missing

### DIFF
--- a/frontend/ReleaseDashboard/TestDashboard.svelte
+++ b/frontend/ReleaseDashboard/TestDashboard.svelte
@@ -488,7 +488,7 @@
                                     >
                                         {testStats.status == "unknown"
                                             ? "Not run"
-                                            : subUnderscores(testStats.status).split(" ").map(v => titleCase(v)).join(" ")}
+                                            : subUnderscores(testStats.status ?? "Unknown").split(" ").map(v => titleCase(v)).join(" ")}
                                         {#if clickedTests[testStats.test.id]}
                                             <div class="text-tiny">Selected</div>
                                         {/if}

--- a/frontend/ReleasePlanner/ReleasePlanTable.svelte
+++ b/frontend/ReleasePlanner/ReleasePlanTable.svelte
@@ -187,7 +187,7 @@
                                     >
                                         {testStats.status == "unknown"
                                             ? "Not run"
-                                            : subUnderscores(testStats.status).split(" ").map(v => titleCase(v)).join(" ")}
+                                            : subUnderscores(testStats.status ?? "Unknown").split(" ").map(v => titleCase(v)).join(" ")}
                                         {#if clickedTests[test.id]}
                                             <div class="text-tiny">Selected</div>
                                         {/if}


### PR DESCRIPTION
This change fixes an issue where dashboards would crash if a test was
added but stats would still be using previously cached values.
