### PR TITLE
feature(ReleasePlanner): Backlinks between plan and view

### DIFF
--- a/argus/backend/controller/main.py
+++ b/argus/backend/controller/main.py
@@ -8,7 +8,7 @@ from flask import (
 from argus.backend.controller.notifications import bp as notifications_bp
 from argus.backend.controller.team_ui import bp as teams_bp
 from argus.backend.service.argus_service import ArgusService
-from argus.backend.models.web import WebFileStorage
+from argus.backend.models.web import ArgusRelease, WebFileStorage
 from argus.backend.service.testrun import TestRunService
 from argus.backend.service.planner_service import PlanningService
 from argus.backend.service.user import UserService, login_required
@@ -93,6 +93,15 @@ def view_dashboard(view_name: str):
     return render_template("view_dashboard.html.j2", data=data_json)
 
 
+@bp.route("/plan/<string:plan_id>")
+@login_required
+def plan_dashboard(plan_id: str):
+    service = PlanningService()
+    plan = service.get_plan(plan_id=plan_id)
+    data_json = plan
+    return render_template("plan_dashboard.html.j2", data=data_json)
+
+
 @bp.route("/alert_debug")
 @login_required
 def alert_debug():
@@ -128,6 +137,13 @@ def release_scheduler(name: str):
         "tests": [dict(test.items()) for test in release_tests],
     }
     return render_template("release_schedule.html.j2", release_name=name, data=data_json)
+
+
+@bp.route("/release/by-id/<string:id>/planner")
+@login_required
+def release_planner_by_id(id: str):
+    release = ArgusRelease.get(id=id)
+    return redirect(url_for("main.release_planner", name=release.name))
 
 
 @bp.route("/release/<string:name>/planner")

--- a/frontend/ReleasePlanner/ReleasePlan.svelte
+++ b/frontend/ReleasePlanner/ReleasePlan.svelte
@@ -3,19 +3,22 @@
     import { getPicture, getUser } from "../Common/UserUtils";
     import { sendMessage } from "../Stores/AlertStore";
     import Fa from "svelte-fa";
-    import { faChevronDown, faChevronUp, faCopy, faTrash } from "@fortawesome/free-solid-svg-icons";
+    import { faArrowUp, faChevronDown, faChevronUp, faCopy, faLink, faTrash } from "@fortawesome/free-solid-svg-icons";
     import { faClone } from "@fortawesome/free-regular-svg-icons";
     import ViewDashboard from "../Views/ViewDashboard.svelte";
     import ReleaseStats from "../Stats/ReleaseStats.svelte";
     import { faEdit } from "@fortawesome/free-regular-svg-icons";
+    import { userList } from "../Stores/UserlistSubscriber";
 
 
     export let plan;
-    export let users;
+    export let detached = false;
+    let users = {};
     export let expandedPlans;
     let planStats;
 
     let owner;
+    $: users = $userList;
     $: owner = getUser(plan.owner, users);
     const dispatch = createEventDispatcher();
 
@@ -54,6 +57,9 @@
 </script>
 
 <div class="rounded p-2 mb-2 bg-white shadow-sm">
