### PR TITLE
fix(plugin/driver_matrix_tests): Use status from pipeline

### DIFF
--- a/argus/backend/plugins/driver_matrix_tests/model.py
+++ b/argus/backend/plugins/driver_matrix_tests/model.py
@@ -422,7 +422,8 @@ class DriverTestRun(PluginModelBase):
 
     def finish_run(self, payload: dict = None):
         self.end_time = datetime.utcnow()
-        self.status = self._determine_run_status().value
+        status = payload.get("status", "passed")
+        self.status = TestStatus(status).value
 
     def submit_logs(self, logs: list[dict]):
         pass


### PR DESCRIPTION
This commit changes the way driver results are interpreted on argus
side. Instead of trying to guesstimate the overall status of the test
the status received from pipeline is now used.
