### PR TITLE
fix(argus/service): Remove implicit 10,000 entity limit on full scans

### DIFF
--- a/argus/backend/service/build_system_monitor.py
+++ b/argus/backend/service/build_system_monitor.py
@@ -20,9 +20,9 @@ class ArgusTestsMonitor(ABC):
 
     def __init__(self) -> None:
         self._cluster = ScyllaCluster.get()
-        self._existing_releases = list(ArgusRelease.all())
-        self._existing_groups = list(ArgusGroup.all())
-        self._existing_tests = list(ArgusTest.all())
+        self._existing_releases = list(ArgusRelease.objects().limit(None))
+        self._existing_groups = list(ArgusGroup.objects().limit(None))
+        self._existing_tests = list(ArgusTest.objects().limit(None))
         self._filtered_groups: list[str] = self.BUILD_SYSTEM_FILTERED_PREFIXES
 
     def create_release(self, release_name):

--- a/argus/backend/service/views.py
+++ b/argus/backend/service/views.py
@@ -110,9 +110,9 @@ class UserViewService:
                 search_func = facet_wrapper(query_func=search_func, facet_query=value, facet_type=facet)
 
 
-        all_tests = ArgusTest.all()
-        all_releases = ArgusRelease.all()
-        all_groups = ArgusGroup.all()
+        all_tests = ArgusTest.objects().limit(None)
+        all_releases = ArgusRelease.objects().limit(None)
+        all_groups = ArgusGroup.objects().limit(None)
         release_by_id = {release.id: partial(self.index_mapper, type="release")(release) for release in all_releases}
         group_by_id = {group.id: partial(self.index_mapper, type="group")(group) for group in all_groups}
         index = [self.index_mapper(t) for t in all_tests]


### PR DESCRIPTION
This commit changes two instances of full scans currently used in Argus
to instead request unlimited amount of rows, rather than defaulting to
standard 10,000. This fixes issues where tests would be missing in
search queries or during build system scanner.
