### PR TITLE
improvement(poetry): Use dev group

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1791,4 +1791,4 @@ email = ["email-validator"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "23fec6cdce47bd18e4f64c5e8d926b57dc675d3c400661a8f061fc090e280c37"
+content-hash = "22c6cde6a903c9c65c79a353bfd6a20c39f8b8b0267d5936cd1577484db5bfd7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ pygithub = "^2.6.1"
 [tool.poetry.group.docker-image.dependencies]
 supervisor = "^4.2.4"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 coverage = "5.5"
 docker = "7.1.0"
 pytest = "6.2.5"


### PR DESCRIPTION
* dev-dependencies are deprecated since poetry 1.2
* poetry.lock was regenerated with `poetry update`