### PR TITLE
improvement(WorkArea): Add Test Execute button

### DIFF
--- a/frontend/TestRun/Jenkins/BuildConfirmationDialog.svelte
+++ b/frontend/TestRun/Jenkins/BuildConfirmationDialog.svelte
@@ -1,0 +1,17 @@
+<script>
+    import { createEventDispatcher } from "svelte";
+
+    /**
+     * @type {Object} args
+     */
+    export let args;
+    const dispatch = createEventDispatcher();
+</script>
+
+<div>
+    This test contains no runs and no runs were found inside Jenkins. A build will be started without parameters to later retrieve them. Do you wish to continue?
+    <div class="p-2">
+        <button class="btn btn-primary me-1" on:click={() => dispatch("exit", { confirm: true })}>OK</button>
+        <button class="btn btn-secondary" on:click={() => dispatch("exit", { confirm: false })}>Cancel</button>
+    </div>
+</div>

--- a/frontend/TestRun/Jenkins/JenkinsCloneModal.svelte
+++ b/frontend/TestRun/Jenkins/JenkinsCloneModal.svelte
@@ -327,7 +327,11 @@
     <div class="d-flex align-items-center justify-content-center p-4">
         <div class="rounded bg-white p-4 h-50">
             <div class="mb-2 d-flex border-bottom pb-2">
-                <h5>Cloning <span class="fw-bold">{buildId}#{buildNumber}</span></h5>
+                {#if buildNumber != -1}
+                    <h5>Cloning <span class="fw-bold">{buildId}#{buildNumber}</span></h5>
+                {:else}
+                    <h5>Cloning <span class="fw-bold">{buildId}</span></h5>
+                {/if}
                 <div class="ms-auto">
                     <button 
                         class="btn btn-close"

--- a/frontend/WorkArea/TestRuns.svelte
+++ b/frontend/WorkArea/TestRuns.svelte
@@ -12,7 +12,7 @@
     import { AVAILABLE_PLUGINS } from "../Common/PluginDispatch";
     import { sendMessage } from "../Stores/AlertStore";
     import TestRunsMessage from "./TestRunsMessage.svelte";
-    import { faGear, faTimes } from "@fortawesome/free-solid-svg-icons";
+    import { faGear, faPlay, faTimes } from "@fortawesome/free-solid-svg-icons";
     import Fa from "svelte-fa";
     import { Collapse } from "bootstrap";
     import JobConfigureModal from "./JobConfigureModal.svelte";
@@ -20,6 +20,7 @@
     import ResultsGraphs from "../TestRun/ResultsGraphs.svelte";
     import { faCopy } from "@fortawesome/free-regular-svg-icons";
     import JenkinsCloneModal from "../TestRun/Jenkins/JenkinsCloneModal.svelte";
+    import JenkinsBuildModal from "../TestRun/Jenkins/JenkinsBuildModal.svelte";
 
     export let testId;
     export let listId = uuidv4();
@@ -119,6 +120,7 @@
     let selectedPlugin = "";
     let configureRequested = false;
     let cloneRequested = false;
+    let execRequested = false;
     let open = true;
     let pluginFixed = false;
     let runsBody = undefined;
@@ -324,6 +326,7 @@
                     {#if applicationCurrentUser.roles.some(v => ["ROLE_ADMIN", "ROLE_MANAGER"].includes(v)) || testInfo.release.name.includes("staging")}
                         <button class="btn" on:click={(e) => {configureRequested = true; e.stopPropagation();}}><Fa icon={faGear}/></button>
                     {/if}
+                    <button class="btn" on:click={(e) => {execRequested = true; e.stopPropagation();}}><Fa icon={faPlay} /></button>
                     <button class="btn" on:click={(e) => {cloneRequested = true; e.stopPropagation();}}><Fa icon={faCopy} /></button>
                 </div>
             {#if removableRuns}
@@ -357,6 +360,15 @@
             oldTestName={testInfo.test.name}
             on:cloneCancel={() => (cloneRequested = false)}
             on:cloneComplete={(e) => { cloneRequested = false; dispatch("cloneSelect", { testId: e.detail.testId }); }}
+        />
+    {/if}
+    {#if execRequested}
+        <JenkinsBuildModal
+            buildId={testInfo.test.build_system_id} 
+            buildNumber={runs.length > 0 ? extractBuildNumber(runs[0]) : undefined}
+            pluginName={testInfo.test.plugin_name}
+            on:rebuildCancel={() => (execRequested = false)}
+            on:rebuildComplete={() => (execRequested = false)}
         />
     {/if}
     <div class="collapse show bg-main shadow-sm rounded" id="collapse-{listId}">


### PR DESCRIPTION
This commits adds a new button to the test runs within argus, allowing
user to either start a build from scratch or rebuild a latest run
without having to open a run to do so. The from scratch implementation
will try to retrieve previous build parameters (In case previous build
wasn't submitted to argus) and if that's not possible, will offer user
to start a build without parameters to be able to retrieve the build on
subsequent call.

Fixes #542
