### PR TITLE
feature(nemesis_widget): allow drill down to test runs

### DIFF
--- a/argus/backend/service/views_widgets/nemesis_stats.py
+++ b/argus/backend/service/views_widgets/nemesis_stats.py
@@ -1,34 +1,34 @@
-from dataclasses import dataclass
 from uuid import UUID
 
 
 from argus.backend.db import ScyllaCluster
 from argus.backend.plugins.sct.testrun import SCTTestRun
 
-@dataclass
-class NemesisStats:
-    version: str
-    name: str
-    duration: int
-    status: str
-
 
 class NemesisStatsService:
-
     def __init__(self) -> None:
         self.cluster = ScyllaCluster.get()
 
     def get_nemesis_data(self, test_id: UUID):
         rows = SCTTestRun.filter(test_id=test_id).only(["id", "nemesis_data", "investigation_status", "packages"]).all()
         nemesis_data = []
-        for test in [row for row in rows if row["investigation_status"].lower() != "ignored"]:
+        for run in [row for row in rows if row["investigation_status"].lower() != "ignored"]:
             try:
-                version = [package.version for package in test["packages"] if package.name == "scylla-server"][0]
+                version = [package.version for package in run["packages"] if package.name == "scylla-server"][0]
             except (IndexError, TypeError):
                 continue
-            if not test["nemesis_data"]:
+            if not run["nemesis_data"]:
                 continue
-            for nemesis in [nemesis for nemesis in test["nemesis_data"]  if nemesis.status in ("succeeded", "failed")]:
-                nemesis_data.append({"version": version, "name": nemesis.name.split("disrupt_")[-1], "duration": nemesis.end_time - nemesis.start_time,
-                                    "status": nemesis.status})
+            for nemesis in [nemesis for nemesis in run["nemesis_data"] if nemesis.status in ("succeeded", "failed")]:
+                nemesis_data.append(
+                    {
+                        "version": version,
+                        "name": nemesis.name.split("disrupt_")[-1],
+                        "start_time": nemesis.start_time,
+                        "duration": nemesis.end_time - nemesis.start_time,
+                        "status": nemesis.status,
+                        "run_id": run["id"],
+                        "stack_trace": nemesis.stack_trace,
+                    }
+                )
         return nemesis_data

--- a/frontend/Views/Widgets/ViewNemesisStats.svelte
+++ b/frontend/Views/Widgets/ViewNemesisStats.svelte
@@ -18,6 +18,29 @@
     let loading = true;
     let filteredData = [];
     let collapsed = true;
+    let selectedNemesis = null;
+
+    // Pagination state
+    let itemsPerPage = 20;
+    let currentPage = 1;
+
+    // Sorting state
+    let sortField = "status";
+    let sortDirection = "asc"; // "asc" or "desc"
+
+    let paginatedRuns = [];
+
+    // Watch for changes in selectedNemesis, currentPage, sortField, and sortDirection
+    $: {
+        if (selectedNemesis) {
+            const runs = filteredData.filter((nemesis) => nemesis.name === selectedNemesis);
+            const sortedRuns = sortRuns(runs);
+            const startIndex = (currentPage - 1) * itemsPerPage;
+            paginatedRuns = sortedRuns.slice(startIndex, startIndex + itemsPerPage);
+        } else {
+            paginatedRuns = [];
+        }
+    }
 
     async function fetchData() {
         try {
@@ -99,7 +122,6 @@
         const typeStats = calculateNemesisTypeStats(data);
         createBarChart(typeStats);
 
-        // Update summary stats
         totalDuration = calculateTotalDuration(data);
         uniqueNemesisCount = calculateUniqueNemesisCount(data);
     }
@@ -208,8 +230,13 @@
                 },
                 interaction: {
                     mode: "index",
-                    intersect: false,
+                    intersect: true,
                     axis: "x",
+                },
+                onHover: (event, chartElements) => {
+                    // Only change cursor when hovering over a bar
+                    const canvas = event.native.target;
+                    canvas.style.cursor = chartElements.length > 0 ? "pointer" : "default";
                 },
                 scales: {
                     x: {
@@ -220,19 +247,127 @@
                         beginAtZero: true,
                     },
                 },
+                onClick: (event, elements) => {
+                    if (elements.length > 0) {
+                        const index = elements[0].index;
+                        const nemesisName = typeStats.names[index];
+                        handleNemesisClick(nemesisName);
+                    }
+                },
             },
         });
