### PR TITLE
improvement(results): add limit lines to graphs

### DIFF
--- a/argus/backend/tests/results_service/test_best_results.py
+++ b/argus/backend/tests/results_service/test_best_results.py
@@ -49,10 +49,10 @@ def test_can_track_best_result(fake_test, client_service, results_service, relea
     # all results should be tracked as best - first submission
     for cell in sample_data:
         key = f"{cell.column}:{cell.row}"
-        assert best_results[key].value == cell.value
-        assert str(best_results[key].run_id) == run.run_id
-    result_date_h = best_results["h_is_better:row"].result_date  # save the result date for later comparison
-    result_date_duration = best_results["duration col name:row"].result_date
+        assert best_results[key][-1].value == cell.value
+        assert str(best_results[key][-1].run_id) == run.run_id
+    result_date_h = best_results["h_is_better:row"][-1].result_date  # save the result date for later comparison
+    result_date_duration = best_results["duration col name:row"][-1].result_date
     # second submission with better results
     run_type, run = get_fake_test_run(test=fake_test)
     results = SampleTable()
@@ -68,11 +68,11 @@ def test_can_track_best_result(fake_test, client_service, results_service, relea
     client_service.submit_results(run_type, run.run_id, results.as_dict())
     best_results = results_service.get_best_results(fake_test.id, results.name)
     # best results should be updated
-    assert best_results["h_is_better:row"].value == 15
-    assert best_results["h_is_better:row"].result_date > result_date_h  # result date should be updated
-    assert best_results["l_is_better:row"].value == 5
-    assert best_results["duration col name:row"].value == 10
-    assert best_results["duration col name:row"].result_date == result_date_duration  # result date should not change as was not updated
+    assert best_results["h_is_better:row"][-1].value == 15
+    assert best_results["h_is_better:row"][-1].result_date > result_date_h  # result date should be updated
+    assert best_results["l_is_better:row"][-1].value == 5
+    assert best_results["duration col name:row"][-1].value == 10
+    assert best_results["duration col name:row"][-1].result_date == result_date_duration  # result date should not change as was not updated
 
 
 def test_can_enable_best_results_tracking(fake_test, client_service, results_service, release, group):
@@ -127,8 +127,8 @@ def test_can_enable_best_results_tracking(fake_test, client_service, results_ser
     client_service.submit_run(run_type, asdict(run))
     client_service.submit_results(run_type, run.run_id, results.as_dict())
     best_results = results_service.get_best_results(fake_test.id, results.name)
-    assert best_results["h_is_better:row"].value == 15
-    assert best_results["l_is_better:row"].value == 5
-    assert best_results["duration col name:row"].value == 10
-    assert best_results["non tracked col name:row"].value == 10
+    assert best_results["h_is_better:row"][-1].value == 15
+    assert best_results["l_is_better:row"][-1].value == 5
+    assert best_results["duration col name:row"][-1].value == 10
+    assert best_results["non tracked col name:row"][-1].value == 10
     assert 'text col name:row' not in best_results  # text column should not be tracked

--- a/argus/backend/tests/results_service/test_create_chartjs.py
+++ b/argus/backend/tests/results_service/test_create_chartjs.py
@@ -1,0 +1,203 @@
+from datetime import datetime
+from uuid import uuid4
+
+from argus.backend.models.result import ArgusGenericResultMetadata, ColumnMetadata, ArgusGenericResultData, ValidationRules
+from argus.backend.service.results_service import create_chartjs, BestResult
+
+
+def test_create_chartjs_without_validation_rules_should_create_chart_without_limits_series():
+    table = ArgusGenericResultMetadata(
+        test_id=uuid4(),
+        name='Test Table',
+        columns_meta=[
+            ColumnMetadata(name='col1', unit='ms', type='FLOAT', higher_is_better=False)
+        ],
+        rows_meta=['row1'],
+        validation_rules={}
+    )
+    data = [
+        ArgusGenericResultData(
+            test_id=table.test_id,
+            name=table.name,
+            run_id=uuid4(),
+            column='col1',
+            row='row1',
+            sut_timestamp=datetime(2021, 1, 1),
+            value=100.0,
+            status='UNSET'
+        )
+    ]
+    best_results = {
+        'col1:row1': [BestResult(key='col1:row1', value=100.0, result_date=datetime(2021, 1, 1), run_id=str(uuid4()))]
+    }
+    graphs = create_chartjs(table, data, best_results)
+    assert len(graphs) == 1
+    assert len(graphs[0]['data']['datasets']) == 1  # no limits series
+
+def test_create_chartjs_without_best_results_should_not_fail():
+    table = ArgusGenericResultMetadata(
+        test_id=uuid4(),
+        name='Test Table',
+        columns_meta=[
+            ColumnMetadata(name='col1', unit='ms', type='FLOAT')
+        ],
+        rows_meta=['row1'],
+        validation_rules={}
+    )
+    data = [
+        ArgusGenericResultData(
+            test_id=table.test_id,
+            name=table.name,
+            run_id=uuid4(),
+            column='col1',
+            row='row1',
+            sut_timestamp=datetime(2021, 1, 1),
+            value=100.0,
+            status='UNSET'
+        )
+    ]
+    best_results = {}
+    graphs = create_chartjs(table, data, best_results)
+    assert len(graphs) == 1
+    assert len(graphs[0]['data']['datasets']) == 1  # no limits series
+
+def test_create_chartjs_with_validation_rules_should_add_limit_series():
+    table = ArgusGenericResultMetadata(
+        test_id=uuid4(),
+        name='Test Table',
+        columns_meta=[
+            ColumnMetadata(name='col1', unit='ms', type='FLOAT', higher_is_better=False)
+        ],
+        rows_meta=['row1'],
+        validation_rules={
+            'col1': [ValidationRules(valid_from=datetime(2021, 1, 1), best_pct=5.0, best_abs=None, fixed_limit=None)]
+        }
+    )
+    data = [
+        ArgusGenericResultData(
+            test_id=table.test_id,
+            name=table.name,
+            run_id=uuid4(),
+            column='col1',
+            row='row1',
+            sut_timestamp=datetime(2021, 2, 1),
+            value=95.0,
+            status='UNSET'
+        )
+    ]
+    best_results = {
+        'col1:row1': [BestResult(key='col1:row1', value=100.0, result_date=datetime(2021, 1, 1), run_id=str(uuid4()))]
+    }
+    graphs = create_chartjs(table, data, best_results)
+    assert 'limit' in graphs[0]['data']['datasets'][0]['data'][0]
+
+def test_chartjs_with_multiple_best_results_and_validation_rules_should_adjust_limits_for_each_point():
+    table = ArgusGenericResultMetadata(
+        test_id=uuid4(),
+        name='Test Table',
+        columns_meta=[
+            ColumnMetadata(name='col1', unit='ms', type='FLOAT', higher_is_better=False)
+        ],
+        rows_meta=['row1'],
+        validation_rules={
+            'col1': [
+                ValidationRules(valid_from=datetime(2021, 1, 1), best_pct=5.0, best_abs=None, fixed_limit=None),
+                ValidationRules(valid_from=datetime(2021, 3, 1), best_pct=None, best_abs=2.0, fixed_limit=None)
+            ]
+        }
+    )
+    data = [
+        ArgusGenericResultData(
+            test_id=table.test_id,
+            name=table.name,
+            run_id=uuid4(),
+            column='col1',
+            row='row1',
+            sut_timestamp=datetime(2021, 2, 1),
+            value=95.0,
+            status='UNSET'
+        ),
+        ArgusGenericResultData(
+            test_id=table.test_id,
+            name=table.name,
+            run_id=uuid4(),
+            column='col1',
+            row='row1',
+            sut_timestamp=datetime(2021, 4, 1),
+            value=90.0,
+            status='UNSET'
+        )
+    ]
+    best_results = {
+        'col1:row1': [
+            BestResult(key='col1:row1', value=100.0, result_date=datetime(2021, 1, 1), run_id=str(uuid4())),
+            BestResult(key='col1:row1', value=94.0, result_date=datetime(2021, 3, 1), run_id=str(uuid4()))
+        ]
+    }
+    graphs = create_chartjs(table, data, best_results)
+    datasets = graphs[0]['data']['datasets']
+    limits = [point.get('limit') for dataset in datasets for point in dataset['data'] if 'limit' in point]
+    assert len(limits) == 2
+    assert limits[0] == 105.0
+    assert limits[1] == 96.0
+
+def test_create_chartjs_no_data_should_not_fail():
+    table = ArgusGenericResultMetadata(
+        test_id=uuid4(),
+        name='Empty Table',
+        columns_meta=[],
+        rows_meta=[],
+        validation_rules={}
+    )
+    data = []
+    best_results = {}
+    graphs = create_chartjs(table, data, best_results)
+    assert len(graphs) == 0
+
+def test_create_chartjs_multiple_columns_and_rows():
+    table = ArgusGenericResultMetadata(
+        test_id=uuid4(),
+        name='Complex Table',
+        columns_meta=[
+            ColumnMetadata(name='col1', unit='ms', type='FLOAT', higher_is_better=False),
+            ColumnMetadata(name='col2', unit='%', type='FLOAT', higher_is_better=True)
+        ],
+        rows_meta=['row1', 'row2'],
+        validation_rules={
+            'col1': [ValidationRules(valid_from=datetime(2021, 1, 1), best_pct=5.0, best_abs=None, fixed_limit=None)]
+        }
+    )
+    data = [
+        ArgusGenericResultData(
+            test_id=table.test_id,
+            name=table.name,
+            run_id=uuid4(),
+            column='col1',
+            row='row1',
+            sut_timestamp=datetime(2021, 1, 1),
+            value=100.0,
+            status='UNSET'
+        ),
+        ArgusGenericResultData(
+            test_id=table.test_id,
+            name=table.name,
+            run_id=uuid4(),
+            column='col2',
+            row='row2',
+            sut_timestamp=datetime(2021, 1, 2),
+            value=50.0,
+            status='UNSET'
+        )
+    ]
+    best_results = {
+        'col1:row1': [
+            BestResult(key='col1:row1', value=100.0, result_date=datetime(2021, 1, 1), run_id=str(uuid4())),
+        ],
+        'col2:row2': [
+            BestResult(key='col2:row2', value=50.0, result_date=datetime(2021, 1, 2), run_id=str(uuid4())),
+        ]
+    }
+    graphs = create_chartjs(table, data, best_results)
+    assert len(graphs) == 2
+    assert len(graphs[0]['data']['datasets']) == 2  # should have also limits dataset
+    assert len(graphs[1]['data']['datasets']) == 1  # no limits series

--- a/frontend/TestRun/ResultsGraph.svelte
+++ b/frontend/TestRun/ResultsGraph.svelte
@@ -28,10 +28,11 @@
         graph.options.plugins.tooltip = {
             callbacks: {
                 label: function (tooltipItem) {
-                    const y = tooltipItem.parsed.y;
+                    const y = tooltipItem.parsed.y.toFixed(2);
                     const x = new Date(tooltipItem.parsed.x).toLocaleDateString("sv-SE");
                     const ori = tooltipItem.raw.ori;
-                    return `${x}: ${ori? ori : y}`;
+                    const limit = tooltipItem.raw.limit;
+                    return `${x}: ${ori? ori : y} (limit: ${limit?.toFixed(2)||"N/A"})`;
                 }
             }
         };


### PR DESCRIPTION
Added limit lines to graphs based on best results and validation rules. When creating graphs, for each point limit is calculated and plotted (also visible in the tooltip).
Have in mind that limits might differ from ones in "Results" tab as client might ignore rules (which most of our test cases currently do).

closes: https://github.com/scylladb/qa-tasks/issues/1763