### PR TITLE
improvement(results): add sending text and screenshots

### DIFF
--- a/argus/backend/controller/api.py
+++ b/argus/backend/controller/api.py
@@ -392,7 +392,7 @@ def test_results():
     if request.method == 'HEAD':
         exists = service.is_results_exist(test_id=UUID(test_id))
         return Response(status=200 if exists else 404)
-    graphs, ticks = service.get_results(test_id=UUID(test_id))
+    graphs, ticks = service.get_test_graphs(test_id=UUID(test_id))
 
     return {
         "status": "ok",

--- a/argus/backend/controller/testrun_api.py
+++ b/argus/backend/controller/testrun_api.py
@@ -8,6 +8,7 @@ from flask import (
 from argus.backend.error_handlers import handle_api_exception
 from argus.backend.models.web import ArgusTest
 from argus.backend.service.jenkins_service import JenkinsService
+from argus.backend.service.results_service import ResultsService
 from argus.backend.service.testrun import TestRunService
 from argus.backend.service.user import api_login_required
 from argus.backend.util.common import get_payload
@@ -67,7 +68,7 @@ def test_run_activity(run_id: str):
 @bp.route("/run/<string:test_id>/<string:run_id>/fetch_results", methods=["GET"])
 @api_login_required
 def fetch_results(test_id: str, run_id: str):
-    tables = TestRunService().fetch_results(test_id=UUID(test_id), run_id=UUID(run_id))
+    tables = ResultsService().get_run_results(test_id=UUID(test_id), run_id=UUID(run_id))
     return {
         "status": "ok",
         "tables": tables

--- a/argus/backend/models/result.py
+++ b/argus/backend/models/result.py
@@ -1,13 +1,6 @@
 from cassandra.cqlengine import columns
 from cassandra.cqlengine.models import Model
 from cassandra.cqlengine.usertype import UserType
-from enum import Enum
-
-
-class Status(Enum):
-    PASS = 0
-    WARNING = 1
-    ERROR = 2
 
 
 class ColumnMetadata(UserType):
@@ -60,4 +53,5 @@ class ArgusGenericResultData(Model):
     row = columns.Ascii(primary_key=True, index=True)
     sut_timestamp = columns.DateTime()  # for sorting
     value = columns.Double()
+    value_text = columns.Text()
     status = columns.Ascii()

--- a/argus/backend/service/testrun.py
+++ b/argus/backend/service/testrun.py
@@ -307,28 +307,6 @@ class TestRunService:
         }
         return response
 
-    def fetch_results(self, test_id: UUID, run_id: UUID) -> list[dict]:
-        cluster = ScyllaCluster.get()
-        query_fields = ["column", "row", "value", "status"]
-        raw_query = (f"SELECT {','.join(query_fields)},WRITETIME(value) as ordering "
-                     f"FROM generic_result_data_v1 WHERE test_id = ? AND run_id = ? AND name = ?")
-        query = cluster.prepare(raw_query)
-        tables_meta = ArgusGenericResultMetadata.filter(test_id=test_id)
-        tables = []
-        for table in tables_meta:
-            cells = cluster.session.execute(query=query, parameters=(test_id, run_id, table.name))
-            if not cells:
-                continue
-            cells = [dict(cell.items()) for cell in cells]
-            tables.append({'meta': {
-                'name': table.name,
-                'description': table.description,
-                'columns_meta': table.columns_meta,
-                'rows_meta': table.rows_meta,
-            },
-                'cells': [{k: v for k, v in cell.items() if k in query_fields} for cell in cells],
-                'order': min([cell['ordering'] for cell in cells] or [0])})
-        return sorted(tables, key=lambda x: x['order'])
 
     def submit_github_issue(self, issue_url: str, test_id: UUID, run_id: UUID):
         user_tokens = UserOauthToken.filter(user_id=g.user.id).all()

--- a/frontend/TestRun/Components/Cell.svelte
+++ b/frontend/TestRun/Components/Cell.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+    type Cell = {
+        value?: string | number;
+        value_text?: string;
+        type?: string;
+    };
+
+    type CellType = "NUMBER" | "TEXT" | "LINK" | "IMAGE";
+    export let cell: Cell;
+    export let selectedScreenshot: string;
+    let value: string;
+    let type: CellType = "TEXT";
+    const durationToStr = (seconds: number) => {
+        const hours = Math.floor(seconds / 3600);
+        const minutes = Math.floor((seconds % 3600) / 60);
+        const secs = seconds % 60;
+        return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
+    };
+    if (cell?.value === undefined) {
+        type = "TEXT";
+        value = "N/A";
+    } else if (typeof cell.value === "string") {
+        value = cell.value;
+        const urlRegex = /^(https?:\/\/[^\s]+)/i; // Ensure the entire string is a URL
+        const imageRegex = /\.(jpeg|jpg|gif|png|bmp|svg)$/i;
+
+        const isUrl = urlRegex.test(value);
+        const isImage = isUrl && imageRegex.test(value); // Checks if it's a URL and ends with an image extension
+
+        type = isImage ? "IMAGE" : isUrl ? "LINK" : "TEXT";
+    } else {
+        const value_number = cell.value;
+        type = "NUMBER";
+        switch (cell.type) {
+        case "FLOAT":
+            value = String(value_number.toFixed(2));
+            break;
+        case "INTEGER":
+            value = String(value_number.toLocaleString());
+            break;
+        case "DURATION":
+            value = String(durationToStr(value_number));
+            break;
+        default:
+            value = String(value_number);
+        }
+    }
+</script>
+
+{#if type === "NUMBER" || type === "TEXT"}
+    {value}
+{:else if type === "LINK"}
+    <a href="{value}" target="_blank" rel="noopener noreferrer">link</a>
+{:else if type === "IMAGE"}
+    <button class="btn btn-primary btn-sm py-0" on:click={() => selectedScreenshot = value}>view</button>
+{/if}
+

--- a/frontend/TestRun/Components/ScreenshotModal.svelte
+++ b/frontend/TestRun/Components/ScreenshotModal.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+    import {faFileDownload, faTimes} from "@fortawesome/free-solid-svg-icons";
+    import Fa from "svelte-fa";
+    import {onMount, onDestroy} from "svelte";
+
+    export let selectedScreenshot: string;
+    console.log("clicked screenshot", selectedScreenshot);
+    function handleKeyDown(event: KeyboardEvent) {
+        if (event.key === "Escape") {
+            selectedScreenshot = "";
+        }
+    }
+
+    onMount(() => {
+        window.addEventListener("keydown", handleKeyDown);
+    });
+
+    onDestroy(() => {
+        window.removeEventListener("keydown", handleKeyDown);
+    });
+</script>
+
+
+{#if selectedScreenshot}
+    <div class="screenshot-modal">
+        <div class="text-end">
+            <div class="d-inline-block screenshot-button">
+                <a href={selectedScreenshot} target="_blank">
+                    <Fa color="#a0a0a0" icon={faFileDownload}/>
+                </a>
+            </div>
+            <div
+                    class="d-inline-block screenshot-button"
+                    on:click={() => {
+                selectedScreenshot = "";
+            }}
+            >
+                <Fa icon={faTimes}/>
+            </div>
+        </div>
+        <div class="d-flex align-items-center justify-content-center my-2">
+            <img
+                    class="screenshot-modal-image"
+                    src={selectedScreenshot}
+                    alt="Screenshot"
+            />
+        </div>
+    </div>
+{/if}
+
+
+<style>
+    .screenshot-modal {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        overflow-y: scroll;
+        background-color: rgba(0, 0, 0, 0.55);
+        z-index: 9999;
+    }
+
+    .screenshot-button {
+        font-size: 32pt;
+        padding: 0 0.25rem;
+        color: rgb(138, 138, 138);
+        cursor: pointer;
+    }
+
+    .screenshot-button:hover {
+        color: white;
+    }
+
+    .screenshot-button:last-child {
+        padding-right: 1rem;
+    }
+
+</style>

--- a/frontend/TestRun/Screenshots.svelte
+++ b/frontend/TestRun/Screenshots.svelte
@@ -1,6 +1,5 @@
 <script>
-    import Fa from "svelte-fa";
-    import { faTimes, faFileDownload } from "@fortawesome/free-solid-svg-icons";
+    import ScreenshotModal from "./Components/ScreenshotModal.svelte";
     export let screenshots = [];
 
     let selectedScreenshot = undefined;
@@ -20,33 +19,7 @@
     <div class="text-muted text-center py-2">No screenshots submitted!</div>
 {/each}
 </div>
-
-{#if selectedScreenshot}
-    <div class="screenshot-modal">
-        <div class="text-end">
-            <div class="d-inline-block screenshot-button">
-                <a href={selectedScreenshot} target="_blank"
-                    ><Fa color="#a0a0a0" icon={faFileDownload} /></a
-                >
-            </div>
-            <div
-                class="d-inline-block screenshot-button"
-                on:click={() => {
-                    selectedScreenshot = undefined;
-                }}
-            >
-                <Fa icon={faTimes} />
-            </div>
-        </div>
-        <div class="d-flex align-items-center justify-content-center my-2">
-            <img
-                class="screenshot-modal-image"
-                src={selectedScreenshot}
-                alt=""
-            />
-        </div>
-    </div>
-{/if}
+<ScreenshotModal bind:selectedScreenshot />
 
 <style>
     .screenshot-thumb {
@@ -62,31 +35,7 @@
         border: solid 2px rgb(209, 209, 209);
     }
 
-    .screenshot-modal {
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        overflow-y: scroll;
-        background-color: rgba(0, 0, 0, 0.55);
-        z-index: 9999;
-    }
 
-    .screenshot-button {
-        font-size: 32pt;
-        padding: 0 0.25rem;
-        color: rgb(138, 138, 138);
-        cursor: pointer;
-    }
-
-    .screenshot-button:hover {
-        color: white;
-    }
-
-    .screenshot-button:last-child {
-        padding-right: 1rem;
-    }
 
     .screenshots-holder {
         flex-wrap: wrap;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
 name = "argus-alm"
-version = "0.12.7"
+version = "0.12.8"
 description = "Argus"
-authors = ["Alexey Kartashov <alexey.kartashov@scylladb.com>"]
+authors = ["Alexey Kartashov <alexey.kartashov@scylladb.com>", "Łukasz Sójka <lukasz.sojka@scylladb.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/scylladb/argus"
 readme = "README.md"


### PR DESCRIPTION
improvement(results): add sending text and screenshots

Implemented support for sending text results to argus.
Text results are ignored in graphs.
If a text result is a link to image it is shown as button which opens
given image in a modal (e.g. screenshots). This enables to send
screenshots from latency_decorator in SCT.

Also did a bit of refactor around results (moved fetching result tables
to `ResultsService` where fits better.


improvement(screenshots): move to separate component

Moved screenshot modal to separate component to reuse it.
Also added 'close by esc' feature.