### PR TITLE
Support multiple releases on graphs

### DIFF
--- a/argus/backend/controller/api.py
+++ b/argus/backend/controller/api.py
@@ -392,11 +392,11 @@ def test_results():
     if request.method == 'HEAD':
         exists = service.is_results_exist(test_id=UUID(test_id))
         return Response(status=200 if exists else 404)
-    graphs, ticks = service.get_test_graphs(test_id=UUID(test_id))
+    graphs, ticks, releases_filters = service.get_test_graphs(test_id=UUID(test_id))
 
     return {
         "status": "ok",
-        "response": {"graphs": graphs, "ticks": ticks}
+        "response": {"graphs": graphs, "ticks": ticks, "releases_filters": releases_filters}
     }
 
 @bp.route("/test_run/comment/get", methods=["GET"])  # TODO: remove

--- a/argus/backend/tests/results_service/test_chartjs_additional_functions.py
+++ b/argus/backend/tests/results_service/test_chartjs_additional_functions.py
@@ -1,0 +1,219 @@
+from uuid import uuid4
+
+import pytest
+from datetime import datetime
+
+from argus.backend.plugins.sct.udt import PackageVersion
+from argus.backend.service.results_service import (
+    get_sorted_data_for_column_and_row,
+    get_min_max_y,
+    coerce_values_to_axis_boundaries,
+    create_chart_options,
+    create_datasets_for_column,
+    create_release_datasets,
+    create_limit_dataset,
+    calculate_limits,
+    calculate_graph_ticks, _identify_most_changed_package, _split_results_by_release,
+    BestResult
+)
+from argus.backend.models.result import ArgusGenericResultMetadata, ArgusGenericResultData, ColumnMetadata, ValidationRules
+
+
+@pytest.fixture
+def package_data():
+    return [
+        PackageVersion(name='scylla-server', version='2024.3.0~dev', date='20241018', revision_id='c3e2bc', build_id='b974e8'),
+        PackageVersion(name='scylla-manager-server', version='3.2.8', date='20240517', revision_id='', build_id='')
+    ]
+
+
+def test_identify_main_package_should_return_most_frequent_package(package_data):
+    packages_list = package_data * 5 + [PackageVersion(name='java-driver', version='3.11.5.3', date='null', revision_id='', build_id='')]
+    main_package = _identify_most_changed_package(packages_list)
+    assert main_package == 'scylla-server'
+
+
+def test_split_results_by_versions_should_group_correctly(package_data):
+    packages = {
+        str(uuid4()): package_data,
+        str(uuid4()): [
+            PackageVersion(name='scylla-server', version='2024.2.0~dev', date='20241018', revision_id='c3e2bc', build_id='b974e8')],
+        str(uuid4()): [PackageVersion(name='scylla-server', version='2024.2.0', date='20241018', revision_id='', build_id='')]
+    }
+    main_package = 'scylla-server'
+    versions_map = _split_results_by_release(packages, main_package)
+    print(versions_map)
+    assert len(versions_map) == 2
+    assert '2024.2' in versions_map
+    assert 'dev' in versions_map
+
+
+def test_get_sorted_data_for_column_and_row():
+    data = [
+        ArgusGenericResultData(run_id=uuid4(), column="col1", row="row1", value=1.5, status="PASS", sut_timestamp=datetime(2023, 10, 23)),
+        ArgusGenericResultData(run_id=uuid4(), column="col1", row="row1", value=2.5, status="PASS", sut_timestamp=datetime(2023, 10, 24)),
+        ArgusGenericResultData(run_id=uuid4(), column="col1", row="row1", value=0.5, status="PASS", sut_timestamp=datetime(2023, 10, 22)),
+        ArgusGenericResultData(run_id=uuid4(), column="col1", row="row2", value=3.5, status="PASS", sut_timestamp=datetime(2023, 10, 25)),
+        ArgusGenericResultData(run_id=uuid4(), column="col2", row="row1", value=4.5, status="PASS", sut_timestamp=datetime(2023, 10, 26)),
+    ]
+    result = get_sorted_data_for_column_and_row(data, "col1", "row1")
+    expected = [
+        {"x": "2023-10-22T00:00:00Z", "y": 0.5},
+        {"x": "2023-10-23T00:00:00Z", "y": 1.5},
+        {"x": "2023-10-24T00:00:00Z", "y": 2.5},
+    ]
+
+    result_without_id = [{"x": item["x"], "y": item["y"]} for item in result]
+
+    assert result_without_id == expected
+
+
+def test_get_min_max_y():
+    datasets = [
+        {
+            "data": [
+                {"x": "2023-10-20T00:00:00Z", "y": 1.0},
+                {"x": "2023-10-21T00:00:00Z", "y": 2.0},
+                {"x": "2023-10-25T00:00:00Z", "y": 3.4},
+                {"x": "2023-10-26T00:00:00Z", "y": 3.9},
+                {"x": "2023-10-26T00:00:00Z", "y": 4.0},
+                {"x": "2023-10-27T00:00:00Z", "y": 100.0},
+            ]
+        }
+    ]
+    min_y, max_y = get_min_max_y(datasets)
+    assert min_y == 1
+    assert max_y == 6
+
+
+def test_coerce_values_to_axis_boundries():
+    datasets = [
+        {
+            "data": [
+                {"x": "2023-10-22T00:00:00Z", "y": 1.0},
+                {"x": "2023-10-23T00:00:00Z", "y": 2.0},
+                {"x": "2023-10-24T00:00:00Z", "y": 3.0},
+                {"x": "2023-10-25T00:00:00Z", "y": 4.0},
+                {"x": "2023-10-26T00:00:00Z", "y": 100.0},
+                {"x": "2023-10-21T00:00:00Z", "y": -50.0},
+            ]
+        }
+    ]
+    min_y = 0
+    max_y = 6
+    coerce_values_to_axis_boundaries(datasets, min_y, max_y)
+    data = datasets[0]["data"]
+    assert data[0]["y"] == 1.0
+    assert data[4]["y"] == 6
+    assert data[4]["ori"] == 100.0
+    assert data[5]["y"] == 0
+    assert data[5]["ori"] == -50.0
+
+
+def test_create_chart_options():
+    table = ArgusGenericResultMetadata(name="Test Table", description="Test Description",
+                                       columns_meta=[ColumnMetadata(name="col1", unit="ms", type="NUMBER", higher_is_better=True)],
+                                       rows_meta=["row1"], validation_rules={})
+    column = table.columns_meta[0]
+    options = create_chart_options(table, column, min_y=0, max_y=10)
+    assert options["plugins"]["title"]["text"] == "Test Table - col1"
+    assert options["scales"]["y"]["title"]["text"] == "[ms]"
+    assert options["scales"]["y"]["min"] == 0
+    assert options["scales"]["y"]["max"] == 10
+
+
+def test_create_datasets_for_column():
+    table = ArgusGenericResultMetadata(
+        name="Test Table",
+        description="Test Description",
+        columns_meta=[ColumnMetadata(name="col1", unit="ms", type="NUMBER", higher_is_better=True)],
+        rows_meta=["row1", "row2"],
+        validation_rules={}
+    )
+    data = [
+        ArgusGenericResultData(run_id=uuid4(), column="col1", row="row1", value=1.5, status="PASS", sut_timestamp=datetime(2023, 10, 23)),
+        ArgusGenericResultData(run_id=uuid4(), column="col1", row="row1", value=2.5, status="PASS", sut_timestamp=datetime(2023, 10, 24)),
+        ArgusGenericResultData(run_id=uuid4(), column="col1", row="row2", value=3.5, status="PASS", sut_timestamp=datetime(2023, 10, 25)),
+    ]
+    best_results = {}
+    releases_map = {"2024.2": [point.run_id for point in data][:1], "2024.3": [point.run_id for point in data][2:]}
+    column = table.columns_meta[0]
+    datasets = create_datasets_for_column(table, data, best_results, releases_map, column)
+    assert len(datasets) == 2
+    labels = [dataset["label"] for dataset in datasets]
+    assert "2024.2 - row1" in labels
+    assert "2024.3 - row2" in labels
+
+
+def test_create_release_datasets():
+    points = [
+        {"x": "2023-10-23T00:00:00Z", "y": 1.5, "id": "run1"},
+        {"x": "2023-10-24T00:00:00Z", "y": 2.5, "id": "run2"},
+        {"x": "2023-10-25T00:00:00Z", "y": 3.5, "id": "run3"},
+    ]
+    row = "row1"
+    releases_map = {"2024.2": ["run1", "run2"], "2024.3": ["run3"]}
+    line_color = 'rgba(255, 0, 0, 1.0)'
+    datasets = create_release_datasets(points, row, releases_map, line_color)
+    assert len(datasets) == 2
+    assert datasets[0]["label"] == "2024.2 - row1"
+    assert datasets[1]["label"] == "2024.3 - row1"
+
+
+def test_create_limit_dataset():
+    points = [
+        {"x": "2023-10-23T00:00:00Z", "y": 1.5, "id": "run1"},
+        {"x": "2023-10-24T00:00:00Z", "y": 2.5, "id": "run2"},
+        {"x": "2023-10-25T00:00:00Z", "y": 3.5, "id": "run3"},
+    ]
+    column = ColumnMetadata(name="col1", unit="ms", type="NUMBER", higher_is_better=True)
+    row = "row1"
+    best_results = {
+        "col1:row1": [BestResult(key="col1:row1", value=2.0, result_date=datetime(2023, 10, 24), run_id="run2")]
+    }
+    table = ArgusGenericResultMetadata(name="Test Table", description="Test Description",
+                                       columns_meta=[column], rows_meta=[row], validation_rules={
+            "col1": [{"fixed_limit": 1.8, "best_pct": 10, "best_abs": 0.2, "valid_from": datetime(2023, 10, 23)}]
+        })
+    line_color = 'rgba(255, 0, 0, 1.0)'
+    is_fixed_limit_drawn = False
+    limit_dataset = create_limit_dataset(points, column, row, best_results, table, line_color, is_fixed_limit_drawn)
+    assert limit_dataset is not None
+    assert limit_dataset["label"] == "limit"
+    assert limit_dataset["data"]
+
+
+def test_calculate_limits():
+    points = [
+        {"x": "2023-10-23T00:00:00Z", "y": 1.5},
+        {"x": "2023-10-24T00:00:00Z", "y": 2.5},
+        {"x": "2023-10-25T00:00:00Z", "y": 3.5},
+    ]
+    best_results = [BestResult(key="col1:row1", value=2.0, result_date=datetime(2023, 10, 24), run_id="run2")]
+    validation_rules_list = [ValidationRules(valid_from=datetime(2023, 10, 23), best_pct=10, best_abs=0.2, fixed_limit=1.8)]
+    higher_is_better = True
+    updated_points = calculate_limits(points, best_results, validation_rules_list, higher_is_better)
+    for point in updated_points:
+        assert 'limit' in point
+
+
+def test_calculate_graph_ticks():
+    graphs = [
+        {
+            "data": {
+                "datasets": [
+                    {"data": [{"x": "2023-10-22T00:00:00Z", "y": 1.0}, {"x": "2023-10-23T00:00:00Z", "y": 2.0}]}
+                ]
+            }
+        },
+        {
+            "data": {
+                "datasets": [
+                    {"data": [{"x": "2023-10-24T00:00:00Z", "y": 3.0}, {"x": "2023-10-25T00:00:00Z", "y": 4.0}]}
+                ]
+            }
+        }
+    ]
+    ticks = calculate_graph_ticks(graphs)
+    assert ticks["min"] == "2023-10-22"
+    assert ticks["max"] == "2023-10-25"

