### PR TITLE
fix(results): copy table copies screenshot links

### DIFF
--- a/frontend/TestRun/Components/Cell.svelte
+++ b/frontend/TestRun/Components/Cell.svelte
@@ -52,6 +52,6 @@
 {:else if type === "LINK"}
     <a href="{value}" target="_blank" rel="noopener noreferrer">link</a>
 {:else if type === "IMAGE"}
-    <button class="btn btn-primary btn-sm py-0" on:click={() => selectedScreenshot = value}>view</button>
+    <button class="btn btn-primary btn-sm py-0" on:click={() => selectedScreenshot = value} data-link="{value}">view</button>
 {/if}
 

--- a/frontend/TestRun/ResultsTab.svelte
+++ b/frontend/TestRun/ResultsTab.svelte
@@ -43,20 +43,39 @@
                 const cells = Array.from(row.querySelectorAll("th, td"));
                 const markdownRow = cells.map(cell => {
                     let cellText = cell.innerText.trim();
+                    let link = "";
+
+                    const linkElement = cell.querySelector("a");
+                    const buttonElement = cell.querySelector("button");
+
+                    if (linkElement) {
+                        link = linkElement.href;
+                    } else if (buttonElement) {
+                        link = buttonElement.getAttribute("data-link");
+                    }
+
                     // Escape all '#' characters to prevent issue linking in GitHub
                     cellText = cellText.replace(/#/g, "#&#8203;");
+
+                    if (link) {
+                        cellText = `[${cellText}](${link})`;
+                    }
+
                     const color = styleToColor(cell.className);
                     if (color) {
                         cellText = `$$\{\\color{${color}}${cellText}}$$`;
                     }
+
                     return cellText;
                 }).join(" | ");
                 markdown += `| ${markdownRow} |\n`;
+
                 if (rowIndex === 0) {
                     const separator = cells.map(() => "---").join(" | ");
                     markdown += `| ${separator} |\n`;
                 }
             });
+
             try {
                 await navigator.clipboard.writeText(markdown);
                 sendMessage("info", "Table copied to clipboard in Markdown format!");


### PR DESCRIPTION
Having screenshots in the table, copy table button does not copy it but just adds 'view' text.

Now this is fixed and copy table button copies link in markdown format for proper reference.

fixes: https://github.com/scylladb/argus/issues/450