### PR TITLE
fix(frontend/argus.css): Force lightmode for markdown comments

### DIFF
--- a/frontend/argus.js
+++ b/frontend/argus.js
@@ -1,5 +1,5 @@
 import {} from "bootstrap";
-import "github-markdown-css";
+import "github-markdown-css/github-markdown-light.css";
 import "./argus.css";
 
 export const applicationCurrentUser = gArgusCurrentUser ?? {};


### PR DESCRIPTION
This temporary fix (until #531 is done) will force markdown to be always
rendered in light mode, preventing issues when users have their browser
theme set to Dark.

Fixes #598
