### PR TITLE
improvement(release_planner): Allow user to attach an existing view

### DIFF
--- a/argus/backend/controller/planner_api.py
+++ b/argus/backend/controller/planner_api.py
@@ -145,7 +145,8 @@ def copy_plan():
 @bp.route("/plan/<string:plan_id>/delete", methods=["DELETE"])
 @api_login_required
 def delete_plan(plan_id: str):
-    result = PlanningService().delete_plan(plan_id)
+    delete_view = bool(int(request.args.get("deleteView", "0")))
+    result = PlanningService().delete_plan(plan_id, delete_view=delete_view)
 
     return {
         "status": "ok",

--- a/argus/backend/service/planner_service.py
+++ b/argus/backend/service/planner_service.py
@@ -32,6 +32,7 @@ class CreatePlanPayload:
     tests: list[str]
     groups: list[str]
     assignments: dict[str, str]
+    view_id: Optional[str] = None
     created_from: Optional[str] = None
 
 
@@ -49,11 +50,11 @@ class TempPlanPayload:
     release_id: str
     tests: list[str]
     groups: list[str]
-    view_id: str
     creation_time: str
     last_updated: str
     ends_at: str
     created_from: Optional[str]
+    view_id: Optional[str] = None
 
 @dataclass(frozen=True, init=True, repr=True, kw_only=True)
 class CopyPlanPayload:
@@ -131,9 +132,13 @@ class PlanningService:
         plan.tests = plan_request.tests
         if plan_request.created_from:
             plan.created_from = plan_request.created_from
-        view = self.create_view_for_plan(plan)
-        plan.view_id = view.id
-
+        if not plan_request.view_id:
+            view = self.create_view_for_plan(plan)
+            plan.view_id = view.id
+        else:
+            plan.view_id = plan_request.view_id
+            view = self.update_view_for_plan(plan, existing=True)
+        
         plan.save()
 
         return plan
@@ -158,15 +163,30 @@ class PlanningService:
         plan.target_version = plan_request.target_version
         plan.description = plan_request.description
         plan.last_updated = datetime.datetime.now(tz=datetime.UTC)
-        plan.save()
 
-        view = self.update_view_for_plan(plan)
-        plan.view_id = view.id
+        if plan_request.view_id:
+            if plan_request.view_id != plan.view_id:
+                try:
+                    old_view: ArgusUserView = ArgusUserView.get(id=plan.view_id)
+                    old_view.plan_id = None
+                    old_view.save()
+                except ArgusUserView.DoesNotExist:
+                    pass
+            plan.view_id = plan_request.view_id
+            view = self.update_view_for_plan(plan, existing=True)
+        else:
+            if plan.view_id:
+                view: ArgusUserView = ArgusUserView.get(id=plan.view_id)
+                view.plan_id = None
+                view.save()
+            view = self.create_view_for_plan(plan)
+            plan.view_id = view.id
+
         plan.save()
         
         return True
 
-    def update_view_for_plan(self, plan: ArgusReleasePlan) -> ArgusUserView:
+    def update_view_for_plan(self, plan: ArgusReleasePlan, existing: bool = False) -> ArgusUserView:
         service = UserViewService()
         release: ArgusRelease = ArgusRelease.get(id=plan.release_id)
 
@@ -174,14 +194,18 @@ class PlanningService:
         view_name = f"{release.name} {version_str}- {plan.name}"
 
         view: ArgusUserView = ArgusUserView.get(id=plan.view_id)
+        if view.plan_id and view.plan_id != plan.id:
+            raise PlannerServiceException("This view is already assigned to another plan.")
+        view.plan_id = plan.id
         settings = json.loads(view.widget_settings)
         items = [f"test:{tid}" for tid in plan.tests]
         items = [*items, *[f"group:{gid}" for gid in plan.groups]]
         entities = service.parse_view_entity_list(items)
         view.tests = entities["tests"]
-        view.display_name = view_name
-        view.name = slugify(view_name)
-        view.description = f"{plan.target_version or ''} Automatic view for the release plan \"{plan.name}\". {plan.description}"
+        if not existing:
+            view.display_name = view_name
+            view.name = slugify(view_name)
+            view.description = f"{plan.target_version or ''} Automatic view for the release plan \"{plan.name}\". {plan.description}"
         view.group_ids = entities["group"]
 
         dash = next(filter(lambda widget: widget["type"] == "testDashboard", settings), None)
@@ -385,11 +409,15 @@ class PlanningService:
     def get_plans_for_release(self, release_id: str | UUID) -> list[ArgusReleasePlan]:
         return list(ArgusReleasePlan.filter(release_id=release_id).all())
 
-    def delete_plan(self, plan_id: str | UUID):
+    def delete_plan(self, plan_id: str | UUID, delete_view: bool = True):
         plan: ArgusReleasePlan = ArgusReleasePlan.get(id=plan_id)
         if plan.view_id:
             view: ArgusUserView = ArgusUserView.get(id=plan.view_id)
-            view.delete()
+            if delete_view:
+                view.delete()
+            else:
+                view.plan_id = None
+                view.save()
 
         plan.delete()
         return True

--- a/argus/backend/service/views.py
+++ b/argus/backend/service/views.py
@@ -24,6 +24,7 @@ class ViewUpdateRequest(TypedDict):
     display_name: str
     tests: list[str]
     widget_settings: str
+    plan_id: str | None
 
 
 class UserViewService:

--- a/frontend/AdminPanel/ViewsManager.svelte
+++ b/frontend/AdminPanel/ViewsManager.svelte
@@ -99,6 +99,7 @@
         newView = {
             id: viewForUpdate.id,
             name: viewForUpdate.name,
+            plan_id: viewForUpdate.plan_id,
             description: viewForUpdate.description,
             displayName: viewForUpdate.display_name,
             settings: viewForUpdate.widget_settings,
@@ -120,6 +121,7 @@
                     name: newView.name,
                     description: newView.description,
                     display_name: newView.displayName,
+                    plan_id: newView.plan_id || null,
                     items: newView.items.map(item => `${item.type}:${item.id}`),
                     widget_settings: JSON.stringify(newWidgets),
                 }
@@ -405,6 +407,7 @@
                 <input class="form-control mb-2" type="text" placeholder="Name (internal)" disabled bind:value={newView.name}>
                 <input class="form-control mb-2" type="text" placeholder="Display name" on:change={() => newView.name = urlSlug.convert(newView.displayName)} bind:value={newView.displayName}>
                 <textarea class="form-control mb-2" type="text" placeholder="Description (optional)" bind:value={newView.description}/>
+                <input class="form-control mb-2" type="text" placeholder="Plan ID (internal)" bind:value={newView.plan_id}>
                 <div class="mb-2">
                     <Select
                         id="viewSelectComponent"

--- a/frontend/ReleasePlanner/ReleasePlanCreator.svelte
+++ b/frontend/ReleasePlanner/ReleasePlanCreator.svelte
@@ -12,6 +12,7 @@
     import ModalWindow from "../Common/ModalWindow.svelte";
     import ReleasePlannerGridView from "./ReleasePlannerGridView.svelte";
     import { filterUser } from "../Common/SelectUtils";
+    import ViewSelect from "../Views/ViewSelect.svelte";
 
 
     export let release;
@@ -23,6 +24,7 @@
     let lastHits = [];
     let participants = [];
     let items = [];
+    let views = [];
     const dispatch = createEventDispatcher();
 
     const TYPE_MARKER = {
@@ -107,6 +109,7 @@
                 participants: plan.participants,
                 target_version: plan.target_version,
                 release_id: plan.release_id,
+                view_id: plan.view_id,
                 tests: plan.tests,
                 groups: plan.groups,
                 assignments: plan.assignments,
@@ -251,6 +254,21 @@
         }
     };
 
