### PR TITLE
improvement(ReleasePlanCreator): Copy assigned user into expanded group

### DIFF
--- a/frontend/ReleasePlanner/ReleasePlanCreator.svelte
+++ b/frontend/ReleasePlanner/ReleasePlanCreator.svelte
@@ -280,6 +280,10 @@
             }
             items = items.filter(v => v.id != groupId);
             items = [...items, ...json.response];
+            if (plan.assignments[groupId]) {
+                json.response.forEach(v => plan.assignments[v.id] = plan.assignments[groupId]);
+                delete plan.assignments[groupId];
+            }
 
         } catch (error) {
             console.log(error);


### PR DESCRIPTION
This commit makes it so that if a user was assigned to a group before
expansion that user is copied to all tests that will be added to the
plan.

Fixes #612
