### PR TITLE
improvement(TestDashboard): Extended filters

### DIFF
--- a/argus/backend/controller/api.py
+++ b/argus/backend/controller/api.py
@@ -139,6 +139,19 @@ def release_pytest_results(release_id: str):
     })
 
 
+@bp.route("/release/<string:release_id>/images")
+@api_login_required
+def release_images(release_id: str):
+    release_id = UUID(release_id)
+    service = ArgusService()
+    distinct_images = service.get_distinct_release_images(release_id=release_id)
+
+    return jsonify({
+        "status": "ok",
+        "response": distinct_images
+    })
+
+
 @bp.route("/release/planner/comment/get/test")
 def get_planner_comment_by_test():
     test_id = request.args.get("id")
@@ -499,10 +512,16 @@ def release_stats_v2():
     release = request.args.get("release")
     limited = bool(int(request.args.get("limited")))
     version = request.args.get("productVersion", None)
+    image_id = request.args.get("imageId", None)
     include_no_version = bool(int(request.args.get("includeNoVersion", True)))
     force = bool(int(request.args.get("force")))
     stats = ReleaseStatsCollector(
-        release_name=release, release_version=version).collect(limited=limited, force=force, include_no_version=include_no_version)
+        release_name=release, release_version=version).collect(
+            limited=limited,
+            force=force,
+            include_no_version=include_no_version,
+            image_id=image_id
+    )
 
     res = jsonify({
         "status": "ok",

--- a/argus/backend/controller/view_api.py
+++ b/argus/backend/controller/view_api.py
@@ -141,12 +141,13 @@ def view_stats():
     limited = bool(int(request.args.get("limited", 0)))
     version = request.args.get("productVersion", None)
     include_no_version = bool(int(request.args.get("includeNoVersion", True)))
+    image_id = request.args.get("imageId", None)
     force = bool(int(request.args.get("force",  0)))
     widget_id = request.args.get("widgetId", None)
     if widget_id:
         widget_id = int(widget_id)
     collector = ViewStatsCollector(view_id=view_id, filter=version)
-    stats = collector.collect(limited=limited, force=force, include_no_version=include_no_version, widget_id=widget_id)
+    stats = collector.collect(limited=limited, force=force, include_no_version=include_no_version, widget_id=widget_id, image_id=image_id)
 
     res = jsonify({
         "status": "ok",
@@ -161,6 +162,17 @@ def view_stats():
 def view_versions(view_id: str):
     service = UserViewService()
     res = service.get_versions_for_view(view_id)
+    return {
+        "status": "ok",
+        "response": res
+    }
+
+
+@bp.route("/<string:view_id>/images", methods=["GET"])
+@api_login_required
+def view_images(view_id: str):
+    service = UserViewService()
+    res = service.get_images_for_view(view_id)
     return {
         "status": "ok",
         "response": res

--- a/argus/backend/plugins/core.py
+++ b/argus/backend/plugins/core.py
@@ -200,6 +200,14 @@ class PluginModelBase(Model):
         raise NotImplementedError()
 
     @classmethod
+    def get_distinct_cloud_images_for_release(cls, release: ArgusRelease):
+        raise NotImplementedError()
+
+    @classmethod
+    def get_distinct_cloud_images_for_view(cls, tests: list[ArgusTest]):
+        raise NotImplementedError()
+
+    @classmethod
     def get_distinct_versions_for_view(cls, tests: list[ArgusTest]) -> list[str]:
         cluster = ScyllaCluster.get()
         statement = cluster.prepare(f"SELECT scylla_version FROM {cls.table_name()} WHERE build_id IN ?")

--- a/argus/backend/service/argus_service.py
+++ b/argus/backend/service/argus_service.py
@@ -176,6 +176,13 @@ class ArgusService:
 
         return sorted(list(unique_versions), reverse=True)
 
+    def get_distinct_release_images(self, release_id: UUID | str) -> list[str]:
+        release_id = UUID(release_id) if isinstance(release_id, str) else release_id
+        release = ArgusRelease.get(id=release_id)
+        images = AVAILABLE_PLUGINS["scylla-cluster-tests"].model.get_distinct_cloud_images_for_release(release)
+
+        return images
+
     def poll_test_runs(self, test_id: UUID, additional_runs: list[UUID], limit: int = 10):
         test: ArgusTest = ArgusTest.get(id=test_id)
 

--- a/argus/backend/service/views.py
+++ b/argus/backend/service/views.py
@@ -8,7 +8,7 @@ from cassandra.cqlengine.models import Model
 from argus.backend.models.plan import ArgusReleasePlan
 from argus.backend.models.pytest import PytestResultTable
 from argus.backend.models.web import ArgusGroup, ArgusRelease, ArgusTest, ArgusUserView, User
-from argus.backend.plugins.loader import all_plugin_models
+from argus.backend.plugins.loader import AVAILABLE_PLUGINS, all_plugin_models
 from argus.backend.service.test_lookup import TestLookup
 from argus.backend.util.common import chunk, current_user
 
@@ -197,6 +197,12 @@ class UserViewService:
                            for ver in plugin.get_distinct_versions_for_view(tests=tests)}
 
         return sorted(list(unique_versions), reverse=True)
+
+    def get_images_for_view(self, view_id: str | UUID) -> list[str]:
+        tests = self.resolve_view_tests(view_id)
+        images = AVAILABLE_PLUGINS["scylla-cluster-tests"].model.get_distinct_cloud_images_for_view(tests)
+
+        return images
 
     def resolve_view_for_edit(self, view_id: str | UUID) -> dict:
         view: ArgusUserView = ArgusUserView.get(id=view_id)

--- a/argus/backend/util/common.py
+++ b/argus/backend/util/common.py
@@ -1,12 +1,13 @@
 from itertools import islice
 import logging
-from typing import Callable, Iterable
+from typing import Callable, Iterable, TypeVar
 from uuid import UUID
 
 from flask import Request, Response, g
 
 from argus.backend.models.web import User
 
+T = TypeVar('T')
 
 LOGGER = logging.getLogger(__name__)
 FlaskView = Callable[..., Response]
@@ -23,7 +24,7 @@ def first(iterable, value, key: Callable = None, predicate: Callable = None):
     return None
 
 
-def chunk(iterable: Iterable, slice_size=90):
+def chunk(iterable: Iterable[T], slice_size=90) -> list[list[T]]:
     it = iter(iterable)
     return iter(lambda: list(islice(it, slice_size)), [])
 

--- a/frontend/Common/TestStatus.js
+++ b/frontend/Common/TestStatus.js
@@ -13,6 +13,20 @@ export const TestStatus = {
     UNKNOWN: "unknown",
 };
 
+export const TestStatusFilterDefaultState = {
+    "created": true,
+    "running": true,
+    "failed": true,
+    "test_error": true,
+    "error": true,
+    "passed": true,
+    "aborted": true,
+    "not_run": true,
+    "not_planned": true,
+    "unknown": true,
+    "skipped": true,
+};
+
 export const TestStatusChangeable = {
     FAILED: "failed",
     TEST_ERROR: "test_error",
@@ -109,8 +123,8 @@ export const StatusButtonCSSClassMap = {
     "passed": "btn-success",
     "aborted": "btn-dark",
     "not_run": "btn-secondary",
-    "not_planned": "btn-muted",
-    "unknown": "btn-muted"
+    "not_planned": "btn-secondary",
+    "unknown": "btn-secondary"
 };
 
 export const StatusSortPriority = {

--- a/frontend/ReleaseDashboard/AssigneeFilter.svelte
+++ b/frontend/ReleaseDashboard/AssigneeFilter.svelte
@@ -4,7 +4,7 @@
     import User from "../Profile/User.svelte";
     import { userList } from "../Stores/UserlistSubscriber";
     import { filterUser } from "../Common/SelectUtils";
-
+    export let user;
     const dispatch = createEventDispatcher();
     let users = {};
     $: users = $userList;
@@ -16,6 +16,7 @@
 
 <div class="w-100">
     <Select
+        value={user}
         itemFilter={filterUser}
         placeholder="Filter..."
         labelIdentifier="username"

--- a/frontend/ReleaseDashboard/TestDashboardFlatView.svelte
+++ b/frontend/ReleaseDashboard/TestDashboardFlatView.svelte
@@ -3,9 +3,8 @@
 
     export let groupStats;
     export let assigneeList;
-    export let userFilter;
     export let clickedTests;
-    export let hideNotPlanned;
+    export let doFilters = (test) => false;
 
 
     const sortTestStats = function (testStats) {
@@ -32,6 +31,6 @@
 
 {#if !groupStats.disabled}
     {#each Object.entries(sortTestStats(groupStats.tests)) as [testId, testStats] (testId)}
-        <TestDashboardTest {assigneeList} bind:clickedTests={clickedTests} {groupStats} {testStats} {hideNotPlanned} {userFilter} on:testClick/>
+        <TestDashboardTest {assigneeList} bind:clickedTests={clickedTests} {groupStats} {testStats} {doFilters} on:testClick/>
     {/each}
 {/if}

--- a/frontend/ReleaseDashboard/TestDashboardGroup.svelte
+++ b/frontend/ReleaseDashboard/TestDashboardGroup.svelte
@@ -13,9 +13,8 @@
     export let dashboardObjectType = "release";
     export let assigneeList;
     export let users;
-    export let userFilter;
+    export let doFilters;
     export let clickedTests;
-    export let hideNotPlanned;
 
     const dispatch = createEventDispatcher();
 
@@ -87,9 +86,9 @@
             </div>
         </h5>
         <div class="collapse" class:show={!collapsed} id="collapse-{groupStats.group.id}">
-            <div class="my-2 d-flex flex-wrap bg-lighter rounded shadow-sm">
+            <div id="testContainer-{groupStats.group.id}" class="my-2 d-flex flex-wrap bg-lighter rounded shadow-sm">
                 {#each Object.entries(sortTestStats(groupStats.tests)) as [testId, testStats] (testId)}
-                    <TestDashboardTest {assigneeList} bind:clickedTests={clickedTests} {groupStats} {testStats} {hideNotPlanned} {userFilter} on:testClick/>
+                    <TestDashboardTest {assigneeList} bind:clickedTests={clickedTests} {groupStats} {testStats} {doFilters} on:testClick/>
                 {:else}
                     <div class="text-dark m-2">No tests for this group</div>
                 {/each}

--- a/frontend/ReleaseDashboard/TestDashboardTest.svelte
+++ b/frontend/ReleaseDashboard/TestDashboardTest.svelte
@@ -12,14 +12,13 @@
     export let groupStats;
     export let assigneeList;
     export let clickedTests;
-    export let hideNotPlanned;
-    export let userFilter;
+    export let doFilters;
     const dispatch = createEventDispatcher();
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <div
-    class:d-none={hideNotPlanned && testStats?.status == TestStatus.NOT_PLANNED || shouldFilterOutByUser(assigneeList, userFilter, testStats)}
+    class:d-none={!doFilters(testStats)}
     class:status-block-active={testStats.start_time != 0}
     class:investigating={testStats?.investigation_status == TestInvestigationStatus.IN_PROGRESS}
     class:should-be-investigated={testStats?.investigation_status == TestInvestigationStatus.NOT_INVESTIGATED && [TestStatus.FAILED, TestStatus.TEST_ERROR].includes(testStats?.status)}


### PR DESCRIPTION
This commit adds new filtering options to the TestDashboard component.
To simplify adding additional filters, a filtering stack object was
introduced to define a filtering operation, its state and its comparison
operation. Each filter state is saved into local storage upon
interaction and restored when reloading the page. Previously available
filters were reworked for the new system.

The filters are:

 * Assignee
 * Status (Improved) - Can now filter out any status, not just not planned
 * Backend (New) - Filters to SCT tests using specified backend
 * ImageId (New) - Filters to SCT tests using specified image

Fixes #319
