### PR TITLE
improvement(results): exclude ignored results from graphs

### DIFF
--- a/argus/backend/tests/results_service/test_best_results.py
+++ b/argus/backend/tests/results_service/test_best_results.py
@@ -2,7 +2,9 @@ import logging
 from dataclasses import asdict, dataclass
 from typing import Any
 
+from argus.backend.plugins.sct.testrun import SCTTestRun
 from argus.backend.tests.conftest import get_fake_test_run, fake_test
+from argus.common.enums import TestInvestigationStatus
 from argus.client.generic_result import GenericResultTable, ColumnMetadata, ResultType, ValidationRule, Status
 
 LOGGER = logging.getLogger(__name__)
@@ -132,3 +134,37 @@ def test_can_enable_best_results_tracking(fake_test, client_service, results_ser
     assert best_results["duration col name:row"][-1].value == 10
     assert best_results["non tracked col name:row"][-1].value == 10
     assert 'text col name:row' not in best_results  # text column should not be tracked
+
+def test_ignored_runs_are_not_considered_in_best_results(fake_test, client_service, results_service, release, group):
+    run_type, run = get_fake_test_run(test=fake_test)
+    results = SampleTable()
+    results.sut_timestamp = 123
+    sample_data = [
+        SampleCell(column="h_is_better", row="row", value=100),
+        SampleCell(column="l_is_better", row="row", value=10),
+    ]
+    for cell in sample_data:
+        results.add_result(column=cell.column, row=cell.row, value=cell.value, status=cell.status)
+    client_service.submit_run(run_type, asdict(run))
+    client_service.submit_results(run_type, run.run_id, results.as_dict())
+    run_type, run2 = get_fake_test_run(test=fake_test)
+    sample_data = [
+        SampleCell(column="h_is_better", row="row", value=200),
+        SampleCell(column="l_is_better", row="row", value=5),
+    ]
+    for cell in sample_data:
+        results.add_result(column=cell.column, row=cell.row, value=cell.value, status=cell.status)
+    client_service.submit_run(run_type, asdict(run2))
+    client_service.submit_results(run_type, run2.run_id, results.as_dict())
+
+    # ignore the second run
+    run_model = SCTTestRun.get(id=run2.run_id)
+    run_model.investigation_status = TestInvestigationStatus.IGNORED.value
+    run_model.save()
+
+    best_results = results_service.get_best_results(fake_test.id, results.name)
+
+    assert best_results["h_is_better:row"][-1].value == 100  # should not consider the second run
+    assert str(best_results["h_is_better:row"][-1].run_id) == run.run_id
+    assert best_results["l_is_better:row"][-1].value == 10   # should not consider the second run
+    assert str(best_results["l_is_better:row"][-1].run_id) == run.run_id


### PR DESCRIPTION
Sometimes results might be wrong (e.g. wrong job configuration) leading to results that outstand and being irrelevant or updating best result value causing validation to break.

If job investigation status is set to `IGNORED` make Argus to skip plotting it and exclude from best results map.

closes: https://github.com/scylladb/argus/issues/462