+    {#if detached}
+        <a href="/release/by-id/{plan.release_id}/planner" class="btn btn-sm btn-secondary"><Fa icon={faArrowUp}/> Back to planner</a>
+    {/if}
     <div class=" d-flex align-items-center">
         <div class="">
             {plan.name}
@@ -70,32 +76,35 @@
                 </div>
             {/if}
         </div>
-        <div class="ms-2">
-            {#if planStats}
-                <button on:click={() => { expandedPlans[plan.id] = (!expandedPlans[plan.id]); }} class="btn btn-primary"><Fa icon={expandedPlans[plan.id] ? faChevronUp : faChevronDown}/></button>
-            {:else}
-                <button class="btn btn-primary"><span class="spinner-grow spinner-grow-sm"></span></button>
-            {/if}
-        </div>
-        {#if !plan.created_from}
+        {#if !detached}
             <div class="ms-2">
-                <button class="btn btn-primary" on:click={() => { dispatch("createFromClick", plan); }}><Fa icon={faClone}/></button>
+                {#if planStats}
+                    <button on:click={() => { expandedPlans[plan.id] = (!expandedPlans[plan.id]); }} class="btn btn-primary"><Fa icon={expandedPlans[plan.id] ? faChevronUp : faChevronDown}/></button>
+                {:else}
+                    <button class="btn btn-primary"><span class="spinner-grow spinner-grow-sm"></span></button>
+                {/if}
+            </div>
+            {#if !plan.created_from}
+                <div class="ms-2">
+                    <button class="btn btn-primary" on:click={() => { dispatch("createFromClick", plan); }}><Fa icon={faClone}/></button>
+                </div>
+            {/if}
+            <div class="ms-2">
+                <button class="btn btn-warning" on:click={() => { dispatch("editClick", plan); }}><Fa icon={faEdit}/></button>
+            </div>
+            <div class="ms-2">
+                <button class="btn btn-success" on:click={() => { dispatch("copyClick", plan); }}><Fa icon={faCopy}/></button>
+            </div>
+            <div class="ms-2">
+                <button on:click={() => { dispatch("deleteClick", plan); }} class="btn btn-danger"><Fa icon={faTrash}/></button>
             </div>
         {/if}
-        <div class="ms-2">
-            <button class="btn btn-warning" on:click={() => { dispatch("editClick", plan); }}><Fa icon={faEdit}/></button>
-        </div>
-        <div class="ms-2">
-            <button class="btn btn-success" on:click={() => { dispatch("copyClick", plan); }}><Fa icon={faCopy}/></button>
-        </div>
-        <div class="ms-2">
-            <button on:click={() => { dispatch("deleteClick", plan); }} class="btn btn-danger"><Fa icon={faTrash}/></button>
-        </div>
     </div>
     <div class="p-2 bg-light-three rounded collapse" class:show={expandedPlans[plan.id]}>
         {#await fetchViewForPlan(plan.view_id)}
             <div class="text-center text-muted p-2">Loading view...</div>
         {:then view}
+            <div><a href="/view/{view.name}" class="btn btn-sm btn-primary"><Fa icon={faLink}/> View</a></div>
             <ViewDashboard bind:stats={planStats} productVersion={plan.target_version} {view}/>
         {/await}
     </div>

--- a/frontend/ReleasePlanner/ReleasePlanner.svelte
+++ b/frontend/ReleasePlanner/ReleasePlanner.svelte
@@ -247,7 +247,6 @@
             <ReleasePlan
                 bind:expandedPlans
                 {plan}
-                {users}
                 on:createFromClick={(e) => {selectedPlan = e.detail; createFromPlan = true; }}
                 on:copyClick={(e) => { selectedPlan = e.detail; copyingPlan = true; }}
                 on:deleteClick={(e) => { selectedPlan = e.detail; deletingPlan = true; }}

--- a/frontend/Views/ViewDashboard.svelte
+++ b/frontend/Views/ViewDashboard.svelte
@@ -1,9 +1,12 @@
 <script>
+    import Fa from "svelte-fa";
     import { WIDGET_TYPES } from "../Common/ViewTypes";
     import { sendMessage } from "../Stores/AlertStore";
+    import { faLink } from "@fortawesome/free-solid-svg-icons";
     export let view;
     export let stats = undefined;
     export let productVersion;
+    export let embedded = false;
     let clickedTests = {};
 
     const handleTestClick = function (detail) {
@@ -50,6 +53,9 @@
 <div class="rounded bg-white m-2 shadow-sm p-2">
     <div>
         <h4>{view.display_name || view.name}</h4>
+        {#if !embedded && view.plan_id}
+            <a href="/plan/{view.plan_id}" class="link-secondary link"><Fa icon={faLink}/>Plan</a>
+        {/if}
     </div>
     <div class="mb-2">
         {#each view.widget_settings as widget}

--- a/frontend/plan.js
+++ b/frontend/plan.js
@@ -1,0 +1,10 @@
+import ReleasePlan from "./ReleasePlanner/ReleasePlan.svelte";
+
+const app = new ReleasePlan({
+    target: document.querySelector("div#planDashboard"),
+    props: {
+        plan: globalThis.ARGUS_PLAN_DATA,
+        detached: true,
+        expandedPlans: { [globalThis.ARGUS_PLAN_DATA.id]: true }
+    }
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,6 +58,10 @@ module.exports = {
             import: "./frontend/release-dashboard.js",
             dependOn: "globalAlert"
         },
+        plan: {
+            import: "./frontend/plan.js",
+            dependOn: "globalAlert"
+        },
         viewDashboard: {
             import: "./frontend/view-dashboard.js",
             dependOn: "globalAlert"


### PR DESCRIPTION
This commit adds two-way linking between a plan and a view. In addition,
plans now have a separate route, allowing them to be opened standalone
from planner (Editing features not available).

Fixes #611
