### PR TITLE
feature(graphs-views): show predefined list of graphs

### DIFF
--- a/argus/backend/controller/api.py
+++ b/argus/backend/controller/api.py
@@ -409,10 +409,42 @@ def test_results():
         return Response(status=200 if exists else 404)
 
     graphs, ticks, releases_filters = service.get_test_graphs(test_id=UUID(test_id), start_date=start_date, end_date=end_date, table_names=table_names)
+    graph_views = service.get_argus_graph_views(test_id=UUID(test_id))
 
     return {
         "status": "ok",
-        "response": {"graphs": graphs, "ticks": ticks, "releases_filters": releases_filters}
+        "response": {"graphs": graphs, "ticks": ticks, "releases_filters": releases_filters, "graph_views": graph_views}
+    }
+
+@bp.route("/create-graph-view", methods=["POST"])
+@api_login_required
+def create_graph_view():
+    payload = get_payload(request)
+    service = ResultsService()
+    test_id = payload["testId"]
+    name = payload["name"]
+    description = payload["description"]
+    graph_view = service.create_argus_graph_view(test_id=UUID(test_id), name=name, description=description)
+    return {
+        "status": "ok",
+        "response": graph_view
+    }
+
+@bp.route("/update-graph-view", methods=["POST"])
+@api_login_required
+def update_graph_view():
+    payload = get_payload(request)
+    service = ResultsService()
+    test_id = payload["testId"]
+    id = payload["id"]
+    name = payload["name"]
+    description = payload["description"]
+    graphs = payload["graphs"]
+    graph_view = service.update_argus_graph_view(test_id=UUID(test_id), view_id=UUID(id), name=name, description=description,
+                                                 graphs=graphs)
+    return {
+        "status": "ok",
+        "response": graph_view
     }
 
 @bp.route("/test_run/comment/get", methods=["GET"])  # TODO: remove

--- a/argus/backend/models/result.py
+++ b/argus/backend/models/result.py
@@ -171,3 +171,11 @@ class ArgusBestResultData(Model):
     key = columns.Ascii(primary_key=True)  # represents pair column:row
     value = columns.Double()
     run_id = columns.UUID()
+
+class ArgusGraphView(Model):
+    __table_name__ = "graph_view_v1"
+    test_id = columns.UUID(partition_key=True)
+    id = columns.UUID(primary_key=True)
+    name = columns.Text()
+    description = columns.Text()
+    graphs = columns.Map(key_type=columns.Text(), value_type=columns.Ascii())  # key: graph name, value: graph properties (e.g. size)

--- a/argus/backend/models/web.py
+++ b/argus/backend/models/web.py
@@ -7,7 +7,7 @@ from cassandra.cqlengine import columns
 from cassandra.util import uuid_from_time, unix_time_from_uuid1  # pylint: disable=no-name-in-module
 
 from argus.backend.models.plan import ArgusReleasePlan
-from argus.backend.models.result import ArgusGenericResultMetadata, ArgusGenericResultData, ArgusBestResultData
+from argus.backend.models.result import ArgusGenericResultMetadata, ArgusGenericResultData, ArgusBestResultData, ArgusGraphView
 from argus.backend.models.view_widgets import WidgetHighlights, WidgetComment
 
 
