### PR TITLE
Add option to pass on extra headers into Argus clients

### DIFF
--- a/argus/client/base.py
+++ b/argus/client/base.py
@@ -34,14 +34,19 @@ class ArgusClient:
         FETCH_RESULTS = "/testrun/$type/$id/fetch_results"
         FINALIZE = "/testrun/$type/$id/finalize"
 
-    def __init__(self, auth_token: str, base_url: str, api_version="v1") -> None:
+    def __init__(self, auth_token: str, base_url: str, api_version="v1", extra_headers: dict | None = None) -> None:
         self._auth_token = auth_token
         self._base_url = base_url
         self._api_ver = api_version
+        self._extra_headers = extra_headers or {}
 
     @property
     def auth_token(self) -> str:
         return self._auth_token
+
+    @property
+    def extra_headers(self) -> dict:
+        return self._extra_headers
 
     def verify_location_params(self, endpoint: str, location_params: dict[str, str]) -> bool:
         required_params: list[str] = re.findall(r"\$[\w_]+", endpoint)
@@ -88,6 +93,7 @@ class ArgusClient:
             "Authorization": f"token {self.auth_token}",
             "Accept": "application/json",
             "Content-Type": "application/json",
+            **self.extra_headers,
         }
 
     def get(self, endpoint: str, location_params: dict[str, str] = None, params: dict = None) -> requests.Response:

--- a/argus/client/driver_matrix_tests/cli.py
+++ b/argus/client/driver_matrix_tests/cli.py
@@ -6,6 +6,7 @@ import logging
 from argus.common.enums import TestStatus
 
 from argus.client.driver_matrix_tests.client import ArgusDriverMatrixClient
+from argus.client.generic.cli import validate_extra_headers
 
 LOGGER = logging.getLogger(__name__)
 
@@ -15,81 +16,87 @@ def cli():
     pass
 
 
-def _submit_driver_result_internal(api_key: str, base_url: str, run_id: str, metadata_path: str):
+def _submit_driver_result_internal(api_key: str, base_url: str, run_id: str, metadata_path: str, extra_headers: dict):
     metadata = json.loads(Path(metadata_path).read_text(encoding="utf-8"))
     LOGGER.info("Submitting results for %s [%s/%s] to Argus...", run_id, metadata["driver_name"], metadata["driver_type"])
     raw_xml = (Path(metadata_path).parent / metadata["junit_result"]).read_bytes()
-    client = ArgusDriverMatrixClient(run_id=run_id, auth_token=api_key, base_url=base_url)
+    client = ArgusDriverMatrixClient(run_id=run_id, auth_token=api_key, base_url=base_url, extra_headers=extra_headers)
     client.submit_driver_result(driver_name=metadata["driver_name"], driver_type=metadata["driver_type"], raw_junit_data=base64.encodebytes(raw_xml))
     LOGGER.info("Done.")
 
-def _submit_driver_failure_internal(api_key: str, base_url: str, run_id: str, metadata_path: str):
+def _submit_driver_failure_internal(api_key: str, base_url: str, run_id: str, metadata_path: str, extra_headers: dict):
     metadata = json.loads(Path(metadata_path).read_text(encoding="utf-8"))
     LOGGER.info("Submitting failure for %s [%s/%s] to Argus...", run_id, metadata["driver_name"], metadata["driver_type"])
-    client = ArgusDriverMatrixClient(run_id=run_id, auth_token=api_key, base_url=base_url)
+    client = ArgusDriverMatrixClient(run_id=run_id, auth_token=api_key, base_url=base_url, extra_headers=extra_headers)
     client.submit_driver_failure(driver_name=metadata["driver_name"], driver_type=metadata["driver_type"], failure_reason=metadata["failure_reason"])
     LOGGER.info("Done.")
 
 
 @click.command("submit-run")
-@click.option("--api-key", help="Argus API key for authorization", required=True)
+@click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
+@click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
 @click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--build-id", required=True, help="Unique job identifier in the build system, e.g. scylla-master/group/job for jenkins (The full path)")
 @click.option("--build-url", required=True, help="Job URL in the build system")
