### PR TITLE
improvement(frontend): Add frontend endpoint for plugin/run_id

### DIFF
--- a/argus/backend/controller/main.py
+++ b/argus/backend/controller/main.py
@@ -9,6 +9,7 @@ from argus.backend.controller.notifications import bp as notifications_bp
 from argus.backend.controller.team_ui import bp as teams_bp
 from argus.backend.service.argus_service import ArgusService
 from argus.backend.models.web import WebFileStorage
+from argus.backend.service.testrun import TestRunService
 from argus.backend.service.user import UserService, login_required
 from argus.backend.service.views import UserViewService
 
@@ -36,6 +37,13 @@ def test_run(run_id: UUID):
 def runs(test_id: UUID):
     additional_runs = request.args.getlist("additionalRuns[]")
     return render_template("standalone_test_with_runs.html.j2", test_id=test_id, additional_runs=additional_runs)
+
+
+@bp.route("/tests/<string:plugin_name>/<string:run_id>")
+@login_required
+def get_run_by_plugin(plugin_name: str, run_id: UUID | str):
+    run = TestRunService().get_run(plugin_name, run_id)
+    return render_template("run_view_by_plugin.html.j2", run=run)
 
 
 @bp.route("/")

--- a/frontend/TestRun/DriverMatrixTestRun.svelte
+++ b/frontend/TestRun/DriverMatrixTestRun.svelte
@@ -79,7 +79,7 @@
     <div class="d-flex px-2 py-2 mb-1 border-bottom bg-white ">
         <div class="p-1">
             {#if testRun}
-                <a class="link-dark" href="/test/{testRun.test_id}/runs?additionalRuns[]={testRun.id}">
+                <a class="link-dark" href="/tests/{testInfo.test.plugin_name}/{testRun.id}">
                     {testRun.build_id}#{buildNumber}
                 </a>
             {/if}

--- a/frontend/TestRun/Generic/GenericTestRun.svelte
+++ b/frontend/TestRun/Generic/GenericTestRun.svelte
@@ -74,7 +74,7 @@
     <div class="d-flex px-2 py-2 mb-1 border-bottom bg-white ">
         <div class="p-1">
             {#if testRun}
-                <a class="link-dark" href="/test/{testRun.test_id}/runs?additionalRuns[]={testRun.id}">
+                <a class="link-dark" href="/tests/{testInfo.test.plugin_name}/{testRun.id}">
                     {testRun.build_id}#{buildNumber}
                 </a>
             {/if}

--- a/frontend/TestRun/Sirenada/SirenadaTestRun.svelte
+++ b/frontend/TestRun/Sirenada/SirenadaTestRun.svelte
@@ -80,7 +80,7 @@
     <div class="d-flex px-2 py-2 mb-1 border-bottom bg-white ">
         <div class="p-1">
             {#if testRun}
-                <a class="link-dark" href="/test/{testRun.test_id}/runs?additionalRuns[]={testRun.id}">
+                <a class="link-dark" href="/tests/{testInfo.test.plugin_name}/{testRun.id}">
                     {testRun.build_id}#{buildNumber}
                 </a>
             {/if}

--- a/frontend/TestRun/TestRun.svelte
+++ b/frontend/TestRun/TestRun.svelte
@@ -133,7 +133,7 @@
     <div class="d-flex px-2 py-2 mb-1 border-bottom bg-white ">
         <div class="p-1">
             {#if testRun}
-                <a class="link-dark" href="/test/{testRun.test_id}/runs?additionalRuns[]={testRun.id}">
+                <a class="link-dark" href="/tests/{testInfo.test.plugin_name}/{testRun.id}">
                     {testRun.build_id}#{buildNumber}
                 </a>
             {/if}

--- a/frontend/run-by-plugin.js
+++ b/frontend/run-by-plugin.js
@@ -1,0 +1,9 @@
+import TestRuns from "./WorkArea/TestRuns.svelte";
+
+const app = new TestRuns({
+    target: document.querySelector("div#testRunBody"),
+    props: {
+        testId: gTestId,
+        additionalRuns: gRun
+    }
+});

--- a/templates/run_view_by_plugin.html.j2
+++ b/templates/run_view_by_plugin.html.j2
@@ -1,0 +1,20 @@
+{% extends "base.html.j2" %}
+
+{% block title %}
+Test Run
+{% endblock %}
+
+{% block javascripts %}
+{{ super() }}
+<script>
+    const gTestId = "{{ run.test_id or undefined }}";
+    const gRun = {{ [run.id] | tojson | safe }}
+</script>
+<script defer src="/s/dist/runByPlugin.bundle.js"></script>
+{% endblock javascripts %}
+
+{% block body %}
+<div class="container p-1" id="testRunBody">
+
+</div>
+{% endblock %}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,6 +46,10 @@ module.exports = {
             import: "./frontend/test-runs-standalone.js",
             dependOn: "globalAlert"
         },
+        runByPlugin: {
+            import: "./frontend/run-by-plugin.js",
+            dependOn: "globalAlert"
+        },
         testRuns: {
             import: "./frontend/test-runs-breakout.js",
             dependOn: "globalAlert"


### PR DESCRIPTION
This commit adds a new endpoint which replaces hard to use
/test/test_id/runs?additionalRuns[]=run_id endpoint into a much more
simpler /tests/plugin_name/run_id endpoint, allowing to build a link to
the test run without knowing test_id in advance and simplifying
sharing/searching for a run.

Part of Task: scylladb/qa-tasks#1490
