### PR TITLE
improvement(results): respond with error when result failed

### DIFF
--- a/argus/backend/error_handlers.py
+++ b/argus/backend/error_handlers.py
@@ -8,9 +8,14 @@ LOGGER = logging.getLogger(__name__)
 class APIException(Exception):
     pass
 
+class DataValidationError(APIException):
+    pass
 
 def handle_api_exception(exception: Exception):
-    LOGGER.error("Exception in %s\n%s", request.endpoint, "".join(format_exception(exception)))
+    if issubclass(exception.__class__, APIException):
+        LOGGER.info("Endpoint %s responded with error %s: %s", request.endpoint, exception.__class__.__name__, str(exception))
+    else:
+        LOGGER.error("Exception in %s\n%s", request.endpoint, "".join(format_exception(exception)))
 
     return {
         "status": "error",

--- a/argus/backend/tests/client_service/test_submit_results.py
+++ b/argus/backend/tests/client_service/test_submit_results.py
@@ -1,0 +1,77 @@
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import pytest
+
+from argus.backend.error_handlers import DataValidationError
+from argus.backend.tests.conftest import get_fake_test_run
+from argus.client.generic_result import GenericResultTable, ColumnMetadata, ResultType, ValidationRule, Status
+
+
+@dataclass
+class SampleCell:
+    column: str
+    row: str
+    value: Any
+    status: Status = Status.UNSET
+
+
+class SampleTable(GenericResultTable):
+    class Meta:
+        name = "Test Table"
+        description = "Test Table Description"
+        Columns = [
+            ColumnMetadata(name="metric1", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
+            ColumnMetadata(name="metric2", unit="ms", type=ResultType.INTEGER, higher_is_better=False),
+        ]
+        ValidationRules = {
+            "metric1": ValidationRule(fixed_limit=100),
+            "metric2": ValidationRule(fixed_limit=200),
+        }
+
+
+def test_submit_results_responds_ok_if_all_cells_pass(fake_test, client_service):
+    run_type, run = get_fake_test_run(test=fake_test)
+    results = SampleTable()
+    results.sut_timestamp = 123
+    sample_data = [
+        SampleCell(column="metric1", row="row1", value=99.99),
+        SampleCell(column="metric2", row="row1", value=199.99),
+    ]
+    for cell in sample_data:
+        results.add_result(column=cell.column, row=cell.row, value=cell.value, status=cell.status)
+    client_service.submit_run(run_type, asdict(run))
+    response = client_service.submit_results(run_type, run.run_id, results.as_dict())
+    assert response["status"] == "ok"
+    assert response["message"] == "Results submitted"
+
+
+def test_submit_results_responds_with_error_when_cell_fails_validation(fake_test, client_service):
+    run_type, run = get_fake_test_run(test=fake_test)
+    results = SampleTable()
+    results.sut_timestamp = 123
+    sample_data = [
+        SampleCell(column="metric1", row="row1", value=100.01),  # Exceeds fixed_limit
+        SampleCell(column="metric2", row="row1", value=50),
+    ]
+    for cell in sample_data:
+        results.add_result(column=cell.column, row=cell.row, value=cell.value, status=cell.status)
+    client_service.submit_run(run_type, asdict(run))
+    with pytest.raises(DataValidationError):
+        client_service.submit_results(run_type, run.run_id, results.as_dict())
+
+
+
+def test_submit_results_responds_with_error_when_cell_has_error(fake_test, client_service):
+    run_type, run = get_fake_test_run(test=fake_test)
+    results = SampleTable()
+    results.sut_timestamp = 123
+    sample_data = [
+        SampleCell(column="metric1", row="row1", value=88, status=Status.ERROR),  # hardcoded error
+        SampleCell(column="metric2", row="row1", value=50),
+    ]
+    for cell in sample_data:
+        results.add_result(column=cell.column, row=cell.row, value=cell.value, status=cell.status)
+    client_service.submit_run(run_type, asdict(run))
+    with pytest.raises(DataValidationError):
+        client_service.submit_results(run_type, run.run_id, results.as_dict())

--- a/argus/backend/tests/results_service/test_best_results.py
+++ b/argus/backend/tests/results_service/test_best_results.py
@@ -2,6 +2,9 @@ import logging
 from dataclasses import asdict, dataclass
 from typing import Any
 
+import pytest
+
+from argus.backend.error_handlers import DataValidationError
 from argus.backend.plugins.sct.testrun import SCTTestRun
 from argus.backend.tests.conftest import get_fake_test_run, fake_test
 from argus.common.enums import TestInvestigationStatus
@@ -155,7 +158,8 @@ def test_ignored_runs_are_not_considered_in_best_results(fake_test, client_servi
     for cell in sample_data:
         results.add_result(column=cell.column, row=cell.row, value=cell.value, status=cell.status)
     client_service.submit_run(run_type, asdict(run2))
-    client_service.submit_results(run_type, run2.run_id, results.as_dict())
+    with pytest.raises(DataValidationError):
+        client_service.submit_results(run_type, run2.run_id, results.as_dict())
 
     # ignore the second run
     run_model = SCTTestRun.get(id=run2.run_id)

--- a/argus/backend/tests/results_service/test_validation_rules.py
+++ b/argus/backend/tests/results_service/test_validation_rules.py
@@ -3,6 +3,9 @@ from dataclasses import asdict, dataclass
 from typing import Any
 from uuid import UUID
 
+import pytest
+
+from argus.backend.error_handlers import DataValidationError
 from argus.backend.tests.conftest import get_fake_test_run, fake_test
 from argus.client.generic_result import GenericResultTable, ColumnMetadata, ResultType, ValidationRule, Status
 
@@ -85,7 +88,8 @@ def test_can_track_validation_rules_changes(fake_test, client_service, results_s
     for cell in sample_data:
         results.add_result(column=cell.column, row=cell.row, value=cell.value, status=cell.status)
     client_service.submit_run(run_type, asdict(run))
-    client_service.submit_results(run_type, run.run_id, results.as_dict())
+    with pytest.raises(DataValidationError):
+        client_service.submit_results(run_type, run.run_id, results.as_dict())
     run_results = results_service.get_run_results(fake_test.id, UUID(run.run_id))
     actual_cells = results_to_dict(run_results[0])
     for cell in sample_data:
@@ -143,7 +147,8 @@ def test_can_track_validation_rules_changes(fake_test, client_service, results_s
     for cell in sample_data:
         results.add_result(column=cell.column, row=cell.row, value=cell.value, status=cell.status)
     client_service.submit_run(run_type, asdict(run))
-    client_service.submit_results(run_type, run.run_id, results.as_dict())
+    with pytest.raises(DataValidationError):
+        client_service.submit_results(run_type, run.run_id, results.as_dict())
     run_results = results_service.get_run_results(fake_test.id, UUID(run.run_id))
     actual_cells = results_to_dict(run_results[0])
     for cell in sample_data:


### PR DESCRIPTION
In case there is a cell with 'ERROR' status, then respond with `error` status, so client may take proper action based on it (e.g. marking test as failed).

refs: https://github.com/scylladb/qa-tasks/issues/1765