### PR TITLE
feature(summary-widget): summary widget

### DIFF
--- a/argus/backend/controller/view_api.py
+++ b/argus/backend/controller/view_api.py
@@ -6,6 +6,7 @@ from flask import (
     request,
 )
 from argus.backend.controller.views_widgets.highlights import bp as highlights_bp
+from argus.backend.controller.views_widgets.summary import bp as summary_bp
 from argus.backend.error_handlers import handle_api_exception
 from argus.backend.models.web import User
 from argus.backend.service.stats import ViewStatsCollector
@@ -16,6 +17,7 @@ from argus.backend.util.common import get_payload
 bp = Blueprint('view_api', __name__, url_prefix='/views')
 LOGGER = logging.getLogger(__name__)
 bp.register_blueprint(highlights_bp)
+bp.register_blueprint(summary_bp)
 bp.register_error_handler(Exception, handle_api_exception)
 
 

--- a/argus/backend/controller/views_widgets/summary.py
+++ b/argus/backend/controller/views_widgets/summary.py
@@ -1,0 +1,42 @@
+from uuid import UUID
+
+from flask import Blueprint, request, g
+
+from argus.backend.models.web import ArgusUserView
+from argus.backend.service.results_service import ResultsService
+from argus.backend.service.user import api_login_required
+from argus.backend.util.common import get_payload
+
+bp = Blueprint("summary", __name__, url_prefix="/widgets")
+
+
+@bp.route("/summary/versioned_runs", methods=["GET"])
+@api_login_required
+def get_versioned_runs():
+    view_id = UUID(request.args.get("view_id"))
+    view: ArgusUserView = ArgusUserView.get(id=view_id)
+    service = ResultsService()
+    versioned_runs = service.get_tests_by_version("scylla-server", view.tests)
+    return {
+        "status": "ok",
+        "response": versioned_runs,
+    }
+
+@bp.route("/summary/runs_results", methods=["POST"])
+@api_login_required
+def get_runs_results():
+    versioned_runs = get_payload(request)
+    service = ResultsService()
+    response = {}
+    for test_id, test_methods in versioned_runs.items():
+        response[test_id] = {}
+        for method, run in test_methods.items():
+            response[test_id][method] = {}
+            run_id = run['run_id']
+            response[test_id][method][run_id] = service.get_run_results(UUID(test_id), UUID(run_id), key_metrics=[
+                "P99 read", "P99 write", "duration", "Throughput write", "Throughput read", "allocs_per_op",
+                "cpu_cycles_per_op", "instructions_per_op", "logallocs_per_op"])
+    return {
+        "status": "ok",
+        "response": response,
+    }

--- a/argus/backend/tests/results_service/test_validation_rules.py
+++ b/argus/backend/tests/results_service/test_validation_rules.py
@@ -37,15 +37,18 @@ class SampleCell:
 
 
 def results_to_dict(results):
