### PR TITLE
fix(plugins/core): Handle missing tests in get_assignment calls

### DIFF
--- a/argus/backend/plugins/driver_matrix_tests/model.py
+++ b/argus/backend/plugins/driver_matrix_tests/model.py
@@ -8,6 +8,7 @@ from typing import Literal, TypedDict
 from uuid import UUID
 from xml.etree import ElementTree
 from cassandra.cqlengine import columns
+from cassandra.cqlengine.models import Model
 from argus.backend.db import ScyllaCluster
 from argus.backend.models.web import ArgusRelease
 from argus.backend.plugins.core import PluginModelBase
@@ -412,7 +413,10 @@ class DriverTestRun(PluginModelBase):
 
     def submit_product_version(self, version: str):
         self.scylla_version = version
-        new_assignee = self.get_assignment(version)
+        try:
+            new_assignee = self.get_assignment(version)
+        except Model.DoesNotExist:
+            new_assignee = None
         if new_assignee:
             self.assignee = new_assignee
 

--- a/argus/backend/plugins/generic/model.py
+++ b/argus/backend/plugins/generic/model.py
@@ -41,7 +41,10 @@ class GenericRun(PluginModelBase):
         pattern = re.compile(r"((?P<short>[\w.~]+)-(?P<build>(0\.)?(?P<date>[0-9]{8,8})\.(?P<commit>\w+).*))")
         if match := pattern.search(version):
             self.scylla_version = match.group("short")
-            new_assignee = self.get_assignment(match.group("short"))
+            try:
+                new_assignee = self.get_assignment(match.group("short"))
+            except Model.DoesNotExist:
+                new_assignee = None
             if new_assignee:
                 self.assignee = new_assignee
             self.set_full_version(version)

--- a/argus/backend/plugins/sct/testrun.py
+++ b/argus/backend/plugins/sct/testrun.py
@@ -216,7 +216,10 @@ class SCTTestRun(PluginModelBase):
 
     def submit_product_version(self, version: str):
         self.scylla_version = version
-        new_assignee = self.get_assignment(version)
+        try:
+            new_assignee = self.get_assignment(version)
+        except Model.DoesNotExist:
+            new_assignee = None
         if new_assignee:
             self.assignee = new_assignee
 

--- a/argus/backend/plugins/sirenada/model.py
+++ b/argus/backend/plugins/sirenada/model.py
@@ -61,7 +61,10 @@ class SirenadaRun(PluginModelBase):
 
     def submit_product_version(self, version: str):
         self.scylla_version = version
-        new_assignee = self.get_assignment(version)
+        try:
+            new_assignee = self.get_assignment(version)
+        except Model.DoesNotExist:
+            new_assignee = None
         if new_assignee:
             self.assignee = new_assignee
 


### PR DESCRIPTION
This commit fixes an issue where generic runs would fail to submit due
to not finding a test entity associated with a run when storing a
version. It adds exception handling to submit_product_version on every
plugin to fix that.

Fixes #524
