### PR TITLE
improvement(plugins/sct): Use 'target' packages to set version

### DIFF
--- a/argus/backend/plugins/sct/service.py
+++ b/argus/backend/plugins/sct/service.py
@@ -63,6 +63,8 @@ class SCTService:
             run: SCTTestRun = SCTTestRun.get(id=run_id)
             for package_dict in packages:
                 package = PackageVersion(**package_dict)
+                if "target" in package.name:
+                    SCTService.process_target_version(run, package)
                 if package not in run.packages:
                     run.packages.append(package)
             run.save()
@@ -72,6 +74,13 @@ class SCTService:
 
         return "added"
 
+
+    @staticmethod
+    def process_target_version(run: SCTTestRun, package: PackageVersion):
+        if "upgrade-target" in run.version_source and package.name == "scylla-server-target":
+            return
+        run.version_source = package.name
+        run.scylla_version = package.version
 
     @staticmethod
     def set_sct_runner(run_id: str, public_ip: str, private_ip: str, region: str, backend: str, name: str = None):

--- a/argus/backend/plugins/sct/testrun.py
+++ b/argus/backend/plugins/sct/testrun.py
@@ -68,6 +68,7 @@ class SCTTestRun(PluginModelBase):
     config_files = columns.List(value_type=columns.Text())
     packages = columns.List(value_type=columns.UserDefinedType(user_type=PackageVersion))
     scylla_version = columns.Text()
+    version_source = columns.Text()
     yaml_test_duration = columns.Integer()
 
     # Test Preset Resources
@@ -215,7 +216,8 @@ class SCTTestRun(PluginModelBase):
         return self.events
 
     def submit_product_version(self, version: str):
-        self.scylla_version = version
+        if not self.version_source:
+            self.scylla_version = version
         try:
             new_assignee = self.get_assignment(version)
         except Model.DoesNotExist:


### PR DESCRIPTION
This commit adds additional logic to package/version submission APIs,
changing the way scylla_version field is set on an SCTTestRun (which
gets later used by TestDashboard widget to filter runs by version).
Primarily, the change is here to address rolling-upgrade runs being
hidden by version filters inside said dashboard when they fail without
upgrading to target version. Because of this, the logic now does the
following:
* A new field has been added to SCTTestRun class, named 'version_source'
    * Said field is used to restrict certain APIs from further changing
      the version based on certain conditions
* submit_product_version will now not set the version if version_source
  has any content (we ignore updates to it from SCT when it installs
  scylla)
* submit_packages will now check if a package has `target` in its name
  and do the following flow:
    * set the version_source and scylla_version if version_source is
      unset
    * if we are setting it again and the package is `upgrade-target`,
      override the scylla_version
    * if we are setting it again and the package is
      `scylla-server-target` while the `version_source` is set to
      `scylla-server-upgrade-target` we don't do anything.

Fixes #533