+    const getAllViews = async function () {
+        try {
+            const response = await fetch("/api/v1/views/all");
+            const json = await response.json();
+            if (json.status != "ok") {
+                throw json;
+            }
+            views = json.response;
+            return views;
+
+        } catch (error) {
+            console.log(error);
+        }
+    };
+
     const resolvePlan = async function (plan) {
         try {
             const response = await fetch(`/api/v1/planning/plan/${plan.id}/resolve_entities`);
@@ -376,6 +394,7 @@
 
     onMount(async () => {
         await getUsers();
+        await getAllViews();
         if (mode == "edit" || mode == "createFrom") {
             plan.assignments = plan.assignee_mapping;
             participants = users.filter(u => plan.participants.includes(u.id));
@@ -475,6 +494,19 @@
                 itemFilter={filterUser}
                 isMulti={true}
                 labelIdentifier="username"
+                optionIdentifier="id"
+            />
+        </div>
+    </div>
+    <div class="d-flex align-items-center mb-2">
+        <div class="w-25 fw-bold me-2">Existing view</div>
+        <div class="flex-fill">
+            <Select
+                value={views.find(p => p.id == plan.view_id)}
+                on:select={(e) => plan.view_id = e.detail.id}
+                items={views}
+                Item={ViewSelect}
+                labelIdentifier="display_name"
                 optionIdentifier="id"
             />
         </div>

--- a/frontend/ReleasePlanner/ReleasePlanner.svelte
+++ b/frontend/ReleasePlanner/ReleasePlanner.svelte
@@ -19,6 +19,7 @@
     let editingPlan = false;
     let copyingPlan = false;
     let createFromPlan = false;
+    let deleteViewForPlan = true;
     let selectedPlan;
     let releaseRedirect = "";
 
@@ -107,7 +108,7 @@
     const handlePlanDelete = async function () {
 
         try {
-            const response = await fetch(`/api/v1/planning/plan/${selectedPlan.id}/delete`, {
+            const response = await fetch(`/api/v1/planning/plan/${selectedPlan.id}/delete?deleteView=${new Number(deleteViewForPlan)}`, {
                 method: "DELETE",
             });
 
@@ -215,6 +216,10 @@
         </div>
         <div slot="body">
             <div>Are you sure you want to delete this plan?</div>
+            <div class="my-2 fw-bold p-2">
+                <label class="form-check-label" for="planDeleteViewCheckbox">Delete attached view</label>
+                <input class="form-check-input" type="checkbox" id="planDeleteViewCheckbox" bind:checked={deleteViewForPlan}>
+            </div>
 
             <div class="d-flex p-2">
                 <button

--- a/frontend/Views/ViewSelect.svelte
+++ b/frontend/Views/ViewSelect.svelte
@@ -1,0 +1,46 @@
+<script>
+    import { faObjectGroup } from "@fortawesome/free-solid-svg-icons";
+    import Fa from "svelte-fa";
+
+    export let item = undefined;
+    export let isActive = false;
+    export let isFirst = false;
+    export let isHover = false;
+</script>
+
+<div
+    class:view-active={isActive}
+    class:view-first={isFirst}
+    class:view-hover={isHover}
+    class="view-element border-bottom"
+>
+    <div class="d-flex align-items-center p-2">
+        <div>
+            <Fa icon={faObjectGroup}/>
+        </div>
+        <div class="ms-2 text-start">
+            <div>{item?.display_name || item.name}</div>
+            <div class="text-muted view-label">{item.description}</div>
+        </div>
+    </div>
+</div>
+
+<style>
+    .view-first {
+        background-color: #ffffff;
+    }
+
+    .view-active {
+        background-color: #6b9cf7;
+    }
+
+    .view-hover {
+        background-color: #4c66f8;
+        color: white;
+        cursor: pointer;
+    }
+
+    .view-element:hover .view-label {
+        color: #c4c4c4 !important;
+    }
+</style>


### PR DESCRIPTION
This commit adds additional logic to support attaching an existing view
to a newly created (or one being edited) plan. Attached view will
preserve its name and description, as well as widgets, but its selection
will be replaced by plan's selection. Additionally, when deleting a
plan, a new checkbox has been added to prevent attached view from being
deleted (in this case it just detaches and becomes a free-standing
view). To handle corner cases, Admin users can now also edit the plan_id
field of views inside view manager, in case manual intervention is
required.

For views, it is assumed that they only linked to 1 plan and cannot be
relinked from a plan without being detached first. The detachment can be
done in two ways:
 * Create a new view and attach it to a plan, thereby detaching the
   previous view
 * Remove view from selection inside Plan Editor, in which case a new
   view (automatic) will be created for the plan

Fixes #610
