### PR TITLE
fix(argus_service.py): Delete previous assignee and create new one

### DIFF
--- a/argus/backend/service/argus_service.py
+++ b/argus/backend/service/argus_service.py
@@ -459,8 +459,13 @@ class ArgusService:
                 self.update_schedule_comment({"newComment": comment, "releaseId": test.release_id, "groupId": test.group_id, "testId": test.id})
 
         schedule_assignee: ArgusScheduleAssignee = ArgusScheduleAssignee.get(schedule_id=schedule_id)
-        schedule_assignee.assignee = assignee
-        schedule_assignee.save()
+        new_assignee = ArgusScheduleAssignee()
+        new_assignee.assignee = assignee
+        new_assignee.release_id = schedule_assignee.release_id
+        new_assignee.schedule_id = schedule_assignee.schedule_id
+        new_assignee.save()
+        schedule_assignee.delete()
+
         return True
 
     def delete_schedule(self, payload: dict) -> dict:


### PR DESCRIPTION
This fixes an issue due to assignee id being the primary key which
causes CQL engine to treat the "old" entity as new one.
