### PR TITLE
feature(TestRun/Jenkins): allow some parameters to be multiline

### DIFF
--- a/frontend/TestRun/Jenkins/ParameterEditor.svelte
+++ b/frontend/TestRun/Jenkins/ParameterEditor.svelte
@@ -71,7 +71,11 @@
                 {#if param.value || paramTab == 2}
                     <div class="mb-1">
                         <label class="form-label fw-bold" for={param.name}>{param.name}</label>
-                        <input class="form-control" id={param.name} type="text" bind:value={buildParams[param.name]}>
+                         {#if (param._class || "").includes("TextParameter")}
+                            <textarea class="form-control" id={param.name} bind:value={buildParams[param.name]} rows="4"></textarea>
+                        {:else}
+                            <input class="form-control" id={param.name} type="text" bind:value={buildParams[param.name]}>
+                        {/if}
                         <div id="paramHelp{sanitizeSelector(param.name)}" class="form-text">{@html param.description}</div>
                     </div>
                 {/if}

--- a/frontend/TestRun/Jenkins/TextParam.svelte
+++ b/frontend/TestRun/Jenkins/TextParam.svelte
@@ -1,0 +1,7 @@
+<script>
+    export let params;
+    export let definition = {};
+    export let wrapper;
+</script>
+
+<textarea class="form-control" type="text" bind:value={params[definition.internalName]} on:change={(e) => wrapper ? wrapper(e, definition, params) : definition.onChange(e, params)} rows="4"></textarea>


### PR DESCRIPTION
Allow some parameters that are multiline in Jenkins to be multiline in Argus, so editing them is easier without having to add newline chars manually.

closes: #668