-def submit_driver_matrix_run(api_key: str, base_url: str, run_id: str, build_id: str, build_url: str):
+def submit_driver_matrix_run(api_key: str, base_url: str, run_id: str, build_id: str, build_url: str, extra_headers: dict):
     LOGGER.info("Submitting %s (%s) to Argus...", build_id, run_id)
-    client = ArgusDriverMatrixClient(run_id=run_id, auth_token=api_key, base_url=base_url)
+    client = ArgusDriverMatrixClient(run_id=run_id, auth_token=api_key, base_url=base_url, extra_headers=extra_headers)
     client.submit_driver_matrix_run(job_name=build_id, job_url=build_url)
     LOGGER.info("Done.")
 
 
 @click.command("submit-driver")
-@click.option("--api-key", help="Argus API key for authorization", required=True)
+@click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
+@click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
 @click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--metadata-path", required=True, help="Path to the metadata .json file that contains path to junit xml and other required information")
-def submit_driver_result(api_key: str, base_url: str, run_id: str, metadata_path: str):
-    _submit_driver_result_internal(api_key=api_key, base_url=base_url, run_id=run_id, metadata_path=metadata_path)
+def submit_driver_result(api_key: str, base_url: str, run_id: str, metadata_path: str, extra_headers: dict):
+    _submit_driver_result_internal(api_key=api_key, base_url=base_url, run_id=run_id, metadata_path=metadata_path, extra_headers=extra_headers)
 
 
 @click.command("fail-driver")
-@click.option("--api-key", help="Argus API key for authorization", required=True)
+@click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
+@click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
 @click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--metadata-path", required=True, help="Path to the metadata .json file that contains path to junit xml and other required information")
-def submit_driver_failure(api_key: str, base_url: str, run_id: str, metadata_path: str):
-    _submit_driver_failure_internal(api_key=api_key, base_url=base_url, run_id=run_id, metadata_path=metadata_path)
+def submit_driver_failure(api_key: str, base_url: str, run_id: str, metadata_path: str, extra_headers: dict):
+    _submit_driver_failure_internal(api_key=api_key, base_url=base_url, run_id=run_id, metadata_path=metadata_path, extra_headers=extra_headers)
 
 
 @click.command("submit-or-fail-driver")
-@click.option("--api-key", help="Argus API key for authorization", required=True)
+@click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
+@click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
 @click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--metadata-path", required=True, help="Path to the metadata .json file that contains path to junit xml and other required information")
-def submit_or_fail_driver(api_key: str, base_url: str, run_id: str, metadata_path: str):
+def submit_or_fail_driver(api_key: str, base_url: str, run_id: str, metadata_path: str, extra_headers: dict):
     metadata = json.loads(Path(metadata_path).read_text(encoding="utf-8"))
     if metadata.get("failure_reason"):
-        _submit_driver_failure_internal(api_key=api_key, base_url=base_url, run_id=run_id, metadata_path=metadata_path)
+        _submit_driver_failure_internal(api_key=api_key, base_url=base_url, run_id=run_id, metadata_path=metadata_path, extra_headers=extra_headers)
     else:
-        _submit_driver_result_internal(api_key=api_key, base_url=base_url, run_id=run_id, metadata_path=metadata_path)
+        _submit_driver_result_internal(api_key=api_key, base_url=base_url, run_id=run_id, metadata_path=metadata_path, extra_headers=extra_headers)
 
 
 @click.command("submit-env")
-@click.option("--api-key", help="Argus API key for authorization", required=True)
+@click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
+@click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
 @click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--env-path", required=True, help="Path to the Build-00.txt file that contains environment information about Scylla")
-def submit_driver_env(api_key: str, base_url: str, run_id: str, env_path: str):
+def submit_driver_env(api_key: str, base_url: str, run_id: str, env_path: str, extra_headers: dict):
     LOGGER.info("Submitting environment for run %s to Argus...", run_id)
     raw_env = Path(env_path).read_text()
