### PR TITLE
fix(stats.py): Add a fallback for old assignments and stats

### DIFF
--- a/argus/backend/service/argus_service.py
+++ b/argus/backend/service/argus_service.py
@@ -622,7 +622,8 @@ class ArgusService:
 
         release = ArgusRelease.get(id=group.release_id)
         if not release.perpetual:
-            return PlanningService().get_assignments_for_tests(group_id, version, plan_id)
+            if assignments := PlanningService().get_assignments_for_tests(group_id, version, plan_id):
+                return assignments
 
         tests = ArgusTest.filter(group_id=group_id).all()
 


### PR DESCRIPTION
This commit fixes an issue where old schedules would not be counted for
tests that have not been run (but have been scheduled). This restores
both the assignee icon and NOT RUN status.
