### PR TITLE
fix(jenkins-triggering): pick the impersonate user according to email

### DIFF
--- a/argus/backend/service/jenkins_service.py
+++ b/argus/backend/service/jenkins_service.py
@@ -220,7 +220,9 @@ class JenkinsService:
     def build_job(self, build_id: str, params: dict, user_override: str = None):
         queue_number = self._jenkins.build_job(build_id, {
             **params,
-            self.RESERVED_PARAMETER_NAME: g.user.username if not user_override else user_override
+            # use the user's email as the default value for the requested by user parameter,
+            # so it would align with how SCT default works, on runs not trigger by argus
+            self.RESERVED_PARAMETER_NAME: g.user.email.split('@')[0] if not user_override else user_override
         })
         return queue_number
 

--- a/argus/backend/service/user.py
+++ b/argus/backend/service/user.py
@@ -90,7 +90,10 @@ class UserService:
         except User.DoesNotExist:
             user = User()
             user.username = user_info.get("login")
-            user.email = email_info[-1].get("email")
+            # pick only scylladb.com emails
+            scylla_email = next(iter([email.get("email") for email in email_info if email.get["email"].endswith("@scylladb.com")]), None)
+            primary_email = next(iter([email.get("email") for email in email_info if email.get["primary"] and email.get["verified"]]), None)
+            user.email = scylla_email or primary_email
             user.full_name = user_info.get("name", user_info.get("login"))
             user.registration_date = datetime.utcnow()
             user.roles = ["ROLE_USER"]


### PR DESCRIPTION
argus rebuild is using the github id/login, to trigger job in jenkins while SCT uses by default the user from the primary email if it's part of scylla emails.
this small diffrence is cause confusion for users which thier email is diffrent from thier github login, and caused cloud resources to be forgotten

this change change the why we select the emails out of the github accout to default to scylla emails, and also to user the user from the email when rebuild jobs, so it would be aligned with SCT