### PR TITLE
improvement(highlights): add markdown support

### DIFF
--- a/frontend/Discussion/CommentEditor.svelte
+++ b/frontend/Discussion/CommentEditor.svelte
@@ -1,5 +1,5 @@
 <script>
-    import { createEventDispatcher } from "svelte";
+    import { createEventDispatcher, onMount } from "svelte";
     import { parse as markdownParse } from "marked";
     import Fa from "svelte-fa";
     import {
@@ -33,6 +33,11 @@
         test_run_id: "",
         posted_at: new Date(),
     };
+    export let entryType = "comment";
+
+    onMount(() => {
+        textArea?.focus();
+    });
 
     const randomTip = function () {
         const editorTips = [
@@ -332,7 +337,7 @@
             <span class="fw-bold"><Fa icon={faLightbulb} /> Tip</span>: {randomTip()}
         </div>
         <div class="ms-auto text-end">
-            {#if mode == "edit"}
+            {#if mode == "edit" || entryType != "comment"}
                 <button
                     class="btn btn-danger"
                     on:click={() => {
@@ -341,7 +346,7 @@
                 >
             {/if}
             <button class="btn btn-success" on:click={handleSubmitComment}
-                >{mode == "post" ? "Submit" : "Update"} comment</button
+            >{mode == "post" ? "Submit" : "Update"} {entryType}</button
             >
         </div>
     </div>

--- a/frontend/Views/Widgets/ViewHighlights/ViewHighlights.svelte
+++ b/frontend/Views/Widgets/ViewHighlights/ViewHighlights.svelte
@@ -6,6 +6,7 @@
     import {userList} from "../../../Stores/UserlistSubscriber";
     import HighlightItem from "./HighlightItem.svelte";
     import ActionItem from "./ActionItem.svelte";
+    import CommentEditor from "../../../Discussion/CommentEditor.svelte";
 
     export let dashboardObject;
     export let settings;
@@ -90,6 +91,7 @@
         };
     }
 
+
     const addEntry = async (type: "highlight" | "action", content: string) => {
         if (!content.trim()) return;
         const response = await fetch("/api/v1/views/widgets/highlights/create", {
@@ -115,6 +117,12 @@
                 showNewHighlight = false;
             }
         }
+    };
+    const handleHightlightCreate = function (e) {
+        addEntry("highlight", e.detail.message);
+    };
+    const handleActionItemCreate = function (e) {
+        addEntry("action", e.detail.message);
     };
 
     const handleToggleArchive = async (event) => {
@@ -314,12 +322,13 @@
                     {/each}
                     <li class="list-group-item">
                         {#if showNewHighlight}
-                            <div class="input-group">
-                                <input type="text" class="form-control" placeholder="New highlight" bind:value={newHighlight}
-                                       on:keydown={(e) => e.key === "Enter" && addEntry("highlight", newHighlight)}
-                                       bind:this={newHighlightInput}>
-                                <button class="btn btn-primary" on:click={() => addEntry("highlight", newHighlight)}>Add</button>
-                                <button class="btn btn-outline-secondary" on:click={() => showNewHighlight = false}>Cancel</button>
+                            <div class="flex-grow-1">
+                                <CommentEditor
+                                        mode="post"
+                                        entryType="highlight"
+                                        on:submitComment={handleHightlightCreate}
+                                        on:cancelEditing={() => (showNewHighlight = false)}
+                                />
                             </div>
                         {:else}
                             <button class="btn w-100 text-start text-muted" on:click={() => showNewHighlight = true}>
@@ -375,12 +384,13 @@
                     {/each}
                     <li class="list-group-item">
                         {#if showNewActionItem}
-                            <div class="input-group">
-                                <input type="text" class="form-control" placeholder="New action item" bind:value={newActionItem}
-                                       on:keydown={(e) => e.key === "Enter" && addEntry("action", newActionItem)}
-                                       bind:this={newActionInput}>
-                                <button class="btn btn-primary" on:click={() => addEntry("action", newActionItem)}>Add</button>
-                                <button class="btn btn-outline-secondary" on:click={() => showNewActionItem = false}>Cancel</button>
+                            <div class="flex-grow-1">
+                                <CommentEditor
+                                        mode="post"
+                                        entryType="action item"
+                                        on:submitComment={handleActionItemCreate}
+                                        on:cancelEditing={() => (showNewActionItem = false)}
+                                />
                             </div>
                         {:else}
                             <button class="btn w-100 text-start text-muted" on:click={() => showNewActionItem = true}>
@@ -418,3 +428,10 @@
         </div>
     {/key}
 </div>
+
+<style>
+    :global(.no-bottom-margin *:last-child) {
+    margin-bottom: 0;
+}
+
+</style>


### PR DESCRIPTION
Added support for highlights widget.
Reused 'comments' editor known from job discussions. Thus implementing all that is supported by this component: titles, links, multi-line content, code blocks etc.

One caveat: mentioning does not trigger notifications yet. This is going to be done in followup task.

closes: https://github.com/scylladb/argus/issues/510

![image](https://github.com/user-attachments/assets/f825b235-eb3a-460c-a3e5-e0baf0f21628)
