### PR TITLE
fix(results): display and submit results fixes

### DIFF
--- a/argus/backend/service/results_service.py
+++ b/argus/backend/service/results_service.py
@@ -26,8 +26,9 @@ class BestResult:
 class Cell:
     column: str
     row: str
-    value: Any
     status: str
+    value: Any | None = None
+    value_text: str | None = None
 
     def update_cell_status_based_on_rules(self, table_metadata: ArgusGenericResultMetadata, best_results: dict[str, BestResult],
                                           ) -> None:

--- a/frontend/TestRun/Components/Cell.svelte
+++ b/frontend/TestRun/Components/Cell.svelte
@@ -16,7 +16,7 @@
         const secs = seconds % 60;
         return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
     };
-    if (cell?.value === undefined) {
+    if (cell?.value === undefined || cell?.value === null) {
         type = "TEXT";
         value = "N/A";
     } else if (typeof cell.value === "string") {

--- a/frontend/TestRun/ResultsTab.svelte
+++ b/frontend/TestRun/ResultsTab.svelte
@@ -118,8 +118,9 @@
                         type: columnTypesMap[column]
                     };
                 }
-
-                table_status = table_status === "PASS" ? status : table_status;
+                if (status !== "UNSET" && status !== "PASS" && table_status !== "ERROR") {
+                    table_status = status;
+                }
             });
             transformedData[tableName].table_status = table_status;
         });


### PR DESCRIPTION
Perf Simple Query results were not displayed due Cell.svelte error on `null` value. Also fixed table error status when there's UNSET status cell value.
And most important, fixing regression in submit_results when submitting tables with text values.