+    }
+
+    function handleNemesisClick(nemesisName) {
+        selectedNemesis = nemesisName;
+        // Reset pagination and sorting when selecting a new nemesis
+        currentPage = 1;
+        sortField = "status";
+        sortDirection = "asc";
+    }
+
+    function clearSelectedNemesis() {
+        selectedNemesis = null;
+    }
+
+    // Sort runs based on the current sort field and direction
+    function sortRuns(runs) {
+        return [...runs].sort((a, b) => {
+            let comparison = 0;
+
+            // Default sorting (status first, then by run_id)
+            if (sortField === "status") {
+                // Status sorting (failed first by default)
+                if (a.status === "failed" && b.status !== "failed") comparison = -1;
+                else if (a.status !== "failed" && b.status === "failed") comparison = 1;
+                else comparison = b.run_id.localeCompare(a.run_id); // Most recent first
+            } else if (sortField === "run_id") {
+                comparison = a.run_id.localeCompare(b.run_id);
+            } else if (sortField === "duration") {
+                comparison = a.duration - b.duration;
+            } else if (sortField === "version") {
+                comparison = a.version.localeCompare(b.version);
+            } else if (sortField === "start_time") {
+                // Use numeric comparison for timestamps
+                comparison = a.start_time - b.start_time;
+            }
+
+            // Apply sort direction
+            return sortDirection === "asc" ? comparison : -comparison;
+        });
+    }
+
+    // Toggle sorting when a column header is clicked
+    function toggleSort(field) {
+        // If clicking the same field, toggle direction
+        if (sortField === field) {
+            sortDirection = sortDirection === "asc" ? "desc" : "asc";
+        } else {
+            // Clear previous sort field and set new one
+            sortField = field;
+            sortDirection = "asc";
+        }
+
+        // Force a reactive update by creating a new array
+        if (selectedNemesis) {
+            const runs = filteredData.filter((nemesis) => nemesis.name === selectedNemesis);
+            const sortedRuns = sortRuns(runs);
+            const startIndex = (currentPage - 1) * itemsPerPage;
+            paginatedRuns = [...sortedRuns.slice(startIndex, startIndex + itemsPerPage)];
+        }
+    }
+
+    // Get total number of pages
+    function getTotalPages(nemesisName) {
+        if (!nemesisName) return 0;
+        const runs = filteredData.filter((nemesis) => nemesis.name === nemesisName);
+        return Math.ceil(runs.length / itemsPerPage);
+    }
+
+    function changePage(page) {
+        currentPage = page;
+    }
+
+    // Extract the first 3 lines of a stack trace
+    function getStackTracePreview(stackTrace) {
+        if (!stackTrace) return "";
+
+        const lines = stackTrace.split("\n");
+        return lines.slice(0, 3).join("\n");
+    }
+
+    // Check if stack trace has more than 3 lines
+    function hasMoreStackTraceLines(stackTrace) {
+        if (!stackTrace) return false;
+
+        return stackTrace.split("\n").length > 3;
+    }
+
+    function formatDuration(seconds) {
+        const hours = Math.floor(seconds / 3600);
+        const minutes = Math.floor((seconds % 3600) / 60);
+        const remainingSeconds = Math.floor(seconds % 60);
+
+        return `${hours}h ${minutes}m ${remainingSeconds}s`;
+    }
+
+    function formatTimestamp(timestamp) {
+        if (!timestamp) return "N/A";
+        // Convert Unix timestamp to Date object
+        const date = new Date(timestamp * 1000);
+        return date.toLocaleDateString("en-CA", { timeZone: "UTC" });
     }
 
     function applyFilter(filter) {
         selectedFilter = filter;
         filteredData = filterData(allNemesisData);
         updateCharts(filteredData);
+        selectedNemesis = null;
     }
 
     function toggleCollapsed() {
         collapsed = !collapsed;
-        if (!collapsed  && !allNemesisData.length) {
+        if (!collapsed && !allNemesisData.length) {
             fetchData().then((data) => {
                 if (!errorMsg) {
                     extractVersionsAndReleases(data);
@@ -240,6 +375,29 @@
                     updateCharts(filteredData);
                 }
             });
+        }
+    }
+
+    function toggleStackTrace(runId) {
+        const preview = document.getElementById(`preview-${runId}`);
+        const full = document.getElementById(`full-${runId}`);
+        const button = document.getElementById(`btn-${runId}`);
+
+        if (!preview || !full || !button) {
+            console.error(`Could not find elements for run ID: ${runId}`);
+            return;
+        }
+
+        if (full.style.display === "block") {
+            // Currently showing full, switch to preview
+            preview.style.display = "block";
+            full.style.display = "none";
+            button.textContent = "Show More";
+        } else {
+            // Currently showing preview, switch to full
+            preview.style.display = "none";
+            full.style.display = "block";
+            button.textContent = "Show Less";
         }
     }
 
@@ -317,6 +475,176 @@
                             </div>
                         </div>
                     </div>
+
+                    {#if selectedNemesis}
+                        <div class="nemesis-details mt-4">
+                            <div class="d-flex justify-content-between align-items-center mb-3">
+                                <h5>Nemesis: {selectedNemesis}</h5>
+                                <button class="btn btn-sm btn-outline-secondary" on:click={clearSelectedNemesis}>
+                                    <i class="bi bi-x" /> Close
+                                </button>
+                            </div>
+
+                            <div class="table-responsive">
+                                {#key paginatedRuns}
+                                    <table class="table table-striped table-hover">
+                                        <thead>
+                                            <tr>
+                                                <th
+                                                    class="status-column sortable"
+                                                    on:click={() => toggleSort("status")}
+                                                >
+                                                    Status
+                                                    <span class="sort-indicator">
+                                                        {#if sortField === "status"}
+                                                            {#if sortDirection === "desc"}
+                                                                <i class="fas fa-sort-down" />
+                                                            {:else}
+                                                                <i class="fas fa-sort-up" />
+                                                            {/if}
+                                                        {/if}
+                                                    </span>
+                                                </th>
+                                                <th
+                                                    class="start-time-column sortable"
+                                                    on:click={() => toggleSort("start_time")}
+                                                >
+                                                    Start Time
+                                                    <span class="sort-indicator">
+                                                        {#if sortField === "start_time"}
+                                                            {#if sortDirection === "desc"}
+                                                                <i class="fas fa-sort-down" />
+                                                            {:else}
+                                                                <i class="fas fa-sort-up" />
+                                                            {/if}
+                                                        {/if}
+                                                    </span>
+                                                </th>
+                                                <th
+                                                    class="duration-column sortable"
+                                                    on:click={() => toggleSort("duration")}
+                                                >
+                                                    Duration
+                                                    <span class="sort-indicator">
+                                                        {#if sortField === "duration"}
+                                                            {#if sortDirection === "desc"}
+                                                                <i class="fas fa-sort-down" />
+                                                            {:else}
+                                                                <i class="fas fa-sort-up" />
+                                                            {/if}
+                                                        {/if}
+                                                    </span>
+                                                </th>
+                                                <th
+                                                    class="version-column sortable"
+                                                    on:click={() => toggleSort("version")}
+                                                >
+                                                    Version
+                                                    <span class="sort-indicator">
+                                                        {#if sortField === "version"}
+                                                            {#if sortDirection === "desc"}
+                                                                <i class="fas fa-sort-down" />
+                                                            {:else}
+                                                                <i class="fas fa-sort-up" />
+                                                            {/if}
+                                                        {/if}
+                                                    </span>
+                                                </th>
+                                                <th>Stack Trace</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {#each paginatedRuns as run, index (run.run_id)}
+                                                <tr>
+                                                    <td class="status-column">
+                                                        {#if run.status === "failed"}
+                                                            <span class="badge bg-danger">Failed</span>
+                                                        {:else}
+                                                            <span class="badge bg-success">Passed</span>
+                                                        {/if}
+                                                    </td>
+                                                    <td class="run-id-column">
+                                                        <a
+                                                            href={`/tests/scylla-cluster-tests/${run.run_id}`}
+                                                            target="_blank"
+                                                        >
+                                                            {formatTimestamp(run.start_time)}
+                                                        </a>
+                                                    </td>
+                                                    <td class="duration-column">{formatDuration(run.duration)}</td>
+                                                    <td class="version-column">{run.version}</td>
+                                                    <td class="stack-trace-column">
+                                                        {#if run.stack_trace}
+                                                            <div class="stack-trace-container">
+                                                                <pre
+                                                                    class="stack-trace-preview"
+                                                                    id={`preview-${run.run_id}`}>{getStackTracePreview(
+                                                                        run.stack_trace
+                                                                    )}</pre>
+                                                                <pre
+                                                                    class="stack-trace-full"
+                                                                    id={`full-${run.run_id}`}
+                                                                    style="display: none;">{run.stack_trace}</pre>
+                                                                {#if hasMoreStackTraceLines(run.stack_trace)}
+                                                                    <button
+                                                                        id={`btn-${run.run_id}`}
+                                                                        class="btn btn-sm btn-outline-secondary mt-1"
+                                                                        on:click={() => toggleStackTrace(run.run_id)}
+                                                                    >
+                                                                        Show More
+                                                                    </button>
+                                                                {/if}
+                                                            </div>
+                                                        {:else}
+                                                            <span class="text-muted">No stack trace available</span>
+                                                        {/if}
+                                                    </td>
+                                                </tr>
+                                            {/each}
+                                        </tbody>
+                                    </table>
+                                {/key}
+
+                                {#if getTotalPages(selectedNemesis) > 1}
+                                    <nav aria-label="Nemesis runs pagination">
+                                        <ul class="pagination pagination-sm justify-content-center">
+                                            <li class="page-item {currentPage === 1 ? 'disabled' : ''}">
+                                                <button
+                                                    class="page-link"
+                                                    on:click={() => changePage(currentPage - 1)}
+                                                    disabled={currentPage === 1}
+                                                >
+                                                    Previous
+                                                </button>
+                                            </li>
+
+                                            {#each Array(getTotalPages(selectedNemesis)) as _, i}
+                                                <li class="page-item {currentPage === i + 1 ? 'active' : ''}">
+                                                    <button class="page-link" on:click={() => changePage(i + 1)}>
+                                                        {i + 1}
+                                                    </button>
+                                                </li>
+                                            {/each}
+
+                                            <li
+                                                class="page-item {currentPage === getTotalPages(selectedNemesis)
+                                                    ? 'disabled'
+                                                    : ''}"
+                                            >
+                                                <button
+                                                    class="page-link"
+                                                    on:click={() => changePage(currentPage + 1)}
+                                                    disabled={currentPage === getTotalPages(selectedNemesis)}
+                                                >
+                                                    Next
+                                                </button>
+                                            </li>
+                                        </ul>
+                                    </nav>
+                                {/if}
+                            </div>
+                        </div>
+                    {/if}
                 {:else}
                     <div class="text-center my-3">
                         <span>Loading nemesis stats...</span>
@@ -331,5 +659,81 @@
     .bar-chart-container {
         width: 100%;
         height: 600px;
+    }
+
+    .small-chart-container {
+        height: 250px;
+    }
+
+    .stack-trace-preview {
+        font-size: 0.8rem;
+        margin-bottom: 0;
+        background-color: #f8f9fa;
+        padding: 0.25rem;
+        border-radius: 0.25rem;
+        white-space: pre-wrap;
+        word-break: break-word;
+        max-height: 4.5em;
+        overflow: hidden;
+    }
+
+    .stack-trace-full {
+        font-size: 0.8rem;
+        margin-bottom: 0;
+        background-color: #f8f9fa;
+        padding: 0.25rem;
+        border-radius: 0.25rem;
+        white-space: pre-wrap;
+        word-break: break-word;
+        max-height: 200px;
+        overflow-y: auto;
+    }
+
+    .stack-trace-container {
+        position: relative;
+    }
+
+    .nemesis-details {
+        border-top: 1px solid #dee2e6;
+        padding-top: 1.5rem;
+    }
+
+    .start-time-column {
+        width: 120px;
+    }
+
+    .duration-column {
+        width: 120px;
+    }
+
+    .version-column {
+        width: 120px;
+    }
+
+    .status-column {
+        width: 80px;
+    }
+
+    /* Sortable table headers */
+    th {
+        cursor: pointer;
+        user-select: none;
+    }
+
+    th:hover {
+        background-color: rgba(0, 0, 0, 0.05);
+    }
+
+    .sortable {
+        position: relative;
+    }
+
+    .sort-indicator {
+        position: absolute;
+        right: 10px;
+        top: 50%;
+        transform: translateY(-50%);
+        font-size: 0.8rem;
+        color: #6c757d;
     }
 </style>


### PR DESCRIPTION
When viewing nemesis stats, user might want to drill down to failures to see more details.

Added possibility to click on nemesis bar (on the graph) to show tabular data about failed/passed runs - similar like it was in ES. User may go to specific test run or just view stack traces of nemesis failures.

closes: https://github.com/scylladb/argus/issues/626

deployed to staging: https://argus-staging.lab.dbaas.scyop.net/view/scylla-2025-1-2025-1-0-test-plan