### PR TITLE
fix(ReleasePlannerGridView): Null-check group stats and force fetch

### DIFF
--- a/frontend/ReleasePlanner/ReleasePlannerGridView.svelte
+++ b/frontend/ReleasePlanner/ReleasePlannerGridView.svelte
@@ -58,7 +58,7 @@
             release: release.name,
             productVersion: selectingFor?.target_version ?? "",
             limited: new Number(false),
-            force: new Number(false),
+            force: new Number(true),
         });
         let response = await fetch("/api/v1/release/stats/v2?" + params, { cache: "reload" });
         let json = await response.json();
@@ -250,7 +250,7 @@
                 ) as [groupId, tests] (groupId)}
             {@const group = gridView.groups[groupId] ?? {}}
             {@const prettyName = group?.pretty_name ?? group?.name}
-            {@const groupStats = releaseStats?.groups[group?.id]}
+            {@const groupStats = releaseStats?.groups?.[group?.id]}
             {#if group && groupStats}
                 <div 
                     class="mb-2 rounded bg-white p-2 border-success" 


### PR DESCRIPTION
This fix fixes an issue where GridView would crash if a release was set
to dormant (so stat fetches don't happen) as well as it forces the stat
fetch to occur even if release is dormant.
