### PR TITLE
fix(ViewTypes.js): Rename duplicate key

### DIFF
--- a/frontend/Common/ViewTypes.js
+++ b/frontend/Common/ViewTypes.js
@@ -127,7 +127,7 @@ export const WIDGET_TYPES = {
         friendlyName: "Graphs Views",
         settingDefinitions: {}
     },
-    releaseStats: {
+    nemesisStats: {
         type: ViewNemesisStats,
         friendlyName: "Nemesis stats",
         settingDefinitions: {


### PR DESCRIPTION
This fixes missing ReleaseStats widget
