### PR TITLE
fix `submit_packages` API to not fail on empty `version_source`

### DIFF
--- a/argus/backend/plugins/sct/service.py
+++ b/argus/backend/plugins/sct/service.py
@@ -77,7 +77,7 @@ class SCTService:
 
     @staticmethod
     def process_target_version(run: SCTTestRun, package: PackageVersion):
-        if "upgrade-target" in run.version_source and package.name == "scylla-server-target":
+        if run.version_source and "upgrade-target" in run.version_source and package.name == "scylla-server-target":
             return
         run.version_source = package.name
         run.scylla_version = package.version


### PR DESCRIPTION
while trying to submit results into Argus from SCT, I've run into those failures that cause in turn to Argus not have the scylla version
```
Traceback (most recent call last):
  File "/home/argus/.cache/pypoetry/virtualenvs/argus-alm-HqUqk8xE-py3.12/lib/python3.12/site-packages/flask/app.py", line 880, in full_di>
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/argus/.cache/pypoetry/virtualenvs/argus-alm-HqUqk8xE-py3.12/lib/python3.12/site-packages/flask/app.py", line 865, in dispatc>
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/argus/app/argus/backend/service/user.py", line 261, in wrapped_view
    return view(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/argus/app/argus/backend/plugins/sct/controller.py", line 16, in sct_submit_packages
    result = SCTService.submit_packages(run_id=run_id, packages=payload["packages"])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/argus/app/argus/backend/plugins/sct/service.py", line 67, in submit_packages
    SCTService.process_target_version(run, package)
  File "/home/argus/app/argus/backend/plugins/sct/service.py", line 80, in process_target_version
    if "upgrade-target" in run.version_source and package.name == "scylla-server-target":
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```