@@ -393,6 +393,7 @@ USED_MODELS: list[Model] = [
     ArgusReleasePlan,
     WidgetHighlights,
     WidgetComment,
+    ArgusGraphView,
 ]
 
 USED_TYPES: list[UserType] = [

--- a/frontend/TestRun/Components/Filters.svelte
+++ b/frontend/TestRun/Components/Filters.svelte
@@ -1,87 +1,87 @@
 <script lang="ts">
-    import {onMount} from 'svelte'
+    import {onMount} from 'svelte';
 
-    export let graphs: any[] = []
-    export let filteredGraphs: any[] = []
-    let tableFilters: { level: number; items: string[] }[] = []
-    let columnFilters: string[] = []
-    let selectedTableFilters: { name: string; level: number }[] = []
-    let selectedColumnFilters: string[] = []
+    export let graphs: any[] = [];
+    export let filteredGraphs: any[] = [];
+    let tableFilters: { level: number; items: string[] }[] = [];
+    let columnFilters: string[] = [];
+    let selectedTableFilters: { name: string; level: number }[] = [];
+    let selectedColumnFilters: string[] = [];
 
     function extractTableFilters() {
-        let fltrs = new Map<number, Set<string>>()
+        let fltrs = new Map<number, Set<string>>();
         for (let g of graphs) {
-            const parts = g.options.plugins.title.text.split("-").slice(0, -1).map(p => p.trim())
+            const parts = g.options.plugins.title.text.split("-").slice(0, -1).map(p => p.trim());
             parts.forEach((p, i) => {
-                const lvl = i + 1
-                if (!fltrs.has(lvl)) fltrs.set(lvl, new Set())
-                fltrs.get(lvl)?.add(p)
-            })
+                const lvl = i + 1;
+                if (!fltrs.has(lvl)) fltrs.set(lvl, new Set());
+                fltrs.get(lvl)?.add(p);
+            });
         }
         tableFilters = [...fltrs.entries()]
             .sort((a, b) => a[0] - b[0])
-            .map(([level, items]) => ({level, items: [...items]}))
+            .map(([level, items]) => ({level, items: [...items]}));
     }
 
     function extractColumnFilters() {
-        let fltrs = new Set<string>()
+        let fltrs = new Set<string>();
         for (let g of graphs) {
-            const parts = g.options.plugins.title.text.split("-").slice(-1).map(p => p.trim())
-            parts.forEach(p => fltrs.add(p))
+            const parts = g.options.plugins.title.text.split("-").slice(-1).map(p => p.trim());
+            parts.forEach(p => fltrs.add(p));
         }
-        columnFilters = [...fltrs]
+        columnFilters = [...fltrs];
     }
 
     function toggleTableFilter(filter: string, level: number) {
-        const existing = selectedTableFilters.find(f => f.level === level)
+        const existing = selectedTableFilters.find(f => f.level === level);
         if (existing && existing.name === filter) {
-            selectedTableFilters = selectedTableFilters.filter(f => f.level !== level)
+            selectedTableFilters = selectedTableFilters.filter(f => f.level !== level);
         } else {
-            selectedTableFilters = [...selectedTableFilters.filter(f => f.level !== level), {name: filter, level}]
+            selectedTableFilters = [...selectedTableFilters.filter(f => f.level !== level), {name: filter, level}];
         }
-        filterTables()
+        filterTables();
     }
 
     function toggleColumnFilter(filter: string) {
         selectedColumnFilters = selectedColumnFilters.includes(filter)
             ? selectedColumnFilters.filter(f => f !== filter)
-            : [...selectedColumnFilters, filter]
-        filterTables()
+            : [...selectedColumnFilters, filter];
+        filterTables();
     }
 
     function filterTables() {
         if (!selectedTableFilters.length && !selectedColumnFilters.length) {
-            filteredGraphs = graphs
-            return
+            filteredGraphs = graphs;
+            return;
         }
         filteredGraphs = graphs.filter(g => {
-            const parts = g.options.plugins.title.text.split("-").map(p => p.trim())
-            const matchTable = selectedTableFilters.every(f => parts.includes(f.name))
-            const matchCol = !selectedColumnFilters.length || selectedColumnFilters.some(f => parts.includes(f))
-            return matchTable && matchCol
-        })
+            const parts = g.options.plugins.title.text.split("-").map(p => p.trim());
+            const matchTable = selectedTableFilters.every(f => parts.includes(f.name));
+            const matchCol = !selectedColumnFilters.length || selectedColumnFilters.some(f => parts.includes(f));
+            return matchTable && matchCol;
+        });
     }
 
     function clearTableFilters() {
-        selectedTableFilters = []
-        filterTables()
+        selectedTableFilters = [];
+        filterTables();
     }
 
     function clearColumnFilters() {
-        selectedColumnFilters = []
-        filterTables()
+        selectedColumnFilters = [];
+        filterTables();
     }
 
     function getTableFilterColor(level: number) {
-        const colors = ["#B8EFFF", "#FECBA1", "#D6B3E6", "#FFE699", "#F0A5C5", "#C4C8CA"]
-        return colors[(level - 1) % colors.length]
+        const colors = ["#B8EFFF", "#FECBA1", "#D6B3E6", "#FFE699", "#F0A5C5", "#C4C8CA"];
+        return colors[(level - 1) % colors.length];
     }
 
     onMount(() => {
-        extractTableFilters()
-        extractColumnFilters()
-        filterTables()
-    })
+        extractTableFilters();
+        extractColumnFilters();
+        filterTables();
+    });
 </script>
 
 <span>Filters:</span>

