### PR TITLE
fix(frontend/WorkArea): Use entity ids for sidebar buttons

### DIFF
--- a/frontend/WorkArea/RunGroup.svelte
+++ b/frontend/WorkArea/RunGroup.svelte
@@ -91,7 +91,7 @@
         <button
             class="accordion-button collapsed"
             data-bs-toggle="collapse"
-            data-bs-target="#collapse{sanitizeSelector(`${release}_${group.name}`)}"
+            data-bs-target="#collapse-{group.id}"
             on:click={handleGroupClick}
         >
             <div class="d-flex flex-column w-100">
@@ -121,7 +121,7 @@
     </h2>
     <div
         class="accordion-collapse collapse"
-        id="collapse{sanitizeSelector(`${release}_${group.name}`)}"
+        id="collapse-{group.id}"
     >
     {#if groupClicked}
         {#await fetchTests()}

--- a/frontend/WorkArea/RunRelease.svelte
+++ b/frontend/WorkArea/RunRelease.svelte
@@ -91,7 +91,7 @@
             class="accordion-button collapsed"
             data-argus-release={release.name}
             data-bs-toggle="collapse"
-            data-bs-target="#collapse{sanitizeSelector(release.name)}"
+            data-bs-target="#collapse-{release.id}"
             on:click={handleReleaseClick}
             >
                 <div class="d-flex flex-column">
@@ -117,7 +117,7 @@
     </h2>
     <div
         class="accordion-collapse collapse"
-        id="collapse{sanitizeSelector(release.name)}"
+        id="collapse-{release.id}"
     >
         <div class="p-2">
             <a href="/dashboard/{release.name}" class="btn btn-sm btn-dark"


### PR DESCRIPTION
This commit fixes an issue that might occur in cases where
`sanitizeSelector` function fails sanitize a selector made out of
concatenated release/group name, leading to a crash. The new method uses
UUID of the button object, i.e. either group id or release id,
preventing the issue from ever occuring.