-    return {
-        cell['column']: {
-            cell['row']: {
-                'value': cell['value'] if cell['value'] is not None else cell['value_text'],
-                'status': cell['status']
+    actual_cells = {}
+    table_data = results['Test Table Name']['table_data']
+
+    for row_key, row_data in table_data.items():
+        for col_name, col_data in row_data.items():
+            if col_name not in actual_cells:
+                actual_cells[col_name] = {}
+            actual_cells[col_name][row_key] = {
+                'value': col_data['value'],
+                'status': col_data['status']
             }
-        }
-        for cell in results['cells']
-    }
+    return actual_cells
 
 
 def test_can_track_validation_rules_changes(fake_test, client_service, results_service, release, group):

--- a/frontend/Common/ViewTypes.js
+++ b/frontend/Common/ViewTypes.js
@@ -9,6 +9,7 @@ import {TestStatus} from "./TestStatus";
 import {subUnderscores, titleCase} from "./TextUtils";
 import ViewHighlights from "../Views/Widgets/ViewHighlights/ViewHighlights.svelte";
 import IntegerValue from "../Views/WidgetSettingTypes/IntegerValue.svelte";
+import SummaryWidget from "../Views/Widgets/SummaryWidget/SummaryWidget.svelte";
 
 export class Widget {
     constructor(position = -1, type = "testDashboard", settings = {}) {
@@ -104,6 +105,18 @@ export const WIDGET_TYPES = {
                 default: 0,
                 help: "Index of the highlight (for support multiple highlight widgets in one view)",
                 displayName: "Index"
+            }
+        },
+    },
+    summary: {
+        type: SummaryWidget,
+        friendlyName: "Per version summary for specified release",
+        settingDefinitions: {
+            packageName: {
+                type: StringValue,
+                default: "scylla-server",
+                help: "Package name (from Packages tab) to monitor",
+                displayName: "Package Name"
             }
         },
     },

--- a/frontend/Github/GithubIssuesCopyModal.svelte
+++ b/frontend/Github/GithubIssuesCopyModal.svelte
@@ -1,0 +1,117 @@
+<script>
+    import Fa from "svelte-fa";
+    import {faClipboard, faCopy} from "@fortawesome/free-solid-svg-icons";
+
+    import ModalWindow from "../Common/ModalWindow.svelte";
+    import {faHtml5, faMarkdown} from "@fortawesome/free-brands-svg-icons";
+    import {titleCase} from "../Common/TextUtils";
+    import Color from "color";
+
+    export let sortedIssues = {};
+    export let currentPage = 0;
+    export let selectedLabels = [];
+    export let btnClass = "btn-success";
+    let issueCopy = false;
+
+
+    const copyIssueTableAsMarkdown = function () {
+        const issues = sortedIssues[currentPage] ?? [];
+        let issueFormattedList = issues
+            .sort((a, b) => a.issue_number - b.issue_number)
+            .map(val => `|${val.state ? `${val.state.state.toUpperCase()} ` : " "}|${val.url}|${val.state ? val.state.labels.map(v => v.name).join("\t") : ""}|${val.state && val.state.assignee ? val.state.assignee.login : ""}|`);
+        navigator.clipboard.writeText(`Current Issues ${selectedLabels.length > 0 ? selectedLabels.map(label => `[${label.name}]`).join(" ") : ""}\n|State|Issue|Tags|Assignee|\n|---|---|---|---|\n${issueFormattedList.join("\n")}`);
+    };
+
+    const copyIssueTableAsText = function () {
+        const issues = sortedIssues[currentPage] ?? [];
+
+        const lines = issues.map(i => ` * ${i.url} (${i?.state?.state ?? ""}) [${i?.state?.assignee?.login ?? "Nobody"}]`);
+        navigator.clipboard.writeText(`Issues\n${lines.join("\n")}`);
+    };
+
+    const copyIssueTableAsHTML = async function () {
+        const table = document.querySelector("div#modalTableIssueView");
+
+        const data = table.innerHTML;
+        // Baseline: June 2024
+        // eslint-disable-next-line no-undef
+        const clipboardItem = new ClipboardItem({
+            "text/html": new Blob([data], {type: "text/html"}),
+            "text/plain": new Blob([data], {type: "text/plain"})
+        });
+
+        await navigator.clipboard.write([clipboardItem]);
+    };
+</script>
+
+<button class="btn {btnClass}" on:click={() => issueCopy = true}>
+    <slot></slot>
+</button>
+
+{#if issueCopy}
+    <ModalWindow on:modalClose={() => issueCopy = false}>
+        <div class="" slot="title">
+            Issues
+        </div>
+        <div class="" slot="body">
+            <div class="mb-2 text-end">
+                <button class="btn btn-outline-primary" on:click={copyIssueTableAsHTML}>
+                    <Fa icon={faHtml5}/>
+                    Copy as HTML
+                </button>
+                <button class="btn btn-outline-primary" on:click={copyIssueTableAsMarkdown}>
+                    <Fa icon={faMarkdown}/>
+                    Copy as Markdown
+                </button>
+                <button class="btn btn-outline-primary" on:click={copyIssueTableAsText}>
+                    <Fa icon={faClipboard}/>
+                    Copy as Text
+                </button>
+            </div>
+            <div id="modalTableIssueView">
+                <table class="table" style="border: solid 1px black">
+                    <thead>
+                    <th style="border: solid 1px black">State</th>
+                    <th style="border: solid 1px black">Issue</th>
+                    <th style="border: solid 1px black">Title</th>
+                    <th style="border: solid 1px black">Tags</th>
+                    <th style="border: solid 1px black">Assignee</th>
+                    </thead>
+                    <tbody>
+                    {#each sortedIssues[currentPage] ?? [] as issue (issue.id)}
+                        <tr>
+                            <td style="border: solid 1px black">{titleCase(issue?.state?.state ?? issue?.last_status + " (?)")}</td>
+                            <td style="border: solid 1px black">
+                                <a class="link-primary" href="{issue.url}">{issue.owner}/{issue.repo}#{issue.issue_number}</a>
+                            </td>
+                            <td style="border: solid 1px black">
+                                {issue.title}
+                            </td>
+                            <td style="border: solid 1px black">
+                                {#if issue.state}
+                                    {#each issue.state.labels as label}
+                                        <span style="text-decoration: underline; color: {Color(`#${label.color}`).darken(0.50)}">{label.name}</span><br>
+                                    {/each}
+                                {:else}
+                                    Unknown
+                                {/if}
+                            </td>
+                            <td style="border: solid 1px black">
+                                {#if issue.state}
+                                    {#if issue.state.assignee}
+                                        <a href="{issue.state.assignee.html_url}">@{issue.state.assignee.login}</a>
+                                    {:else}
+                                        None
+                                    {/if}
+                                {:else}
+                                    Unknown
+                                {/if}
+                            </td>
+                        </tr>
+                    {/each}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </ModalWindow>
+{/if}

--- a/frontend/TestRun/Components/ResultTable.svelte
+++ b/frontend/TestRun/Components/ResultTable.svelte
@@ -1,0 +1,212 @@
+<script>
+    import { faMarkdown } from "@fortawesome/free-brands-svg-icons";
+    import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
+    import { ResultCellStatusStyleMap } from "../../Common/TestStatus";
+    import Cell from "./Cell.svelte";
+    import Fa from "svelte-fa";
+    import { sendMessage } from "../../Stores/AlertStore";
+
+    export let table_name;
+    export let result;
+    export let selectedScreenshot;
+
+    let showDescription = false;
+
+    const tableStyleToColor = {
+        "table-success": "green",
+        "table-danger": "red",
+        "table-warning": "yellow",
+        "table-secondary": "gray",
+    };
+
+    function styleToColor(classList) {
+        const classes = classList.split(" ");
+        for (let className of classes) {
+            if (className.startsWith("table-") && tableStyleToColor[className]) {
+                return tableStyleToColor[className];
+            }
+        }
+        return "";
+    }
+
+    async function copyResultTableAsMarkdown(event) {
+        const table = event.currentTarget.closest("table");
+        let markdown = "";
+
+        if (table) {
+            const rows = Array.from(table.querySelectorAll("tr"));
+            rows.forEach((row, rowIndex) => {
+                const cells = Array.from(row.querySelectorAll("th, td"));
+                const markdownRow = cells.map(cell => {
+                    let cellText = cell.innerText.trim();
+                    let link = "";
+
+                    const linkElement = cell.querySelector("a");
+                    const buttonElement = cell.querySelector("button");
+
+                    if (linkElement) {
+                        link = linkElement.href;
+                    } else if (buttonElement) {
+                        link = buttonElement.getAttribute("data-link");
+                    }
+
+                    cellText = cellText.replace(/#/g, "#&#8203;");
+
+                    if (link) {
+                        cellText = `[${cellText}](${link})`;
+                    }
+
+                    const color = styleToColor(cell.className);
+                    if (color) {
+                        cellText = `$$\{\\color{${color}}${cellText}}$$`;
+                    }
+
+                    return cellText;
+                }).join(" | ");
+                markdown += `| ${markdownRow} |\n`;
+
+                if (rowIndex === 0) {
+                    const separator = cells.map(() => "---").join(" | ");
+                    markdown += `| ${separator} |\n`;
+                }
+            });
+
+            try {
+                await navigator.clipboard.writeText(markdown);
+                sendMessage("info", "Table copied to clipboard in Markdown format!");
+            } catch (err) {
+                sendMessage("error", "Failed to copy: ", err);
+            }
+        }
+    }
+
+    function toggleDescription() {
+        showDescription = !showDescription;
+    }
+</script>
+
+<li class="result-item {result.table_status}">
+    <div class="result-content">
+        <div class="table-header">
+            <h5>{table_name}</h5>
+            <button class="btn btn-outline-secondary btn-sm p-1" on:click={toggleDescription}>
+                <Fa icon={faInfoCircle} size="sm"/>
+            </button>
+        </div>
+        {#if showDescription}
+            <p class="table-description">{result.description}</p>
+        {/if}
+        <div class="table-responsive">
+            <div class="table-container">
+                <table class="table table-sm table-bordered">
+                    <thead class="thead-dark">
+                    <tr>
+                        <th>
+                            <button class="btn btn-outline-success btn-sm p-1" on:click={copyResultTableAsMarkdown}>
+                                <Fa icon={faMarkdown} size="sm"/>
+                            </button>
+                        </th>
+                        {#each result.columns as col}
+                            <th>{col.name} <span class="unit">{col.unit ? `[${col.unit}]` : ''}</span></th>
+                        {/each}
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {#each result.rows as row}
+                        <tr>
+                            <td>{row}</td>
+                            {#each result.columns as col}
+                                {#key result.table_data[row][col.name]}
+                                    <td class="{ResultCellStatusStyleMap[result.table_data[row][col.name]?.status || 'NULL']}">
+                                        <Cell cell={result.table_data[row][col.name]} bind:selectedScreenshot/>
+                                    </td>
+                                {/key}
+                            {/each}
+                        </tr>
+                    {/each}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</li>
+
+<style>
+    .result-item {
+        margin-bottom: 1rem;
+        display: flex;
+        font-size: 0.9rem;
+    }
+
+    .result-item::before {
+        content: "";
+        display: block;
+        width: 3px;
+        background-color: #ddd;
+        margin-right: 0.5rem;
+        border-radius: 1px;
+    }
+
+    .result-item.PASS::before {
+        background-color: var(--bs-success) !important;
+    }
+
+    .result-item.ERROR::before {
+        background-color: var(--bs-danger) !important;
+    }
+
+    .result-content {
+        flex-grow: 1;
+    }
+
+    .table-header {
+        display: flex;
+        align-items: center;
+        margin-bottom: 0.25rem;
+    }
+
+    .table-header h5 {
+        margin: 0;
+        margin-right: 0.5rem;
+        font-size: 1rem;
+    }
+
+    .table-description {
+        margin-bottom: 0.5rem;
+        font-style: italic;
+        color: #666;
+        font-size: 0.85rem;
+    }
+
+    .table-responsive {
+        display: flex;
+        /*justify-content: center;*/
+    }
+
+    .table-container {
+        max-width: fit-content;
+    }
+
+    table {
+        width: auto;
+        min-width: 100%;
+        table-layout: auto;
+        font-size: 0.85rem;
+    }
+
+    th, td {
+        text-align: center;
+        padding: 0.25rem !important;
+    }
+
+    .unit {
+        font-size: 0.75em;
+        color: gray;
+        vertical-align: top;
+    }
+
+    :global(.btn-sm) {
+        font-size: 0.75rem;
+    }
+</style>
+

--- a/frontend/Views/Widgets/SummaryWidget/RunIssues.svelte
+++ b/frontend/Views/Widgets/SummaryWidget/RunIssues.svelte
@@ -1,0 +1,57 @@
+<script type="ts">
+    import Fa from "svelte-fa";
+    import {onMount} from "svelte";
+    import GithubIssue from "../../../Github/GithubIssue.svelte";
+    import {faBug} from "@fortawesome/free-solid-svg-icons";
+    import GithubIssuesCopyModal from "../../../Github/GithubIssuesCopyModal.svelte";
+
+    export let runId;
+    export let runStatus;
+    let issues = [];
+    let fetching = true;
+    $: paginatedIssues = [issues];
+
+
+    const fetchIssues = async function () {
+        issues = [];
+        fetching = true;
+        try {
+            let params = new URLSearchParams({
+                filterKey: "run_id",
+                id: runId,
+            }).toString();
+            let apiResponse = await fetch("/api/v1/issues/get?" + params);
+            let apiJson = await apiResponse.json();
+            if (apiJson.status === "ok") {
+                issues = apiJson.response;
+                fetching = false;
+            } else {
+                throw apiJson;
+            }
+        } catch (error) {
+            console.log(error);
+        }
+    };
+    onMount(async () => {
+        if (runStatus === "failed") {
+            await fetchIssues();
+        }
+    });
+
+</script>
+{#if runStatus === "failed"}
+    {#if fetching}
+        <div class="text-center">
+            <div class="spinner-border text-primary" role="status">
+                <span class="visually-hidden">Loading...</span>
+            </div>
+        </div>
+    {:else}
+        {#if issues.length > 0}
+            <GithubIssuesCopyModal sortedIssues={paginatedIssues} btnClass="btn-danger">
+                {issues.length}
+                <Fa icon={faBug}/>
+            </GithubIssuesCopyModal>
+        {/if}
+    {/if}
+{/if}

--- a/frontend/Views/Widgets/SummaryWidget/SummaryWidget.svelte
+++ b/frontend/Views/Widgets/SummaryWidget/SummaryWidget.svelte
@@ -1,0 +1,386 @@
+<script lang="ts">
+    import {onMount} from "svelte";
+    import Fa from 'svelte-fa';
+    import Select from "svelte-select";
+    import {
+        faChevronLeft,
+        faChevronRight,
+        faChevronDown,
+        faChevronUp,
+        faExclamationTriangle,
+        faTimesCircle,
+        faCheckCircle
+    } from '@fortawesome/free-solid-svg-icons';
+    import ResultTable from "../../../TestRun/Components/ResultTable.svelte";
+
+    export let dashboardObject;
+
+    let versions = [];
+    let versioned_runs = {};
+    let test_info = {};
+    let selectedVersionTestInfo = {};
+    let currentVersionIndex = 0;
+    let runResults = {};
+    let selectedScreenshot = "";
+    let expandedTests = {};
+    let currentVersionRuns = {};
+    let filters = {};
+    let selectedFilters = {};
+    let filteredTables = {};
+    let showFilters = {};
+    let versionItems = [];
+    let selectedVersionItem = {};
+
+    $: currentVersionIndex = selectedVersionItem.value;
+
+    onMount(async () => {
+        await fetchResults();
+    });
+    $: if (versions.length > 0) fetchRunResults(currentVersionIndex);
+
+    async function fetchResults() {
+        const response = await fetch(`/api/v1/views/widgets/summary/versioned_runs?view_id=${dashboardObject.id}`);
+        const responseJson = await response.json();
+        versioned_runs = responseJson.response.versions;
+        test_info = responseJson.response.test_info;
+        versions = Object.keys(versioned_runs);
+        versionItems = versions.map((version, index) => ({
+            value: index,
+            label: formatVersion(version)
+        }));
+        selectedVersionItem = versionItems[versions.length - 1];
+        await fetchRunResults(versions.length - 1);
+    }
+
+    async function fetchRunResults(currentVersionIndex = 0) {
+        currentVersionRuns = versioned_runs[versions[currentVersionIndex]];
+        const isEnterprise = versions[currentVersionIndex].split('.')[0].length > 3;
+        selectedVersionTestInfo = {...test_info};
+        selectedVersionTestInfo = Object.fromEntries(
+            Object.entries(selectedVersionTestInfo).filter(([testId, testData]) =>
+                isEnterprise
+                    ? testData.build_id.startsWith('scylla-enterprise')
+                    : !testData.build_id.startsWith('scylla-enterprise')
+            )
+        );
+        const runs_response = await fetch(`/api/v1/views/widgets/summary/runs_results`, {
+            method: "POST",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify(currentVersionRuns)
+        });
+        const responseJson = await runs_response.json();
+        runResults = responseJson.response;
+        Object.keys(selectedVersionTestInfo).forEach(testId => {
+            if (!runResults[testId]) {
+                runResults[testId] = {notRun: true};
+            }
+        });
+        expandedTests = Object.fromEntries(Object.keys(runResults).map(testId => [testId, false]));
+        Object.keys(currentVersionRuns).forEach(testId => {
+            const testData = currentVersionRuns[testId];
+            let hasFailedStatus = false;
+            Object.values(testData).forEach(runObj => {
+                if (runObj.status !== 'passed') {
+                    hasFailedStatus = true;
+                }
+            });
+            if (hasFailedStatus) {
+                expandedTests[testId] = true;
+                if (runResults[testId]) {
+                    runResults[testId].hasFailedStatus = true;
+                } else {
+                    runResults[testId] = {hasFailedStatus: true};
+                }
+            }
+        });
+        extractFiltersPerTest();
+    }
+
+    function extractFiltersPerTest() {
+        Object.keys(runResults).forEach(testId => {
+            filters[testId] = [];
+            showFilters[testId] = false;
+            const fltrs = new Map();
+
+            const testData = runResults[testId];
+            if (!testData.notRun) {
+                const tableNames = [];
+                selectedFilters[testId] = [];
+                Object.values(testData).forEach(methodData => {
+                    if (methodData && typeof methodData === 'object') {
+                        Object.values(methodData).forEach(resultsArray => {
+                            if (Array.isArray(resultsArray)) {
+                                resultsArray.forEach(tableEntry => {
+                                    Object.keys(tableEntry).forEach(table_name => {
+                                        tableNames.push({
+                                            name: table_name,
+                                            status: tableEntry[table_name].table_status
+                                        });
+                                    });
+                                });
+                            }
+                        });
+                    }
+                });
+
+                tableNames.forEach(name => {
+                    const parts = name.name.split("-");
+                    parts.forEach((part, index) => {
+                        const level = index + 1;
+                        if (!fltrs.has(level)) {
+                            fltrs.set(level, new Set());
+                        }
+                        fltrs.get(level).add(part.trim());
+                        if (name.status !== 'PASS' && level < 3) {
+                            selectedFilters[testId].push({
+                                name: part.trim(),
+                                level: level
+                            });
+                        }
+                    });
+                });
+
+                filters[testId] = Array.from(fltrs.entries())
+                    .sort(([left], [right]) => left - right)
+                    .map(([level, items]) => ({
+                        level,
+                        items: Array.from(items)
+                    }))
+                    .filter(entry => entry.items.length > 1);
+
+                showFilters[testId] = filters[testId].some(entry => entry.items.length >= 2);
+                selectedFilters[testId] = [...selectedFilters[testId]];
+                const maxLevel = Math.max(...selectedFilters[testId].map(f => f.level));
+                selectedFilters[testId] = selectedFilters[testId].filter(f => f.level === maxLevel);
+            }
+        });
+        filterTablesPerTest();
+    }
+
+    function toggleFilter(testId, filterName, level) {
+        const currentFilter = selectedFilters[testId].find(f => f.level === level && f.name === filterName);
+        if (currentFilter) {
+            selectedFilters[testId] = selectedFilters[testId].filter(f => !(f.level === level && f.name === filterName));
+        } else {
+            selectedFilters[testId] = [...selectedFilters[testId], {name: filterName, level}];
+        }
+        filterTablesPerTest();
+    }
+
+    function filterTablesPerTest() {
+        Object.keys(runResults).forEach(testId => {
+            const testData = runResults[testId];
+            filteredTables[testId] = {};
+            if (!testData.notRun) {
+                Object.entries(testData).forEach(([methodName, methodData]) => {
+                    if (methodName !== 'hasFailedStatus') {
+                        filteredTables[testId][methodName] = {};
+                        Object.entries(methodData).forEach(([runId, resultsArray]) => {
+                            const filteredResultsArray = [];
+
+                            resultsArray.forEach(tableEntry => {
+                                const filteredTableEntry = {};
+
+                                Object.entries(tableEntry).forEach(([table_name, result]) => {
+                                    const parts = table_name.split("-").map(part => part.trim());
+                                    const include = selectedFilters[testId].some(filter => parts.includes(filter.name));
+
+                                    if (include || selectedFilters[testId].length === 0) {
+                                        filteredTableEntry[table_name] = result;
+                                    }
+                                });
+
+                                if (Object.keys(filteredTableEntry).length > 0) {
+                                    filteredResultsArray.push(filteredTableEntry);
+                                }
+                            });
+
+                            filteredTables[testId][methodName][runId] = filteredResultsArray;
+                        });
+                    }
+                });
+            }
+        });
+    }
+
+
+    function getFilterColor(level) {
+        const filterColors = ["#7fbfff", "#ff7f7f", "#ffbf7f", "#bf7fff", "#bf7f7f", "#7fffff", "#ffff7f"];
+        return filterColors[(level - 2) % filterColors.length];
+    }
+
+
+    function formatVersion(version) {
+        const parts = version.split('-');
+        return `${parts[0]} (${parts[1]}) - ${parts[2]}`;
+    }
+
+    function toggleTest(testId) {
+        expandedTests[testId] = !expandedTests[testId];
+        expandedTests = {...expandedTests};
+    }
+</script>
+
+<div class="card shadow-sm">
+    {#if versions.length === 0}
+        <div class="card-body">
+            <div class="alert alert-info">
+                <Fa icon={faExclamationTriangle} class="me-2"/>
+                No test results available
+            </div>
+        </div>
+    {:else}
+        <div class="card-header bg-primary">
+            <div class="d-flex justify-content-between align-items-center">
+                <h3 class="mb-0 text-white">Test Results Summary</h3>
+                <div class="d-flex align-items-center">
+                    <button class="btn btn-outline-light me-2"
+                            on:click={() => selectedVersionItem = versionItems[currentVersionIndex-1]}
+                            disabled={currentVersionIndex === 0}>
+                        <Fa icon={faChevronLeft}/>
+                    </button>
+                    <div style="width: 380px">
+                        <Select bind:value={selectedVersionItem} items={versionItems} isClearable={false} />
+                    </div>
+                    <button class="btn btn-outline-light ms-2"
+                            on:click={() => selectedVersionItem = versionItems[currentVersionIndex+1]}
+                            disabled={currentVersionIndex === versions.length - 1}>
+                        <Fa icon={faChevronRight}/>
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="card-body">
+            {#each Object.entries(runResults) as [testId, testData]}
+                <div class="mb-4 p-3 border rounded {testData.notRun ? 'border-warning' : testData.hasFailedStatus ? 'border-danger' : 'border-success'}">
+                    <h4 class="d-flex justify-content-between align-items-center">
+                        <span class={testData.notRun ? 'text-warning' : testData.hasFailedStatus ? 'text-danger' : 'text-success'}>
+                            {selectedVersionTestInfo[testId]?.name || selectedVersionTestInfo[testId]?.build_id?.split("/")?.pop() || testId}
+                            {#if testData.notRun}
+                                <Fa icon={faExclamationTriangle} class="text-warning ms-2"/>
+                            {:else if testData.hasFailedStatus}
+                                <Fa icon={faTimesCircle} class="text-danger ms-2"/>
+                            {:else}
+                                <Fa icon={faCheckCircle} class="text-success ms-2"/>
+                            {/if}
+                        </span>
+                        <button class="btn btn-outline-secondary" on:click={() => toggleTest(testId)}>
+                            <Fa icon={expandedTests[testId] ? faChevronUp : faChevronDown}/>
+                        </button>
+                    </h4>
+                    {#if expandedTests[testId]}
+                        {#if showFilters[testId]}
+                            <div class="filters-container">
+                                <button class="btn btn-outline-dark colored"
+                                        on:click={() => { selectedFilters[testId] = []; filterTablesPerTest(); }}>X
+                                </button>
+                                {#each filters[testId] as filterGroup}
+                                    {#each filterGroup.items as filter}
+                                        <button
+                                                class="btn btn-outline-dark colored"
+                                                on:click={() => toggleFilter(testId, filter, filterGroup.level)}
+                                                class:selected={selectedFilters[testId].some(f => f.name === filter && f.level === filterGroup.level)}
+                                                style="background-color: {getFilterColor(filterGroup.level)}"
+                                        >
+                                            {filter}
+                                        </button>
+                                    {/each}
+                                {/each}
+                            </div>
+                        {/if}
+                        <div class="test-methods-container mt-3">
+                            {#if testData.notRun}
+                                <div class="alert alert-warning">
+                                    <Fa icon={faExclamationTriangle} class="me-2"/>
+                                    This test was not run in this version.
+                                </div>
+                            {:else}
+                                {#each Object.entries(filteredTables[testId]) as [methodName, methodData]}
+                                    <div class="test-method-column">
+                                        {#each Object.entries(methodData) as [runId, results]}
+                                            <h5 class="mt-3">
+                                                <a href="/tests/scylla-cluster-tests/{runId}" target="_blank"
+                                                   class="text-decoration-none">
+                                                    {methodName}
+                                                </a>
+                                                {#if currentVersionRuns[testId]?.[methodName]?.status === 'passed'}
+                                                    <Fa icon={faCheckCircle} class="text-success ms-2"/>
+                                                {:else if currentVersionRuns[testId]?.[methodName]?.status === 'failed'}
+                                                    <Fa icon={faTimesCircle} class="text-danger ms-2"/>
+                                                {:else}
+                                                    <Fa icon={faExclamationTriangle} class="text-warning ms-2"/>
+                                                {/if}
+                                                (started by {currentVersionRuns[testId]?.[methodName]?.started_by})
+                                            </h5>
+                                            <ul class="result-list list-group">
+                                                {#each results as tableEntry}
+                                                    {#each Object.entries(tableEntry) as [table_name, result]}
+                                                        <li class="list-group-item">
+                                                            <ResultTable table_name={table_name} result={result}
+                                                                         bind:selectedScreenshot/>
+                                                        </li>
+                                                    {/each}
+                                                {/each}
+                                            </ul>
+                                        {/each}
+                                    </div>
+                                {/each}
+                            {/if}
+                        </div>
+                    {/if}
+                </div>
+            {/each}
+        </div>
+    {/if}
+</div>
+
+<style>
+    .filters-container {
+        display: flex;
+        flex-direction: row;
+        justify-content: flex-start;
+        align-content: flex-start;
+        margin-bottom: 20px;
+        flex-wrap: wrap;
+    }
+
+    .filters-container button {
+        margin: 2px;
+        padding: 5px 10px;
+        cursor: pointer;
+        border: 1px solid #6c757d;
+        border-radius: 0.25rem;
+        background-color: #fff;
+        color: #212529;
+        font-size: 0.875rem;
+    }
+
+    .filters-container button.selected {
+        background-color: #0d6efd;
+        color: #fff;
+        border-color: #0d6efd;
+    }
+
+    .filters-container button:hover {
+        background-color: #f8f9fa;
+    }
+
+    button.colored:not(.selected):not(:hover) {
+        background-color: #f0f0f0 !important;
+    }
+
+    .test-methods-container {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
+    }
+
+    .test-method-column {
+        flex: 1;
+        min-width: 300px;
+    }
+
+    .result-list {
+        padding-left: 0;
+    }
+</style>

--- a/frontend/Views/Widgets/SummaryWidget/SummaryWidget.svelte
+++ b/frontend/Views/Widgets/SummaryWidget/SummaryWidget.svelte
@@ -12,6 +12,7 @@
         faCheckCircle
     } from '@fortawesome/free-solid-svg-icons';
     import ResultTable from "../../../TestRun/Components/ResultTable.svelte";
+    import RunIssues from "./RunIssues.svelte";
 
     export let dashboardObject;
 
@@ -240,7 +241,7 @@
                         <Fa icon={faChevronLeft}/>
                     </button>
                     <div style="width: 380px">
-                        <Select bind:value={selectedVersionItem} items={versionItems} isClearable={false} />
+                        <Select bind:value={selectedVersionItem} items={versionItems} isClearable={false}/>
                     </div>
                     <button class="btn btn-outline-light ms-2"
                             on:click={() => selectedVersionItem = versionItems[currentVersionIndex+1]}
@@ -298,30 +299,34 @@
                                 {#each Object.entries(filteredTables[testId]) as [methodName, methodData]}
                                     <div class="test-method-column">
                                         {#each Object.entries(methodData) as [runId, results]}
-                                            <h5 class="mt-3">
-                                                <a href="/tests/scylla-cluster-tests/{runId}" target="_blank"
-                                                   class="text-decoration-none">
-                                                    {methodName}
-                                                </a>
-                                                {#if currentVersionRuns[testId]?.[methodName]?.status === 'passed'}
-                                                    <Fa icon={faCheckCircle} class="text-success ms-2"/>
-                                                {:else if currentVersionRuns[testId]?.[methodName]?.status === 'failed'}
-                                                    <Fa icon={faTimesCircle} class="text-danger ms-2"/>
-                                                {:else}
-                                                    <Fa icon={faExclamationTriangle} class="text-warning ms-2"/>
-                                                {/if}
-                                                (started by {currentVersionRuns[testId]?.[methodName]?.started_by})
-                                            </h5>
-                                            <ul class="result-list list-group">
-                                                {#each results as tableEntry}
-                                                    {#each Object.entries(tableEntry) as [table_name, result]}
-                                                        <li class="list-group-item">
-                                                            <ResultTable table_name={table_name} result={result}
-                                                                         bind:selectedScreenshot/>
-                                                        </li>
+                                            {#key runId}
+                                                <h5 class="mt-3">
+                                                    <a href="/tests/scylla-cluster-tests/{runId}" target="_blank"
+                                                       class="text-decoration-none">
+                                                        {methodName}
+                                                    </a>
+                                                    {#if currentVersionRuns[testId]?.[methodName]?.status === 'passed'}
+                                                        <Fa icon={faCheckCircle} class="text-success ms-2"/>
+                                                    {:else if currentVersionRuns[testId]?.[methodName]?.status === 'failed'}
+                                                        <Fa icon={faTimesCircle} class="text-danger ms-2"/>
+                                                    {:else}
+                                                        <Fa icon={faExclamationTriangle} class="text-warning ms-2"/>
+                                                    {/if}
+                                                    (started by {currentVersionRuns[testId]?.[methodName]?.started_by})
+                                                    <RunIssues runId={runId} runStatus={currentVersionRuns[testId]?.[methodName]?.status}/>
+                                                </h5>
+                                                <ul class="result-list list-group">
+                                                    {#each results as tableEntry}
+                                                        {#each Object.entries(tableEntry) as [table_name, result]}
+                                                            <li class="list-group-item">
+                                                                <ResultTable table_name={table_name} result={result}
+                                                                             bind:selectedScreenshot/>
+                                                            </li>
+                                                        {/each}
                                                     {/each}
-                                                {/each}
-                                            </ul>
+                                                </ul>
+                                            {/key}
+
                                         {/each}
                                     </div>
                                 {/each}


### PR DESCRIPTION
View widged showing tests statuses and results per Scylla version. Each test can be expanded to see results (tables) with key metrics. Initial features:
1. Results summary by scylla version (date, scm revision)
2. passed tests are collapsed by default
3. not run tests marked as warning
4. hiding tables with all cells green ... many more but small ones.

caveats:
1. works only with scylla-server package
2. tests filtering based on release (oss vs enterprise) implementation is poor as will work only with scylla-master and scylla-enterprise argus releases
3. key metrics are hardcoded, followup issue: https://github.com/scylladb/qa-tasks/issues/1821

Did a refactor of ResultsTab - extracted ResultTable to be able to reuse it across different parts of Argus (like Summary Widget)

refs: https://github.com/scylladb/argus/issues/486