### PR TITLE
improvement(client): Allow GenericResultTable with dynamic parameters

### DIFF
--- a/argus/backend/service/planner_service.py
+++ b/argus/backend/service/planner_service.py
@@ -144,7 +144,7 @@ class PlanningService:
         else:
             plan.view_id = plan_request.view_id
             view = self.update_view_for_plan(plan, existing=True)
-        
+
         plan.save()
 
         return plan

--- a/argus/backend/tests/client_service/test_submit_results.py
+++ b/argus/backend/tests/client_service/test_submit_results.py
@@ -5,7 +5,8 @@ import pytest
 
 from argus.backend.error_handlers import DataValidationError
 from argus.backend.tests.conftest import get_fake_test_run
-from argus.client.generic_result import GenericResultTable, ColumnMetadata, ResultType, ValidationRule, Status
+from argus.client.generic_result import ColumnMetadata, ResultType, ValidationRule, Status, \
+    StaticGenericResultTable
 
 
 @dataclass
@@ -16,7 +17,7 @@ class SampleCell:
     status: Status = Status.UNSET
 
 
-class SampleTable(GenericResultTable):
+class SampleTable(StaticGenericResultTable):
     class Meta:
         name = "Test Table"
         description = "Test Table Description"

--- a/argus/backend/tests/results_service/test_best_results.py
+++ b/argus/backend/tests/results_service/test_best_results.py
@@ -8,12 +8,12 @@ from argus.backend.error_handlers import DataValidationError
 from argus.backend.plugins.sct.testrun import SCTTestRun
 from argus.backend.tests.conftest import get_fake_test_run, fake_test
 from argus.common.enums import TestInvestigationStatus
-from argus.client.generic_result import GenericResultTable, ColumnMetadata, ResultType, ValidationRule, Status
+from argus.client.generic_result import ColumnMetadata, ResultType, ValidationRule, Status, StaticGenericResultTable
 
 LOGGER = logging.getLogger(__name__)
 
 
-class SampleTable(GenericResultTable):
+class SampleTable(StaticGenericResultTable):
     class Meta:
         name = "Test Table Name"
         description = "Test Table Description"
@@ -102,7 +102,7 @@ def test_can_enable_best_results_tracking(fake_test, client_service, results_ser
     best_results = results_service.get_best_results(fake_test.id, results.name)
     assert 'non tracked col name:row' not in best_results  # non tracked column should not be tracked
 
-    class TrackingAllSampleTable(GenericResultTable):
+    class TrackingAllSampleTable(StaticGenericResultTable):
         class Meta:
             name = "Test Table Name"
             description = "Test Table Description"

--- a/argus/backend/tests/results_service/test_validation_rules.py
+++ b/argus/backend/tests/results_service/test_validation_rules.py
@@ -7,12 +7,12 @@ import pytest
 
 from argus.backend.error_handlers import DataValidationError
 from argus.backend.tests.conftest import get_fake_test_run, fake_test
-from argus.client.generic_result import GenericResultTable, ColumnMetadata, ResultType, ValidationRule, Status
+from argus.client.generic_result import ColumnMetadata, ResultType, ValidationRule, Status, StaticGenericResultTable
 
 LOGGER = logging.getLogger(__name__)
 
 
-class SampleTable(GenericResultTable):
+class SampleTable(StaticGenericResultTable):
     class Meta:
         name = "Test Table Name"
         description = "Test Table Description"

--- a/argus/client/generic_result.py
+++ b/argus/client/generic_result.py
@@ -161,5 +161,6 @@ class StaticGenericResultTable(GenericResultTable):
             description=description or meta.description,
             columns=columns or getattr(meta, "Columns", getattr(meta, "columns", None)),
             sut_package_name=sut_package_name or getattr(meta, "sut_package_name", ""),
-            validation_rules=validation_rules or getattr(meta, "ValidationRules", getattr(meta, "validation_rules", {})),
+            validation_rules=validation_rules or getattr(
+                meta, "ValidationRules", getattr(meta, "validation_rules", {})),
         )

--- a/argus/client/generic_result.py
+++ b/argus/client/generic_result.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from enum import Enum, auto
+from functools import cached_property
 from typing import Union
 
 
