### PR TITLE
improvement(graphs): add show graph button for each column in results

### DIFF
--- a/argus/backend/controller/api.py
+++ b/argus/backend/controller/api.py
@@ -395,6 +395,7 @@ def test_results():
     test_id = request.args.get("testId")
     start_date_str = request.args.get("startDate")
     end_date_str = request.args.get("endDate")
+    table_names = request.args.getlist("tableNames[]")
 
     if not test_id:
         raise Exception("No testId provided")
@@ -407,7 +408,7 @@ def test_results():
         exists = service.is_results_exist(test_id=UUID(test_id))
         return Response(status=200 if exists else 404)
 
-    graphs, ticks, releases_filters = service.get_test_graphs(test_id=UUID(test_id), start_date=start_date, end_date=end_date)
+    graphs, ticks, releases_filters = service.get_test_graphs(test_id=UUID(test_id), start_date=start_date, end_date=end_date, table_names=table_names)
 
     return {
         "status": "ok",

--- a/argus/backend/service/results_service.py
+++ b/argus/backend/service/results_service.py
@@ -500,9 +500,13 @@ class ResultsService:
 
         return [{entry['table_name']: entry['table_data']} for entry in table_entries]
 
-    def get_test_graphs(self, test_id: UUID, start_date: datetime | None = None, end_date: datetime | None = None):
+    def get_test_graphs(self, test_id: UUID, start_date: datetime | None = None, end_date: datetime | None = None, table_names: list[str] | None = None):
         runs_details = self._get_runs_details(test_id)
         tables_meta = self._get_tables_metadata(test_id=test_id)
+
+        if table_names:
+            tables_meta = [table for table in tables_meta if table.name in table_names]
+
         graphs = []
         releases_filters = set()
         for table in tables_meta:

--- a/frontend/Common/ModalWindow.svelte
+++ b/frontend/Common/ModalWindow.svelte
@@ -1,12 +1,19 @@
 <script>
     import { createEventDispatcher } from "svelte";
+    import { onMount, onDestroy } from "svelte";
 
     const dispatch = createEventDispatcher();
 
     export let widthClass = "h-50";
 
+    function handleKeyDown(event) {
+        if (event.key === "Escape") {
+            dispatch("modalClose");
+        }
+    }
 </script>
 
+<svelte:window on:keydown={handleKeyDown} />
 <div class="modal-window">
     <div class="d-flex align-items-center justify-content-center p-4">
         <div class="rounded bg-white p-4 {widthClass}">

--- a/frontend/TestRun/Components/GraphFilters.svelte
+++ b/frontend/TestRun/Components/GraphFilters.svelte
@@ -1,0 +1,106 @@
+<script>
+    import dayjs from "dayjs";
+    import {createEventDispatcher, onMount} from "svelte";
+
+    export let dateRange = 6;
+    export let releasesFilters = {};
+
+    let showCustomInputs = false;
+    let startDate = "";
+    let endDate = "";
+
+    const dispatch = createEventDispatcher();
+
+    const setDateRange = (months) => {
+        if (months === -1) {
+            showCustomInputs = true;
+            return;
+        }
+        const now = dayjs();
+        endDate = now.format('YYYY-MM-DD');
+        const pastDate = now.subtract(months, 'month');
+        startDate = pastDate.format('YYYY-MM-DD');
+        showCustomInputs = false;
+        dispatch('dateChange', { startDate, endDate });
+    };
+
+    const toggleReleaseFilter = (release) => {
+        releasesFilters[release] = !releasesFilters[release];
+        dispatch('releaseChange', { releasesFilters });
+    };
+
+    onMount(() => {
+        setDateRange(dateRange);
+    });
+
+    $: setDateRange(dateRange);
+</script>
+
+<div class="filters-container">
+    <span class="my-auto">Time range:</span>
+    <div class="input-group input-group-inline input-group-sm mx-2">
+        <button class="btn btn-outline-primary btn-sm"
+                class:active={dateRange === 1}
+                on:click={() => dateRange = 1}>
+            Last Month
+        </button>
+        <button class="btn btn-outline-primary btn-sm"
+                class:active={dateRange === 3}
+                on:click={() => dateRange = 3}>
+            Last 3 Months
+        </button>
+        <button class="btn btn-outline-primary btn-sm"
+                class:active={dateRange === 6}
+                on:click={() => dateRange = 6}>
+            Last 6 Months
+        </button>
+        <button class="btn btn-outline-primary btn-sm"
+                class:active={dateRange === 12}
+                on:click={() => dateRange = 12}>
+            Last year
+        </button>
+        <button class="btn btn-outline-primary btn-sm"
+                class:active={dateRange === 24}
+                on:click={() => dateRange = 24}>
+            Last 2 years
+        </button>
+        <button class="btn btn-outline-primary btn-sm"
+                on:click={() => dateRange = -1}
+                class:active={showCustomInputs}>
+            Custom
+        </button>
+        {#if showCustomInputs}
+            <input type="date" class="form-control date-input" bind:value={startDate} on:change={() => dispatch('dateChange', { startDate, endDate })}/>
+            <input type="date" class="form-control date-input" bind:value={endDate} on:change={() => dispatch('dateChange', { startDate, endDate })}/>
+        {/if}
+    </div>
+    <span class="my-auto">Releases:</span>
+    <div class="input-group input-group-inline input-group-sm mx-2">
+        {#each Object.keys(releasesFilters) as release}
+            <button class="btn btn-sm btn-outline-dark"
+                    on:click={() => toggleReleaseFilter(release)}
+                    class:active={releasesFilters[release]}
+            >
+                {release}
+            </button>
+        {/each}
+    </div>
+</div>
+
+<style>
+    .filters-container {
+        display: flex;
+        flex-wrap: nowrap;
+        align-items: center;
+        margin: 10px 0;
+        gap: 10px;
+    }
+
+    .date-input {
+        width: 150px;
+    }
+
+    .input-group {
+        flex-wrap: nowrap;
+    }
+</style>

--- a/frontend/TestRun/Components/ScreenshotModal.svelte
+++ b/frontend/TestRun/Components/ScreenshotModal.svelte
@@ -9,17 +9,9 @@
             selectedScreenshot = "";
         }
     }
-
-    onMount(() => {
-        window.addEventListener("keydown", handleKeyDown);
-    });
-
-    onDestroy(() => {
-        window.removeEventListener("keydown", handleKeyDown);
-    });
 </script>
 
-
+<svelte:window on:keydown={handleKeyDown} />
 {#if selectedScreenshot}
     <div class="screenshot-modal">
         <div class="text-end">

--- a/frontend/TestRun/ResultsGraph.svelte
+++ b/frontend/TestRun/ResultsGraph.svelte
@@ -11,6 +11,7 @@
     export let test_id = "";
     export let width = 500;
     export let height = 300;
+    export let responsive = false;
     export let releasesFilters = {};
     let chart;
     let showModal = false;
@@ -118,7 +119,7 @@
         const tickValues = calculateTickValues(xValues, width, ticksGapPx);
 
         graph.options.animation = false;
-        graph.options.responsive = false;
+        graph.options.responsive = responsive;
         graph.options.lazy = true;
         graph.options.plugins.tooltip = {
             position: "above",

--- a/frontend/TestRun/ResultsGraphs.svelte
+++ b/frontend/TestRun/ResultsGraphs.svelte
@@ -2,6 +2,7 @@
     import {createEventDispatcher, onMount} from "svelte";
     import {sendMessage} from "../Stores/AlertStore";
     import ResultsGraph from "./ResultsGraph.svelte";
+    import GraphFilters from "./Components/GraphFilters.svelte";
     import dayjs from "dayjs";
     import queryString from "query-string";
 
@@ -16,16 +17,14 @@
     let filteredGraphs = [];
     let startDate = "";
     let endDate = "";
-    let dateRange = 3;
+    let dateRange = 6;
     let showCustomInputs = false;
     let width = 500;  // default width for each chart
     let height = 300;  // default height for each chart
 
-    $: setDateRange(dateRange);
-
     const dispatch = createEventDispatcher();
 
-    const dispatch_run_click = (e) => {
+    const dispatchRunClick = (e) => {
         dispatch("runClick", {runId: e.detail.runId});
     };
 
@@ -69,26 +68,14 @@
         return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
     };
 
-    const setDefaultDateRange = () => {
-        const now = dayjs();
-        endDate = now.format('YYYY-MM-DD');
-        const pastDate = now.subtract(3, 'month');
-        startDate = pastDate.format('YYYY-MM-DD');
+    const handleDateChange = (event) => {
+        startDate = event.detail.startDate;
+        endDate = event.detail.endDate;
+        fetchTestResults(test_id);
     };
 
-    const setDateRange = (months) => {
-        if (months === -1) {
-            startDate = "";
-            endDate = "";
-            showCustomInputs = true;
-            return;
-        }
-        const now = dayjs();
-        endDate = now.format('YYYY-MM-DD');
-        const pastDate = now.subtract(months, 'month');
-        startDate = pastDate.format('YYYY-MM-DD');
-        showCustomInputs = false;
-        fetchTestResults(test_id);
+    const handleReleaseChange = () => {
+        filterGraphs();
     };
 
     const extractTableFilters = () => {
@@ -179,59 +166,17 @@
     };
 
     onMount(() => {
-        setDefaultDateRange();
+        // setDefaultDateRange();
+        // fetchTestResults(test_id);
     });
 </script>
-<div class="filters-container">
-    <span class="my-auto">Time range:</span>
-    <div class="input-group input-group-inline input-group-sm mx-2">
-        <button class="btn btn-outline-primary btn-sm"
-                class:active={dateRange === 1}
-                on:click={() => dateRange = 1}>
-            Last Month
-        </button>
-        <button class="btn btn-outline-primary btn-sm"
-                class:active={dateRange === 3}
-                on:click={() => dateRange = 3}>
-            Last 3 Months
-        </button>
-        <button class="btn btn-outline-primary btn-sm"
-                class:active={dateRange === 6}
-                on:click={() => dateRange = 6}>
-            Last 6 Months
-        </button>
-        <button class="btn btn-outline-primary btn-sm"
-                class:active={dateRange === 12}
-                on:click={() => dateRange = 12}>
-            Last year
-        </button>
-        <button class="btn btn-outline-primary btn-sm"
-                class:active={dateRange === 24}
-                on:click={() => dateRange = 24}>
-            Last 2 years
-        </button>
-        <button class="btn btn-outline-primary btn-sm"
-                on:click={() => dateRange = -1}
-                class:active={showCustomInputs}>
-            Custom
-        </button>
-        {#if showCustomInputs}
-            <input type="date" class="form-control date-input" bind:value={startDate} on:change={() => fetchTestResults(test_id)}/>
-            <input type="date" class="form-control date-input" bind:value={endDate} on:change={() => fetchTestResults(test_id)}/>
-        {/if}
-    </div>
-    <span class="my-auto">Releases:</span>
-    <div class="input-group input-group-inline input-group-sm mx-2">
-        {#each Object.keys(releasesFilters) as release}
-            <button class="btn btn-sm btn-outline-dark"
-                    on:click={() => toggleReleaseFilter(release)}
-                    class:active={releasesFilters[release]}
-            >
-                {release}
-            </button>
-        {/each}
-    </div>
-</div>
+
+<GraphFilters
+        bind:dateRange
+        bind:releasesFilters
+        on:dateChange={handleDateChange}
+        on:releaseChange={handleReleaseChange}
+/>
 
 <span>Filters:</span>
 <div class="filters-container  ">
@@ -286,7 +231,7 @@
                     test_id={test_id}
                     index={graph.id}
                     releasesFilters={releasesFilters}
-                    on:runClick={dispatch_run_click}
+                    on:runClick={dispatchRunClick}
             />
         </div>
     {/each}

--- a/frontend/TestRun/ResultsTab.svelte
+++ b/frontend/TestRun/ResultsTab.svelte
@@ -144,7 +144,12 @@
         </div>
         <ul class="result-list">
             {#each Object.entries(filteredTables) as [table_name, result]}
-                <ResultTable table_name={table_name} result={result} bind:selectedScreenshot/>
+                <ResultTable
+                    table_name={table_name}
+                    result={result}
+                    test_id={test_id}
+                    bind:selectedScreenshot
+                />
             {/each}
         </ul>
     </div>

--- a/frontend/Views/Widgets/SummaryWidget/SummaryWidget.svelte
+++ b/frontend/Views/Widgets/SummaryWidget/SummaryWidget.svelte
@@ -351,8 +351,12 @@
                                                     {#each results as tableEntry}
                                                         {#each Object.entries(tableEntry) as [table_name, result]}
                                                             <li class="list-group-item">
-                                                                <ResultTable table_name={table_name} result={result}
-                                                                             bind:selectedScreenshot/>
+                                                                <ResultTable
+                                                                    {table_name}
+                                                                    {result}
+                                                                    test_id={testId}
+                                                                    bind:selectedScreenshot
+                                                                />
                                                             </li>
                                                         {/each}
                                                     {/each}


### PR DESCRIPTION
When viewing results tables users now can view graph for selected column to see values from the past/future.

closes: https://github.com/scylladb/qa-tasks/issues/1822

![image](https://github.com/user-attachments/assets/a2822d25-7cb4-4bda-b8f4-5f8608f56ea3)
after clicking one:
![image](https://github.com/user-attachments/assets/b7555d0e-f272-4d3d-a283-d00c229ef7a4)

clicking on the point opens new browser window (popup, without navigation bar) with selected test run.
Works also in summary view widget.