### PR TITLE
fix(highlight): fix markdown formatting

### DIFF
--- a/frontend/Views/Widgets/ViewHighlights/ActionItem.svelte
+++ b/frontend/Views/Widgets/ViewHighlights/ActionItem.svelte
@@ -63,7 +63,7 @@
         {#if !isEditing}
             <div class="img-profile me-2" style="background-image: url('{getPicture(creator?.picture_id)}');" data-bs-toggle="tooltip"
                  title="{creator?.username}"/>
-            <div class="d-flex align-items-center flex-grow-1">
+            <div class="d-flex align-items-center flex-grow-1 markdown-body">
                 <input id="checkbox-{action.id}" class="form-check-input me-2 mt-0" type="checkbox" disabled={isArchived}
                        bind:checked={action.isCompleted} on:change={toggleComplete}>
                 <label class="form-check-label no-bottom-margin"

--- a/frontend/Views/Widgets/ViewHighlights/HighlightItem.svelte
+++ b/frontend/Views/Widgets/ViewHighlights/HighlightItem.svelte
@@ -61,7 +61,7 @@
         {#if !isEditing}
             <div class="img-profile me-2" style="background-image: url('{getPicture(creator?.picture_id)}');" data-bs-toggle="tooltip"
                  title="{creator?.username}"/>
-            <div class="d-flex align-items-center flex-grow-1 no-bottom-margin-p">
+            <div class="d-flex align-items-center flex-grow-1 no-bottom-margin-p markdown-body">
                 <span class="no-bottom-margin">{@html marked.parse(highlight.content, markdownRendererOptions)}</span>
             </div>
             <div class="d-flex align-items-center">


### PR DESCRIPTION
Missed `markdown-body` class for highlights widget making tables not displayed correctly.