--- a/argus/backend/tests/results_service/test_create_chartjs.py
+++ b/argus/backend/tests/results_service/test_create_chartjs.py
@@ -30,7 +30,8 @@ def test_create_chartjs_without_validation_rules_should_create_chart_without_lim
     best_results = {
         'col1:row1': [BestResult(key='col1:row1', value=100.0, result_date=datetime(2021, 1, 1), run_id=str(uuid4()))]
     }
-    graphs = create_chartjs(table, data, best_results)
+    releases_map = {"1.0": [point.run_id for point in data]}
+    graphs = create_chartjs(table, data, best_results, releases_map)
     assert len(graphs) == 1
     assert len(graphs[0]['data']['datasets']) == 1  # no limits series
 
@@ -57,7 +58,8 @@ def test_create_chartjs_without_best_results_should_not_fail():
         )
     ]
     best_results = {}
-    graphs = create_chartjs(table, data, best_results)
+    releases_map = {"1.0": [point.run_id for point in data]}
+    graphs = create_chartjs(table, data, best_results, releases_map)
     assert len(graphs) == 1
     assert len(graphs[0]['data']['datasets']) == 1  # no limits series
 
@@ -88,7 +90,8 @@ def test_create_chartjs_with_validation_rules_should_add_limit_series():
     best_results = {
         'col1:row1': [BestResult(key='col1:row1', value=100.0, result_date=datetime(2021, 1, 1), run_id=str(uuid4()))]
     }
