### PR TITLE
fix(frontend): Handle error conditions for retrieving test runs

### DIFF
--- a/argus/backend/controller/main.py
+++ b/argus/backend/controller/main.py
@@ -44,6 +44,9 @@ def runs(test_id: UUID):
 @login_required
 def get_run_by_plugin(plugin_name: str, run_id: UUID | str):
     run = TestRunService().get_run(plugin_name, run_id)
+    if not run:
+        flash(f"Run {plugin_name}/{run_id} not found.", "error")
+        return redirect(url_for("main.error", type=404))
     return render_template("run_view_by_plugin.html.j2", run=run)
 
 

--- a/frontend/Profile/ProfileJob.svelte
+++ b/frontend/Profile/ProfileJob.svelte
@@ -3,7 +3,7 @@
     import { fade } from "svelte/transition";
     import { sendMessage } from "../Stores/AlertStore";
     import { extractBuildNumber } from "../Common/RunUtils";
-    import { InvestigationBackgroundCSSClassMap, InvestigationStatusIcon, StatusBackgroundCSSClassMap } from "../Common/TestStatus";
+    import { InvestigationStatusIcon, StatusBackgroundCSSClassMap } from "../Common/TestStatus";
     import { faChevronCircleDown, faChevronCircleUp } from "@fortawesome/free-solid-svg-icons";
     import Fa from "svelte-fa";
     import TestRuns from "../WorkArea/TestRuns.svelte";
@@ -12,6 +12,7 @@
     export let jobs = [];
     const dispatch = createEventDispatcher();
     let testInfo;
+    let failedFetch = false;
     let investigating = false;
 
     const fetchTestInfo = async function () {
@@ -33,6 +34,7 @@
             } else {
                 sendMessage("error", "Error fetching user jobs\nUnknown error. Check console for details", "ProfileJobs::testInfo");
             }
+            failedFetch = true;
             console.log(e);
         }
     };
@@ -87,9 +89,16 @@
             {/if}
         </div>
     {:else}
-        JobId: {jobId} <span class="spinner-grow"></span> Loading...
-        <div>
-            Total Jobs: {jobs.length}
-        </div>
+        {#if failedFetch}
+            <div>
+                Unable to load test info. The test might have been removed.
+                <div>TestId: {jobId}</div>
+            </div>
+        {:else}
+            TestId: {jobId} <div><span class="spinner-grow"></span> Loading...</div>
+            <div>
+                Total Jobs: {jobs.length}
+            </div>
+        {/if}
     {/if}
 </div>


### PR DESCRIPTION
This commit adds error handling for two endpoints related to fetching
test runs. In case of ProfileJobs, it adds a message indicating to the
user that something went wrong, instead of showing loading forever.

The other case is specifying invalid id to the /tests/plugin endpoint,
in this case, a 404 redirect is generated with an error message.

Fixes #512
