### PR TITLE
fix(summary-widget): use upgraded or upgrade-target as summary version

### DIFF
--- a/argus/backend/plugins/sct/testrun.py
+++ b/argus/backend/plugins/sct/testrun.py
@@ -267,7 +267,7 @@ class SCTTestRun(PluginModelBase):
         except IndexError:
             scylla_package_upgraded = None
         try:
-            scylla_package = [package for package in self.packages if package.name == "scylla-server"][0]
+            scylla_package = scylla_package_upgraded or [package for package in self.packages if package.name == "scylla-server"][0]
         except IndexError:
             raise ValueError("Scylla package not found in packages - cannot determine SUT timestamp")
         return (datetime.strptime(scylla_package.date, '%Y%m%d').replace(tzinfo=timezone.utc).timestamp()

--- a/argus/backend/service/results_service.py
+++ b/argus/backend/service/results_service.py
@@ -593,14 +593,14 @@ class ResultsService:
                 test_method = row['test_method']
                 if not test_method:
                     continue
-                sut_version = next(
-                    (f"{pkg.version}-{pkg.date}-{pkg.revision_id}" for pkg in packages if pkg.name == f"{sut_package_name}-upgraded"),
-                    None
-                ) or next(
-                    (f"{pkg.version}-{pkg.date}-{pkg.revision_id}" for pkg in packages if pkg.name.startswith(sut_package_name)),
-                    None
-                )
-
+                for sut_name in [f"{sut_package_name}-upgraded",
+                            f"{sut_package_name}-upgrade-target",
+                            sut_package_name,
+                            f"{sut_package_name}-target"
+                            ]:
+                    sut_version = next((f"{pkg.version}-{pkg.date}-{pkg.revision_id}" for pkg in packages if pkg.name == sut_name), None)
+                    if sut_version:
+                        break
                 if sut_version is None:
                     continue
                 method_name = test_method.rsplit('.', 1)[-1]


### PR DESCRIPTION
In case upgrade test fails before upgrading any node,
scylla-server-upgrade-target should be taken as Scylla version.
Otherwise summary widget won't show such run for given Scylla version.

Fixed automatic sut_timestamp in results as was not using upgraded version too 