### PR TITLE
fix(plugins/sct): Support SCT runner for resources table

### DIFF
--- a/argus/backend/plugins/sct/controller.py
+++ b/argus/backend/plugins/sct/controller.py
@@ -40,7 +40,8 @@ def sct_set_runner(run_id: str):
         public_ip=payload["public_ip"],
         private_ip=payload["private_ip"],
         region=payload["region"],
-        backend=payload["backend"]
+        backend=payload["backend"],
+        name=payload.get("name")
     )
     return {
         "status": "ok",

--- a/argus/client/sct/client.py
+++ b/argus/client/sct/client.py
@@ -56,7 +56,7 @@ class ArgusSCTClient(ArgusClient):
         response = super().set_status(run_type=self.test_type, run_id=self.run_id, new_status=new_status)
         self.check_response(response)
 
-    def set_sct_runner(self, public_ip: str, private_ip: str, region: str, backend: str) -> None:
+    def set_sct_runner(self, public_ip: str, private_ip: str, region: str, backend: str, name: str = None) -> None:
         """
             Sets runner information for an SCT run.
         """
@@ -69,6 +69,7 @@ class ArgusSCTClient(ArgusClient):
                 "private_ip": private_ip,
                 "region": region,
                 "backend": backend,
+                "name": name,
             }
         )
         self.check_response(response)


### PR DESCRIPTION
This commit adds logic to add SCT runner to the resource table and also
adds client support for its name. Additionally, it adds a workaround for
older client versions, where SCT runner will be submitted without a
name.

Fixes scylladb/scylla-cluster-tests#9543
