### PR TITLE
improvement(ViewDashboard): Per-widget item filtering

### DIFF
--- a/argus/backend/controller/view_api.py
+++ b/argus/backend/controller/view_api.py
@@ -142,8 +142,11 @@ def view_stats():
     version = request.args.get("productVersion", None)
     include_no_version = bool(int(request.args.get("includeNoVersion", True)))
     force = bool(int(request.args.get("force",  0)))
+    widget_id = request.args.get("widgetId", None)
+    if widget_id:
+        widget_id = int(widget_id)
     collector = ViewStatsCollector(view_id=view_id, filter=version)
-    stats = collector.collect(limited=limited, force=force, include_no_version=include_no_version)
+    stats = collector.collect(limited=limited, force=force, include_no_version=include_no_version, widget_id=widget_id)
 
     res = jsonify({
         "status": "ok",
@@ -169,6 +172,16 @@ def view_versions(view_id: str):
 def view_resolve(view_id: str):
     service = UserViewService()
     res = service.resolve_view_for_edit(view_id)
+    return {
+        "status": "ok",
+        "response": res
+    }
+
+@bp.route("/<string:view_id>/resolve/tests", methods=["GET"])
+@api_login_required
+def view_resolve_tests(view_id: str):
+    service = UserViewService()
+    res = service.resolve_view_tests(view_id)
     return {
         "status": "ok",
         "response": res

--- a/argus/backend/service/planner_service.py
+++ b/argus/backend/service/planner_service.py
@@ -85,6 +85,7 @@ class PlanningService:
         {
             "position": 1,
             "type": "githubIssues",
+            "filter": [],
             "settings": {
                 "submitDisabled": True,
                 "aggregateByIssue": True
@@ -93,6 +94,7 @@ class PlanningService:
         {
             "position": 2,
             "type": "releaseStats",
+            "filter": [],
             "settings": {
                 "horizontal": False,
                 "displayExtendedStats": True,
@@ -102,6 +104,7 @@ class PlanningService:
         {
             "position": 3,
             "type": "testDashboard",
+            "filter": [],
             "settings": {
                 "targetVersion": True,
                 "versionsIncludeNoVersion": False,

--- a/frontend/AdminPanel/ViewWidget.svelte
+++ b/frontend/AdminPanel/ViewWidget.svelte
@@ -1,14 +1,16 @@
 <script>
     import Fa from "svelte-fa";
     import { WIDGET_TYPES, Widget } from "../Common/ViewTypes";
-    import { faEdit, faList, faTrash } from "@fortawesome/free-solid-svg-icons";
+    import { faEdit, faList, faQuestionCircle, faTrash } from "@fortawesome/free-solid-svg-icons";
     import { createEventDispatcher, onMount } from "svelte";
+    import { titleCase } from "../Common/TextUtils";
 
 
     /**
      * @type {Widget}
      */
     export let widgetSettings = {};
+    export let items = [];
 
     let editingSettings = false;
     const dispatch = createEventDispatcher();
@@ -24,7 +26,10 @@
             });
     };
 
-    onMount(() => populateWidgetSettings());
+    onMount(populateWidgetSettings);
+    onMount(() => {
+        if (!widgetSettings.filter) widgetSettings.filter = [];
+    });
 </script>
 
 <div class="mb-2 rounded bg-white p-2">
@@ -62,6 +67,17 @@
                     </div>
                 </div>
                 <div>
+                    <div>
+                        <div class="mb-2">
+                            Item Filter <span title="Only selected items will be shown in the widget. No selection - Show all"><Fa icon={faQuestionCircle}/></span>
+                            <button class="btn btn-sm btn-outline-danger" on:click={() => (widgetSettings.filter = [])}>Clear All</button>
+                        </div>
+                        <select class="form-select" multiple size=10 bind:value={widgetSettings.filter}>
+                            {#each items as item}
+                                <option value="{item.id}"><span class="fw-bold">[{titleCase(item.type)}]</span> {item.pretty_name || item.name}</option>
+                            {/each}
+                        </select>
+                    </div>
                     {#each Object.entries(WIDGET_DEF.settingDefinitions) as [settingName, definition] (settingName)}
                         {#if typeof definition.type !== "string"}
                             <svelte:component this={definition.type} bind:settings={widgetSettings.settings} {definition} {settingName} />

--- a/frontend/AdminPanel/ViewsManager.svelte
+++ b/frontend/AdminPanel/ViewsManager.svelte
@@ -450,7 +450,7 @@
                             </button>
                         </div>
                         {#each newWidgets as widget (widget.position)}
-                            <ViewWidget bind:widgetSettings={widget} on:removeWidget={removeWidget}/>
+                            <ViewWidget bind:widgetSettings={widget} items={newView.items} on:removeWidget={removeWidget}/>
                         {/each}
                     </div>
                 </div>

--- a/frontend/Common/ViewTypes.js
+++ b/frontend/Common/ViewTypes.js
@@ -20,9 +20,12 @@ export class Widget {
         this.position = position;
         this.type = type;
         this.settings = settings;
+        this.filter = [];
     }
 }
 
+// sha1("")
+export const GLOBAL_STATS_KEY = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
 
 export const WIDGET_TYPES = {
     UNSUPPORTED: {
@@ -47,6 +50,12 @@ export const WIDGET_TYPES = {
                 default: true,
                 help: "Include No Version results for stat fetches",
                 displayName: "Include No Version"
+            },
+            flatView: {
+                type: CheckValue,
+                default: false,
+                help: "Do not group tests by group",
+                displayName: "Flat View"
             },
             productVersion: {
                 type: StringValue,

--- a/frontend/ReleaseDashboard/FlatViewHelper.svelte
+++ b/frontend/ReleaseDashboard/FlatViewHelper.svelte
@@ -1,0 +1,5 @@
+<div class="p-2 shadow mb-2 rounded bg-main">
+    <div class="my-2 d-flex flex-wrap bg-lighter rounded shadow-sm">
+        <slot><!-- optional fallback --></slot>
+    </div>
+</div>

--- a/frontend/ReleaseDashboard/GroupedViewHelper.svelte
+++ b/frontend/ReleaseDashboard/GroupedViewHelper.svelte
@@ -1,0 +1,3 @@
+<div>
+    <slot><!-- optional fallback --></slot>
+</div>

--- a/frontend/ReleaseDashboard/TestDashboardFlatView.svelte
+++ b/frontend/ReleaseDashboard/TestDashboardFlatView.svelte
@@ -1,0 +1,37 @@
+<script>
+    import TestDashboardTest from "./TestDashboardTest.svelte";
+
+    export let groupStats;
+    export let assigneeList;
+    export let userFilter;
+    export let clickedTests;
+    export let hideNotPlanned;
+
+
+    const sortTestStats = function (testStats) {
+        const testPriorities = {
+            failed: 6,
+            passed: 5,
+            running: 4,
+            created: 3,
+            aborted: 2,
+            not_run: 1,
+            not_planned: 0,
+            unknown: -1,
+
+        };
+        let tests = Object.values(testStats)
+            .sort((a, b) => testPriorities[b.status] - testPriorities[a.status] || a.test.name.localeCompare(b.test.name))
+            .reduce((tests, testStats) => {
+                tests[testStats.test.id] = testStats;
+                return tests;
+            }, {});
+        return tests;
+    };
+</script>
+
+{#if !groupStats.disabled}
+    {#each Object.entries(sortTestStats(groupStats.tests)) as [testId, testStats] (testId)}
+        <TestDashboardTest {assigneeList} bind:clickedTests={clickedTests} {groupStats} {testStats} {hideNotPlanned} {userFilter} on:testClick/>
+    {/each}
+{/if}

--- a/frontend/ReleaseDashboard/TestDashboardGroup.svelte
+++ b/frontend/ReleaseDashboard/TestDashboardGroup.svelte
@@ -1,0 +1,99 @@
+<script>
+    import { createEventDispatcher } from "svelte";
+    import NumberStats from "../Stats/NumberStats.svelte";
+    import { getPicture } from "../Common/UserUtils";
+    import Fa from "svelte-fa";
+    import { faArrowDown, faArrowUp } from "@fortawesome/free-solid-svg-icons";
+    import TestDashboardTest from "./TestDashboardTest.svelte";
+
+    export let stats;
+    export let groupStats;
+    export let collapsed;
+    export let filtered = false;
+    export let dashboardObjectType = "release";
+    export let assigneeList;
+    export let users;
+    export let userFilter;
+    export let clickedTests;
+    export let hideNotPlanned;
+
+    const dispatch = createEventDispatcher();
+
+
+    const sortTestStats = function (testStats) {
+        const testPriorities = {
+            failed: 6,
+            passed: 5,
+            running: 4,
+            created: 3,
+            aborted: 2,
+            not_run: 1,
+            not_planned: 0,
+            unknown: -1,
+
+        };
+        let tests = Object.values(testStats)
+            .sort((a, b) => testPriorities[b.status] - testPriorities[a.status] || a.test.name.localeCompare(b.test.name))
+            .reduce((tests, testStats) => {
+                tests[testStats.test.id] = testStats;
+                return tests;
+            }, {});
+        return tests;
+    };
+</script>
+
+{#if !groupStats.disabled}
+    <div class="p-2 shadow mb-2 rounded bg-main" class:d-none={filtered}>
+        <h5 class="mb-2 d-flex">
+            <div class="flex-fill">
+                <div class="mb-2">{#if dashboardObjectType != "release"}<span class="d-inline-block border p-1 me-1">{stats.releases?.[groupStats.group.release_id]?.name ?? "" }</span>{/if}{groupStats.group.pretty_name || groupStats.group.name}</div>
+                <div class="mb-2">
+                    <NumberStats displayInvestigations={true} stats={groupStats} displayPercentage={true} on:quickSelect/>
+                </div>
+                {#if Object.keys(assigneeList.groups).length > 0 && Object.keys(users).length > 0}
+                    <div class="shadow-sm bg-main rounded d-inline-block p-2">
+                        <div class="d-flex align-items-center">
+                            <img
+                                class="img-thumb ms-2"
+                                src={getPicture(
+                                    users[assigneeList.groups[groupStats.group.id]?.[0]]
+                                        ?.picture_id
+                                )}
+                                alt=""
+                            />
+                            <span class="ms-2 fs-6"
+                                >{users[assigneeList.groups[groupStats.group.id]?.[0]]
+                                    ?.full_name ?? "unassigned"}</span
+                            >
+                        </div>
+                    </div>
+                {/if}
+            </div>
+            <div class="ms-auto">
+                <button
+                    class="btn btn-sm"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#collapse-{groupStats.group.id}"
+                    on:click={() => {
+                        dispatch("toggleCollapse", `collapse-${groupStats.group.id}`);
+                    }}
+                >
+                {#if collapsed}
+                    <Fa icon={faArrowDown}/>
+                {:else}
+                    <Fa icon={faArrowUp}/>
+                {/if}
+                </button>
+            </div>
+        </h5>
+        <div class="collapse" class:show={!collapsed} id="collapse-{groupStats.group.id}">
+            <div class="my-2 d-flex flex-wrap bg-lighter rounded shadow-sm">
+                {#each Object.entries(sortTestStats(groupStats.tests)) as [testId, testStats] (testId)}
+                    <TestDashboardTest {assigneeList} bind:clickedTests={clickedTests} {groupStats} {testStats} {hideNotPlanned} {userFilter} on:testClick/>
+                {:else}
+                    <div class="text-dark m-2">No tests for this group</div>
+                {/each}
+            </div>
+        </div>
+    </div>
+{/if}

--- a/frontend/ReleaseDashboard/TestDashboardTest.svelte
+++ b/frontend/ReleaseDashboard/TestDashboardTest.svelte
@@ -1,0 +1,121 @@
+<script>
+    import { createEventDispatcher } from "svelte";
+    import { InvestigationStatusIcon, StatusBackgroundCSSClassMap, TestInvestigationStatus, TestInvestigationStatusStrings, TestStatus } from "../Common/TestStatus";
+    import { subUnderscores, titleCase } from "../Common/TextUtils";
+    import AssigneeList from "../WorkArea/AssigneeList.svelte";
+    import { timestampToISODate } from "../Common/DateUtils";
+    import Fa from "svelte-fa";
+    import { faBug, faComment } from "@fortawesome/free-solid-svg-icons";
+    import { getAssigneesForTest, shouldFilterOutByUser } from "./TestDashboard.svelte";
+
+    export let testStats;
+    export let groupStats;
+    export let assigneeList;
+    export let clickedTests;
+    export let hideNotPlanned;
+    export let userFilter;
+    const dispatch = createEventDispatcher();
+</script>
+
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<div
+    class:d-none={hideNotPlanned && testStats?.status == TestStatus.NOT_PLANNED || shouldFilterOutByUser(assigneeList, userFilter, testStats)}
+    class:status-block-active={testStats.start_time != 0}
+    class:investigating={testStats?.investigation_status == TestInvestigationStatus.IN_PROGRESS}
+    class:should-be-investigated={testStats?.investigation_status == TestInvestigationStatus.NOT_INVESTIGATED && [TestStatus.FAILED, TestStatus.TEST_ERROR].includes(testStats?.status)}
+    class="rounded bg-main status-block m-1 d-flex flex-column overflow-hidden shadow-sm"
+    on:click={() => {
+        dispatch("testClick", { testStats, groupStats });
+    }}
+>
+    <div
+        class="{StatusBackgroundCSSClassMap[
+            testStats.status
+        ]} text-center text-light p-1 border-bottom"
+    >
+        {testStats.status == "unknown"
+            ? "Not run"
+            : subUnderscores(testStats.status ?? "Unknown").split(" ").map(v => titleCase(v)).join(" ")}
+        {#if clickedTests[testStats.test.id]}
+            <div class="text-tiny">Selected</div>
+        {/if}
+    </div>
+    <div class="p-1 text-small d-flex align-items-center">
+        <div class="ms-1">{testStats.test.name}
+        {#if testStats.buildNumber}
+            - <span class="fw-bold">#{testStats.buildNumber}</span> <span class="text-muted">({timestampToISODate(testStats.start_time).split(" ")[0]})</span>
+        {/if}
+        </div>
+    </div>
+    <div class="d-flex flex-fill align-items-end justify-content-end p-1">
+        <div class="p-1 me-auto">
+            {#if assigneeList.tests[testStats.test.id] || assigneeList.groups[groupStats.group.id] || testStats.last_runs?.[0]?.assignee}
+                <AssigneeList
+                    smallImage={false}
+                    assignees={getAssigneesForTest(
+                        assigneeList,
+                        testStats.test.id,
+                        groupStats.group.id,
+                        testStats.last_runs ?? [],
+                    )}
+                />
+            {/if}
+        </div>
+        {#if testStats.investigation_status && (testStats.status != TestStatus.PASSED || testStats.investigation_status != TestInvestigationStatus.NOT_INVESTIGATED)}
+            <div
+                class="p-1"
+                title="Investigation: {TestInvestigationStatusStrings[
+                    testStats.investigation_status
+                ]}"
+            >
+                <Fa
+                    color="#000"
+                    icon={InvestigationStatusIcon[
+                        testStats.investigation_status
+                    ]}
+                />
+            </div>
+        {/if}
+        {#if testStats.hasBugReport}
+            <div class="p-1" title="Has a bug report">
+                <Fa color="#000" icon={faBug} />
+            </div>
+        {/if}
+        {#if testStats.hasComments}
+            <div class="p-1" title="Has a comment">
+                <Fa color="#000" icon={faComment} />
+            </div>
+        {/if}
+    </div>
+</div>
+
+
+<style>
+    .status-block {
+        width: 178px;
+        max-height: 160px;
+        box-sizing: border-box;
+        cursor: pointer;
+    }
+
+    .img-thumb {
+        border-radius: 50%;
+        width: 32px;
+    }
+
+    .text-small {
+        font-size: 0.8em;
+    }
+
+    .text-tiny {
+        font-size: 0.6em;
+    }
+
+    .should-be-investigated {
+        border: 3px solid #dc3545 !important;
+    }
+
+    .investigating {
+        border: 3px solid #ff9036 !important;
+    }
+</style>

--- a/frontend/ReleasePlanner/ReleasePlan.svelte
+++ b/frontend/ReleasePlanner/ReleasePlan.svelte
@@ -9,13 +9,14 @@
     import ReleaseStats from "../Stats/ReleaseStats.svelte";
     import { faEdit } from "@fortawesome/free-regular-svg-icons";
     import { userList } from "../Stores/UserlistSubscriber";
+    import { GLOBAL_STATS_KEY } from "../Common/ViewTypes";
 
 
     export let plan;
     export let detached = false;
     let users = {};
     export let expandedPlans;
-    let planStats;
+    let planStats = {};
 
     let owner;
     $: users = $userList;
@@ -72,7 +73,7 @@
             {plan.target_version}
             {#if planStats}
                 <div>
-                    <ReleaseStats releaseStats={planStats} />
+                    <ReleaseStats releaseStats={planStats[GLOBAL_STATS_KEY]} />
                 </div>
             {/if}
         </div>

--- a/frontend/Views/ViewDashboard.svelte
+++ b/frontend/Views/ViewDashboard.svelte
@@ -1,13 +1,20 @@
 <script>
     import Fa from "svelte-fa";
-    import { WIDGET_TYPES } from "../Common/ViewTypes";
     import { sendMessage } from "../Stores/AlertStore";
     import { faLink } from "@fortawesome/free-solid-svg-icons";
+    import { GLOBAL_STATS_KEY, WIDGET_TYPES } from "../Common/ViewTypes";
+    import sha1 from "js-sha1";
     export let view;
-    export let stats = undefined;
+    export let stats = {};
     export let productVersion;
     export let embedded = false;
     let clickedTests = {};
+    let resolvedTests = [];
+    const versionDispatch = {
+        GLOBAL_STATS_KEY: productVersion,
+    };
+
+    console.log(versionDispatch);
 
     const handleTestClick = function (detail) {
         if (detail.start_time == 0) {
@@ -20,6 +27,40 @@
         } else {
             delete clickedTests[key];
             clickedTests = clickedTests;
+        }
+    };
+
+    const resolveViewTests = async function() {
+        if (resolvedTests.length > 0) {
+            return resolvedTests;
+        }
+        try {
+            let response = await fetch(`/api/v1/views/${view.id}/resolve/tests`);
+            if (response.status !== 200) {
+                throw new Error("Non-200 status code returned from API.");
+            }
+            let json = await response.json();
+            if (json.status === "ok") {
+                resolvedTests = json.response;
+                return resolvedTests;
+            } else {
+                throw json;
+            }
+        } catch (error) {
+            if (error?.status === "error") {
+                sendMessage(
+                    "error",
+                    `API Error resolving view tests.\nMessage: ${error.response.arguments[0]}`,
+                    "ViewDashboard::resolveViewTests"
+                );
+            } else {
+                sendMessage(
+                    "error",
+                    "A backend error occurred during view test resolution.",
+                    "ViewDashboard::resolveViewTests"
+                );
+                console.log(error);
+            }
         }
     };
 
@@ -48,6 +89,26 @@
         });
     };
 
+    const calculateWidgetStatsKey = function (widget) {
+        return sha1((widget.filter ?? []).join(""));
+    };
+
+    const filterViewForWidget = async function (widget) {
+        let viewCopy = structuredClone(view);
+        if (!widget.filter || widget.filter.length === 0) {
+            return viewCopy;
+        }
+        let tests = await resolveViewTests();
+        tests = tests.reduce((acc, test) => {
+            acc[test.id] = test;
+            return acc;
+        }, {});
+        viewCopy.tests = viewCopy.tests.filter((item) => {
+            const test = tests[item.id] ?? {};
+            return ["id", "release_id", "group_id"].some((key) => widget.filter.includes(test[key]));
+        });
+        return viewCopy;
+    };
 </script>
 
 <div class="rounded bg-white m-2 shadow-sm p-2">
@@ -60,20 +121,25 @@
     <div class="mb-2">
         {#each view.widget_settings as widget}
             <div class="mb-2">
-                <svelte:component
-                    this={WIDGET_TYPES[widget.type]?.type ?? WIDGET_TYPES.UNSUPPORTED.type}
-                    dashboardObject={view}
-                    dashboardObjectType="view"
-                    settings={widget.settings}
-                    bind:stats={stats}
-                    bind:productVersion={productVersion}
-                    bind:clickedTests={clickedTests}
-                    on:statsUpdate
-                    on:testClick={(e) => handleTestClick(e.detail)}
-                    on:versionChange
-                    on:quickSelect={handleQuickSelect}
-                    on:deleteRequest={handleDeleteRequest}
-                />
+                {#await filterViewForWidget(widget)}
+                    <span class="spinner-grow spinner-grow-sm"></span> Loading...
+                {:then view}
+                    <svelte:component
+                        this={WIDGET_TYPES[widget.type]?.type ?? WIDGET_TYPES.UNSUPPORTED.type}
+                        widgetId={widget.position}
+                        dashboardObject={view}
+                        dashboardObjectType="view"
+                        settings={widget.settings}
+                        bind:stats={stats[calculateWidgetStatsKey(widget)]}
+                        bind:productVersion={versionDispatch[calculateWidgetStatsKey(widget)]}
+                        bind:clickedTests={clickedTests}
+                        on:statsUpdate
+                        on:testClick={(e) => handleTestClick(e.detail)}
+                        on:versionChange
+                        on:quickSelect={handleQuickSelect}
+                        on:deleteRequest={handleDeleteRequest}
+                    />
+                {/await}
             </div>
         {:else}
             <div class="alert alert-danger">No widgets defined for view!</div>

--- a/frontend/Views/Widgets/ViewTestDashboard.svelte
+++ b/frontend/Views/Widgets/ViewTestDashboard.svelte
@@ -5,6 +5,7 @@
     export let settings;
     export let productVersion;
     export let clickedTests;
+    export let widgetId;
 
     import TestDashboard from "../../ReleaseDashboard/TestDashboard.svelte";
     import TestPopoutSelector from "../../ReleaseDashboard/TestPopoutSelector.svelte";
@@ -16,6 +17,7 @@
             dashboardObject={dashboardObject}
             {dashboardObjectType}
             {settings}
+            {widgetId}
             bind:productVersion={productVersion}
             bind:stats={stats}
             bind:clickedTests={clickedTests}


### PR DESCRIPTION
This commit implements per-widget entitity filtering for views,
allowing users to select which tests/groups/releases they want shown on
the widget in a specific view. To facilitate this, stat fetching has
been modified to accept widget id (position) of a view and then filter
tests accordingly. On the frontend side to facilitate conflict-free stat
fetching (for example from two TestDashboards) a hashmap has been
introduced to handle multiple stat objects and to dispatch them
correctly to each widget.

Caveats:
* Release Planner views in general are not supported and contain
  several unwanted interactions:
    * If test dashboard is modified to filter anything, release
      planner stat bar will be gray (since there's no more anchor
      for it to get the stats from)
    * Anything version related will conflict
* TestDashboard has a setting for a specific ScyllaVersion filter
  preset - this is not compatible and will make that filter set only
  output that version, which might be undesirable.
* Aside from TestDashboard, currently no other widgets implement
  stat fetch, so filtering for them might not be interesting.
  However the widget will now receive filtered set of tests, which
  should make the performance summaries automatically support this
  feature.

Fixes #393