-    graphs = create_chartjs(table, data, best_results)
+    releases_map = {"1.0": [point.run_id for point in data]}
+    graphs = create_chartjs(table, data, best_results, releases_map)
     assert 'limit' in graphs[0]['data']['datasets'][0]['data'][0]
 
 def test_chartjs_with_multiple_best_results_and_validation_rules_should_adjust_limits_for_each_point():
@@ -134,7 +137,8 @@ def test_chartjs_with_multiple_best_results_and_validation_rules_should_adjust_l
             BestResult(key='col1:row1', value=94.0, result_date=datetime(2021, 3, 1), run_id=str(uuid4()))
         ]
     }
-    graphs = create_chartjs(table, data, best_results)
+    releases_map = {"1.0": [point.run_id for point in data]}
+    graphs = create_chartjs(table, data, best_results, releases_map)
     datasets = graphs[0]['data']['datasets']
     limits = [point.get('limit') for dataset in datasets for point in dataset['data'] if 'limit' in point]
     assert len(limits) == 2
@@ -151,7 +155,8 @@ def test_create_chartjs_no_data_should_not_fail():
     )
     data = []
     best_results = {}
-    graphs = create_chartjs(table, data, best_results)
+    releases_map = {"1.0": []}
+    graphs = create_chartjs(table, data, best_results, releases_map)
     assert len(graphs) == 0
 
 def test_create_chartjs_multiple_columns_and_rows():