--- a/frontend/TestRun/Components/Filters.svelte
+++ b/frontend/TestRun/Components/Filters.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+    import {onMount} from 'svelte'
+
+    export let graphs: any[] = []
+    export let filteredGraphs: any[] = []
+    let tableFilters: { level: number; items: string[] }[] = []
+    let columnFilters: string[] = []
+    let selectedTableFilters: { name: string; level: number }[] = []
+    let selectedColumnFilters: string[] = []
+
+    function extractTableFilters() {
+        let fltrs = new Map<number, Set<string>>()
+        for (let g of graphs) {
+            const parts = g.options.plugins.title.text.split("-").slice(0, -1).map(p => p.trim())
+            parts.forEach((p, i) => {
+                const lvl = i + 1
+                if (!fltrs.has(lvl)) fltrs.set(lvl, new Set())
+                fltrs.get(lvl)?.add(p)
+            })
+        }
+        tableFilters = [...fltrs.entries()]
+            .sort((a, b) => a[0] - b[0])
+            .map(([level, items]) => ({level, items: [...items]}))
+    }
+
+    function extractColumnFilters() {
+        let fltrs = new Set<string>()
+        for (let g of graphs) {
+            const parts = g.options.plugins.title.text.split("-").slice(-1).map(p => p.trim())
+            parts.forEach(p => fltrs.add(p))
+        }
+        columnFilters = [...fltrs]
+    }
+
+    function toggleTableFilter(filter: string, level: number) {
+        const existing = selectedTableFilters.find(f => f.level === level)
+        if (existing && existing.name === filter) {
+            selectedTableFilters = selectedTableFilters.filter(f => f.level !== level)
+        } else {
+            selectedTableFilters = [...selectedTableFilters.filter(f => f.level !== level), {name: filter, level}]
+        }
+        filterTables()
+    }
+
+    function toggleColumnFilter(filter: string) {
+        selectedColumnFilters = selectedColumnFilters.includes(filter)
+            ? selectedColumnFilters.filter(f => f !== filter)
+            : [...selectedColumnFilters, filter]
+        filterTables()
+    }
+
+    function filterTables() {
+        if (!selectedTableFilters.length && !selectedColumnFilters.length) {
+            filteredGraphs = graphs
+            return
+        }
+        filteredGraphs = graphs.filter(g => {
+            const parts = g.options.plugins.title.text.split("-").map(p => p.trim())
+            const matchTable = selectedTableFilters.every(f => parts.includes(f.name))
+            const matchCol = !selectedColumnFilters.length || selectedColumnFilters.some(f => parts.includes(f))
+            return matchTable && matchCol
+        })
+    }
+
+    function clearTableFilters() {
+        selectedTableFilters = []
+        filterTables()
+    }
+
+    function clearColumnFilters() {
+        selectedColumnFilters = []
+        filterTables()
+    }
+
+    function getTableFilterColor(level: number) {
+        const colors = ["#B8EFFF", "#FECBA1", "#D6B3E6", "#FFE699", "#F0A5C5", "#C4C8CA"]
+        return colors[(level - 1) % colors.length]
+    }
+
+    onMount(() => {
+        extractTableFilters()
+        extractColumnFilters()
+        filterTables()
+    })
+</script>
+
+<span>Filters:</span>
+<div class="filters-container">
+    <div class="input-group input-group-inline input-group-sm mx-1">
+        <button class="btn btn-outline-dark colored" on:click={clearTableFilters}>X</button>
+    </div>
+    {#each tableFilters as group}
+        <div class="input-group input-group-inline input-group-sm mx-1">
+            {#each group.items as filter}
+                <button
+                        class="btn btn-outline-dark colored"
+                        on:click={()=>toggleTableFilter(filter,group.level)}
+                        class:selected={selectedTableFilters.some(f=>f.name===filter)}
+                        style="background-color:{getTableFilterColor(group.level)}">
+                    {filter}
+                </button>
+            {/each}
+        </div>
+    {/each}
+</div>
+
+<span>Metrics:</span>
+<div class="filters-container">
+    <div class="input-group input-group-inline input-group-sm mx-1">
+        <button class="btn btn-outline-dark colored" on:click={clearColumnFilters}>X</button>
+    </div>
+    <div class="input-group input-group-inline input-group-sm mx-1">
+        {#each columnFilters as filter}
+            <button
+                    class="btn btn-outline-dark colored"
+                    on:click={()=>toggleColumnFilter(filter)}
+                    class:selected={selectedColumnFilters.includes(filter)}
+                    style="background-color: #a3e2cc">
+                {filter}
+            </button>
+        {/each}
+    </div>
+</div>
+
+<style>
+    .filters-container {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        margin-bottom: 20px
+    }
+
+    .input-group-inline {
+        width: auto;
+    }
+
+    button.colored:not(.selected):not(:hover) {
+        background-color: #f0f0f0 !important;
+    }
+
+    .date-input {
+        max-width: 200px;
+    }
+</style>

--- a/frontend/TestRun/ResultsGraphs.svelte
+++ b/frontend/TestRun/ResultsGraphs.svelte
@@ -1,33 +1,46 @@
-<script>
-    import {createEventDispatcher, onMount} from "svelte";
+<script lang="ts">
+    import {createEventDispatcher} from "svelte";
+    import queryString from "query-string";
     import {sendMessage} from "../Stores/AlertStore";
     import ResultsGraph from "./ResultsGraph.svelte";
+    import Filters from "./Components/Filters.svelte";
+    import {faMinus, faPlus} from "@fortawesome/free-solid-svg-icons";
+    import Fa from "svelte-fa";
     import GraphFilters from "./Components/GraphFilters.svelte";
-    import dayjs from "dayjs";
-    import queryString from "query-string";
 
-    export let test_id = "";
-    let graphs = [];
-    let ticks = {};
-    let releasesFilters = {};
-    let tableFilters = [];
-    let columnFilters = [];
-    let selectedTableFilters = [];
-    let selectedColumnFilters = [];
-    let filteredGraphs = [];
+    export let test_id: string = "";
+    let graphs: any[] = [];
+    let allGraphs: any[] = [];
+    let filteredGraphs: any[] = [];
+    let releasesFilters: Record<string, boolean> = {};
+    let ticks: Record<string, any> = {};
+    let width = 500;
+    let height = 350;
     let startDate = "";
     let endDate = "";
     let dateRange = 6;
     let showCustomInputs = false;
-    let width = 500;  // default width for each chart
-    let height = 350;  // default height for each chart
+    let graphViews: {
+        test_id: string;
+        id: string;
+        name: string;
+        description: string;
+        graphs: Record<string, any>;
+    }[] = [];
+    let showModal = false;
+    let activeTab = 0;
+    let form = {name: "", description: ""};
+    let showAddGraphModal = false;
+    let showRemoveGraphModal = false;
+    let selectedGraph: any;
+    let selectedView = "";
 
+    $: allTabs = ["All Graphs", ...graphViews.map((v) => v.name), "+ View"];
     const dispatch = createEventDispatcher();
 
     const dispatchRunClick = (e) => {
         dispatch("runClick", {runId: e.detail.runId});
     };
-
 
     const generateRandomHash = () => {
         return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
@@ -39,85 +52,152 @@
         fetchTestResults(test_id);
     };
 
-    const handleReleaseChange = () => {
-        filterGraphs();
-    };
 
-    const extractTableFilters = () => {
-        let fltrs = new Map();
-        graphs.forEach(graph => {
-            const title = graph.options.plugins.title.text;
-            const parts = title.split("-").slice(0, -1);
-            parts.forEach((part, index) => {
-                const level = index + 1;
-                if (!fltrs.has(level)) {
-                    fltrs.set(level, new Set());
-                }
-                fltrs.get(level).add(part.trim());
-            });
-        });
-        tableFilters = Array.from(fltrs.entries()).sort((a, b) => a[0] - b[0]).map(entry => ({
-            level: entry[0],
-            items: Array.from(entry[1])
-        }));
-    };
-
-    async function fetchTestResults(tid: string) {
+    async function fetchTestResults(testId: string) {
         try {
-            const params = queryString.stringify({testId: tid, startDate, endDate})
-            const res = await fetch(`/api/v1/test-results?${params}`)
-            if (res.status !== 200) throw `HTTP Error ${res.status}`
-            const data = await res.json()
-            if (data.status !== 'ok') throw `API Error: ${data.message}`
-            graphs = data.response.graphs.map((g: any) => ({...g, id: generateRandomHash()}))
-            ticks = data.response.ticks
-            releasesFilters = Object.fromEntries(data.response.releases_filters.map((r: string) => [r, true]))
+            const params = queryString.stringify({testId: testId, startDate, endDate});
+            const res = await fetch(`/api/v1/test-results?${params}`);
+            if (res.status !== 200) throw new Error(`HTTP Error ${res.status}`);
+
+            const data = await res.json();
+            if (data.status !== "ok") throw new Error(`API Error: ${data.message}`);
+
+            allGraphs = data.response.graphs.map((g: any) => ({
+                ...g,
+                id: generateRandomHash(),
+            }));
+            ticks = data.response.ticks;
+            graphs = allGraphs;
+            graphViews = data.response.graph_views;
+            releasesFilters = Object.fromEntries(
+                data.response.releases_filters.map((r: string) => [r, true])
+            );
         } catch (e) {
-            sendMessage('error', 'A backend error occurred', 'ResultsGraphs::fetchTestResults')
-            console.log(e)
+            sendMessage("error", "A backend error occurred", "ResultsGraphs::fetchTestResults");
+            console.error(e);
         }
-        filterGraphs();
-    };
+    }
 
+    function handleTabClick(i: number) {
+        if (allTabs[i] === "+ View") showModal = true;
+        else activeTab = i;
+        if (activeTab > 0) graphs = Object.keys(graphViews[activeTab - 1].graphs).map((g) => getGraphsByName(g)[0]);
+        else graphs = allGraphs;
+    }
 
-    const filterGraphs = () => {
-        if (selectedTableFilters.length === 0 && selectedColumnFilters.length === 0) {
-            filteredGraphs = graphs.map(graph => ({...graph, id: generateRandomHash()}));
-        } else {
-            filteredGraphs = graphs
-                .filter(graph => {
-                    const title = graph.options.plugins.title.text;
-                    const parts = title.split("-").map(part => part.trim());
-                    const matchesTableFilters = selectedTableFilters.every(filter => parts.includes(filter.name));
-                    const matchesColumnFilters = selectedColumnFilters.length === 0
-                        || selectedColumnFilters.some(filter => parts.includes(filter));
-                    return matchesTableFilters && matchesColumnFilters;
-                })
-                .map(graph => ({...graph, id: generateRandomHash()}));
+    function closeModal() {
+        showModal = false;
+    }
+
+    function getGraphsByName(graphName: string) {
+        return allGraphs.filter((g) => g.options?.plugins?.title?.text === graphName);
+    }
+
+    function openAddGraphModal(g: any) {
+        selectedGraph = g;
+        showAddGraphModal = true;
+    }
+
+    function openRemoveGraphModal(g: any) {
+        selectedGraph = g;
+        showRemoveGraphModal = true;
+    }
+
+    function closeAddGraphModal() {
+        showAddGraphModal = false;
+    }
+
+    function closeRemoveGraphModal() {
+        showRemoveGraphModal = false;
+    }
+
+    async function saveNewView() {
+        const payload = {
+            testId: test_id,
+            name: form.name,
+            description: form.description,
+        };
+        try {
+            const res = await fetch("/api/v1/create-graph-view", {
+                method: "POST",
+                headers: {"Content-Type": "application/json"},
+                body: JSON.stringify(payload),
+            });
+            if (!res.ok) throw new Error(`Error: ${res.status}`);
+            const data = await res.json();
+            if (data.status !== "ok") throw new Error(data.message);
+
+            graphViews = [...graphViews, data.response];
+            form = {name: "", description: ""};
+            closeModal();
+        } catch (e) {
+            sendMessage("error", "Failed to create graph view", "saveNewView");
         }
+    }
+
+    async function updateArgusGraphView(view: {
+        id: string;
+        name: string;
+        description: string;
+        graphs: Record<string, any>;
+    }) {
+        const payload = {
+            testId: test_id,
+            id: view.id,
+            name: view.name,
+            description: view.description,
+            graphs: view.graphs,
+        };
+
+        try {
+            const res = await fetch("/api/v1/update-graph-view", {
+                method: "POST",
+                headers: {"Content-Type": "application/json"},
+                body: JSON.stringify(payload),
+            });
+            if (!res.ok) throw new Error(`Error: ${res.status}`);
+            const data = await res.json();
+            if (data.status !== "ok") throw new Error(data.message);
+
+            const idx = graphViews.findIndex((v) => v.id === view.id);
+            if (idx !== -1) graphViews[idx] = data.response;
+        } catch (e) {
+            sendMessage("error", "Failed to update graph view", "updateArgusGraphView");
+        }
+    }
+
+    function addGraphToView() {
+        if (!selectedView) return;
+        const idx = graphViews.findIndex((v) => v.name === selectedView);
+        if (idx === -1) return;
+
+        graphViews[idx].graphs = {
+            ...graphViews[idx].graphs,
+            [selectedGraph.options.plugins.title.text]: "{}",
+        };
+
+        updateArgusGraphView(graphViews[idx]);
+        closeAddGraphModal();
+    }
+
+    function removeGraph() {
+        if (!selectedGraph) return;
+
+        const activeViewId = graphViews[activeTab - 1]?.id;
+        const idx = graphViews.findIndex((v) => v.id === activeViewId);
+        if (idx === -1) return;
+
+        const graphName = selectedGraph?.options?.plugins?.title?.text;
+        delete graphViews[idx].graphs[graphName];
+        graphs = Object.keys(graphViews[activeTab - 1].graphs).map((g) => getGraphsByName(g)[0]);
+
+        updateArgusGraphView(graphViews[idx]);
+        closeRemoveGraphModal();
+    }
+    const handleReleaseChange = () => {
+        filteredGraphs = [...filteredGraphs];
     };
 
-    const getTableFilterColor = (level) => {
-        const intermediateColors = [
-            "#B8EFFF",
-            "#FECBA1",
-            "#D6B3E6",
-            "#FFE699",
-            "#F0A5C5",
-            "#C4C8CA",
-        ];
-        return intermediateColors[level - 1 % intermediateColors.length];
-    };
-
-    const toggleReleaseFilter = (filterName) => {
-        releasesFilters[filterName] = !releasesFilters[filterName];
-        filterGraphs();
-    };
-
-    onMount(() => {
-        // setDefaultDateRange();
-        // fetchTestResults(test_id);
-    });
 </script>
 
 <GraphFilters
@@ -127,14 +207,31 @@
         on:releaseChange={handleReleaseChange}
 />
 
-
+<ul class="nav nav-tabs mb-3">
+    {#each allTabs as t, i}
+        <li class="nav-item">
+            <a class="nav-link {activeTab === i ? 'active' : ''}" on:click={() => handleTabClick(i)}>{t}</a>
+        </li>
+    {/each}
+</ul>
+<h5 class="text-center">{graphViews[activeTab - 1]?.description || "All graphs"}</h5>
 {#key graphs}
     <Filters {graphs} bind:filteredGraphs/>
 {/key}
 <div class="charts-container">
+    {#key filteredGraphs}
     {#each filteredGraphs as graph (graph.id)}
         <div class="chart-container"
              class:big-size={filteredGraphs.length < 2}>
+            {#if activeTab === 0}
+                    <button class="add-btn" on:click={() => openAddGraphModal(graph)} title="add to graph view">
+                        <Fa icon={faPlus}/>
+                    </button>
+                {:else}
+                    <button class="add-btn" on:click={() => openRemoveGraphModal(graph)} title="Remove from graph view">
+                        <Fa icon={faMinus}/>
+                    </button>
+                {/if}
             <ResultsGraph
                     {graph}
                     {ticks}
@@ -147,39 +244,117 @@
             />
         </div>
     {/each}
+        {/key}
 </div>
 
+{#if showModal}
+    <div class="modal show d-block" tabindex="-1" role="dialog" on:click={closeModal}>
+        <div class="modal-dialog" role="document" on:click|stopPropagation>
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">New View</h5>
+                    <button type="button" class="close" on:click={closeModal}>&times;</button>
+                </div>
+                <div class="modal-body">
+                    <div class="form-group">
+                        <label>Name</label>
+                        <input class="form-control" type="text" bind:value={form.name}/>
+                    </div>
+                    <div class="form-group">
+                        <label>Description</label>
+                        <textarea class="form-control" bind:value={form.description}></textarea>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-primary" on:click={saveNewView}>Save</button>
+                    <button type="button" class="btn btn-secondary" on:click={closeModal}>Cancel</button>
+                </div>
+            </div>
+        </div>
+    </div>
+{/if}
+
+{#if showAddGraphModal}
+    <div class="modal show d-block" tabindex="-1" role="dialog" on:click={closeAddGraphModal}>
+        <div class="modal-dialog" role="document" on:click|stopPropagation>
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Add Graph to View</h5>
+                    <button type="button" class="close" on:click={closeAddGraphModal}>&times;</button>
+                </div>
+                <div class="modal-body">
+                    <div class="form-group">
+                        <label>Select Graph View</label>
+                        <select class="form-control" bind:value={selectedView}>
+                            <option value="" disabled>Select a view</option>
+                            {#each graphViews as v}
+                                <option value={v.name}>{v.name}</option>
+                            {/each}
+                        </select>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-primary" on:click={addGraphToView}>Add</button>
+                    <button class="btn btn-secondary" on:click={closeAddGraphModal}>Cancel</button>
+                </div>
+            </div>
+        </div>
+    </div>
+{/if}
+
+{#if showRemoveGraphModal}
+    <div class="modal show d-block" tabindex="-1" role="dialog" on:click={closeRemoveGraphModal}>
+        <div class="modal-dialog" role="document" on:click|stopPropagation>
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Remove Graph?</h5>
+                    <button type="button" class="close" on:click={closeRemoveGraphModal}>&times;</button>
+                </div>
+                <div class="modal-body">
+                    <p>Remove <strong>{selectedGraph?.options?.plugins?.title?.text}</strong> from this view?</p>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-danger" on:click={removeGraph}>Remove</button>
+                    <button class="btn btn-secondary" on:click={closeRemoveGraphModal}>Cancel</button>
+                </div>
+            </div>
+        </div>
+    </div>
+{/if}
+
 <style>
-    .filters-container {
-        display: flex;
-        flex-direction: row;
-        flex-wrap: wrap;
-        margin-bottom: 20px
-    }
-
-    .input-group-inline {
-        width: auto
-    }
-
     .charts-container {
         display: flex;
         flex-wrap: wrap;
         justify-content: center;
-        align-items: center
+        align-items: center;
     }
 
     .chart-container {
         display: flex;
         justify-content: center;
         align-items: center;
-        margin: 10px
+        margin: 10px;
+        position: relative;
     }
 
     .big-size {
-        width: 90%
+        width: 90%;
     }
 
-    .date-input {
-        max-width: 130px
+    .add-btn {
+        position: absolute;
+        top: 10px;
+        left: 10px;
+        background: none;
+        border: none;
+        cursor: pointer;
+        color: #888;
+        font-size: 1.2em;
+        z-index: 1000;
+    }
+
+    .add-btn:hover {
+        color: #333;
     }
 </style>


### PR DESCRIPTION
Users are allowed to create 'Graph Views' which can store specific
graphs. Created Graph Views are visible in test's graph window and can
be selected for quick look on saved graphs list. This way saving time
for playing with filters.

Graph Views may have a name and description.

closes: https://github.com/scylladb/argus/issues/554

Main View with all the graphs:
![image](https://github.com/user-attachments/assets/3ba1fdda-5b3d-44d7-9316-309df848e2d8)

When View is activated:
![image](https://github.com/user-attachments/assets/ea295624-8b27-4703-a55e-1b7b944ceeeb)

Adding new view:
![image](https://github.com/user-attachments/assets/17d6795f-0666-42e4-986d-eba78a676fd0)

Graphs may be added/removed by left top corner button (with tooltip).
Filters are created for each Graph View and work within it.