### PR TITLE
feature(service/planner_service): Trigger jenkins jobs by plans

### DIFF
--- a/argus/backend/controller/planner_api.py
+++ b/argus/backend/controller/planner_api.py
@@ -176,3 +176,16 @@ def resolve_plan_entities(plan_id: str):
         "status": "ok",
         "response": result,
     }
+
+@bp.route("/plan/trigger", methods=["POST"])
+@api_login_required
+def trigger_jobs_for_plans():
+
+    payload = get_payload(request)
+    service = PlanningService()
+    result = service.trigger_jobs(payload)
+
+    return {
+        "status": "ok",
+        "response": result,
+    }

--- a/argus/backend/models/plan.py
+++ b/argus/backend/models/plan.py
@@ -12,7 +12,7 @@ class ArgusReleasePlan(Model):
     description = columns.Text()
     owner = columns.UUID(required=True)
     participants = columns.List(value_type=columns.UUID)
-    target_version = columns.Ascii()
+    target_version = columns.Ascii(index=True)
     assignee_mapping = columns.Map(key_type=columns.UUID, value_type=columns.UUID)
     release_id = columns.UUID(index=True)
     tests = columns.List(value_type=columns.UUID)

--- a/argus/backend/models/web.py
+++ b/argus/backend/models/web.py
@@ -177,6 +177,7 @@ class ArgusTest(Model):
     enabled = columns.Boolean(default=lambda: True)
     build_system_url = columns.Text()
     plugin_name = columns.Text()
+    plugin_subtype = columns.Text()
 
     def __eq__(self, other):
         if isinstance(other, ArgusTest):

--- a/argus/backend/service/jenkins_service.py
+++ b/argus/backend/service/jenkins_service.py
@@ -69,6 +69,17 @@ class JenkinsService:
 
         return params
 
+    def latest_build(self, build_id: str) -> int:
+        try:
+            job_info = self._jenkins.get_job_info(name=build_id)
+            last_build = job_info.get("lastBuild")
+            if not last_build:
+                return -1
+            return last_build["number"]
+        except jenkins.JenkinsException:
+            raise JenkinsServiceError("Job doesn't exist", build_id)
+        
+
     def get_releases_for_clone(self, test_id: str):
         test_id = UUID(test_id)
         # TODO: Filtering based on origin location / user preferences

--- a/argus/client/generic/client.py
+++ b/argus/client/generic/client.py
@@ -7,6 +7,10 @@ LOGGER = logging.getLogger(__name__)
 class ArgusGenericClient(ArgusClient):
     test_type = "generic"
     schema_version: None = "v1"
+
+    class Routes(ArgusClient.Routes):
+        TRIGGER_JOBS = "/planning/plan/trigger"
+
     def __init__(self, auth_token: str, base_url: str, api_version="v1") -> None:
         super().__init__(auth_token, base_url, api_version)
 
@@ -22,6 +26,24 @@ class ArgusGenericClient(ArgusClient):
         response = self.submit_run(run_type=self.test_type, run_body=request_body)
         self.check_response(response)
 
+    def trigger_jobs(self, common_params: dict[str, str], params: list[dict[str, str]], version: str = None, release: str = None, plan_id: str = None):
+        request_body = {
+            "common_params": common_params,
+            "params": params,
+            "version": version,
+            "release": release,
+            "plan_id": plan_id,
+        }
+        response = self.post(
+            endpoint=self.Routes.TRIGGER_JOBS,
+            location_params={},
+            body={
+                **self.generic_body,
+                **request_body,
+            }
+        )
+        self.check_response(response)
+        return response.json()
 
     def finalize_generic_run(self, run_id: str, status: str, scylla_version: str | None = None):
         response = self.finalize_run(run_type=self.test_type, run_id=run_id, body={

--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -44,3 +44,77 @@ Accepts following parameters:
   "status": "ok"
 }
 ```
+
+```http
+POST /api/v1/planning/plan/trigger
+```
+
+Accepts following payload:
+
+Type: application/json
+
+| Parameter | Type | Description |
+| --------- | ---- | ------------|
+| release          | string     | Release name to trigger plans in (can be mixed vith version to narrow filter)            |
+| plan_id          | string     | Specific plan id to trigger            |
+| version          | string     | Target scylla version of plans to trigger             |
+| common_params          | object{ param_name: value }     | Common parameters, such as backend            |
+| params          | object{ param_name: value }[]     | specific job parameters            |
+
+Example payload:
+
+```json
+{
+  {
+  "version": "2024.3.1~rc0",
+  "release": "scylla-master",
+  "plan_id": "some-plan-uuid",
+  "common_params": {
+      "instance_provision": "spot",
+  },
+  "params": [
+      {
+          "test": "longevity",
+          "backend": "aws",
+          "region": "eu-west-1",
+          "scylla_ami_id": "ami-abcd"
+      },
+      {
+          "test": "longevity",
+          "backend": "azure",
+          "region": "us-east1",
+          "azure_image_id": "/subscriptions…",
+      }
+  ]
+  }
+
+}
+```
+
+```json
+{
+  "response": {
+    "jobs": [
+      "http://jenkins/path/job/one/1",
+      "http://jenkins/path/job/two/3",
+      "http://jenkins/path/job/three/5",
+      "http://jenkins/path/job/four/9"
+    ],
+    "failed_to_execute": [
+      "path/job/one",
+      "path/job/two",
+      "path/job/three",
+      "path/job/four"
+    ]
+  }, 
+  "status": "ok"
+}
+```
+
+Additionally, this endpoint is available inside `argus-client-generic` executable, as follows:
+
+```bash
+argus-client-generic trigger-jobs --api-key $key --version $version --plan_id $id --release $release --job-info-file $file_path
+```
+
+`--job-info-file` is a .json file containing `common_params` and `params` parts of the payload, everything else is specified on the command line.


### PR DESCRIPTION
This commit adds a new feature to the Release Planning API - allowing
API consumers to trigger jobs from within argus in Jenkins. The endpoint
accepts target version (for example "6.2.0") in which case it will
trigger all plans with this version (release independent), release name
(will trigger all plans within that relase) or specific plan id (will
only trigger that plan). The API client provides the parameters in two
parts: as a set of common parameters intended for each job (useful for
things like provision_type) and an additional per job
type/backend/region set that each job will require in order to trigger.
Currently, only longevity is supported.

Fixes #377
