### PR TITLE
feature(graphs): filter data points by date filters

### DIFF
--- a/argus/backend/controller/api.py
+++ b/argus/backend/controller/api.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime, timezone
 from uuid import UUID
 import requests
 from flask import (
@@ -386,13 +387,21 @@ def test_info():
 @api_login_required
 def test_results():
     test_id = request.args.get("testId")
+    start_date_str = request.args.get("startDate")
+    end_date_str = request.args.get("endDate")
+
     if not test_id:
         raise Exception("No testId provided")
+
+    start_date = datetime.fromisoformat(start_date_str).astimezone(timezone.utc) if start_date_str else None
+    end_date = datetime.fromisoformat(end_date_str).astimezone(timezone.utc) if end_date_str else None
+
     service = ResultsService()
     if request.method == 'HEAD':
         exists = service.is_results_exist(test_id=UUID(test_id))
         return Response(status=200 if exists else 404)
-    graphs, ticks, releases_filters = service.get_test_graphs(test_id=UUID(test_id))
+
+    graphs, ticks, releases_filters = service.get_test_graphs(test_id=UUID(test_id), start_date=start_date, end_date=end_date)
 
     return {
         "status": "ok",

--- a/argus/backend/tests/results_service/test_chartjs_additional_functions.py
+++ b/argus/backend/tests/results_service/test_chartjs_additional_functions.py
@@ -197,7 +197,7 @@ def test_calculate_limits():
         assert 'limit' in point
 
 
-def test_calculate_graph_ticks():
+def test_calculate_graph_ticks_with_data_returns_min_max_ticks():
     graphs = [
         {
             "data": {
@@ -217,3 +217,23 @@ def test_calculate_graph_ticks():
     ticks = calculate_graph_ticks(graphs)
     assert ticks["min"] == "2023-10-22"
     assert ticks["max"] == "2023-10-25"
+
+def test_calculate_graph_ticks_without_data_does_not_fail():
+    graphs = [
+        {
+            "data": {
+                "datasets": [
+                    {"data": []}
+                ]
+            }
+        },
+        {
+            "data": {
+                "datasets": [
+                    {"data": []}
+                ]
+            }
+        }
+    ]
+    ticks = calculate_graph_ticks(graphs)
+    assert ticks == {}

--- a/argus/backend/tests/results_service/test_results_service.py
+++ b/argus/backend/tests/results_service/test_results_service.py
@@ -1,0 +1,100 @@
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+import pytest
+from argus.backend.models.result import ArgusGenericResultMetadata, ArgusGenericResultData, ColumnMetadata
+from argus.backend.service.results_service import ResultsService
+
+@pytest.fixture
+def setup_data(argus_db):
+    test_id = uuid4()
+    table = ArgusGenericResultMetadata(
+        test_id=test_id,
+        name='Test Table',
+        columns_meta=[
+            ColumnMetadata(name='col1', unit='ms', type='FLOAT', higher_is_better=False)
+        ],
+        rows_meta=['row1'],
+        validation_rules={}
+    )
+    data = [
+        ArgusGenericResultData(
+            test_id=test_id,
+            name=table.name,
+            run_id=uuid4(),
+            column='col1',
+            row='row1',
+            sut_timestamp=datetime.today() - timedelta(days=10),
+            value=100.0,
+            status='UNSET'
+        ).save(),
+        ArgusGenericResultData(
+            test_id=test_id,
+            name=table.name,
+            run_id=uuid4(),
+            column='col1',
+            row='row1',
+            sut_timestamp=datetime.today() - timedelta(days=5),
+            value=150.0,
+            status='UNSET'
+        ).save(),
+        ArgusGenericResultData(
+            test_id=test_id,
+            name=table.name,
+            run_id=uuid4(),
+            column='col1',
+            row='row1',
+            sut_timestamp=datetime.today() - timedelta(days=1),
+            value=200.0,
+            status='UNSET'
+        ).save()
+    ]
+    return test_id, table, data
+
+
+def test_results_service_should_return_results_within_date_range(setup_data):
+    test_id, table, data = setup_data
+    service = ResultsService()
+
+    start_date = datetime.today() - timedelta(days=7)
+    end_date = datetime.today() - timedelta(days=2)
+
+    filtered_data = service._get_tables_data(
+        test_id=test_id,
+        table_name=table.name,
+        ignored_runs=[],
+        start_date=start_date,
+        end_date=end_date
+    )
+
+    assert len(filtered_data) == 1
+    assert filtered_data[0].value == 150.0
+
+def test_results_service_should_return_no_results_outside_date_range(setup_data):
+    test_id, table, data = setup_data
+    service = ResultsService()
+
+    start_date = datetime.today() - timedelta(days=20)
+    end_date = datetime.today() - timedelta(days=15)
+
+    filtered_data = service._get_tables_data(
+        test_id=test_id,
+        table_name=table.name,
+        ignored_runs=[],
+        start_date=start_date,
+        end_date=end_date
+    )
+
+    assert len(filtered_data) == 0
+
+def test_results_service_should_return_all_results_with_no_date_range(setup_data):
+    test_id, table, data = setup_data
+    service = ResultsService()
+
+    filtered_data = service._get_tables_data(
+        test_id=test_id,
+        table_name=table.name,
+        ignored_runs=[]
+    )
+
+    assert len(filtered_data) == 3


### PR DESCRIPTION
In order to narrow down graphs range, date filters were added (by start and end date) with ability to quickly switch between 1,3 and 6 recent months. Last 3 months filter is on by default.

closes: https://github.com/scylladb/argus/issues/474