### PR TITLE
improvement(notification_manager): Add "Assigned to a run" notification

### DIFF
--- a/argus/backend/service/client_service.py
+++ b/argus/backend/service/client_service.py
@@ -1,4 +1,5 @@
 from uuid import UUID
+
 from argus.backend.db import ScyllaCluster
 from argus.backend.models.result import ArgusGenericResultMetadata, ArgusGenericResultData
 from argus.backend.plugins.core import PluginModelBase
@@ -25,6 +26,7 @@ class ClientService:
     def submit_run(self, run_type: str, request_data: dict) -> str:
         model = self.get_model(run_type)
         model.submit_run(request_data=request_data)
+
         return "Created"
     
     def get_run(self, run_type: str, run_id: str):

--- a/argus/backend/service/notification_manager.py
+++ b/argus/backend/service/notification_manager.py
@@ -93,7 +93,8 @@ class NotificationSenderBase:
 
 class ArgusDBNotificationSaver(NotificationSenderBase):
     CONTENT_TEMPLATES = {
-        ArgusNotificationTypes.Mention: lambda p: render_template("notifications/mention.html.j2", **p if p else {})
+        ArgusNotificationTypes.Mention: lambda p: render_template("notifications/mention.html.j2", **p if p else {}),
+        ArgusNotificationTypes.AssigneeChange: lambda p: render_template("notifications/assigned.html.j2", **p if p else {}),
     }
 
     def send_notification(self, receiver: UUID, sender: UUID, notification_type: ArgusNotificationTypes, source_type: ArgusNotificationSourceTypes,
@@ -117,7 +118,8 @@ class ArgusDBNotificationSaver(NotificationSenderBase):
 class EmailNotificationServiceSender(NotificationSenderBase):
     CONTENT_TEMPLATES = {
         ArgusNotificationTypes.Mention: lambda p: render_template(
-            "notifications/email_mention.html.j2", **p if p else {})
+            "notifications/email_mention.html.j2", **p if p else {}),
+        ArgusNotificationTypes.AssigneeChange: lambda p: render_template("notifications/assigned_email.html.j2", **p if p else {}),
     }
 
     def __init__(self):

--- a/argus/backend/service/testrun.py
+++ b/argus/backend/service/testrun.py
@@ -203,6 +203,21 @@ class TestRunService:
             group_id=test.group_id,
             test_id=test.id
         )
+        self.notification_manager.send_notification(
+            receiver=new_assignee_user.id,
+            sender=g.user.id,
+            notification_type=ArgusNotificationTypes.AssigneeChange,
+            source_type=ArgusNotificationSourceTypes.TestRun,
+            source_id=run.id,
+            source_message=str(run.test_id),
+            content_params={
+                "username": g.user.username,
+                "run_id": run.id,
+                "test_id": test.id,
+                "build_id": run.build_id,
+                "build_number": get_build_number(run.build_job_url),
+            }
+        )
         return {
             "test_run_id": run.id,
             "assignee": str(new_assignee_user.id) if new_assignee_user else None

--- a/frontend/Common/ArgusNotification.ts
+++ b/frontend/Common/ArgusNotification.ts
@@ -14,6 +14,7 @@ export enum NotificationTypes {
 
 export enum NotificationSource {
     Comment = "COMMENT",
+    TestRun = "TEST_RUN"
 }
 
 export interface ArgusNotificationJSON {

--- a/frontend/Profile/Notification.svelte
+++ b/frontend/Profile/Notification.svelte
@@ -3,6 +3,7 @@
     import { apiMethodCall } from "../Common/ApiUtils";
     import NotificationCommentWrapper from "./NotificationCommentWrapper.svelte";
     import { ArgusNotification, ArgusShortSummary, NotificationSource, NotificationsState } from "../Common/ArgusNotification";
+    import NotificationTestRunWrapper from "./NotificationTestRunWrapper.svelte";
     export let summary: ArgusShortSummary;
 
     let notification: ArgusNotification;
@@ -15,6 +16,7 @@
 
     const ComponentSourceMap: ComponentSourceType = {
         [NotificationSource.Comment]: NotificationCommentWrapper,
+        [NotificationSource.TestRun]: NotificationTestRunWrapper,
     };
 
     const SupportDataFetch = {
@@ -27,8 +29,11 @@
                 supportDataReady = true;
                 supportData = result.response;
             }
-        }
-    }
+        },
+        [NotificationSource.TestRun]: async () => {
+            return {};
+        },
+    };
 
     const setNotificationAsRead = async function() {
         let params = {
@@ -36,7 +41,7 @@
         };
         let result = await apiMethodCall("/api/v1/notifications/read", params, "POST");
         if (result.status === "ok") {
-
+            //empty
         }
     };
 

--- a/frontend/Profile/NotificationTestRunWrapper.svelte
+++ b/frontend/Profile/NotificationTestRunWrapper.svelte
@@ -1,0 +1,7 @@
+<script>
+    export let supportData;
+</script>
+
+<div>
+    <!-- Placeholder -->
+</div>

--- a/templates/notifications/assigned.html.j2
+++ b/templates/notifications/assigned.html.j2
@@ -1,0 +1,1 @@
+You were assigned by <span class='fw-bold'>@{{ username }}</span> to <a href='{{url_for("main.runs", **{ "test_id": test_id, "additionalRuns[]": run_id })}}'>{{ build_id }}#{{ build_number }}</a>.

--- a/templates/notifications/assigned_email.html.j2
+++ b/templates/notifications/assigned_email.html.j2
@@ -1,0 +1,1 @@
+<div>You were assigned by <span style="font-weight:bold">@{{ username }}</span> to <a href='{{ config["BASE_URL"] }}{{url_for("main.runs", **{ "test_id": test_id, "additionalRuns[]": run_id })}}'>{{ build_id }}#{{ build_number }}</a>. </div>


### PR DESCRIPTION
This commit adds both internal and email notification for assignments to
runs within argus. Manual assignments done by a user on a test run card
send a notification/email from him.

Fixes #398