-    client = ArgusDriverMatrixClient(run_id=run_id, auth_token=api_key, base_url=base_url)
+    client = ArgusDriverMatrixClient(run_id=run_id, auth_token=api_key, base_url=base_url, extra_headers=extra_headers)
     client.submit_env(raw_env)
     LOGGER.info("Done.")
 
 
 @click.command("finish-run")
-@click.option("--api-key", help="Argus API key for authorization", required=True)
+@click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
+@click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
 @click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--status", required=True, help="Resulting job status")

--- a/argus/client/driver_matrix_tests/client.py
+++ b/argus/client/driver_matrix_tests/client.py
@@ -12,8 +12,8 @@ class ArgusDriverMatrixClient(ArgusClient):
         SUBMIT_DRIVER_FAILURE = "/driver_matrix/result/fail"
         SUBMIT_ENV = "/driver_matrix/env/submit"
 
-    def __init__(self, run_id: UUID, auth_token: str, base_url: str, api_version="v1") -> None:
-        super().__init__(auth_token, base_url, api_version)
+    def __init__(self, run_id: UUID, auth_token: str, base_url: str, api_version="v1", extra_headers: dict | None = None) -> None:
+        super().__init__(auth_token, base_url, api_version, extra_header=extra_headers)
         self.run_id = run_id
 
     def submit_driver_matrix_run(self, job_name: str, job_url: str) -> None:

--- a/argus/client/generic/cli.py
+++ b/argus/client/generic/cli.py
@@ -1,4 +1,5 @@
 import json
+from json.decoder import JSONDecodeError
 from pathlib import Path
 import click
 import logging
@@ -8,6 +9,15 @@ from argus.client.generic.client import ArgusGenericClient
 
 LOGGER = logging.getLogger(__name__)
 
+def validate_extra_headers(ctx, param, value):
+    if isinstance(value, dict):
+        return value
+
+    try:
+        return json.loads(value)
+    except JSONDecodeError as ex:
+        raise click.BadParameter(f"--extra-headers should be in json format:\n\n{value}\n\n{ex}")
+
 
 @click.group
 def cli():
@@ -15,41 +25,44 @@ def cli():
 
 
 @click.command("submit")
-@click.option("--api-key", help="Argus API key for authorization", required=True)
+@click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
 @click.option("--id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--build-id", required=True, help="Unique job identifier in the build system, e.g. scylla-master/group/job for jenkins (The full path)")
 @click.option("--build-url", required=True, help="Job URL in the build system")
 @click.option("--started-by", required=True, help="Username of the user who started the job")
 @click.option("--scylla-version", required=False, default=None, help="Version of Scylla used for this job")
-def submit_run(api_key: str, base_url: str, id: str, build_id: str, build_url: str, started_by: str, scylla_version: str = None):
+@click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
+def submit_run(api_key: str, base_url: str, id: str, build_id: str, build_url: str, started_by: str, scylla_version: str = None, extra_headers: dict | None = None):
     LOGGER.info("Submitting %s (%s) to Argus...", build_id, id)
-    client = ArgusGenericClient(auth_token=api_key, base_url=base_url)
+    client = ArgusGenericClient(auth_token=api_key, base_url=base_url, extra_headers=extra_headers)
     client.submit_generic_run(build_id=build_id, run_id=id, started_by=started_by, build_url=build_url, scylla_version=scylla_version)
     LOGGER.info("Done.")
 
 
 @click.command("finish")
-@click.option("--api-key", help="Argus API key for authorization", required=True)
+@click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
 @click.option("--id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--status", required=True, help="Resulting job status")
 @click.option("--scylla-version", required=False, default=None, help="Version of Scylla used for this job")
-def finish_run(api_key: str, base_url: str, id: str, status: str, scylla_version: str = None):
-    client = ArgusGenericClient(auth_token=api_key, base_url=base_url)
+@click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
+def finish_run(api_key: str, base_url: str, id: str, status: str, scylla_version: str = None, extra_headers: dict | None = None):
+    client = ArgusGenericClient(auth_token=api_key, base_url=base_url, extra_headers=extra_headers)
     status = TestStatus(status)
     client.finalize_generic_run(run_id=id, status=status, scylla_version=scylla_version)
 
 
 @click.command("trigger-jobs")
