### PR TITLE
release argus client 0.13.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "argus-alm"
-version = "0.13.0"
+version = "0.13.1"
 description = "Argus"
 authors = ["Alexey Kartashov <alexey.kartashov@scylladb.com>", "Łukasz Sójka <lukasz.sojka@scylladb.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Recently we updated client but forgot to update version and release it. It's been released&pushed to pypi. This commit bumps version.