@@ -35,7 +36,7 @@ class ColumnMetadata:
             "name": self.name,
             "unit": self.unit,
             "type": str(self.type),
-            "higher_is_better": self.higher_is_better
+            "higher_is_better": self.higher_is_better,
         }
 
 
@@ -86,21 +87,39 @@ class Cell:
 
     def as_dict(self) -> dict:
         cell = {"value_text": self.value} if isinstance(self.value, str) else {"value": self.value}
-        cell.update({
-            "column": self.column,
-            "row": self.row,
-            "status": str(self.status)
-        })
+        cell.update({"column": self.column, "row": self.row, "status": str(self.status)})
         return cell
 
 
 @dataclass
-class GenericResultTable(metaclass=ResultTableMeta):
+class GenericResultTable:
     """
     Base class for all Generic Result Tables in Argus. Use it as a base class for your result table.
     """
-    sut_timestamp: int = 0  # automatic timestamp based on SUT version. Works only with SCT and refers to Scylla version.
+
+    name: str = ""
+    description: str = ""
+    columns: list[ColumnMetadata] = field(default_factory=list)
+    # automatic timestamp based on SUT version. Works only with SCT and refers to Scylla version.
+    sut_timestamp: int = 0
+    sut_package_name: str = ""
     results: list[Cell] = field(default_factory=list)
+    validation_rules: dict[str, ValidationRule] = field(default_factory=dict)
+
+    @cached_property
+    def column_types(self):
+        """Return columns types as a dictionary."""
+        return {column.name: column.type for column in self.columns}
+
+    def __post_init__(self):
+        """Validate validation rules."""
+        for col_name, rule in self.validation_rules.items():
+            if col_name not in self.column_types:
+                raise ValueError(f"ValidationRule column {col_name} not found in the table")
+            if self.column_types[col_name] == ResultType.TEXT:
+                raise ValueError(f"Validation rules don't apply to TEXT columns")
+            if not isinstance(rule, ValidationRule):
+                raise ValueError(f"Validation rule for column {col_name} is not of type ValidationRule")
 
     def as_dict(self) -> dict:
         rows = []
@@ -119,7 +138,7 @@ class GenericResultTable(metaclass=ResultTableMeta):
         return {
             "meta": meta_info,
             "sut_timestamp": self.sut_timestamp,
-            "results": [result.as_dict() for result in self.results]
+            "results": [result.as_dict() for result in self.results],
         }
 
     def add_result(self, column: str, row: str, value: Union[int, float, str], status: Status):
@@ -128,3 +147,19 @@ class GenericResultTable(metaclass=ResultTableMeta):
         if isinstance(value, str) and self.column_types[column] != ResultType.TEXT:
             raise ValueError(f"Column {column} is not of type TEXT")
         self.results.append(Cell(column=column, row=row, value=value, status=status))
+
+
+class StaticGenericResultTable(GenericResultTable):
+    """Results class for static results metainformation, defined in Meta class."""
+
+    def __init__(
+        self, name=None, description=None, columns=None, sut_package_name=None, validation_rules=None
+    ):
+        meta = getattr(self.__class__, "Meta")
+        super().__init__(
+            name=name or meta.name,
+            description=description or meta.description,
+            columns=columns or getattr(meta, "Columns", getattr(meta, "columns", None)),
+            sut_package_name=sut_package_name or getattr(meta, "sut_package_name", ""),
+            validation_rules=validation_rules or getattr(meta, "ValidationRules", getattr(meta, "validation_rules", {})),
+        )

