### PR TITLE
fix(plugins/sct): Fix serialization of ResourceState enum

### DIFF
--- a/argus/backend/plugins/sct/udt.py
+++ b/argus/backend/plugins/sct/udt.py
@@ -53,7 +53,7 @@ class CloudSetupDetails(UserType):
 class CloudResource(UserType):
     __type_name__ = "CloudResource_v3"
     name = columns.Text()
-    state = columns.Text(default=lambda: ResourceState.RUNNING)
+    state = columns.Text(default=lambda: ResourceState.RUNNING.value)
     resource_type = columns.Text()
     instance_info = columns.UserDefinedType(user_type=CloudInstanceDetails)
 


### PR DESCRIPTION
The default value of state field was not being serialized properly due
to cqlengine being unable to handle Enum classes, fixed by getting the
Enum value in the default handler. This fixes an issue where SCT runner
would not be set with a vague "SyntaxException" error due to not
providing ResourceState.
