### PR TITLE
improvement(graph): sticky tooltips

### DIFF
--- a/frontend/TestRun/ResultsGraph.svelte
+++ b/frontend/TestRun/ResultsGraph.svelte
@@ -250,7 +250,6 @@
             },
         };
         graph.options.scales.x.min = ticks["min"];
-        graph.options.scales.x.max = ticks["max"];
         graph.options.scales.x.ticks = {
             minRotation: 45,
             callback: function (value, index) {


### PR DESCRIPTION
Graph tooltips now can be clicked to make it stick - eases screenshot, enables copying content. Also has clear button ("open") for opening related test. Tests are open in new popup window, so user doesn't lose focus from graph and can open multiple windows with tests.

closes: https://github.com/scylladb/argus/issues/508

![image](https://github.com/user-attachments/assets/95fc2a51-7214-4afa-aefc-7437a2104be0)
