### PR TITLE
fix(templates/base.html.j2): Do not parse JSON provided by the backend

### DIFF
--- a/templates/base.html.j2
+++ b/templates/base.html.j2
@@ -10,11 +10,11 @@
     <link rel="shortcut icon" href="/s/argus.png" type="image/png">
     {% block javascripts %}
     <script>
-        var globalFlashes = JSON.parse('{{ get_flashed_messages(with_categories=true) | tojson | safe }}');
+        var globalFlashes = {{ get_flashed_messages(with_categories=true) | tojson | safe }};
     </script>
     {% if g.user %}
     <script>
-        var gArgusCurrentUser = JSON.parse('{{ g.user | safe_user | tojson | safe }}');
+        var gArgusCurrentUser = {{ g.user | safe_user | tojson | safe }};
     </script>
     {% endif %}
     <script src="/s/dist/fontAwesome.bundle.js"></script>


### PR DESCRIPTION
This commit fixes an issue where some users would not be able to use
argus because parts of their usernames contained unescaped json
sequences, which would fail JSON.parse. As a replacement, templates now
receive JSON as a JS object literal.
