### PR TITLE
improvement(results): track best and validate results

### DIFF
--- a/argus/backend/models/result.py
+++ b/argus/backend/models/result.py
@@ -1,12 +1,21 @@
+import math
+from datetime import datetime, timezone
+
 from cassandra.cqlengine import columns
 from cassandra.cqlengine.models import Model
 from cassandra.cqlengine.usertype import UserType
 
+class ValidationRules(UserType):
+    valid_from = columns.DateTime()
+    best_pct = columns.Double()  # max value limit relative to best result in percent unit
+    best_abs = columns.Double()  # max value limit relative to best result in absolute unit
+    fixed_limit = columns.Double()  # fixed limit
 
 class ColumnMetadata(UserType):
     name = columns.Ascii()
     unit = columns.Text()
     type = columns.Ascii()
+    higher_is_better = columns.Boolean()  # used for tracking best results, if None - no tracking
 
 
 class ArgusGenericResultMetadata(Model):
@@ -15,13 +24,68 @@ class ArgusGenericResultMetadata(Model):
     name = columns.Text(required=True, primary_key=True)
     description = columns.Text()
     columns_meta = columns.List(value_type=columns.UserDefinedType(ColumnMetadata))
+    validation_rules = columns.Map(key_type=columns.Ascii(), value_type=columns.List(columns.UserDefinedType(ValidationRules)))
     rows_meta = columns.List(value_type=columns.Ascii())
 
     def __init__(self, **kwargs):
         kwargs["columns_meta"] = [ColumnMetadata(**col) for col in kwargs.pop('columns_meta', [])]
+        validation_rules = kwargs.pop('validation_rules', {})
+
+        if validation_rules:
+            for column, rule in validation_rules.items():
+                if not isinstance(rule, list):
+                    rule['valid_from'] = datetime.now(timezone.utc)
+                    validation_rules[column] = [rule]
+            kwargs["validation_rules"] = {k: [ValidationRules(**rules) for rules in v] for k, v in validation_rules.items()}
         super().__init__(**kwargs)
 
