### PR TITLE
improvement(highlights): send notification to action item assignee

### DIFF
--- a/argus/backend/controller/views_widgets/highlights.py
+++ b/argus/backend/controller/views_widgets/highlights.py
@@ -1,5 +1,4 @@
-from dataclasses import dataclass, asdict
-from datetime import datetime, UTC
+from dataclasses import asdict
 from uuid import UUID
 
 from flask import Blueprint, request, g
@@ -80,6 +79,9 @@ def set_assignee():
     payload = HighlightSetAssignee(**get_payload(request))
     service = HighlightsService()
     updated_action_item = service.set_assignee(payload)
+    if payload.assignee_id:
+        service.send_action_notification(sender_id=g.user.id, username=g.user.username, view_id=payload.view_id,
+                                         assignee_id=payload.assignee_id, action=updated_action_item.content)
     return {"status": "ok", "response": asdict(updated_action_item)}
 
 

--- a/argus/backend/models/web.py
+++ b/argus/backend/models/web.py
@@ -236,12 +236,14 @@ class ArgusNotificationTypes(str, Enum):
     StatusChange = "TYPE_STATUS_CHANGE"
     AssigneeChange = "TYPE_ASSIGNEE_CHANGE"
     ScheduleChange = "TYPE_SCHEDULE_CHANGE"
+    ViewActionItemAssignee = "TYPE_VIEW_ACTION_ITEM_ASSIGNEE"
 
 
 class ArgusNotificationSourceTypes(str, Enum):
     TestRun = "TEST_RUN"
     Schedule = "SCHEDULE"
     Comment = "COMMENT"
+    ViewActionItem = "VIEW_ACTION_ITEM"
 
 
 class ArgusNotificationState(IntEnum):

--- a/argus/backend/service/notification_manager.py
+++ b/argus/backend/service/notification_manager.py
@@ -57,6 +57,7 @@ class NotificationSenderBase:
         ArgusNotificationTypes.StatusChange: "A run you are assigned to changed status",
         ArgusNotificationTypes.AssigneeChange: "You were assigned to a run",
         ArgusNotificationTypes.ScheduleChange: "You were assigned to a schedule",
+        ArgusNotificationTypes.ViewActionItemAssignee: "You were assigned to a view action item",
     }
 
     CONTENT_TEMPLATES = {}
@@ -95,6 +96,8 @@ class ArgusDBNotificationSaver(NotificationSenderBase):
     CONTENT_TEMPLATES = {
         ArgusNotificationTypes.Mention: lambda p: render_template("notifications/mention.html.j2", **p if p else {}),
         ArgusNotificationTypes.AssigneeChange: lambda p: render_template("notifications/assigned.html.j2", **p if p else {}),
+        ArgusNotificationTypes.ViewActionItemAssignee: lambda p: render_template(
+            "notifications/view_action_item_assigned.html.j2", **p if p else {}),
     }
 
     def send_notification(self, receiver: UUID, sender: UUID, notification_type: ArgusNotificationTypes, source_type: ArgusNotificationSourceTypes,
@@ -120,6 +123,7 @@ class EmailNotificationServiceSender(NotificationSenderBase):
         ArgusNotificationTypes.Mention: lambda p: render_template(
             "notifications/email_mention.html.j2", **p if p else {}),
         ArgusNotificationTypes.AssigneeChange: lambda p: render_template("notifications/assigned_email.html.j2", **p if p else {}),
+        ArgusNotificationTypes.ViewActionItemAssignee: lambda p: render_template("notifications/view_action_item_assigned_email.html.j2", **p if p else {}),
     }
 
     def __init__(self):

--- a/argus/backend/tests/view_widgets/test_highlights_api.py
+++ b/argus/backend/tests/view_widgets/test_highlights_api.py
@@ -1,5 +1,6 @@
 import json
 from datetime import datetime, UTC
+from unittest.mock import patch
 from uuid import uuid4, UUID
 
 from flask import g
@@ -303,8 +304,8 @@ def test_set_completed_should_not_work_for_highlight(flask_client):
     assert response.json["status"] == "error"
     assert response.json["response"]["exception"] == "NotFound"
 
-
-def test_set_assignee_should_set_assignee_for_action_item(flask_client):
+@patch("argus.backend.controller.views_widgets.highlights.HighlightsService.send_action_notification")
+def test_set_assignee_should_set_assignee_for_action_item(notification, flask_client):
     view_id = str(uuid4())
     created_at = datetime.now(UTC)
     action_item_entry = WidgetHighlights(
@@ -333,6 +334,7 @@ def test_set_assignee_should_set_assignee_for_action_item(flask_client):
     assert response.status_code == 200
     assert response.json["status"] == "ok"
     assert response.json["response"]["assignee_id"] == new_assignee_id
+    assert notification.call_count == 1
 
     updated_entry = WidgetHighlights.objects(view_id=UUID(view_id), index=0, created_at=created_at).first()
     assert str(updated_entry.assignee_id) == new_assignee_id

--- a/frontend/Common/ArgusNotification.ts
+++ b/frontend/Common/ArgusNotification.ts
@@ -14,7 +14,8 @@ export enum NotificationTypes {
 
 export enum NotificationSource {
     Comment = "COMMENT",
-    TestRun = "TEST_RUN"
+    TestRun = "TEST_RUN",
+    ViewActionItem = "VIEW_ACTION_ITEM",
 }
 
 export interface ArgusNotificationJSON {

--- a/frontend/Profile/Notification.svelte
+++ b/frontend/Profile/Notification.svelte
@@ -17,6 +17,7 @@
     const ComponentSourceMap: ComponentSourceType = {
         [NotificationSource.Comment]: NotificationCommentWrapper,
         [NotificationSource.TestRun]: NotificationTestRunWrapper,
+        [NotificationSource.ViewActionItem]: NotificationTestRunWrapper,
     };
 
     const SupportDataFetch = {
@@ -31,6 +32,9 @@
             }
         },
         [NotificationSource.TestRun]: async () => {
+            return {};
+        },
+        [NotificationSource.ViewActionItem]: async () => {
             return {};
         },
     };

--- a/templates/notifications/view_action_item_assigned.html.j2
+++ b/templates/notifications/view_action_item_assigned.html.j2
@@ -1,0 +1,3 @@
+You were assigned by <span class='fw-bold'>@{{ username }}</span> to View Action <a
+        href='{{ url_for("main.view_dashboard", **{ "view_name": view_name}) }}'>{{ display_name }}</a>.
+<p>Action: {{ action }}</p>

--- a/templates/notifications/view_action_item_assigned_email.html.j2
+++ b/templates/notifications/view_action_item_assigned_email.html.j2
@@ -1,0 +1,4 @@
+<div>You were assigned by <span style="font-weight:bold">@{{ username }}</span> to View Action<a href='
+        {{ config["BASE_URL"] }}{{ url_for("main.view_dashboard", **{ "view_name": view_name}) }}'>{{ display_name }}</a>.
+    <p>Action: {{ action }}</p>
+</div>


### PR DESCRIPTION
When assigning action item in Highlights Widget,
assignee will get Argus Notification with
link to the view and action details.

closes: https://github.com/scylladb/argus/issues/500