### PR TITLE
feature(argus/client): Endpoint for retrieving the run

### DIFF
--- a/argus/backend/controller/client_api.py
+++ b/argus/backend/controller/client_api.py
@@ -23,6 +23,15 @@ def submit_run(run_type: str):
         "response": result
     }
 
+@bp.route("/testrun/<string:run_type>/<string:run_id>/get", methods=["GET"])
+@api_login_required
+def get_run(run_type: str, run_id: str):
+    result = ClientService().get_run(run_type=run_type, run_id=run_id)
+    return {
+        "status": "ok",
+        "response": result
+    }
+
 
 @bp.route("/testrun/<string:run_type>/<string:run_id>/heartbeat", methods=["POST"])
 @api_login_required

--- a/argus/backend/service/client_service.py
+++ b/argus/backend/service/client_service.py
@@ -26,6 +26,14 @@ class ClientService:
         model = self.get_model(run_type)
         model.submit_run(request_data=request_data)
         return "Created"
+    
+    def get_run(self, run_type: str, run_id: str):
+        model = self.get_model(run_type)
+        try:
+            run = model.get(id=run_id)
+        except model.DoesNotExist:
+            return None
+        return run
 
     def heartbeat(self, run_type: str, run_id: str) -> int:
         model = self.get_model(run_type)

--- a/argus/client/base.py
+++ b/argus/client/base.py
@@ -24,6 +24,7 @@ class ArgusClient:
     class Routes():
         # pylint: disable=too-few-public-methods
         SUBMIT = "/testrun/$type/submit"
+        GET = "/testrun/$type/$id/get"
         HEARTBEAT = "/testrun/$type/$id/heartbeat"
         GET_STATUS = "/testrun/$type/$id/get_status"
         SET_STATUS = "/testrun/$type/$id/set_status"
@@ -125,7 +126,23 @@ class ArgusClient:
             **self.generic_body,
             **run_body
         })
-    
+
+    def get_run(self, run_type: str = None, run_id: UUID | str = None) -> requests.Response:
+
+        if not run_type and hasattr(self, "test_type"):
+            run_type = self.test_type
+
+        if not run_id and hasattr(self, "run_id"):
+            run_id = self.run_id
+
+        if not (run_type and run_id):
+            raise ValueError("run_type and run_id must be set in func params or object attributes")
+
+        response = self.get(endpoint=self.Routes.GET, location_params={"type": run_type, "id": run_id })
+        self.check_response(response)
+
+        return response.json()["response"]
+
     def get_status(self, run_type: str = None, run_id: UUID = None) -> TestStatus:
         if not run_type and hasattr(self, "test_type"):
             run_type = self.test_type


### PR DESCRIPTION
This commit adds a new endpoint and a client method to retrieve
currently instantiated run data. This is useful in case client wants to
check/validate run before doing something to it.

Task: scylladb/scylla-cluster-tests#7483
