### PR TITLE
fix(plugins/core): Add a fallback for old schedules

### DIFF
--- a/argus/backend/plugins/core.py
+++ b/argus/backend/plugins/core.py
@@ -83,7 +83,8 @@ class PluginModelBase(Model):
             if associated_test.id in plan.tests:
                 return plan.assignee_mapping.get(associated_test.id, plan.owner)
 
-        return None
+        # FIXME: Legacy fallback until we fully migrate to new plans
+        return self._legacy_get_scheduled_assignee(associated_test=associated_test, associated_release=associated_release)
     
 
     def get_scheduled_assignee(self) -> UUID:

--- a/templates/releases.html.j2
+++ b/templates/releases.html.j2
@@ -20,19 +20,22 @@ Releases
                             <div class="release-stats mb-1"></div>
                     </div>
                 </div>
-                <div class="col-4">
-                    <div class="d-flex align-items-center h-100">
+                <div class="col-4 p-2">
+                    <div class="d-flex justify-content-center flex-column">
                         <div class="btn-group">
-                            <a href="{{ url_for('main.release_dashboard', release_name=release.name) }}" class="btn btn-primary"><i class="fas fa-tachometer-alt"></i> Dashboard</a>
+                            <a href="{{ url_for('main.release_dashboard', release_name=release.name) }}" class="btn btn-outline-success"><i class="fas fa-tachometer-alt"></i> Dashboard</a>
                             {% if release.perpetual %}
-                            <a href="{{ url_for('main.duty_planner', name=release.name) }}" class="btn btn-primary"><i class="fas fa-calendar-alt"></i> Duty Planning</a>
+                            <a href="{{ url_for('main.duty_planner', name=release.name) }}" class="btn btn-outline-success"><i class="fas fa-calendar-alt"></i> Duty Planning</a>
                             {% else %}
-                            <a href="{{ url_for('main.release_planner', name=release.name) }}" class="btn btn-primary"><i class="fas fa-calendar-alt"></i> Duty Planning</a>
+                            <a href="{{ url_for('main.release_planner', name=release.name) }}" class="btn btn-outline-success"><i class="fas fa-calendar-alt"></i> Release Planner</a>
                             {% endif %}
                         </div>
+                        {% if not release.perpetual %}
+                            <a class="link-secondary" href="{{ url_for('main.release_scheduler', name=release.name) }}">Legacy Scheduler</a>
+                        {% endif %}
                     </div>
-                </div>
             </div>
+                </div>
         {% endfor %}
     </div>
 {% endblock %}


### PR DESCRIPTION
This allows new planning to coexist with plans used in old ArgusSchedule
implementation.
