### PR TITLE
improvement(test-data): download full releases data

### DIFF
--- a/argus/backend/util/config.py
+++ b/argus/backend/util/config.py
@@ -10,7 +10,7 @@ LOGGER = logging.getLogger(__name__)
 class Config:
     CONFIG = None
     CONFIG_PATHS = [
-        Path("./config/argus_web.yaml"),
+        Path(__file__).parents[3] / "config" / "argus_web.yaml",
         Path("argus_web.yaml"),
     ]
 

--- a/dev-db/export_data.py
+++ b/dev-db/export_data.py
@@ -1,17 +1,33 @@
 import json
 from pathlib import Path
 
-from argus.backend.models.web import ArgusRelease
+from argus.backend.models.web import ArgusRelease, ArgusTest, ArgusGroup
 from argus.backend.plugins.sct.testrun import SCTTestRun
 from argus.backend.db import ScyllaCluster
 from argus.backend.util.encoders import ArgusJSONEncoder
 db = ScyllaCluster.get()
 
-release = ArgusRelease.get(name="enterprise-2023.1") # change name here
+release_name = "perf-regression" # change name here
+dest = Path(__file__).parent / "sample_data" / release_name
+dest.mkdir(parents=True, exist_ok=True)
+release = ArgusRelease.get(name=release_name)
+print(f"Saving release {release.id}")
+(dest / "release.json").write_text(json.dumps(release, cls=ArgusJSONEncoder))
+
+print('getting groups data')
+for group in ArgusGroup.filter(release_id=release.id).all():
+    print(f"Saving group {group.id}")
+    (dest / f"group_{group.id}.json").write_text(json.dumps(group, cls=ArgusJSONEncoder))
+
+print('getting test data')
+for test in ArgusTest.filter(release_id=release.id).all():
+    print(f"Saving test {test.id}")
+    (dest / f"test_{test.id}.json").write_text(json.dumps(test, cls=ArgusJSONEncoder))
+
+print('getting runs data')
 total = db.session.execute(f"SELECT count(build_id) FROM sct_test_run WHERE release_id = {release.id}").one()["system.count(build_id)"]
 idx = 0
 for run in SCTTestRun.filter(release_id=release.id).all():
     idx += 1
-    with Path(f"./dev-db/sample_data/{run.id}.json").open(mode="wt", encoding="utf-8") as dst:
-        print(f"Saving {run.id} [{idx}/{total}]")
-        json.dump(run, dst, cls=ArgusJSONEncoder)
+    print(f"Saving {run.id} [{idx}/{total}]")
+    (dest / f"run_{run.id}.json").write_text(json.dumps(run, cls=ArgusJSONEncoder))

--- a/dev-db/import_data.py
+++ b/dev-db/import_data.py
@@ -1,4 +1,3 @@
-import glob
 from pathlib import Path
 import json
 
@@ -6,11 +5,43 @@ from argus.backend.plugins.sct.testrun import SCTTestRun
 from argus.backend.db import ScyllaCluster
 
 db = ScyllaCluster.get()
-for file in (Path(p) for p in glob.glob("./dev-db/sample_data/*.json")):
+
+release_name = "perf-regression" # change name here
+dest = Path(__file__).parent / "sample_data" / release_name
+
+print('importing releases')
+statement = db.prepare(f"INSERT INTO argus_release_v2 JSON ?")
+with (dest / "release.json").open(mode="rt", encoding="utf-8") as src:
+    release_raw = src.read()
+    release = json.loads(release_raw)
+    db.session.execute(statement, parameters=(release_raw,))
+    print(f"Saved {release['id']}")
+
+print('importing groups')
+statement = db.prepare("INSERT INTO argus_group_v2 JSON ?")
+for file in dest.glob("group_*.json"):
+    with file.open(mode="rt", encoding="utf-8") as src:
+        group_raw = src.read()
+        group = json.loads(group_raw)
+        db.session.execute(statement, parameters=(group_raw,))
+        print(f"Saved {group['id']}")
+
+print('importing tests')
+statement = db.prepare("INSERT INTO argus_test_v2 JSON ?")
+for file in dest.glob("test_*.json"):
+    with file.open(mode="rt", encoding="utf-8") as src:
+        job_raw = src.read()
+        future_job = json.loads(job_raw)
+        db.session.execute(statement, parameters=(job_raw,))
+        print(f"Saved {future_job['id']}")
+
+print("importing runs")
+statement = db.prepare("INSERT INTO sct_test_run JSON ?")
+for file in dest.glob("run_*.json"):
     with file.open(mode="rt", encoding="utf-8") as src:
         run_raw = src.read()
         future_row = json.loads(run_raw)
-        db.session.execute(db.prepare("INSERT INTO sct_test_run JSON ?"), parameters=(run_raw,))
+        db.session.execute(statement, parameters=(run_raw,))
         run: SCTTestRun = SCTTestRun.get(id=future_row["id"])
         run.assign_categories()
         run.save()


### PR DESCRIPTION
Added possibility to download whole release data and import it without errors. Previous script didn't work if release/group/job was not imported previously.