-@click.option("--api-key", help="Argus API key for authorization", required=True)
+@click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
 @click.option("--version", help="Scylla version to filter plans by", default=None, required=False)
 @click.option("--plan-id", help="Specific plan id for filtering", default=None, required=False)
 @click.option("--release", help="Release name to filter plans by", default=None, required=False)
 @click.option("--job-info-file", required=True, help="JSON file with trigger information (see detailed docs)")
-def trigger_jobs(api_key: str, base_url: str, job_info_file: str, version: str, plan_id: str, release: str):
-    client = ArgusGenericClient(auth_token=api_key, base_url=base_url)
+@click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
+def trigger_jobs(api_key: str, base_url: str, job_info_file: str, version: str, plan_id: str, release: str, extra_headers: dict | None = None):
+    client = ArgusGenericClient(auth_token=api_key, base_url=base_url, extra_headers=extra_headers)
     path = Path(job_info_file)
     if not path.exists():
         LOGGER.error("File not found: %s", job_info_file)

--- a/argus/client/generic/client.py
+++ b/argus/client/generic/client.py
@@ -11,8 +11,8 @@ class ArgusGenericClient(ArgusClient):
     class Routes(ArgusClient.Routes):
         TRIGGER_JOBS = "/planning/plan/trigger"
 
-    def __init__(self, auth_token: str, base_url: str, api_version="v1") -> None:
-        super().__init__(auth_token, base_url, api_version)
+    def __init__(self, auth_token: str, base_url: str, api_version="v1", extra_headers: dict | None = None) -> None:
+        super().__init__(auth_token, base_url, api_version, extra_headers=extra_headers)
 
     def submit_generic_run(self, build_id: str, run_id: str, started_by: str, build_url: str, scylla_version: str | None = None):
         request_body = {

--- a/argus/client/sct/client.py
+++ b/argus/client/sct/client.py
@@ -27,8 +27,8 @@ class ArgusSCTClient(ArgusClient):
         SUBMIT_EVENTS = "/sct/$id/events/submit"
         SUBMIT_JUNIT_REPORT = "/sct/$id/junit/submit"
 
-    def __init__(self, run_id: UUID, auth_token: str, base_url: str, api_version="v1") -> None:
-        super().__init__(auth_token, base_url, api_version)
+    def __init__(self, run_id: UUID, auth_token: str, base_url: str, api_version="v1", extra_headers: dict | None = None) -> None:
+        super().__init__(auth_token, base_url, api_version, extra_headers=extra_headers)
         self.run_id = run_id
 
     def submit_sct_run(self, job_name: str, job_url: str, started_by: str, commit_id: str,

--- a/argus/client/sirenada/client.py
+++ b/argus/client/sirenada/client.py
@@ -43,9 +43,9 @@ class ArgusSirenadaClient(ArgusClient):
         "skipped": "skipped"
     }
 
-    def __init__(self, auth_token: str, base_url: str, api_version="v1") -> None:
+    def __init__(self, auth_token: str, base_url: str, api_version="v1", extra_headers: dict | None = None) -> None:
         self.results_path: Path | None = None
-        super().__init__(auth_token, base_url, api_version)
+        super().__init__(auth_token, base_url, api_version, extra_headers=extra_headers)
 
     def _verify_required_files_exist(self, results_path: Path):
         assert (results_path / self._junit_xml_filename).exists(), "Missing jUnit XML results file!"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "argus-alm"
-version = "0.13.1"
+version = "0.14.0"
 description = "Argus"
 authors = ["Alexey Kartashov <alexey.kartashov@scylladb.com>", "Łukasz Sójka <lukasz.sojka@scylladb.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
for purpose of identificaton of the code part sending out results into argus, we should be able to configure as needed the headers the client are sending out.

this change introducs extra argument to clients, and to thier CLIs