### PR TITLE
improvement(TestRunInfo): show grafana link if monitor is up

### DIFF
--- a/frontend/TestRun/TestRunInfo.svelte
+++ b/frontend/TestRun/TestRunInfo.svelte
@@ -26,7 +26,7 @@
 
     const locateGrafanaNode = function () {
         return test_run.allocated_resources.find((node) => {
-            return new RegExp(/\-monitor\-node\-/).test(node.name);
+            return new RegExp(/\-monitor\-node\-/).test(node.name) && node.state === "running";
         });
     };
 
@@ -254,14 +254,15 @@
                 />
             {/if}
             <div class="btn-group">
-                {#if InProgressStatuses.includes(test_run.status) && locateGrafanaNode()}
+                {#if locateGrafanaNode()}
                     <a
                         target="_blank"
                         href="http://{locateGrafanaNode().instance_info
-                            .public_ip}:3000/"
+                        .public_ip}:3000/"
                         class="btn btn-outline-warning">Open Grafana</a
                     >
-                {:else}
+                {/if}
+                {#if !InProgressStatuses.includes(test_run.status)}
                     <a
                         href="https://jenkins.scylladb.com/view/QA/job/QA-tools/job/hydra-show-monitor/parambuild/?test_id={test_run.id}"
                         class="btn btn-outline-primary"


### PR DESCRIPTION
We want to show grafana link if monitor node is up, not only when test is in progress.
Still, because monitor state may be outdated, showing restore monitoring stack buttons.

There's a plan to improve keeping instances state up to date by enhancing cloud cleanup scripts to update Argus.

refs: https://github.com/scylladb/qa-tasks/issues/328