### PR TITLE
improvement(run details): added test method

### DIFF
--- a/argus/backend/plugins/sct/testrun.py
+++ b/argus/backend/plugins/sct/testrun.py
@@ -109,6 +109,7 @@ class SCTTestRun(PluginModelBase):
     stress_cmd = columns.Text()
 
     histograms = columns.List(value_type=columns.Map(key_type=columns.Text(), value_type=columns.UserDefinedType(user_type=PerformanceHDRHistogram)))
+    test_method = columns.Ascii()
 
     @classmethod
     def _stats_query(cls) -> str:
@@ -199,6 +200,7 @@ class SCTTestRun(PluginModelBase):
 
             run.config_files = req.sct_config.get("config_files")
             run.region_name = regions
+            run.test_method = req.sct_config.get("test_method")
             run.save()
 
         return run

--- a/frontend/TestRun/IssueTemplate.svelte
+++ b/frontend/TestRun/IssueTemplate.svelte
@@ -162,6 +162,9 @@ OS / Image: `{test_run?.cloud_setup?.db_node?.image_id ?? "No image"}` ({test_ru
 Test: `{test?.name}`
 Test id: `{test_run.id}`
 Test name: `{test_run.build_id}`
+{#if test_run.test_method}
+    Test method: `{test_run.test_method}`
+{/if}
 Test config file(s):
 
 - [{(test_run.config_files?.[0] ?? "None").split("/").reverse()[0]}](https://github.com/scylladb/scylla-cluster-tests/blob/{test_run.scm_revision_id}/{test_run.config_files[0]})

--- a/frontend/TestRun/TestRunInfo.svelte
+++ b/frontend/TestRun/TestRunInfo.svelte
@@ -63,6 +63,12 @@
                     <span class="fw-bold">Test:</span>
                     {(test?.pretty_name || test?.name) ?? "#NO_TEST"}
                 </li>
+                {#if test_run.test_method}
+                    <li>
+                        <span class="fw-bold">Test Method:</span>
+                        {test_run.test_method}
+                    </li>
+                {/if}
                 <li>
                     <span class="fw-bold">Id:</span>
                     {test_run.id}


### PR DESCRIPTION
For jobs that run tests in parallel it's important to see what test method was used (e.g. in perf tests it defines the workload).

Added additional param that recently was added to SCT config (`test_method`) and it's displayed in "Run Details".

closes: https://github.com/scylladb/argus/issues/375