### PR TITLE
fix(ViewTypes.js): Add a fallback widget in case of undefined widgets

### DIFF
--- a/frontend/Common/ViewTypes.js
+++ b/frontend/Common/ViewTypes.js
@@ -1,6 +1,7 @@
 import ViewGithubIssues from "../Views/Widgets/ViewGithubIssues.svelte";
 import ViewReleaseStats from "../Views/Widgets/ViewReleaseStats.svelte";
 import ViewTestDashboard from "../Views/Widgets/ViewTestDashboard.svelte";
+import ViewUnsupportedPlaceholder from "../Views/Widgets/ViewUnsupportedPlaceholder.svelte";
 import CheckValue from "../Views/WidgetSettingTypes/CheckValue.svelte";
 import MultiSelectValue from "../Views/WidgetSettingTypes/MultiSelectValue.svelte";
 import StringValue from "../Views/WidgetSettingTypes/StringValue.svelte";
@@ -17,6 +18,13 @@ export class Widget {
 
 
 export const WIDGET_TYPES = {
+    UNSUPPORTED: {
+        type: ViewUnsupportedPlaceholder,
+        hidden: true,
+        friendlyName: "Dummy widget",
+        settingDefinitions: {
+        }
+    },
     testDashboard: {
         type: ViewTestDashboard,
         friendlyName: "Test Dashboard",

--- a/frontend/Views/ViewDashboard.svelte
+++ b/frontend/Views/ViewDashboard.svelte
@@ -55,7 +55,7 @@
         {#each view.widget_settings as widget}
             <div class="mb-2">
                 <svelte:component
-                    this={WIDGET_TYPES[widget.type].type}
+                    this={WIDGET_TYPES[widget.type]?.type ?? WIDGET_TYPES.UNSUPPORTED.type}
                     dashboardObject={view}
                     dashboardObjectType="view"
                     settings={widget.settings}

--- a/frontend/Views/Widgets/ViewUnsupportedPlaceholder.svelte
+++ b/frontend/Views/Widgets/ViewUnsupportedPlaceholder.svelte
@@ -1,0 +1,3 @@
+<div class="alert alert-warning p-2 m-2 text-center">
+    This widget is not supported by this version of argus.
+</div>


### PR DESCRIPTION
This fix addresses a potential issue where a widget created on a newer
version of argus will cause an error on an older one when it is loaded
from the database.
