### PR TITLE
fix(sut_timestamp): lookup all the possible package names

### DIFF
--- a/argus/backend/plugins/core.py
+++ b/argus/backend/plugins/core.py
@@ -232,7 +232,7 @@ class PluginModelBase(Model):
     def finish_run(self, payload: dict = None):
         raise NotImplementedError()
 
-    def sut_timestamp(self) -> float:
+    def sut_timestamp(self, sut_package_name) -> float:
         raise NotImplementedError()
 
 class PluginInfoBase:

--- a/argus/backend/service/client_service.py
+++ b/argus/backend/service/client_service.py
@@ -104,7 +104,7 @@ class ClientService:
             table_metadata = ArgusGenericResultMetadata(test_id=run.test_id, **results["meta"])
             table_metadata.save()
         if results.get("sut_timestamp", 0) == 0:
-            results["sut_timestamp"] = run.sut_timestamp()  # automatic sut_timestamp
+            results["sut_timestamp"] = run.sut_timestamp(results.get('sut_package_name', 'scylla-server'))  # automatic sut_timestamp
         results["sut_timestamp"] = datetime.fromtimestamp(results["sut_timestamp"])
         best_results = results_service.update_best_results(test_id=run.test_id, table_name=table_name, table_metadata=table_metadata,
                                                            cells=cells, run_id=run_id)


### PR DESCRIPTION
since for `scylla-server` we can have multiple names availble in diffrent stages of the test we should honor those name, so if we report thing before the some of them are reported, it should still work.

regardless the default behavier of `sut_timestamp` should follow the `sut_package_name` if provided, it make much more sane usability-wise.