### PR TITLE
improvement(graphs): add subtitle from table description

### DIFF
--- a/argus/backend/service/results_service.py
+++ b/argus/backend/service/results_service.py
@@ -311,10 +311,10 @@ def create_chart_options(table: ArgusGenericResultMetadata, column: ColumnMetada
     """
     options = copy.deepcopy(default_options)
     options["plugins"]["title"]["text"] = f"{table.name} - {column.name}"
+    options["plugins"]["subtitle"] = {"text": table.description, "display": True} if table.description else {"text": ""}
     options["scales"]["y"]["title"]["text"] = f"[{column.unit}]" if column.unit else ""
     options["scales"]["y"]["min"] = min_y
     options["scales"]["y"]["max"] = max_y
-
     return options
 
 

--- a/frontend/TestRun/ResultsGraph.svelte
+++ b/frontend/TestRun/ResultsGraph.svelte
@@ -10,7 +10,7 @@
     export let index = 0;
     export let test_id = "";
     export let width = 500;
-    export let height = 300;
+    export let height = 350;
     export let responsive = false;
     export let releasesFilters = {};
     let chart;

--- a/frontend/TestRun/ResultsGraphs.svelte
+++ b/frontend/TestRun/ResultsGraphs.svelte
@@ -20,7 +20,7 @@
     let dateRange = 6;
     let showCustomInputs = false;
     let width = 500;  // default width for each chart
-    let height = 300;  // default height for each chart
+    let height = 350;  // default height for each chart
 
     const dispatch = createEventDispatcher();
 


### PR DESCRIPTION
Graphs got subtitle based on result table's description.

closes: https://github.com/scylladb/argus/issues/496

example:
![image](https://github.com/user-attachments/assets/412899f1-f4bf-42e3-83b4-66a9a250e4d6)
