### PR TITLE
fix(testRun): fix disappearing comment content

### DIFF
--- a/frontend/TestRun/DriverMatrixTestRun.svelte
+++ b/frontend/TestRun/DriverMatrixTestRun.svelte
@@ -31,10 +31,15 @@
     let activeTab = tab.toLowerCase() || "details";
     let failedToLoad = false;
 
+    // Track which tabs have been visited
+    let visitedTabs = {};
+    visitedTabs[activeTab] = true;
+
     const setActiveTab = (tabName) => {
         tabName = tabName.toLowerCase();
         if (tabName !== activeTab) {
             activeTab = tabName;
+            visitedTabs[tabName] = true;
             if (!window.location.pathname.startsWith("/workspace")) {
                 const newUrl = `/tests/${testInfo.test.plugin_name}/${runId}/${tabName}`;
                 history.replaceState({}, "", newUrl);
@@ -223,7 +228,7 @@
                     id="nav-discuss-{runId}"
                     role="tabpanel"
                 >
-                    {#if activeTab === 'discuss'}
+                    {#if visitedTabs['discuss']}
                         <TestRunComments {testRun} {testInfo}/>
                     {/if}
                 </div>
@@ -235,7 +240,7 @@
                     role="tabpanel"
                 >
                     <div class="py-2 bg-white">
-                        {#if activeTab === 'issues'}
+                        {#if visitedTabs['issues']}
                             <IssueTab {testInfo} {runId} />
                         {/if}
                     </div>
@@ -247,7 +252,7 @@
                     id="nav-activity-{runId}"
                     role="tabpanel"
                 >
-                    {#if activeTab === 'activity'}
+                    {#if visitedTabs['activity']}
                         <ActivityTab id={runId} />
                     {/if}
                 </div>

--- a/frontend/TestRun/Generic/GenericTestRun.svelte
+++ b/frontend/TestRun/Generic/GenericTestRun.svelte
@@ -25,10 +25,15 @@
     let activeTab = tab.toLowerCase() || "details";
     let failedToLoad = false;
 
+    // Track which tabs have been visited
+    let visitedTabs = {};
+    visitedTabs[activeTab] = true;
+
     const setActiveTab = (tabName) => {
         tabName = tabName.toLowerCase();
         if (tabName !== activeTab) {
             activeTab = tabName;
+            visitedTabs[tabName] = true;
             if (!window.location.pathname.startsWith("/workspace")) {
                 const newUrl = `/tests/${testInfo.test.plugin_name}/${runId}/${tabName}`;
                 history.replaceState({}, "", newUrl);
@@ -197,7 +202,7 @@
                     id="nav-discuss-{runId}"
                     role="tabpanel"
                 >
-                    {#if activeTab === 'discuss'}
+                    {#if visitedTabs['discuss']}
                         <TestRunComments {testRun} {testInfo}/>
                     {/if}
                 </div>
@@ -209,7 +214,7 @@
                     role="tabpanel"
                 >
                     <div class="py-2 bg-white">
-                        {#if activeTab === 'issues'}
+                        {#if visitedTabs['issues']}
                             <IssueTab {testInfo} {runId} />
                         {/if}
                     </div>
@@ -221,7 +226,7 @@
                     id="nav-activity-{runId}"
                     role="tabpanel"
                 >
-                    {#if activeTab === 'activity'}
+                    {#if visitedTabs['activity']}
                         <ActivityTab id={runId} />
                     {/if}
                 </div>

--- a/frontend/TestRun/Sirenada/SirenadaTestRun.svelte
+++ b/frontend/TestRun/Sirenada/SirenadaTestRun.svelte
@@ -32,10 +32,15 @@
     let activeTab = tab.toLowerCase() || "details";
     let failedToLoad = false;
 
+    // Track which tabs have been visited
+    let visitedTabs = {};
+    visitedTabs[activeTab] = true;
+
     const setActiveTab = (tabName) => {
         tabName = tabName.toLowerCase();
         if (tabName !== activeTab) {
             activeTab = tabName;
+            visitedTabs[tabName] = true;
             if (!window.location.pathname.startsWith("/workspace")) {
                 const newUrl = `/tests/${testInfo.test.plugin_name}/${runId}/${tabName}`;
                 history.replaceState({}, "", newUrl);
@@ -224,7 +229,7 @@
                     id="nav-discuss-{runId}"
                     role="tabpanel"
                 >
-                    {#if activeTab === 'discuss'}
+                    {#if visitedTabs['discuss']}
                         <TestRunComments {testRun} {testInfo}/>
                     {/if}
                 </div>
@@ -237,7 +242,7 @@
                 >
                     <SirenadaIssueTemplate test_run={testRun} test={testInfo.test} />
                     <div class="py-2 bg-white">
-                        {#if activeTab === 'issues'}
+                        {#if visitedTabs['issues']}
                             <IssueTab {testInfo} {runId} />
                         {/if}
                     </div>
@@ -249,7 +254,7 @@
                     id="nav-activity-{runId}"
                     role="tabpanel"
                 >
-                    {#if activeTab === 'activity'}
+                    {#if visitedTabs['activity']}
                         <ActivityTab id={runId} />
                     {/if}
                 </div>

--- a/frontend/TestRun/TestRun.svelte
+++ b/frontend/TestRun/TestRun.svelte
@@ -51,6 +51,10 @@
     let jUnitFetched: boolean = false;
     let jUnitResults: any[] = [];
 
+    // Track which tabs have been visited
+    let visitedTabs: Record<string, boolean> = {};
+    visitedTabs[activeTab] = true;
+
     const fetchTestRunData = async function () {
         try {
             let run = await fetchRun(testInfo.test.plugin_name, runId);
@@ -115,6 +119,7 @@
         tabName = tabName.toLowerCase();
         if (tabName !== activeTab) {
             activeTab = tabName;
+            visitedTabs[tabName] = true;
             if (!window.location.pathname.startsWith("/workspace")) {
                 const newUrl = `/tests/${testInfo.test.plugin_name}/${runId}/${tabName}`;
                 history.replaceState({}, "", newUrl);
@@ -427,7 +432,7 @@
                     id="nav-results-{runId}"
                     role="tabpanel"
                 >
-                    {#if activeTab === "results"}
+                    {#if visitedTabs["results"]}
                         <ResultsTab id={runId} test_id={testInfo.test.id} />
                     {/if}
                 </div>
@@ -438,7 +443,7 @@
                     id="nav-events-{runId}"
                     role="tabpanel"
                 >
-                    {#if activeTab === "events"}
+                    {#if visitedTabs["events"]}
                         <EventsTab {testRun} />
                     {/if}
                 </div>
@@ -458,7 +463,7 @@
                     id="nav-logs-{runId}"
                     role="tabpanel"
                 >
-                    {#if activeTab === "logs"}
+                    {#if visitedTabs["logs"]}
                         <ArtifactTab {testRun} on:refreshRequest={fetchTestRunData} />
                     {/if}
                 </div>
@@ -469,7 +474,7 @@
                     id="nav-discuss-{runId}"
                     role="tabpanel"
                 >
-                    {#if activeTab === "discuss"}
+                    {#if visitedTabs["discuss"]}
                         <TestRunComments {testRun} {testInfo} />
                     {/if}
                 </div>
@@ -481,7 +486,7 @@
                     role="tabpanel"
                 >
                     <IssueTemplate test_run={testRun} test={testInfo.test} />
-                    {#if activeTab === "issues"}
+                    {#if visitedTabs["issues"]}
                         <IssueTab {testInfo} {runId} />
                     {/if}
                 </div>
@@ -492,7 +497,7 @@
                     id="nav-activity-{runId}"
                     role="tabpanel"
                 >
-                    {#if activeTab === "activity"}
+                    {#if visitedTabs["activity"]}
                         <ActivityTab id={runId} />
                     {/if}
                 </div>


### PR DESCRIPTION
After recent changes, tab content is recreated when swiching tabs. This causes error of comment content disappear and also reloads events each time events tab is visited (etc.).

This fix makes behavior like before, so tab content is not recreated after visiting it.

fixes: https://github.com/scylladb/argus/issues/641