### PR TITLE
fix(planner_service): Batch tests query

### DIFF
--- a/argus/backend/service/planner_service.py
+++ b/argus/backend/service/planner_service.py
@@ -460,8 +460,10 @@ class PlanningService:
         plan: ArgusReleasePlan = ArgusReleasePlan.get(id=plan_id)
 
         release: ArgusRelease = ArgusRelease.get(id=plan.release_id)
-        tests: list[ArgusTest] = list(ArgusTest.filter(id__in=plan.tests).all())
-        test_groups: list[ArgusGroup] = ArgusGroup.filter(id__in=[t.group_id for t in tests]).all()
+        tests: list[ArgusTest] = []
+        for batch in chunk(plan.tests):
+            tests.extend(ArgusTest.filter(id__in=batch).all())
+        test_groups: list[ArgusGroup] = ArgusGroup.filter(id__in=list({t.group_id for t in tests})).all()
         test_groups = { g.id: g for g in test_groups }
         groups: list[ArgusGroup] = list(ArgusGroup.filter(id__in=plan.groups).all())
 


### PR DESCRIPTION
This fixes an issue where if a plan has more than 100 tests assigned,
the logic for resolving said tests fails with cartesian product
exceeding the query.