-    def update_if_changed(self, new_data: dict) -> None:
+    def update_validation_rules(self, key: str, new_rule_dict: dict) -> bool:
+        """
+        Checks if the most recent ValidationRule for the given key matches the new_rule_dict.
+        If not, adds the new rule to the list with the current timestamp.
+
+        :param key: The key (column name) in the validation_rules map to update.
+        :param new_rule_dict: A dictionary containing the new validation rule values.
+        :return: True if a new rule was added, False if the existing rule matches.
+        """
+        rules_list = self.validation_rules.get(key, [])
+        most_recent_rule = None
+
+        if rules_list:
+            most_recent_rule = rules_list[-1]
+
+        fields_to_compare = [field for field in ValidationRules._fields if field != 'valid_from']
+        rules_match = True
+        if most_recent_rule:
+            for field in fields_to_compare:
+                db_value = getattr(most_recent_rule, field)
+                new_value = new_rule_dict.get(field)
+                if db_value is None and new_value is None:
+                    continue
+                if db_value is None or new_value is None:
+                    rules_match = False
+                    break
+                if not math.isclose(db_value, new_value, rel_tol=1e-9, abs_tol=0.0):
+                    rules_match = False
+                    break
+        else:
+            rules_match = False
+
+        if not rules_match:
+            new_rule = ValidationRules(
+                valid_from=datetime.now(timezone.utc),
+                best_pct=new_rule_dict.get('best_pct'),
+                best_abs=new_rule_dict.get('best_abs'),
+                fixed_limit=new_rule_dict.get('fixed_limit')
+            )
+            rules_list.append(new_rule)
+            self.validation_rules = self.validation_rules or {}
+            self.validation_rules.update({key: rules_list})
+            return True
+
+        return False  # Existing rule matches
+
+    def update_if_changed(self, new_data: dict) -> "ArgusGenericResultMetadata":
         """
         Updates table metadata if changed column/description or new rows were added.
         See that rows can only be added, not removed once was sent.
@@ -31,18 +95,26 @@ class ArgusGenericResultMetadata(Model):
         for field, value in new_data.items():
             if field == "columns_meta":
                 value = [ColumnMetadata(**col) for col in value]
+                if self.columns_meta != value:
+                    self.columns_meta = value
+                    updated = True
             elif field == "rows_meta":
                 added_rows = []
                 for row in value:
                     if row not in self.rows_meta:
                         added_rows.append(row)
-                value = self.rows_meta + added_rows
-            if getattr(self, field) != value:
+                        updated = True
+                self.rows_meta += added_rows
+            elif field == "validation_rules":
+                if any([self.update_validation_rules(key, rules) for key, rules in value.items()]):
+                    updated = True
+            elif getattr(self, field) != value:
                 setattr(self, field, value)
                 updated = True
 
         if updated:
             self.save()
+        return self
 
 class ArgusGenericResultData(Model):
     __table_name__ = "generic_result_data_v1"
@@ -55,3 +127,12 @@ class ArgusGenericResultData(Model):
     value = columns.Double()
     value_text = columns.Text()
     status = columns.Ascii()
+
+class ArgusBestResultData(Model):
+    __table_name__ = "generic_result_best_v1"
+    test_id = columns.UUID(partition_key=True)
+    name = columns.Text(partition_key=True)
+    key = columns.Ascii(primary_key=True)  # represents pair column:row
+    result_date = columns.DateTime(primary_key=True, clustering_order="DESC")
+    value = columns.Double()
+    run_id = columns.UUID()

--- a/argus/backend/models/web.py
+++ b/argus/backend/models/web.py
@@ -6,7 +6,7 @@ from cassandra.cqlengine.usertype import UserType
 from cassandra.cqlengine import columns
 from cassandra.util import uuid_from_time, unix_time_from_uuid1  # pylint: disable=no-name-in-module
 
-from argus.backend.models.result import ArgusGenericResultMetadata, ArgusGenericResultData
+from argus.backend.models.result import ArgusGenericResultMetadata, ArgusGenericResultData, ArgusBestResultData
 
 
 def uuid_now():
@@ -381,6 +381,7 @@ USED_MODELS: list[Model] = [
     ArgusScheduleTest,
     ArgusGenericResultMetadata,
     ArgusGenericResultData,
+    ArgusBestResultData,
 ]
 
 USED_TYPES: list[UserType] = [

--- a/argus/backend/plugins/sct/testrun.py
+++ b/argus/backend/plugins/sct/testrun.py
@@ -258,7 +258,10 @@ class SCTTestRun(PluginModelBase):
             scylla_package_upgraded = [package for package in self.packages if package.name == "scylla-server-upgraded"][0]
         except IndexError:
             scylla_package_upgraded = None
-        scylla_package = scylla_package_upgraded or [package for package in self.packages if package.name == "scylla-server"][0]
+        try:
+            scylla_package = [package for package in self.packages if package.name == "scylla-server"][0]
+        except IndexError:
+            raise ValueError("Scylla package not found in packages - cannot determine SUT timestamp")
         return (datetime.strptime(scylla_package.date, '%Y%m%d').replace(tzinfo=timezone.utc).timestamp()
                 + int(scylla_package.revision_id, 16) % 1000000 / 1000000)
 

--- a/argus/backend/service/results_service.py
+++ b/argus/backend/service/results_service.py
@@ -1,13 +1,59 @@
 import copy
 import logging
 import math
+import operator
+from datetime import datetime, timezone
+from functools import partial
 from typing import List, Dict, Any
 from uuid import UUID
 
+from dataclasses import dataclass
 from argus.backend.db import ScyllaCluster
-from argus.backend.models.result import ArgusGenericResultMetadata, ArgusGenericResultData
+from argus.backend.models.result import ArgusGenericResultMetadata, ArgusGenericResultData, ArgusBestResultData
 
 LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class BestResult:
+    key: str
+    value: float
+    result_date: datetime
+    run_id: str
+
+
+@dataclass
+class Cell:
+    column: str
+    row: str
+    value: Any
+    status: str
+
+    def update_cell_status_based_on_rules(self, table_metadata: ArgusGenericResultMetadata, best_results: dict[str, BestResult],
+                                          ) -> None:
+        column_validation_rules = table_metadata.validation_rules.get(self.column)
+        rules = column_validation_rules[-1] if column_validation_rules else {}
+        higher_is_better = next((col.higher_is_better for col in table_metadata.columns_meta if col.name == self.column), None)
+        if not rules or self.status != "UNSET" or higher_is_better is None:
+            return
+        is_better = partial(operator.gt, self.value) if higher_is_better else partial(operator.lt, self.value)
+        key = f"{self.column}:{self.row}"
+        limits = []
+        if rules.fixed_limit is not None:
+            limits.append(rules.fixed_limit)
+
+        if best_result := best_results.get(key):
+            best_value = best_result.value
+            if (best_pct := rules.best_pct) is not None:
+                multiplier = 1 - best_pct / 100 if higher_is_better else 1 + best_pct / 100
+                limits.append(best_value * multiplier)
+            if (best_abs := rules.best_abs) is not None:
+                limits.append(best_value - best_abs if higher_is_better else best_value + best_abs)
+        if all(is_better(limit) for limit in limits):
+            self.status = "PASS"
+        else:
+            self.status = "ERROR"
+
 
 default_options = {
     "scales": {
@@ -146,10 +192,10 @@ def calculate_graph_ticks(graphs: List[Dict]) -> dict[str, str]:
 
 
 class ResultsService:
-    
+
     def __init__(self):
         self.cluster = ScyllaCluster.get()
-    
+
     def _get_tables_metadata(self, test_id: UUID) -> list[ArgusGenericResultMetadata]:
         query_fields = ["name", "description", "columns_meta", "rows_meta"]
         raw_query = (f"SELECT {','.join(query_fields)}"
@@ -157,6 +203,12 @@ class ResultsService:
         query = self.cluster.prepare(raw_query)
         tables_meta = self.cluster.session.execute(query=query, parameters=(test_id,))
         return [ArgusGenericResultMetadata(**table) for table in tables_meta]
+
+    def get_table_metadata(self, test_id: UUID, table_name: str) -> ArgusGenericResultMetadata:
+        raw_query = ("SELECT * FROM generic_result_metadata_v1 WHERE test_id = ? AND name = ?")
+        query = self.cluster.prepare(raw_query)
+        table_meta = self.cluster.session.execute(query=query, parameters=(test_id, table_name))
+        return [ArgusGenericResultMetadata(**table) for table in table_meta][0] if table_meta else None
 
     def get_run_results(self, test_id: UUID, run_id: UUID) -> list[dict]:
         query_fields = ["column", "row", "value", "value_text", "status"]
@@ -199,3 +251,66 @@ class ResultsService:
     def is_results_exist(self, test_id: UUID):
         """Verify if results for given test id exist at all."""
         return bool(ArgusGenericResultMetadata.objects(test_id=test_id).only(["name"]).limit(1))
+
+    def get_best_results(self, test_id: UUID, name: str) -> List[BestResult]:
+        query_fields = ["key", "value", "result_date", "run_id"]
+        raw_query = (f"SELECT {','.join(query_fields)}"
+                     f" FROM generic_result_best_v1 WHERE test_id = ? and name = ?")
+        query = self.cluster.prepare(raw_query)
+        best_results = self.cluster.session.execute(query=query, parameters=(test_id, name))
+        return [BestResult(**best) for best in best_results]
+
+    @staticmethod
+    def _update_best_value(best_results: dict[str, list[dict]], higher_is_better_map: dict[str, bool | None], cells: list[dict],
+                           sut_timestamp: float, run_id: str
+                           ) -> dict[str, list[dict]]:
+
+        for cell in cells:
+            if "column" not in cell or "row" not in cell or "value" not in cell:
+                continue
+            column, row, value = cell["column"], cell["row"], cell["value"]
+            key_name = f"{column}_{row}"
+            if higher_is_better_map[column] is None:
+                # skipping updating best value when higher_is_better is not set (not enabled by user)
+                return best_results
+            if key_name not in best_results:
+                best_results[key_name] = []
+                current_best = None
+            else:
+                current_best = best_results[key_name][-1]
+                if current_best["sut_timestamp"].timestamp() > sut_timestamp:
+                    # skip updating best value when testing older version than current best
+                    # as would have to update all values between these dates to make cells statuses to be consistent
+                    return best_results
+
+            is_better = partial(operator.gt, value) if higher_is_better_map[column] else partial(operator.lt, value)
+            if current_best is None or is_better(current_best["value"]):
+                best_results[key_name].append({"sut_timestamp": sut_timestamp, "value": value, "run_id": run_id})
+        return best_results
+
+    def update_best_results(self, test_id: UUID, table_name: str, cells: list[Cell],
+                            table_metadata: ArgusGenericResultMetadata, run_id: str) -> dict[str, BestResult]:
+        """update best results for given test_id and table_name based on cells values - if any value is better than current best"""
+        higher_is_better_map = {meta["name"]: meta.higher_is_better for meta in table_metadata.columns_meta}
+        best_results = {}
+        for best in self.get_best_results(test_id=test_id, name=table_name):
+            if best.key not in best_results:
+                best_results[best.key] = best
+
+        for cell in cells:
+            if cell.value is None:
+                # textual value, skip
+                continue
+            key = f"{cell.column}:{cell.row}"
+            if higher_is_better_map[cell.column] is None:
+                # skipping updating best value when higher_is_better is not set (not enabled by user)
+                continue
+            current_best = best_results.get(key)
+            is_better = partial(operator.gt, cell.value) if higher_is_better_map[cell.column] \
+                else partial(operator.lt, cell.value)
+            if current_best is None or is_better(current_best.value):
+                result_date = datetime.now(timezone.utc)
+                best_results[key] = BestResult(key=key, value=cell.value, result_date=result_date, run_id=run_id)
+                ArgusBestResultData(test_id=test_id, name=table_name, key=key, value=cell.value, result_date=result_date,
+                                    run_id=run_id).save()
+        return best_results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "argus-alm"
-version = "0.12.8"
+version = "0.12.9"
 description = "Argus"
 authors = ["Alexey Kartashov <alexey.kartashov@scylladb.com>", "Łukasz Sójka <lukasz.sojka@scylladb.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Results to make difference need to change test status depending if are passing or failing. At first idea was to force clients to adjust test status. This commit adds possibility to Argus to track best results for given test and validate incoming results based on rules defined by Argus clients.

List of improvements:
1. Argus tracks best result for each column&row pair in tables, including `run_id` and `result_date` for future reference. Evaluated only when `higher_is_better` column metadata is set. Stored in separate table to track the changes (and correctly show validation rules calculated limits for given time)
2. Argus client may provide validation rules for each column. Supported validations (can set multiple of them):
- fixed_value - verifying if value is better than it
- best_pct - verifying if value is better than margin percent from best value
- best_abs - vefifying if value is better than margin absolute from best value Validation rules are tracked for future reference.
3. Argus evaluates each submitted cell against current validation rules and best result for given sut_timestamp. Marks cell as ERROR if rule finds its value below any rule limit. Validation is skipped if cell status is other than `UNSET`.

refs: https://github.com/scylladb/qa-tasks/issues/1765