### PR TITLE
fix(results): fix show graph for columns without unit

### DIFF
--- a/frontend/TestRun/Components/ResultTable.svelte
+++ b/frontend/TestRun/Components/ResultTable.svelte
@@ -187,7 +187,7 @@
                             </button>
                         </th>
                         {#each result.columns as col}
-                            {#if col.unit}
+                            {#if col.type !== 'TEXT'}
                                 <th class="clickable" on:click={() => openGraphModal(col.name)} title="Show metric history">
                                     <div class="column-header">
                                         {col.name}<span


### PR DESCRIPTION
There were assumption, than columns without unit are textual and don't have graphs. This is wrong - perf simple query results don't have units but have graphs.

Fix is about using proper assumption: if column type is not TEXT then there is graph.