### PR TITLE
fix(highlights): don't redraw on usersList update

### DIFF
--- a/frontend/Views/Widgets/ViewHighlights/ViewHighlights.svelte
+++ b/frontend/Views/Widgets/ViewHighlights/ViewHighlights.svelte
@@ -49,9 +49,11 @@
     let newActionInput: HTMLInputElement;
     let newHighlightInput: HTMLInputElement;
 
-    $: users = $userList;
-    $: if (users) {
-        redraw++;
+    $: {
+        if (Object.keys(users).length === 0 && Object.keys($userList).length > 0) {
+            users = $userList;
+            redraw++
+        }
     }
 
     onMount(async () => {


### PR DESCRIPTION
Highlights widget gets redrawn when userList changes. This is not required usually as userList should not change.

fixes: https://github.com/scylladb/argus/issues/564