### PR TITLE
fix(graphs): hide button if no graphs available

### DIFF
--- a/argus/backend/controller/api.py
+++ b/argus/backend/controller/api.py
@@ -4,7 +4,7 @@ import requests
 from flask import (
     Blueprint,
     g,
-    request
+    request, Response
 )
 from flask.json import jsonify
 from argus.backend.error_handlers import handle_api_exception
@@ -382,13 +382,16 @@ def test_info():
         "response": info
     }
 
-@bp.route("/test-results", methods=["GET"])
+@bp.route("/test-results", methods=["GET", "HEAD"])
 @api_login_required
 def test_results():
     test_id = request.args.get("testId")
     if not test_id:
         raise Exception("No testId provided")
     service = ResultsService()
+    if request.method == 'HEAD':
+        exists = service.is_results_exist(test_id=UUID(test_id))
+        return Response(status=200 if exists else 404)
     info = service.get_results(test_id=UUID(test_id))
 
     return {

--- a/argus/backend/service/results_service.py
+++ b/argus/backend/service/results_service.py
@@ -138,3 +138,7 @@ class ResultsService:
             data = ArgusGenericResultData.objects(test_id=test_id, name=table.name).all()
             graphs.extend(create_chartjs(table, data))
         return graphs
+
+    def is_results_exist(self, test_id: UUID):
+        """Verify if results for given test id exist at all."""
+        return bool(ArgusGenericResultMetadata.objects(test_id=test_id).only(["name"]).limit(1))

--- a/frontend/WorkArea/TestRuns.svelte
+++ b/frontend/WorkArea/TestRuns.svelte
@@ -372,6 +372,7 @@
                 <TestRunsSelector
                     {runs}
                     {testInfo}
+                    {testId}
                     bind:clickedTestRuns={clickedTestRuns}
                     on:runClick={handleTestRunClick}
                     on:closeRun={handleTestRunClose}

--- a/frontend/WorkArea/TestRunsSelector.svelte
+++ b/frontend/WorkArea/TestRunsSelector.svelte
@@ -8,6 +8,7 @@
     import { sendMessage } from "../Stores/AlertStore";
 
     export let testInfo = {};
+    export let testId;
     export let runs = [];
     export let clickedTestRuns = {};
 
@@ -16,8 +17,23 @@
     let header;
     let ignoreReason = "";
     let modal;
+    let showGraphButton = false;
+
+    const showGraphsButtonIfResultsExist = async function () {
+        try {
+            let res = await fetch(`/api/v1/test-results?testId=${testId}`, {
+                method: "HEAD"
+            });
+            if (res.status === 200) {
+                showGraphButton = true;
+            }
+        } catch (error) {
+            console.error("Error while finding if results are present:", error);
+        }
+    };
 
     onMount(() => {
+        showGraphsButtonIfResultsExist();
         let observer = new IntersectionObserver((entries) => {
             let entry = entries[0];
             if (!entry) return;
@@ -41,16 +57,18 @@
             {testInfo.test.name} ({testInfo.release.name}/{testInfo.group.name})
         </div>
     {/if}
-    <div class="me-2 mb-2 d-inline-block">
-        <button
-            class="btn btn-light"
-            on:click={() => {
+    {#if showGraphButton}
+        <div class="me-2 mb-2 d-inline-block">
+            <button
+                    class="btn btn-light"
+                    on:click={() => {
                 dispatch("showGraph");
             }}
-        >
-            <Fa icon={faChartLine}/>
-        </button>
-    </div>
+            >
+                <Fa icon={faChartLine}/>
+            </button>
+        </div>
+    {/if}
     {#each runs as run (run.id)}
         <div class="me-2 mb-2 d-inline-block">
             <div class="btn-group">


### PR DESCRIPTION
In case graphs for given test are not available, showing graph button is misleading. This may cause people get used to missing graphs and never look there.

Fix is about showing graphs button only when there are results. Results are verified by metadata tables being present for given test.