@@ -197,7 +202,8 @@ def test_create_chartjs_multiple_columns_and_rows():
             BestResult(key='col2:row2', value=50.0, result_date=datetime(2021, 1, 2), run_id=str(uuid4())),
         ]
     }
-    graphs = create_chartjs(table, data, best_results)
+    releases_map = {"1.0": [point.run_id for point in data]}
+    graphs = create_chartjs(table, data, best_results, releases_map)
     assert len(graphs) == 2
     assert len(graphs[0]['data']['datasets']) == 2  # should have also limits dataset
     assert len(graphs[1]['data']['datasets']) == 1  # no limits series

--- a/frontend/TestRun/Components/ScreenshotModal.svelte
+++ b/frontend/TestRun/Components/ScreenshotModal.svelte
@@ -4,7 +4,6 @@
     import {onMount, onDestroy} from "svelte";
 
     export let selectedScreenshot: string;
-    console.log("clicked screenshot", selectedScreenshot);
     function handleKeyDown(event: KeyboardEvent) {
         if (event.key === "Escape") {
             selectedScreenshot = "";

--- a/frontend/TestRun/ResultsGraphs.svelte
+++ b/frontend/TestRun/ResultsGraphs.svelte
@@ -6,6 +6,7 @@
     export let test_id = "";
     let graphs = [];
     let ticks = {};
+    let releasesFilters = {};
     let tableFilters = [];
     let columnFilters = [];
     let selectedTableFilters = [];
@@ -32,6 +33,7 @@
             const response = results["response"];
             graphs = response["graphs"].map((graph) => ({...graph, id: generateRandomHash()}));
             ticks = response["ticks"];
+            releasesFilters = Object.fromEntries(response["releases_filters"].map(key => [key, true]));
             extractTableFilters();
             extractColumnFilters();
             filterGraphs();
@@ -128,8 +130,20 @@
     };
 
     const getTableFilterColor = (level) => {
-        const intermediateColors = ["#ff7f7f", "#7fbfff", "#ffbf7f", "#bf7fff", "#ffff7f", "#7fffff", "#bf7f7f"];
-        return intermediateColors[level % intermediateColors.length];
+        const intermediateColors = [
+            "#B8EFFF",
+            "#FECBA1",
+            "#D6B3E6",
+            "#FFE699",
+            "#F0A5C5",
+            "#C4C8CA",
+        ];
+        return intermediateColors[level - 1 % intermediateColors.length];
+    };
+
+    const toggleReleaseFilter = (filterName) => {
+        releasesFilters[filterName] = !releasesFilters[filterName];
+        filterGraphs();
     };
 
     onMount(() => {
@@ -153,18 +167,38 @@
         <button
                 on:click={() => toggleColumnFilter(filter)}
                 class:selected={selectedColumnFilters.some(f => f === filter)}
-                style="background-color: #7fff7f"
+                style="background-color: #a3e2cc"
         >
             {filter}
         </button>
     {/each}
     <button on:click={() => { selectedTableFilters = []; selectedColumnFilters = []; filterGraphs(); }}>Show All</button>
-</div>
 
+</div>
+<div class="filters-container">
+    {#each Object.keys(releasesFilters) as release}
+        <button
+                on:click={() => toggleReleaseFilter(release)}
+                class:selected={releasesFilters[release]}
+                class="m-2"
+        >
+            {release}
+        </button>
+    {/each}
+</div>
 <div class="charts-container">
     {#each filteredGraphs as graph (graph.id)}
-        <div class="chart-container {filteredGraphs.length<2? 'big-size': ''}">
-            <ResultsGraph {graph} {ticks} {width} {height} test_id={test_id} index={graph.id} on:runClick={dispatch_run_click}/>
+        <div class="chart-container {filteredGraphs.length < 2 ? 'big-size' : ''}">
+            <ResultsGraph
+                    {graph}
+                    {ticks}
+                    height={filteredGraphs.length === 1 ? 600 : height}
+                    width={filteredGraphs.length === 1 ? 1000 : width}
+                    test_id={test_id}
+                    index={graph.id}
+                    releasesFilters={releasesFilters}
+                    on:runClick={dispatch_run_click}
+            />
         </div>
     {/each}
 </div>


### PR DESCRIPTION
Performance job can run against different scylla release. Because it was
not taken into account, graph lines don't differentiate between them
making impossible to distinguish different releases.

This commit adds support for mixing different SUT releases in one job
and make them visible as separate series on graphs. Additional
'releases' filters were added to easily toggle releases that should be
shown.

closes: https://github.com/scylladb/argus/issues/473