### PR TITLE
improvement(graphs): graph run link in tooltip opens new tab

### DIFF
--- a/frontend/TestRun/ResultsGraph.svelte
+++ b/frontend/TestRun/ResultsGraph.svelte
@@ -108,11 +108,6 @@
         return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
     }
 
-    const handleOpenRun = (e) => {
-        const runId = e.detail;
-        window.open(`/tests/scylla-cluster-tests/${runId}`, "_blank", "popup");
-    };
-
     function handleChartClick(event, elements, chart) {
         if (elements[0]) {
             const dataset_idx = elements[0].datasetIndex;
@@ -203,7 +198,7 @@
 
                         const runId = context.chart.data.datasets[dataPoint.datasetIndex].data[dataPoint.dataIndex].id;
                         innerHtml += `<div class="d-flex justify-content-end mt-2">`;
-                        innerHtml += `<button class="btn btn-success btn-sm" onclick="document.getElementById('graph-${test_id}-${index}').dispatchEvent(new CustomEvent('openRun', {detail: '${runId}'}))">Open <i class="fas fa-external-link-alt"></i></button>`;
+                        innerHtml += `<a href="/tests/scylla-cluster-tests/${runId}" class="btn btn-success btn-sm" target="_blank">Open <i class="fas fa-external-link-alt"></i></a>`;
                         innerHtml += `</div>`;
 
                         // Add separator between points if not the last one
@@ -318,7 +313,7 @@
     <button class="enlarge-btn" on:click={openModal}>
         <Fa icon={faExpand} />
     </button>
-    <canvas id="graph-{test_id}-{index}" {width} {height} on:openRun={handleOpenRun} />
+    <canvas id="graph-{test_id}-{index}" {width} {height} />
 </div>
 
 {#if showModal}

--- a/frontend/TestRun/ResultsGraphs.svelte
+++ b/frontend/TestRun/ResultsGraphs.svelte
@@ -351,7 +351,7 @@
         cursor: pointer;
         color: #888;
         font-size: 1.2em;
-        z-index: 1000;
+        z-index: 999;
     }
 
     .add-btn:hover {


### PR DESCRIPTION
Open run button in tooltip was a button and was opening linked run in popup window. This is not what users expect.

Changed it to be normal link - so user sees where it links on hover and may use right click to select how to open it. By default it opens in new tab.