### PR TITLE
improvement(results): allow manual sut selection

### DIFF
--- a/argus/backend/models/result.py
+++ b/argus/backend/models/result.py
@@ -27,6 +27,7 @@ class ArgusGenericResultMetadata(Model):
     columns_meta = columns.List(value_type=columns.UserDefinedType(ColumnMetadata))
     validation_rules = columns.Map(key_type=columns.Ascii(), value_type=columns.List(columns.UserDefinedType(ValidationRules)))
     rows_meta = columns.List(value_type=columns.Ascii())
+    sut_package_name = columns.Ascii()
 
     def __init__(self, **kwargs):
         kwargs["columns_meta"] = [ColumnMetadata(**col) for col in kwargs.pop('columns_meta', [])]

--- a/argus/backend/tests/client_service/test_submit_results.py
+++ b/argus/backend/tests/client_service/test_submit_results.py
@@ -20,6 +20,7 @@ class SampleTable(GenericResultTable):
     class Meta:
         name = "Test Table"
         description = "Test Table Description"
+        sut_package_name = "test_package"
         Columns = [
             ColumnMetadata(name="metric1", unit="ms", type=ResultType.FLOAT, higher_is_better=False),
             ColumnMetadata(name="metric2", unit="ms", type=ResultType.INTEGER, higher_is_better=False),
@@ -42,6 +43,7 @@ def test_submit_results_responds_ok_if_all_cells_pass(fake_test, client_service)
         results.add_result(column=cell.column, row=cell.row, value=cell.value, status=cell.status)
     client_service.submit_run(run_type, asdict(run))
     response = client_service.submit_results(run_type, run.run_id, results.as_dict())
+    assert results.as_dict()["meta"]["sut_package_name"] == "test_package"
     assert response["status"] == "ok"
     assert response["message"] == "Results submitted"
 

--- a/argus/backend/tests/results_service/test_result_metadata.py
+++ b/argus/backend/tests/results_service/test_result_metadata.py
@@ -50,10 +50,12 @@ def test_update_if_changed():
         "name": "Updated Metadata",
         "columns_meta": [{"name": "col1", "unit": "ms", "type": "float", "higher_is_better": True}],
         "validation_rules": {"col1": {"best_pct": 95.0, "best_abs": 105.0, "fixed_limit": 50.0}},
-        "rows_meta": ["row1"]
+        "rows_meta": ["row1"],
+        "sut_package_name": "new_package",
     }
     updated_metadata = metadata.update_if_changed(new_data)
     assert updated_metadata.name == "Updated Metadata"
+    assert updated_metadata.sut_package_name == "new_package"
     assert len(updated_metadata.columns_meta) == 1
     assert len(updated_metadata.rows_meta) == 2  # should not remove rows from other runs
     assert len(updated_metadata.validation_rules["col1"]) == 2  # keep also the old rule

--- a/argus/client/generic_result.py
+++ b/argus/client/generic_result.py
@@ -62,6 +62,7 @@ class ResultTableMeta(type):
             cls_instance.description = meta.description
             cls_instance.columns = meta.Columns
             cls_instance.column_types = {column.name: column.type for column in cls_instance.columns}
+            cls_instance.sut_package_name = getattr(meta, 'sut_package_name', '')
             cls_instance.rows = []
             validation_rules = getattr(meta, 'ValidationRules', {})
             for col_name, rule in validation_rules.items():
@@ -98,7 +99,6 @@ class GenericResultTable(metaclass=ResultTableMeta):
     Base class for all Generic Result Tables in Argus. Use it as a base class for your result table.
     """
     sut_timestamp: int = 0  # automatic timestamp based on SUT version. Works only with SCT and refers to Scylla version.
-    sut_details: str = ""
     results: list[Cell] = field(default_factory=list)
 
     def as_dict(self) -> dict:
@@ -112,12 +112,12 @@ class GenericResultTable(metaclass=ResultTableMeta):
             "description": self.description,
             "columns_meta": [column.as_dict() for column in self.columns],
             "rows_meta": rows,
-            "validation_rules": {k: v.as_dict() for k, v in self.validation_rules.items()}
+            "validation_rules": {k: v.as_dict() for k, v in self.validation_rules.items()},
+            "sut_package_name": self.sut_package_name,
         }
         return {
             "meta": meta_info,
             "sut_timestamp": self.sut_timestamp,
-            "sut_details": self.sut_details,
             "results": [result.as_dict() for result in self.results]
         }
 


### PR DESCRIPTION
In some cases it will be hard to automatically select proper SUT - test that runs for the first time, or not supported package name by automatic sut selection.

Allowed client (tests) to specify 'sut_package_name' - bypassing automatic selection.

fixes: https://github.com/scylladb/argus/issues/550