### PR TITLE
fix(generic-result): fix updating table metadata

### DIFF
--- a/argus/backend/models/result.py
+++ b/argus/backend/models/result.py
@@ -28,6 +28,28 @@ class ArgusGenericResultMetadata(Model):
         kwargs["columns_meta"] = [ColumnMetadata(**col) for col in kwargs.pop('columns_meta', [])]
         super().__init__(**kwargs)
 
+    def update_if_changed(self, new_data: dict) -> None:
+        """
+        Updates table metadata if changed column/description or new rows were added.
+        See that rows can only be added, not removed once was sent.
+        Columns may be removed, but data in results table persists.
+        """
+        updated = False
+        for field, value in new_data.items():
+            if field == "columns_meta":
+                value = [ColumnMetadata(**col) for col in value]
+            elif field == "rows_meta":
+                added_rows = []
+                for row in value:
+                    if row not in self.rows_meta:
+                        added_rows.append(row)
+                value = self.rows_meta + added_rows
+            if getattr(self, field) != value:
+                setattr(self, field, value)
+                updated = True
+
+        if updated:
+            self.save()
 
 class ArgusGenericResultData(Model):
     __table_name__ = "generic_result_data_v1"

--- a/argus/backend/service/client_service.py
+++ b/argus/backend/service/client_service.py
@@ -74,7 +74,11 @@ class ClientService:
     def submit_results(self, run_type: str, run_id: str, results: dict) -> str:
         model = self.get_model(run_type)
         run = model.load_test_run(UUID(run_id))
-        ArgusGenericResultMetadata(test_id=run.test_id, **results["meta"]).save()
+        existing_table = ArgusGenericResultMetadata.objects(test_id=run.test_id, name=results["meta"]["name"]).first()
+        if existing_table:
+            existing_table.update_if_changed(results["meta"])
+        else:
+            ArgusGenericResultMetadata(test_id=run.test_id, **results["meta"]).save()
         if results.get("sut_timestamp", 0) == 0:
             results["sut_timestamp"] = run.sut_timestamp()  # automatic sut_timestamp
         table_name = results["meta"]["name"]


### PR DESCRIPTION
When test sends only one row to Argus it should be appended. So needs to update table metadata (only in case new row is added). In case of column/description changes, always update with new value.

Fixes issue when sending results in parts (row by row instead all at once)