### PR TITLE
improvement(feature/planner): Enable for all releases

### DIFF
--- a/argus/backend/plugins/core.py
+++ b/argus/backend/plugins/core.py
@@ -69,8 +69,6 @@ class PluginModelBase(Model):
     def get_assignment(self, version: str | None = None) -> UUID | None:
         associated_test: ArgusTest = ArgusTest.get(build_system_id=self.build_id)
         associated_release: ArgusRelease = ArgusRelease.get(id=associated_test.release_id)
-        if associated_release.perpetual:
-            return self._legacy_get_scheduled_assignee(associated_test=associated_test, associated_release=associated_release)
 
         plans: list[ArgusReleasePlan] = list(ArgusReleasePlan.filter(release_id=associated_release.id))
 

--- a/argus/backend/service/argus_service.py
+++ b/argus/backend/service/argus_service.py
@@ -581,8 +581,8 @@ class ArgusService:
     def get_groups_assignees(self, release_id: UUID | str, version: str = None, plan_id: UUID = None):
         release_id = UUID(release_id) if isinstance(release_id, str) else release_id
         release = ArgusRelease.get(id=release_id)
-        if not release.perpetual:
-            return PlanningService().get_assignments_for_groups(release_id, version, plan_id)
+        if assignments := PlanningService().get_assignments_for_groups(release_id, version, plan_id):
+            return assignments
 
         groups = ArgusGroup.filter(release_id=release_id).all()
         group_ids = [group.id for group in groups if group.enabled]
@@ -621,9 +621,8 @@ class ArgusService:
         group = ArgusGroup.get(id=group_id)
 
         release = ArgusRelease.get(id=group.release_id)
-        if not release.perpetual:
-            if assignments := PlanningService().get_assignments_for_tests(group_id, version, plan_id):
-                return assignments
+        if assignments := PlanningService().get_assignments_for_tests(group_id, version, plan_id):
+            return assignments
 
         tests = ArgusTest.filter(group_id=group_id).all()
 

--- a/argus/backend/service/stats.py
+++ b/argus/backend/service/stats.py
@@ -290,7 +290,7 @@ class ReleaseStats:
         if not self.release.enabled and not force:
             return
 
-        if not self.release.perpetual and not limited:
+        if not limited:
             plans: list[ArgusReleasePlan] = list(ArgusReleasePlan.filter(release_id=self.release.id).all())
             self.plans = plans if not filter else [plan for plan in plans if version_filter == plan.target_version]
             self.test_schedules = reduce(

--- a/templates/releases.html.j2
+++ b/templates/releases.html.j2
@@ -24,14 +24,12 @@ Releases
                     <div class="d-flex justify-content-center flex-column">
                         <div class="btn-group">
                             <a href="{{ url_for('main.release_dashboard', release_name=release.name) }}" class="btn btn-outline-success"><i class="fas fa-tachometer-alt"></i> Dashboard</a>
-                            {% if release.perpetual %}
-                            <a href="{{ url_for('main.duty_planner', name=release.name) }}" class="btn btn-outline-success"><i class="fas fa-calendar-alt"></i> Duty Planning</a>
-                            {% else %}
                             <a href="{{ url_for('main.release_planner', name=release.name) }}" class="btn btn-outline-success"><i class="fas fa-calendar-alt"></i> Release Planner</a>
-                            {% endif %}
                         </div>
                         {% if not release.perpetual %}
                             <a class="link-secondary" href="{{ url_for('main.release_scheduler', name=release.name) }}">Legacy Scheduler</a>
+                        {% else %}
+                            <a href="{{ url_for('main.duty_planner', name=release.name) }}" class="link-secondary">Legacy Duty Planning</a>
                         {% endif %}
                     </div>
             </div>


### PR DESCRIPTION
This commit enables new release planner for all releases within argus
and deprecates previously available timed "Duty Planning" feature. It
removes most checks for 'perpetual' release flag when retrieving
assignes and allows plans to be read for those releases as well, as well
as enabling the button to open the planner for such releases.
