### PR TITLE
fix(results): fix ordering of best results table clustering keys

### DIFF
--- a/argus/backend/models/result.py
+++ b/argus/backend/models/result.py
@@ -129,10 +129,10 @@ class ArgusGenericResultData(Model):
     status = columns.Ascii()
 
 class ArgusBestResultData(Model):
-    __table_name__ = "generic_result_best_v1"
+    __table_name__ = "generic_result_best_v2"
     test_id = columns.UUID(partition_key=True)
     name = columns.Text(partition_key=True)
-    key = columns.Ascii(primary_key=True)  # represents pair column:row
     result_date = columns.DateTime(primary_key=True, clustering_order="DESC")
+    key = columns.Ascii(primary_key=True)  # represents pair column:row
     value = columns.Double()
     run_id = columns.UUID()


### PR DESCRIPTION
In future we're going to need to fetch best results for given point in time. Currently it's not efficient as would require reading rows that happened after requested point in time. This is because 'result_date' where clause restriction must happen along with 'key' restriction.

To tackle that problem, need to reorder 'key' and 'result_date' columns. Better to do it early, before we have data there, so we don't need to migrate anything.