### PR TITLE
fix(service/testrun): Do not send a mention to yourself

### DIFF
--- a/argus/backend/service/testrun.py
+++ b/argus/backend/service/testrun.py
@@ -223,7 +223,7 @@ class TestRunService:
         mentions = set(mentions)
         for potential_mention in re.findall(self.RE_MENTION, message_stripped):
             if user := User.exists_by_name(potential_mention.lstrip("@")):
-                mentions.add(user)
+                mentions.add(user) if user.id != g.user.id else None
 
         test: ArgusTest = ArgusTest.get(id=test_id)
         plugin = self.get_plugin(test.plugin_name)


### PR DESCRIPTION
This commit checks whether or not a queued mention would be for the user
writing the comment and prevent sending a notification for that mention.

Fixes #197
