### PR TITLE
fix(graphs): adjust filters similar to result tables

### DIFF
--- a/frontend/TestRun/ResultsGraph.svelte
+++ b/frontend/TestRun/ResultsGraph.svelte
@@ -22,6 +22,7 @@
                 }
             }
         };
+        graph.options.animation = false;
         graph.options.plugins.tooltip = {
             callbacks: {
                 label: function (tooltipItem) {

--- a/frontend/TestRun/ResultsGraphs.svelte
+++ b/frontend/TestRun/ResultsGraphs.svelte
@@ -1,20 +1,21 @@
 <script>
     import {createEventDispatcher, onMount} from "svelte";
-    import { sendMessage } from "../Stores/AlertStore";
+    import {sendMessage} from "../Stores/AlertStore";
     import ResultsGraph from "./ResultsGraph.svelte";
 
     export let test_id = "";
     let graphs = [];
-    let allFilters = [];
-    let filters = [];
-    let selectedFilters = [];
+    let tableFilters = [];
+    let columnFilters = [];
+    let selectedTableFilters = [];
+    let selectedColumnFilters = [];
     let filteredGraphs = [];
     let width = 500;  // default width for each chart
     let height = 300;  // default height for each chart
     const dispatch = createEventDispatcher();
 
     const dispatch_run_click = (e) => {
-        dispatch("runClick", { runId: e.detail.runId });
+        dispatch("runClick", {runId: e.detail.runId});
     };
 
     const fetchTestResults = async function (testId) {
@@ -27,8 +28,9 @@
             if (results.status != "ok") {
                 return Promise.reject(`API Error: ${results.message}, while trying to fetch test results`);
             }
-            graphs = results["response"].map((graph) => ({ ...graph, id: generateRandomHash() }));
-            extractFilters();
+            graphs = results["response"].map((graph) => ({...graph, id: generateRandomHash()}));
+            extractTableFilters();
+            extractColumnFilters();
             filterGraphs();
         } catch (error) {
             if (error?.status === "error") {
@@ -52,94 +54,79 @@
         return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
     };
 
-    const extractFilters = () => {
+    const extractTableFilters = () => {
         let fltrs = new Map();
         graphs.forEach(graph => {
             const title = graph.options.plugins.title.text;
-            const parts = title.split("-");
+            const parts = title.split("-").slice(0, -1);
             parts.forEach((part, index) => {
-                const level = index === parts.length - 1 ? 7 : index + 1;
+                const level = index + 1;
                 if (!fltrs.has(level)) {
                     fltrs.set(level, new Set());
                 }
                 fltrs.get(level).add(part.trim());
             });
         });
-        allFilters = Array.from(fltrs.entries()).sort((a, b) => a[0] - b[0]).map(entry => ({
+        tableFilters = Array.from(fltrs.entries()).sort((a, b) => a[0] - b[0]).map(entry => ({
             level: entry[0],
             items: Array.from(entry[1])
         }));
-        filters = [...allFilters];
     };
 
-    const toggleFilter = (filterName, level) => {
-        const currentFilter = selectedFilters.find(f => f.level === level);
+    const extractColumnFilters = () => {
+        let fltrs = new Set();
+        graphs.forEach(graph => {
+            const title = graph.options.plugins.title.text;
+            const parts = title.split("-").slice(-1);
+            parts.forEach(part => {
+                fltrs.add(part.trim());
+            });
+        });
+        columnFilters = Array.from(fltrs);
+    };
+
+    const toggleTableFilter = (filterName, level) => {
+        const currentFilter = selectedTableFilters.find(f => f.level === level);
         if (currentFilter && currentFilter.name === filterName) {
-            selectedFilters = selectedFilters.filter(f => f.level !== level);
+            selectedTableFilters = selectedTableFilters.filter(f => f.level !== level);
         } else {
-            selectedFilters = selectedFilters.filter(f => f.level !== level);
-            selectedFilters = [...selectedFilters, { name: filterName, level }];
+            selectedTableFilters = [
+                ...selectedTableFilters.filter(f => f.level !== level),
+                {name: filterName, level}
+            ];
         }
         filterGraphs();
-        updateAvailableFilters();
+    };
+
+    const toggleColumnFilter = (filterName) => {
+        if (selectedColumnFilters.includes(filterName)) {
+            selectedColumnFilters = selectedColumnFilters.filter(f => f !== filterName);
+        } else {
+            selectedColumnFilters = [...selectedColumnFilters, filterName];
+        }
+        filterGraphs();
     };
 
     const filterGraphs = () => {
-        if (selectedFilters.length === 0) {
-            filteredGraphs = graphs.map(graph => ({ ...graph, id: generateRandomHash() }));
+        if (selectedTableFilters.length === 0 && selectedColumnFilters.length === 0) {
+            filteredGraphs = graphs.map(graph => ({...graph, id: generateRandomHash()}));
         } else {
             filteredGraphs = graphs
                 .filter(graph => {
                     const title = graph.options.plugins.title.text;
                     const parts = title.split("-").map(part => part.trim());
-                    return selectedFilters.every(filter => parts.includes(filter.name));
+                    const matchesTableFilters = selectedTableFilters.every(filter => parts.includes(filter.name));
+                    const matchesColumnFilters = selectedColumnFilters.length === 0
+                        || selectedColumnFilters.some(filter => parts.includes(filter));
+                    return matchesTableFilters && matchesColumnFilters;
                 })
-                .map(graph => ({ ...graph, id: generateRandomHash() }));
+                .map(graph => ({...graph, id: generateRandomHash()}));
         }
     };
 
-    const updateAvailableFilters = () => {
-        let applicableFilters = new Map();
-        filteredGraphs.forEach(graph => {
-            const title = graph.options.plugins.title.text;
-            const parts = title.split("-");
-            parts.forEach((part, index) => {
-                const level = index === parts.length - 1 ? 7 : index + 1;
-                if (!applicableFilters.has(level)) {
-                    applicableFilters.set(level, new Set());
-                }
-                applicableFilters.get(level).add(part.trim());
-            });
-        });
-
-        filters = allFilters.map(filterGroup => ({
-            level: filterGroup.level,
-            items: filterGroup.items.filter(item =>
-                applicableFilters.has(filterGroup.level) && applicableFilters.get(filterGroup.level).has(item)
-            )
-        }));
-
-        // Remove lower level filters if they become inapplicable
-        selectedFilters = selectedFilters.filter(filter =>
-            filters.some(group =>
-                group.level === filter.level &&
-                group.items.includes(filter.name)
-            )
-        );
-    };
-
-    const getFilterColor = (level) => {
-        const firstColor = "#ff7f7f";
-        const lastColor = "#7fff7f";
-        const intermediateColors = ["#7fbfff", "#ffbf7f", "#bf7fff", "#ffff7f", "#7fffff", "#bf7f7f"];
-
-        if (level === 1) {
-            return firstColor;
-        } else if (level === 7) {
-            return lastColor;
-        } else {
-            return intermediateColors[(level - 2) % intermediateColors.length];
-        }
+    const getTableFilterColor = (level) => {
+        const intermediateColors = ["#ff7f7f", "#7fbfff", "#ffbf7f", "#bf7fff", "#ffff7f", "#7fffff", "#bf7f7f"];
+        return intermediateColors[level % intermediateColors.length];
     };
 
     onMount(() => {
@@ -148,18 +135,27 @@
 </script>
 
 <div class="filters-container">
-    {#each filters as filterGroup}
+    {#each tableFilters as filterGroup}
         {#each filterGroup.items as filter}
             <button
-                    on:click={() => toggleFilter(filter, filterGroup.level)}
-                    class:selected={selectedFilters.some(f => f.name === filter)}
-                    style="background-color: {getFilterColor(filterGroup.level)}"
+                    on:click={() => toggleTableFilter(filter, filterGroup.level)}
+                    class:selected={selectedTableFilters.some(f => f.name === filter)}
+                    style="background-color: {getTableFilterColor(filterGroup.level)}"
             >
                 {filter}
             </button>
         {/each}
     {/each}
-    <button on:click={() => { selectedFilters = []; filterGraphs(); updateAvailableFilters(); }}>Show All</button>
+    {#each columnFilters as filter}
+        <button
+                on:click={() => toggleColumnFilter(filter)}
+                class:selected={selectedColumnFilters.some(f => f === filter)}
+                style="background-color: #7fff7f"
+        >
+            {filter}
+        </button>
+    {/each}
+    <button on:click={() => { selectedTableFilters = []; selectedColumnFilters = []; filterGraphs(); }}>Show All</button>
 </div>
 
 <div class="charts-container">
@@ -186,7 +182,7 @@
     }
 
     .big-size {
-        width: 50%;
+        width: 45%;
     }
 
     .filters-container {


### PR DESCRIPTION
Graph filters are adjusting according to selections - this behavior differs from one in results tables and confuses users. Also it's harder to switch between different graphs (as requires deselect previous filter to show the other ones).

Adjusted graphs filters to work similarly like in results tables. Graphs thou have another level of filtering: columns (as each table column is a separate graph). These filters are not exclusive and users can select multiple of them - to show interesting multiple columns only.