--- a/argus/client/tests/test_results.py
+++ b/argus/client/tests/test_results.py
@@ -1,0 +1,160 @@
+import pytest
+
+from argus.client.generic_result import (
+    StaticGenericResultTable,
+    Status,
+    ColumnMetadata,
+    ResultType,
+    ValidationRule,
+    GenericResultTable,
+)
+
+
+class TestStaticResults(StaticGenericResultTable):
+    """
+    Testing Results, which contain all the information in Meta class
+    """
+
+    class Meta:
+        name = "Important Static Results"
+        description = "This is a test for important static results."
+        columns = [
+            ColumnMetadata(name="column1", unit="unit1", type=ResultType.INTEGER, higher_is_better=True),
+        ]
+        validation_rules = {"column1": ValidationRule(best_pct=10, best_abs=20, fixed_limit=30)}
+
+
+class TestDynamicResults(GenericResultTable):
+    """
+    Testing Results, which pass all the information in the constructor
+    """
+
+    def __init__(self, operation):
+        super().__init__(
+            name=f"{operation} - Dynamic Results",
+            description=f"Dynamic results for {operation}",
+            columns=[
+                ColumnMetadata(name="column1", unit="unit1", type=ResultType.INTEGER, higher_is_better=True),
+                ColumnMetadata(name="column2", unit="unit2", type=ResultType.FLOAT, higher_is_better=False),
+            ],
+            validation_rules={"column1": ValidationRule(best_pct=10, best_abs=20, fixed_limit=30)},
+        )
+
+
+class TestMixedResults(StaticGenericResultTable):
+    """
+    Testing Results, which combine Meta class with some dynamic information
+    """
+
+    def __init__(self, operation):
+        super().__init__(name=f"{operation} - Dynamic Results")
+
+    class Meta:
+        description = "This is a test for mixed results."
+        columns = [
+            ColumnMetadata(name="column1", unit="unit1", type=ResultType.INTEGER, higher_is_better=True),
+            ColumnMetadata(name="column2", unit="unit2", type=ResultType.FLOAT, higher_is_better=False),
+        ]
+        validation_rules = {"column1": ValidationRule(best_pct=10, best_abs=20, fixed_limit=30)}
+
+
+def test_static_results():
+    """
+    Tests that you can create Results with all the information in the Meta class
+    """
+    results = TestStaticResults()
+    serialized = results.as_dict()
+    assert serialized["meta"]["name"] == TestStaticResults.Meta.name
+    assert serialized["meta"]["description"] == TestStaticResults.Meta.description
+    assert len(serialized["meta"]["rows_meta"]) == 0
+    assert len(serialized["meta"]["columns_meta"]) == 1
+    assert len(serialized["meta"]["validation_rules"]) == 1
+    assert len(serialized["results"]) == 0
+
+
+def test_dynamic_results():
+    """
+    Tests that you can create Results with all the information in the constructor
+    """
+    results = TestDynamicResults("Write")
+    serialized = results.as_dict()
+    assert serialized["meta"]["name"] == "Write - Dynamic Results"
+    assert serialized["meta"]["description"] == "Dynamic results for Write"
+    assert len(serialized["meta"]["rows_meta"]) == 0
+    assert len(serialized["meta"]["columns_meta"]) == 2
+    assert len(serialized["meta"]["validation_rules"]) == 1
+    assert len(serialized["results"]) == 0
+
+
+def test_mixed_results():
+    """
+    Tests that you can create Results, which combine Meta class with some dynamic information
+    """
+    results = TestMixedResults("Write")
+    serialized = results.as_dict()
+    assert serialized["meta"]["name"] == "Write - Dynamic Results"
+    assert serialized["meta"]["description"] == "This is a test for mixed results."
+
+    assert len(serialized["meta"]["rows_meta"]) == 0
+    assert len(serialized["meta"]["columns_meta"]) == 2
+    assert len(serialized["meta"]["validation_rules"]) == 1
+    assert len(serialized["results"]) == 0
+
+
+def test_add_results():
+    """Tests add results method"""
+    results = TestStaticResults()
+    results.add_result(column="column1", row="row1", value=10, status=Status.UNSET)
+    results.add_result(column="column1", row="row2", value=20, status=Status.UNSET)
+    serialized = results.as_dict()
+
+    assert len(serialized["meta"]["rows_meta"]) == 2
+    assert len(serialized["results"]) == 2
+
+
+def test_no_column():
+    """Tests validation for validation rule with nonexistent column"""
+
+    class NoColumnRule(StaticGenericResultTable):
+        class Meta:
+            name = "Testing results"
+            description = ""
+            columns = [
+                ColumnMetadata(name="column1", unit="unit1", type=ResultType.INTEGER, higher_is_better=True),
+            ]
+            validation_rules = {"nonexistent": ValidationRule(best_pct=10, best_abs=20, fixed_limit=30)}
+
+    with pytest.raises(ValueError, match="not found"):
+        NoColumnRule()
+
+
+def test_different_type():
+    """Tests validation of validation rule type"""
+
+    class BadType(StaticGenericResultTable):
+        class Meta:
+            name = "Testing results"
+            description = ""
+            columns = [
+                ColumnMetadata(name="column1", unit="unit1", type=ResultType.INTEGER, higher_is_better=True),
+            ]
+            validation_rules = {"nonexistent": "test"}
+
+    with pytest.raises(ValueError, match="ValidationRule"):
+        BadType()
+
+
+def test_text_rule():
+    """Test validation of rules for TEXT types"""
+
+    class TextType(StaticGenericResultTable):
+        class Meta:
+            name = "Testing results"
+            description = ""
+            columns = [
+                ColumnMetadata(name="column1", unit="unit1", type=ResultType.TEXT, higher_is_better=True),
+            ]
+            validation_rules = {"column1": ValidationRule(best_pct=10, best_abs=20, fixed_limit=30)}
+
+    with pytest.raises(ValueError, match="TEXT"):
+        TextType()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "argus-alm"
-version = "0.14.2"
+version = "0.15.0"
 description = "Argus"
 authors = ["Alexey Kartashov <alexey.kartashov@scylladb.com>", "Łukasz Sójka <lukasz.sojka@scylladb.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
### Problem statement

Currently, `GenericResultTable` is highly tied to the Meta class, which contains validation logic for validation rule. This creates a necessity of using Meta class even for cases where name is dynamic, which results in nested classes like this:

```python
def send_perf_simple_query_result_to_argus(argus_client: ArgusClient, result: dict):
    stats = result["stats"]
    workload = result["test_properties"]["type"]
    parameters = result["parameters"]

    class PerfSimpleQueryResult(GenericResultTable):
        class Meta:
            name = f"{workload} - Perf Simple Query"
            description = json.dumps(parameters)
            Columns = [ColumnMetadata(name="allocs_per_op", unit="", type=ResultType.FLOAT, higher_is_better=False),
                       ColumnMetadata(name="cpu_cycles_per_op", unit="", type=ResultType.FLOAT, higher_is_better=False),
                       ColumnMetadata(name="instructions_per_op", unit="",
                                      type=ResultType.FLOAT, higher_is_better=False),
                       ColumnMetadata(name="logallocs_per_op", unit="", type=ResultType.FLOAT, higher_is_better=False),
                       ColumnMetadata(name="mad tps", unit="", type=ResultType.FLOAT, higher_is_better=True),
                       ColumnMetadata(name="max tps", unit="", type=ResultType.FLOAT, higher_is_better=True),
                       ColumnMetadata(name="median tps", unit="", type=ResultType.FLOAT, higher_is_better=True),
                       ColumnMetadata(name="min tps", unit="", type=ResultType.FLOAT, higher_is_better=True),
                       ColumnMetadata(name="tasks_per_op", unit="", type=ResultType.FLOAT, higher_is_better=False),
                       ]

            ValidationRules = {
                "allocs_per_op": ValidationRule(best_pct=5),
                "instructions_per_op": ValidationRule(best_pct=5),
            }
```
which in my opinion, should not be necessary as it is impossible to reuse such class.

### Solution

* Move validation and all arguments into `GenericResultTable`
   * This means validation of validation rules is now only on instantiation of the class, not on class creation, but given how we used it, it should make no difference
* Introduce `StaticGenericResultTable`, which reads the data from `Meta` class as before.
   * Users can use either  `GenericResultTable` or `StaticGenericResultTable`, dependening on the use case.
   * All current usages in SCT will have to be changed to `StaticGenericResultTable` instead. This could be prevented by renaming but that would cause other problems (i.e. we would just switch the part we have to change)
   * Add alternative names in the Meta class (`Columns` -> `columns`, `ValidationRules` -> `validation_rules`)
        * This unifies the naming as some of the variables were using different naming scheme
* Add tests to both verify and showcase the new possibilities
