### PR TITLE
fix(results): remove units when not present

### DIFF
--- a/argus/backend/service/results_service.py
+++ b/argus/backend/service/results_service.py
@@ -118,7 +118,7 @@ def create_chartjs(table, data):
             continue
         options = copy.deepcopy(default_options)
         options["plugins"]["title"]["text"] = f"{table.name} - {column.name}"
-        options["scales"]["y"]["title"]["text"] = f"[{column.unit}]"
+        options["scales"]["y"]["title"]["text"] = f"[{column.unit}]" if column.unit else ""
         options["scales"]["y"]["min"] = min_y
         options["scales"]["y"]["max"] = max_y
         graphs.append({"options": options, "data":

--- a/frontend/TestRun/ResultsTab.svelte
+++ b/frontend/TestRun/ResultsTab.svelte
@@ -272,7 +272,7 @@
                             <tr>
                                 <th></th>
                                 {#each result.columns as col}
-                                    <th>{col.name} <span class="unit">[{col.unit}]</span></th>
+                                    <th>{col.name} <span class="unit">{col.unit ? `[${col.unit}]` : ''}</span></th>
                                 {/each}
                             </tr>
                             </thead>


### PR DESCRIPTION
Sometimes results don't have units - in that case graphs and result tables print `[]` which is confusing.

Remove braces when no unit is present in graphs and result tables.