### PR TITLE
feature(frontend): Add possibility to clone empty jobs

### DIFF
--- a/frontend/TestRun/Jenkins/BuildSuccessPlaceholder.svelte
+++ b/frontend/TestRun/Jenkins/BuildSuccessPlaceholder.svelte
@@ -93,8 +93,16 @@
                     <div>
                         This is a first build, which will require a re-run to actually start.
                         <div class="my-2 p-2">
-                            <button class="w-100 btn btn-success" on:click={() => dispatch("exit", { firstBuildRestart: true })}>
+                            <button class="w-100 btn btn-success" on:click={() => dispatch("exit", { firstBuildRestart: true, buildNumber: buildInfo.number })}>
                                 <Fa icon={faArrowCircleRight} /> Start build #2
+                            </button>
+                        </div>
+                    </div>
+                {:else}
+                    <div>
+                        <div class="my-2 p-2">
+                            <button class="w-100 btn btn-success" on:click={() => dispatch("exit", { firstBuildRestart: false, buildNumber: buildInfo.number })}>
+                                <Fa icon={faArrowCircleRight} /> Exit and add the test to workspace
                             </button>
                         </div>
                     </div>

--- a/frontend/TestRun/Jenkins/CloneSuccess.svelte
+++ b/frontend/TestRun/Jenkins/CloneSuccess.svelte
@@ -21,7 +21,8 @@
         <div>
             <button class="btn btn-success w-100" on:click={() => {
                 dispatch("exit", {
-                    newBuildId: args.result.new_entity.build_system_id
+                    newBuildId: args.result.new_entity.build_system_id,
+                    newTestId: args.result.new_entity.id,
                 });
             }}>Next</button>
         </div>

--- a/frontend/TestRun/TestRun.svelte
+++ b/frontend/TestRun/TestRun.svelte
@@ -304,7 +304,7 @@
                     id="nav-details-{runId}"
                     role="tabpanel"
                 >
-                    <TestRunInfo test_run={testRun} release={testInfo.release} group={testInfo.group} test={testInfo.test}/>
+                    <TestRunInfo test_run={testRun} release={testInfo.release} group={testInfo.group} test={testInfo.test} on:cloneComplete/>
                 </div>
                 {#if testRun.subtest_name && Object.values(Subtests).includes(testRun.subtest_name)}
                     <svelte:component this={SubtestTabBodyComponents[testRun.subtest_name]} {testRun}/>

--- a/frontend/TestRun/TestRunInfo.svelte
+++ b/frontend/TestRun/TestRunInfo.svelte
@@ -14,12 +14,14 @@
     } from "../Common/RunUtils";
     import JenkinsBuildModal from "./Jenkins/JenkinsBuildModal.svelte";
     import JenkinsCloneModal from "./Jenkins/JenkinsCloneModal.svelte";
+    import { createEventDispatcher } from "svelte";
     export let test_run = {};
     export let release;
     export let group;
     export let test;
     let rebuildRequested = false;
     let cloneRequested = false;
+    const dispatch = createEventDispatcher();
 
     let cmd_hydraInvestigateShowMonitor = `hydra investigate show-monitor ${test_run.id}`;
     let cmd_hydraInvestigateShowLogs = `hydra investigate show-logs ${test_run.id}`;
@@ -250,7 +252,7 @@
                     groupId={group.id}
                     oldTestName={test.name}
                     on:cloneCancel={() => (cloneRequested = false)}
-                    on:cloneComplete={() => (cloneRequested = false)}
+                    on:cloneComplete={(e) => {cloneRequested = false; dispatch("cloneComplete", { testId: e.detail.testId }); }}
                 />
             {/if}
             <div class="btn-group">

--- a/frontend/WorkArea/TestRunDispatcher.svelte
+++ b/frontend/WorkArea/TestRunDispatcher.svelte
@@ -7,4 +7,4 @@
 
 </script>
 
-<svelte:component this={AVAILABLE_PLUGINS?.[testInfo.test.plugin_name] ?? AVAILABLE_PLUGINS.unknown} {runId} {testInfo} {buildNumber} on:closeRun on:investigationStatusChange on:runStatusChange />
+<svelte:component this={AVAILABLE_PLUGINS?.[testInfo.test.plugin_name] ?? AVAILABLE_PLUGINS.unknown} {runId} {testInfo} {buildNumber} on:closeRun on:investigationStatusChange on:runStatusChange on:cloneComplete />

--- a/frontend/WorkArea/TestRunsPanel.svelte
+++ b/frontend/WorkArea/TestRunsPanel.svelte
@@ -109,6 +109,9 @@
             parent="#accordionTestRuns"
             removableRuns={workAreaAttached}
             on:testRunRemove
+            on:cloneSelect={(e) => {
+                testRuns = [...testRuns, e.detail.testId];
+            }}
         />
     {/each}
 </div>


### PR DESCRIPTION
This commit adds a new button alongside "Configure" button on the job
collapse, allowing user to clone a job without having to run one first.
In this case, the parameter retrieval is skipped initially, and the
parameters are retrieved from the new job. In case of pressing this
button on a job with runs, the flow is largely the same as normal clone,
the parameters are taken from the latest job. Additionally, for
usability, last stage now gives user possibility to instantly add newly
created job to the workspace.

Fixes #379
