### PR TITLE
fix(summaryWidget): remove filtering tests based on product

### DIFF
--- a/frontend/Views/Widgets/SummaryWidget/SummaryWidget.svelte
+++ b/frontend/Views/Widgets/SummaryWidget/SummaryWidget.svelte
@@ -84,15 +84,7 @@
 
     async function fetchRunResults(currentVersionIndex = 0) {
         currentVersionRuns = versioned_runs[versions[currentVersionIndex]];
-        const isEnterprise = versions[currentVersionIndex].split('.')[0].length > 3;
         selectedVersionTestInfo = {...test_info};
-        selectedVersionTestInfo = Object.fromEntries(
-            Object.entries(selectedVersionTestInfo).filter(([testId, testData]) =>
-                isEnterprise
-                    ? testData.build_id.startsWith('scylla-enterprise')
-                    : !testData.build_id.startsWith('scylla-enterprise')
-            )
-        );
         const runs_response = await fetch(`/api/v1/views/widgets/summary/runs_results`, {
             method: "POST",
             headers: {"Content-Type": "application/json"},


### PR DESCRIPTION
We used to mix tests for enterprise/OSS versions in a view. When selecting one of it we wanted to exclude tests from the other (seeing only enterprise tests when enterprise version were selected). 
Now it's no longer needed and we started to mix master and enterprise tests in one view causing tests from `scylla-master` release not appearing.

fix by removing this filter.