### PR TITLE
fix(hightlights-view): fix comment section in action items

### DIFF
--- a/frontend/Views/Widgets/ViewHighlights/ActionItem.svelte
+++ b/frontend/Views/Widgets/ViewHighlights/ActionItem.svelte
@@ -101,6 +101,7 @@
                 />
             </div>
         {/if}
+    </div>
         {#if action.showComments}
             <div class="mt-2 col-md-10">
                 <ul class="list-group list-group-flush">


### PR DESCRIPTION
Action items missed one div enclosing mark. Fix it to repair layout.