### PR TITLE
feature(frontend): Pytest Overview Widget

### DIFF
--- a/argus/backend/controller/view_api.py
+++ b/argus/backend/controller/view_api.py
@@ -10,6 +10,7 @@ from argus.backend.controller.views_widgets.summary import bp as summary_bp
 from argus.backend.controller.views_widgets.graphs import bp as graphs_bp
 from argus.backend.controller.views_widgets.nemesis_stats import bp as nemesis_stats_bp
 from argus.backend.controller.views_widgets.graphed_stats import bp as graphed_stats_bp
+from argus.backend.controller.views_widgets.pytest import bp as pytest_bp
 from argus.backend.error_handlers import handle_api_exception
 from argus.backend.models.web import User
 from argus.backend.service.stats import ViewStatsCollector
@@ -24,6 +25,7 @@ bp.register_blueprint(summary_bp)
 bp.register_blueprint(graphs_bp)
 bp.register_blueprint(graphed_stats_bp)
 bp.register_blueprint(nemesis_stats_bp)
+bp.register_blueprint(pytest_bp)
 bp.register_error_handler(Exception, handle_api_exception)
 
 

--- a/argus/backend/controller/views_widgets/pytest.py
+++ b/argus/backend/controller/views_widgets/pytest.py
@@ -1,0 +1,52 @@
+from uuid import UUID
+
+from flask import Blueprint
+
+from argus.backend.service.user import api_login_required
+from argus.backend.service.views_widgets.pytest import PytestViewService
+
+bp = Blueprint("pytest", __name__, url_prefix="/widgets")
+
+
+@bp.route("/pytest/view", methods=["GET"])
+@api_login_required
+def get_versioned_runs():
+    service = PytestViewService()
+    return {
+        "status": "ok",
+        "response": 0,
+    }
+
+
+@bp.route("/pytest/release/<string:release_id>/results")
+@api_login_required
+def get_release_pytest_results(release_id: str):
+    release_id = UUID(release_id)
+    service = PytestViewService()
+    res = service.release_results(release_id)
+
+    return {
+        "status": "ok",
+        "response": res
+    }
+
+
+@bp.route("/pytest/view/<string:view_id>/results", methods=["GET"])
+@api_login_required
+def get_view_pytest_results(view_id: str):
+    service = PytestViewService()
+    res = service.view_results(view_id)
+    return {
+        "status": "ok",
+        "response": res
+    }
+
+@bp.route("/pytest/<string:test_name>/<string:id>/fields", methods=["GET"])
+@api_login_required
+def get_user_fields_for_test(test_name: str, id: str):
+    service = PytestViewService()
+    res = service.get_user_fields_for_result(test_name, id)
+    return {
+        "status": "ok",
+        "response": res
+    }

--- a/argus/backend/models/pytest.py
+++ b/argus/backend/models/pytest.py
@@ -20,7 +20,8 @@ class PytestSubmitData(TypedDict):
     user_fields: dict[str, Any]
 
 
-class PytestResultTable(Model):
+class PytestResultTableOld(Model):
+    __table_name__ = "pytest_result_table"
     name = columns.Text(primary_key=True, partition_key=True)
     id = columns.TimeUUID(primary_key=True, clustering_order="DESC",
                           default=lambda: uuid_from_time(datetime.now(tz=UTC)))
@@ -47,3 +48,27 @@ class PytestResultTable(Model):
             "CREATE INDEX IF NOT EXISTS pytest_result_table_user_entries_idx ON pytest_result_table (ENTRIES(user_fields))")
         session.execute(
             "CREATE INDEX IF NOT EXISTS pytest_result_table_user_value_idx ON pytest_result_table (VALUES(user_fields))")
+
+
+class PytestResultTable(Model):
+    __table_name__ = "pytest_v2"
+    name = columns.Text(partition_key=True, primary_key=True)
+    status = columns.Text(primary_key=True, default=lambda: PytestStatus.PASSED.value)
+    id = columns.DateTime(primary_key=True, default=lambda: datetime.now(tz=UTC))
+    test_type = columns.Text(required=True)
+    run_id = columns.UUID(index=True, required=True)
+    test_id = columns.UUID(index=True)
+    release_id = columns.UUID(index=True)
+    duration = columns.Double()
+    message = columns.Text()
+    test_timestamp = columns.DateTime() # timestamp for the submitted test
+    session_timestamp = columns.DateTime() # timestamp of the test session
+    markers = columns.List(value_type=columns.Text())
+
+
+class PytestUserField(Model):
+    __table_name__ = "pytest_user_field"
+    name = columns.Text(partition_key=True, primary_key=True)
+    id = columns.DateTime(primary_key=True)
+    field_name = columns.Text(primary_key=True)
+    field_value = columns.Text()

--- a/argus/backend/models/web.py
+++ b/argus/backend/models/web.py
@@ -8,7 +8,7 @@ from cassandra.util import uuid_from_time, unix_time_from_uuid1
 
 from argus.backend.models.github_issue import GithubIssue, IssueLink
 from argus.backend.models.plan import ArgusReleasePlan
-from argus.backend.models.pytest import PytestResultTable
+from argus.backend.models.pytest import PytestResultTable, PytestResultTableOld, PytestUserField
 from argus.backend.models.result import ArgusGenericResultMetadata, ArgusGenericResultData, ArgusBestResultData, ArgusGraphView
 from argus.backend.models.runtime_store import RuntimeStore
 from argus.backend.models.view_widgets import WidgetHighlights, WidgetComment
@@ -398,6 +398,8 @@ USED_MODELS: list[Model] = [
     GithubIssue,
     IssueLink,
     PytestResultTable,
+    PytestUserField,
+    PytestResultTableOld,
 ]
 
 USED_TYPES: list[UserType] = [

--- a/argus/backend/service/views_widgets/pytest.py
+++ b/argus/backend/service/views_widgets/pytest.py
@@ -1,0 +1,193 @@
+from collections import defaultdict
+from datetime import UTC, date, datetime, timedelta
+from functools import reduce
+from pprint import pformat
+import re
+import logging
+from typing import NamedTuple, TypedDict
+from uuid import UUID
+from time import sleep, time
+
+
+from humanize import naturaltime
+from flask import request
+from cassandra.util import uuid_from_time, unix_time_from_uuid1
+from argus.backend.db import ScyllaCluster
+from argus.backend.models.pytest import PytestResultTable, PytestUserField
+from argus.backend.models.web import ArgusTest, ArgusUserView
+from argus.backend.plugins.generic.plugin import PluginInfo as GenericPluginInfo
+from argus.backend.util.common import chunk
+from argus.common.enums import PytestStatus
+
+LOGGER = logging.getLogger(__name__)
+
+
+class PytestResult(TypedDict):
+    hits: list[PytestResultTable]
+    barChart: dict
+    pieChart: dict
+
+class PytestViewService:
+    def __init__(self) -> None:
+        self.cluster = ScyllaCluster.get()
+
+    @staticmethod
+    def stringify_result(result: dict) -> str:
+        try:
+            return f"{result.name} {result.message or ''} {' '.join(f'{mark}' for mark in (result.markers or []))}".lower()
+        except Exception as exc:
+            LOGGER.error("%s", result, exc_info=True)
+            raise exc
+
+    def get_user_fields_for_result(self, name: str, id: str):
+        field_rows = PytestUserField.filter(name=name,  id=datetime.fromisoformat(id)).all()
+        result = { row["field_name"]: row["field_value"] for row in field_rows }
+
+        return result
+
+    @staticmethod
+    def do_user_field_filter(field: str, value: str, negated: bool, result: dict) -> bool:
+
+        if not (field_value := (result["user_fields"] or {}).get(field)):
+            return field not in (result["user_fields"] or {}) if negated else field in (result["user_fields"]or {})
+
+        res = field_value == value
+
+        if negated:
+            return not res
+        return res
+
+    def view_results(self, view_id: str | UUID):
+        return self.result_filter()
+
+    def release_results(self, release_id: str | UUID):
+        return self.result_filter()
+
+    def prepare_pie_chart(self, hits: list[dict]) -> dict:
+        def count_status(acc: dict, result: dict):
+            acc[result["status"]] += 1
+            return acc
+        return reduce(count_status, hits, defaultdict(lambda: 0))
+
+    def prepare_bar_chart(self, hits: list[dict], before: datetime, after: datetime) -> dict:
+        start_date = None
+        end_date = None
+        if not before and not after:
+            start_date = date.fromtimestamp(hits[-1]["id"].timestamp())
+            end_date = date.today()
+        elif before and not after:
+            start_date = date.fromtimestamp(hits[-1]["id"].timestamp())
+            end_date = date.fromtimestamp(before.timestamp())
+        elif after and not before:
+            start_date = date.fromtimestamp(after.timestamp())
+            end_date = date.today()
+        else:
+            start_date = date.fromtimestamp(after.timestamp())
+            end_date = date.fromtimestamp(before.timestamp())
+
+        bucket_days = (end_date - start_date).days
+        buckets = {date.today() - timedelta(days=d): defaultdict(lambda: 0) for d in range(bucket_days)}
+        for hit in hits:
+            if hit["session_timestamp"]:
+                key = date.fromtimestamp(hit["session_timestamp"].timestamp())
+                bucket = buckets.get(key, defaultdict(lambda: 0))
+                bucket[hit["status"]] += 1
+                buckets[key] = bucket
+
+
+        buckets = { k.strftime("%Y-%m-%d"): v for k, v in reversed(buckets.items())}
+        datasets = []
+        for status in PytestStatus:
+            datasets.append({
+                "label": status.value,
+                "data": [result.get(status.value, 0) for result in buckets.values()]
+            })
+
+        return {
+            "labels": list(buckets.keys()),
+            "datasets": datasets,
+        }
+
+    def result_filter(self) -> PytestResult:
+        db = ScyllaCluster.get()
+        test = request.args.get("test")
+
+        unique_tests: list[str] = []
+        unique_tests.extend((row["name"] for row in db.session.execute(f"SELECT DISTINCT name FROM pytest_v2", timeout=60.0).all()))
+
+        if test:
+            LOGGER.warning(test)
+            unique_tests = [t for t in unique_tests if re.search(re.escape(test), t)]
+
+        limit = request.args.get("limit", 500)
+        before = request.args.get("before")
+        after = request.args.get("after")
+        enabled_statuses = request.args.getlist("status[]")
+        query = request.args.get("query")
+        filters = request.args.getlist("filters[]")
+        markers = request.args.getlist("markers[]")
+
+        db_query = "SELECT test_id, id, name, run_id, message, session_timestamp, status, markers, duration, test_type FROM pytest_v2"
+        query_filters = []
+
+        if before:
+            before = datetime.fromtimestamp(int(before), tz=UTC)
+            query_filters.append(("id <= ?", before))
+
+        if after:
+            after = datetime.fromtimestamp(int(after), tz=UTC)
+            query_filters.append(("id >= ?", after))
+
+        prepared = db.prepare(db_query)
+        results: list[NamedTuple] = []
+        if isinstance(enabled_statuses, list) and len(enabled_statuses) > 0:
+            query_filters.append(("status in ?", enabled_statuses))
+
+        results = []
+        for sequential_batch in chunk(unique_tests, 1000):
+            futures = []
+            for partition_chunk in chunk(sequential_batch, 100):
+                parallel_filter = [*query_filters]
+                parallel_query = db_query
+                partition_filter = [("name IN ?", partition_chunk), *parallel_filter]
+                parallel_query += " WHERE "
+                parallel_query += " AND ".join([f for f, _ in partition_filter])
+                prepared = db.prepare(parallel_query)
+                future = db.session.execute_async(prepared, parameters=[p for _, p in partition_filter], timeout=60.0, execution_profile="read_fast_named_tuple")
+                futures.append(future)
+            results.extend([row for future in futures for row in future.result()])
+
+        if markers:
+            for marker in markers:
+                results = [result for result in results if marker in (result.markers or [])]
+        if query:
+            pattern = re.compile(query.lower())
+            results = [result for result in results if re.search(pattern, self.stringify_result(result))]
+        user_fields = {}
+
+        if filters:
+            base_filter_query = db.prepare("SELECT * FROM pytest_user_field WHERE name IN ? AND id IN ?")
+            futures = []
+            for batch in chunk((r.name,  r.id) for r in results):
+                future = db.session.execute_async(base_filter_query, parameters=[[b[0] for b in batch], [b[1] for b in batch]], timeout=60.0, execution_profile="read_fast")
+                futures.append(future)
+            filter_rows = [row for future in futures for row in future.result()]
+            for row in filter_rows:
+                key = (row["name"], row["id"])
+                val = user_fields.get(key, {})
+                val[row["field_name"]] = row["field_value"]
+                user_fields[key] = val
+            results = [{**result._asdict(), "user_fields": user_fields.get((result.name, result.id), {})} for result in results]
+            filters = [(f[0] == "!", f.lstrip("!").split("=", 1)[0], f.lstrip("!").split("=", 1)[1]) for f in filters]
+            for negated, field, value in filters:
+                results = [result for result in results if self.do_user_field_filter(field, value, negated, result)]
+        else:
+            results = [result._asdict() for result in results]
+
+        results = sorted(results, key=lambda r: r["id"], reverse=True)
+        return {
+            "total": len(results),
+            "barChart": self.prepare_bar_chart(results, before, after),
+            "pieChart": self.prepare_pie_chart(results),
+            "hits": results[:limit]
+        }

--- a/argus/backend/tests/conftest.py
+++ b/argus/backend/tests/conftest.py
@@ -8,6 +8,8 @@ from docker import DockerClient
 from flask import g
 
 from argus.backend.plugins.loader import all_plugin_types
+from argus.backend.service.testrun import TestRunService
+from argus.backend.service.views_widgets.pytest import PytestViewService
 from argus.backend.util.config import Config
 
 os.environ['DOCKER_HOST'] = ""
@@ -131,6 +133,16 @@ def release_manager_service(argus_db) -> ReleaseManagerService:
 @fixture(scope='session')
 def client_service(argus_db):
     return ClientService()
+
+
+@fixture(scope='session')
+def pv_service(argus_db) -> PytestViewService:
+    return PytestViewService()
+
+
+@fixture(scope='session')
+def testrun_service(argus_db) -> TestRunService:
+    return TestRunService()
 
 
 @fixture(scope='session')

--- a/argus/backend/tests/pytest_service/test_submit_results.py
+++ b/argus/backend/tests/pytest_service/test_submit_results.py
@@ -1,0 +1,157 @@
+from datetime import datetime, UTC
+
+import pytest
+
+from argus.backend.service.views_widgets.pytest import PytestViewService
+from argus.backend.service.client_service import ClientService
+from argus.backend.service.testrun import TestRunService
+
+
+def test_valid_results(client_service: ClientService, pv_service: PytestViewService):
+
+    sample_data = {
+        "name": "testSuite::test_sample",
+        "timestamp": 1753687331.758162,
+        "session_timestamp": 1753687331.758162,
+        "test_type": "dtest",
+        "run_id": "879b516b-6e93-4c4c-9c86-dd0f2fda5c66",
+        "status": "passed",
+        "duration": 1.27434,
+        "markers": ["dtest_full", "dtest"],
+        "user_fields": {
+            "SCYLLA_MODE": "release",
+            "SCYLLA_VERSION": "2023.1",
+        }
+    }
+
+    result = client_service.submit_pytest_result(sample_data)
+
+    assert sample_data["name"] == result["name"]
+    assert datetime.fromtimestamp(sample_data["timestamp"], tz=UTC) == result["id"]
+
+    fields = pv_service.get_user_fields_for_result(result["name"], result["id"].isoformat())
+
+    assert fields == sample_data["user_fields"]
+
+
+def test_avg_duration(testrun_service: TestRunService, client_service: ClientService):
+
+    sample_data = {
+        "name": "testSuite::test_sample_duration_avg",
+        "timestamp": 1753687331.758162,
+        "session_timestamp": 1753687331.758162,
+        "test_type": "dtest",
+        "run_id": "879b516b-6e93-4c4c-9c86-dd0f2fda5c66",
+        "status": "passed",
+        "duration": 1.27434,
+        "markers": ["dtest_full", "dtest"],
+        "user_fields": {
+            "SCYLLA_MODE": "release",
+            "SCYLLA_VERSION": "2023.1",
+        }
+    }
+
+    durations = [3, 5, 7]
+    sample_tests = [{**sample_data, "timestamp": 1753687331.758162 + (i*10), "duration": durations[i]} for i in  range(3)]
+
+    for sample in sample_tests:
+        client_service.submit_pytest_result(sample)
+
+    result = testrun_service.get_pytest_test_field_stats(sample_data["name"], "duration", "avg", {})
+
+    assert sum(durations)/len(durations) == result[sample_data["name"]]["duration"]["avg"]
+
+
+def test_avg_duration_with_status_query(testrun_service: TestRunService, client_service: ClientService):
+
+    sample_data = {
+        "name": "testSuite::test_sample_duration_avg",
+        "timestamp": 1753687331.758162,
+        "session_timestamp": 1753687331.758162,
+        "test_type": "dtest",
+        "run_id": "879b516b-6e93-4c4c-9c86-dd0f2fda5c66",
+        "status": "passed",
+        "duration": 1.27434,
+        "markers": ["dtest_full", "dtest"],
+        "user_fields": {
+            "SCYLLA_MODE": "release",
+            "SCYLLA_VERSION": "2023.1",
+        }
+    }
+
+    durations = [3, 5, 7]
+    sample_tests = [{**sample_data, "timestamp": 1753687331.758162 + (i*10), "duration": durations[i]} for i in  range(3)]
+
+    for sample in sample_tests:
+        client_service.submit_pytest_result(sample)
+
+    result = testrun_service.get_pytest_test_field_stats(sample_data["name"], "duration", "avg", {})
+
+    assert sum(durations)/len(durations) == result[sample_data["name"]]["duration"]["avg"]
+
+    result = testrun_service.get_pytest_test_field_stats(sample_data["name"], "duration", "avg", {"status": "passed"})
+    assert sum(durations)/len(durations) == result[sample_data["name"]]["duration"]["avg"]
+
+
+def test_avg_duration_with_time_query(testrun_service: TestRunService, client_service: ClientService):
+
+    sample_data = {
+        "name": "testSuite::test_sample_duration_avg",
+        "timestamp": 1753687331.758162,
+        "session_timestamp": 1753687331.758162,
+        "test_type": "dtest",
+        "run_id": "879b516b-6e93-4c4c-9c86-dd0f2fda5c66",
+        "status": "passed",
+        "duration": 1.27434,
+        "markers": ["dtest_full", "dtest"],
+        "user_fields": {
+            "SCYLLA_MODE": "release",
+            "SCYLLA_VERSION": "2023.1",
+        }
+    }
+
+    since = 1753680000
+    durations = [3, 5, 7]
+    sample_tests = [{**sample_data, "timestamp": 1753687331.758162 + (i*10), "duration": durations[i]} for i in  range(3)]
+
+    for sample in sample_tests:
+        client_service.submit_pytest_result(sample)
+
+    result = testrun_service.get_pytest_test_field_stats(sample_data["name"], "duration", "avg", {})
+
+    assert sum(durations)/len(durations) == result[sample_data["name"]]["duration"]["avg"]
+
+    result = testrun_service.get_pytest_test_field_stats(sample_data["name"], "duration", "avg", {"since": since})
+    assert sum(durations)/len(durations) == result[sample_data["name"]]["duration"]["avg"]
+
+
+def test_avg_duration_with_status_and_time_query(testrun_service: TestRunService, client_service: ClientService):
+
+    sample_data = {
+        "name": "testSuite::test_sample_duration_avg",
+        "timestamp": 1753687331.758162,
+        "session_timestamp": 1753687331.758162,
+        "test_type": "dtest",
+        "run_id": "879b516b-6e93-4c4c-9c86-dd0f2fda5c66",
+        "status": "passed",
+        "duration": 1.27434,
+        "markers": ["dtest_full", "dtest"],
+        "user_fields": {
+            "SCYLLA_MODE": "release",
+            "SCYLLA_VERSION": "2023.1",
+        }
+    }
+
+    durations = [3, 5, 7]
+    since = 1753680000
+    sample_tests = [{**sample_data, "timestamp": 1753687331.758162 + (i*10), "duration": durations[i]} for i in  range(3)]
+
+    for sample in sample_tests:
+        client_service.submit_pytest_result(sample)
+
+    result = testrun_service.get_pytest_test_field_stats(sample_data["name"], "duration", "avg", {})
+
+    assert sum(durations)/len(durations) == result[sample_data["name"]]["duration"]["avg"]
+
+    result = testrun_service.get_pytest_test_field_stats(sample_data["name"], "duration", "avg", {"status": "passed", "since": since})
+    assert sum(durations)/len(durations) == result[sample_data["name"]]["duration"]["avg"]

--- a/argus/backend/util/encoders.py
+++ b/argus/backend/util/encoders.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from flask.json.provider import DefaultJSONProvider
 import cassandra.cqlengine.usertype as ut
 import cassandra.cqlengine.models as m
+from cassandra.util import OrderedMapSerializedKey
 
 
 LOGGER = logging.getLogger(__name__)
@@ -40,6 +41,8 @@ class ArgusJSONProvider(DefaultJSONProvider):
         match o:
             case UUID():
                 return str(o)
+            case OrderedMapSerializedKey():
+                return dict(o)
             case ut.UserType():
                 o = {str(k): v for k, v in o.items()}
                 o = cls.process_nested_dicts(o)

--- a/frontend/Common/TestStatus.js
+++ b/frontend/Common/TestStatus.js
@@ -166,6 +166,85 @@ export const ResultCellStatusStyleMap = {
 };
 
 export const NemesisStatusToTestStatus = {
-  "skipped": "aborted",
-  "succeeded": "passed",
-}
+    "skipped": "aborted",
+    "succeeded": "passed",
+};
+
+export const PytestStatus = {
+    PASSED: "passed",
+    FAILURE: "failure",
+    SKIPPED: "skipped",
+    ERROR: "error",
+    XFAILED: "xfailed",
+    XPASS: "xpass",
+    PASSED_ERROR: "passed & error",
+    FAILURE_ERROR: "failure & error",
+    SKIPPED_ERROR: "skipped & error",
+    ERROR_ERROR: "error & error",
+};
+
+export const PytestColors = {
+    [PytestStatus.PASSED]: "#198754",
+    [PytestStatus.FAILURE]: "#dc3545",
+    [PytestStatus.ERROR]: "#ffc107",
+    [PytestStatus.SKIPPED]: "#212529",
+    [PytestStatus.XFAILED]: "#442529",
+    [PytestStatus.XPASS]: "#198754",
+    [PytestStatus.PASSED_ERROR]: "#438754",
+    [PytestStatus.FAILURE_ERROR]: "#ee5545",
+    [PytestStatus.SKIPPED_ERROR]: "#445533",
+    [PytestStatus.ERROR_ERROR]: "#ddaa07",
+};
+
+export const PytestBgStyles = {
+    [PytestStatus.PASSED]: "bg-success",
+    [PytestStatus.FAILURE]: "bg-danger",
+    [PytestStatus.ERROR]: "bg-warning",
+    [PytestStatus.SKIPPED]: "bg-dark",
+    [PytestStatus.XFAILED]: "bg-light",
+    [PytestStatus.XPASS]: "bg-light",
+    [PytestStatus.PASSED_ERROR]: "bg-warning",
+    [PytestStatus.FAILURE_ERROR]: "bg-danger",
+    [PytestStatus.SKIPPED_ERROR]: "bg-dark",
+    [PytestStatus.ERROR_ERROR]: "bg-warning",
+};
+
+export const PytestFgStyles = {
+    [PytestStatus.PASSED]: "text-success",
+    [PytestStatus.FAILURE]: "text-danger",
+    [PytestStatus.ERROR]: "text-warning",
+    [PytestStatus.SKIPPED]: "text-dark",
+    [PytestStatus.XFAILED]: "text-light",
+    [PytestStatus.XPASS]: "text-light",
+    [PytestStatus.PASSED_ERROR]: "text-warning",
+    [PytestStatus.FAILURE_ERROR]: "text-danger",
+    [PytestStatus.SKIPPED_ERROR]: "text-dark",
+    [PytestStatus.ERROR_ERROR]: "text-warning",
+};
+
+
+export const PytestTextStyles = {
+    [PytestStatus.PASSED]: "text-light",
+    [PytestStatus.FAILURE]: "text-light",
+    [PytestStatus.ERROR]: "text-dark",
+    [PytestStatus.SKIPPED]: "text-light",
+    [PytestStatus.XFAILED]: "text-dark",
+    [PytestStatus.XPASS]: "text-dark",
+    [PytestStatus.PASSED_ERROR]: "text-dark",
+    [PytestStatus.FAILURE_ERROR]: "text-light",
+    [PytestStatus.SKIPPED_ERROR]: "text-light",
+    [PytestStatus.ERROR_ERROR]: "text-dark",
+};
+
+export const PytestBtnStyles = {
+    [PytestStatus.PASSED]: "btn-success",
+    [PytestStatus.FAILURE]: "btn-danger",
+    [PytestStatus.ERROR]: "btn-warning",
+    [PytestStatus.SKIPPED]: "btn-dark",
+    [PytestStatus.XFAILED]: "btn-light",
+    [PytestStatus.XPASS]: "btn-light",
+    [PytestStatus.PASSED_ERROR]: "btn-warning",
+    [PytestStatus.FAILURE_ERROR]: "btn-danger",
+    [PytestStatus.SKIPPED_ERROR]: "btn-dark",
+    [PytestStatus.ERROR_ERROR]: "btn-warning",
+};

--- a/frontend/Common/ViewTypes.js
+++ b/frontend/Common/ViewTypes.js
@@ -6,7 +6,7 @@ import CheckValue from "../Views/WidgetSettingTypes/CheckValue.svelte";
 import MultiSelectValue from "../Views/WidgetSettingTypes/MultiSelectValue.svelte";
 import MultiStringValue from "../Views/WidgetSettingTypes/MultiStringValue.svelte";
 import StringValue from "../Views/WidgetSettingTypes/StringValue.svelte";
-import {TestStatus} from "./TestStatus";
+import {PytestStatus, TestStatus} from "./TestStatus";
 import {subUnderscores, titleCase} from "./TextUtils";
 import ViewHighlights from "../Views/Widgets/ViewHighlights/ViewHighlights.svelte";
 import IntegerValue from "../Views/WidgetSettingTypes/IntegerValue.svelte";
@@ -14,6 +14,7 @@ import SummaryWidget from "../Views/Widgets/SummaryWidget/SummaryWidget.svelte";
 import GraphWidget from "../Views/Widgets/GraphsWidget/GraphsWidget.svelte";
 import ViewNemesisStats from "../Views/Widgets/ViewNemesisStats.svelte";
 import ViewGraphedStats from "../Views/Widgets/ViewGraphedStats.svelte";
+import PytestOverviewWidget from "../Views/Widgets/PytestWidget/PytestOverviewWidget.svelte";
 
 export class Widget {
     constructor(position = -1, type = "testDashboard", settings = {}) {
@@ -154,6 +155,26 @@ export const WIDGET_TYPES = {
                 help: "Regular expressions to filter out tests (e.g. .*/artifacts/)",
                 displayName: "Test Filters"
             },
+        },
+    },
+    pytestOverview: {
+        type: PytestOverviewWidget,
+        friendlyName: "Pytest Stats",
+        settingDefinitions: {
+            collapsed: {
+                type: CheckValue,
+                default: false,
+                help: "Show widget full-screen or as collapsible accordion",
+                displayName: "Collapsible"
+            },
+            enabledStatuses: {
+                type: MultiSelectValue,
+                default: Object.values(PytestStatus),
+                values: Object.values(PytestStatus),
+                labels: Object.keys(PytestStatus).map(s => subUnderscores(s).split(" ").map(s => titleCase(s)).join(" ")),
+                help: "Select which statuses to enable by default",
+                displayName: "Statuses shown by default"
+            }
         },
     },
 };

--- a/frontend/Views/Widgets/PytestWidget/PytestCalendarSelector.svelte
+++ b/frontend/Views/Widgets/PytestWidget/PytestCalendarSelector.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+    import dayjs from "dayjs";
+    import { createEventDispatcher } from "svelte";
+
+    export let before: number | null;
+    export let after: number | null;
+    let isRange = !!before;
+    const dispatch = createEventDispatcher();
+
+    $: dateBefore = before ? dayjs.unix(before).format("YYYY-MM-DDTHH:mm") : null;
+    $: dateAfter = after ? dayjs.unix(after).format("YYYY-MM-DDTHH:mm") : null;
+    $: {
+        isRange ? null : before = null;
+        dispatch("setDirty");
+    }
+
+    const handleAfterChange = function(e: Event) {
+        const input = e.currentTarget as HTMLInputElement;
+        if (!input) {
+            after = null;
+            return;
+        }
+        after = dayjs(input.value, "YYYY-MM-DDTHH:mm").unix();
+        dispatch("setDirty");
+    };
+
+    const handleBeforeChange = function(e: Event) {
+        const input = e.currentTarget as HTMLInputElement;
+        if (!input) {
+            before = null;
+            return;
+        }
+        before = dayjs(input.value, "YYYY-MM-DDTHH:mm").unix();
+        dispatch("setDirty");
+    };
+</script>
+
+<div class="mb-2">
+    <div class="input-group">
+        <span class="input-group-text">
+            <input class="form-check-input mt-0 me-1" type="checkbox" bind:checked={isRange}>
+            Range
+        </span>
+        <span class="input-group-text">After</span>
+        <input class="form-control" type="datetime-local" bind:value={dateAfter} on:input={handleAfterChange}>
+        {#if isRange}
+        <span class="input-group-text">Before</span>
+            <input class="form-control" type="datetime-local" bind:value={dateBefore} on:input={handleBeforeChange}>
+        {/if}
+    </div>
+</div>

--- a/frontend/Views/Widgets/PytestWidget/PytestCollapseHelper.svelte
+++ b/frontend/Views/Widgets/PytestWidget/PytestCollapseHelper.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+    import { Collapse } from "bootstrap";
+    import { createEventDispatcher } from "svelte";
+
+    let collapse: Element;
+    let firstTime = true;
+    const dispatch = createEventDispatcher();
+
+    const handleAccordionOpen = function () {
+        if (firstTime) {
+            firstTime = false;
+            dispatch("open");
+        }
+
+        new Collapse(collapse, { toggle: true });
+    };
+</script>
+
+<div class="accordion">
+    <div class="accordion-item">
+        <h2 class="accordion-header" id="headingOne">
+            <button class="accordion-button collapsed" type="button" on:click={handleAccordionOpen}> Pytest Overview </button>
+        </h2>
+        <div bind:this={collapse} class="accordion-collapse collapse">
+            <div class="accordion-body">
+                <slot />
+            </div>
+        </div>
+    </div>
+</div>

--- a/frontend/Views/Widgets/PytestWidget/PytestFlatHelper.svelte
+++ b/frontend/Views/Widgets/PytestWidget/PytestFlatHelper.svelte
@@ -1,0 +1,12 @@
+<script>
+    import { createEventDispatcher, onMount } from "svelte";
+
+    const dispatch = createEventDispatcher();
+
+    onMount(() => {
+        dispatch("open");
+    });
+</script>
+<slot>
+
+</slot>

--- a/frontend/Views/Widgets/PytestWidget/PytestOverviewWidget.svelte
+++ b/frontend/Views/Widgets/PytestWidget/PytestOverviewWidget.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+    import PytestCollapseHelper from "./PytestCollapseHelper.svelte";
+    import PytestFlatHelper from "./PytestFlatHelper.svelte";
+    import ViewPytestOverview from "./ViewPytestOverview.svelte";
+    export let dashboardObject: Record<string, unknown>;
+    /**
+     * @type {string}
+     */
+    export let dashboardObjectType: string;
+    export let settings: {
+        collapsed: boolean,
+        enabledStatuses: string[]
+    };
+
+    let opened = false;
+</script>
+
+<svelte:component this={settings.collapsed ? PytestCollapseHelper : PytestFlatHelper} on:open={() => (opened = true)}>
+{#if opened}
+    <ViewPytestOverview {dashboardObject} {dashboardObjectType} {settings}/>
+{/if}
+</svelte:component>

--- a/frontend/Views/Widgets/PytestWidget/PytestResultRow.svelte
+++ b/frontend/Views/Widgets/PytestWidget/PytestResultRow.svelte
@@ -1,0 +1,138 @@
+<script lang="ts">
+    import Fa from "svelte-fa";
+    import { PytestResult } from "./ViewPytestOverview.svelte";
+    import { faChevronDown, faChevronUp, faClipboard, faCopy, faFilter, faSearch } from "@fortawesome/free-solid-svg-icons";
+    import { PytestBgStyles, PytestTextStyles } from "../../../Common/TestStatus";
+    import humanizeDuration from "humanize-duration";
+    import { timestampToISODate } from "../../../Common/DateUtils";
+    import { createEventDispatcher } from "svelte";
+
+    export let test: PytestResult;
+
+    const dispatch = createEventDispatcher();
+    type UserFields = Record<string, string>;
+
+    let testExpanded = false;
+
+    const fetchUserFields = async function(name: string, id: string): Promise<UserFields> {
+        try {
+            const res = await fetch(`/api/v1/views/widgets/pytest/${name}/${id}/fields`);
+            const json = await res.json();
+
+            if (json.status !== "ok") {
+                throw json;
+            }
+
+            return Promise.resolve(json.response as UserFields);
+        } catch (e) {
+            console.log("Failed fetching userfields", e);
+        }
+
+        return {};
+    };
+
+    let showDetails = false;
+</script>
+
+<div class="p-1 bg-white rounded mb-2 p-2">
+    <div class="d-flex flex-wrap align-items-center">
+        <div class="overflow-hidden test-name">
+            {test.name}
+            <button
+                class="btn btn-sm btn-dark d-none"
+                on:click={() => dispatch("testSelect", test.name)}
+            >
+                <Fa icon={faSearch}/>
+            </button>
+        </div>
+        <div class="ms-auto rounded px-2 bg-light text-dark">
+            {humanizeDuration(test.duration * 1000, {round: true, largest: 2})}
+        </div>
+        <div class="ms-2 rounded px-2 bg-dark text-light">
+            {test.test_type}
+        </div>
+        <div class="ms-2">
+            <a class="bg-primary px-2 d-inline-block rounded text-light" href="/tests/generic/{test.run_id}"><Fa icon={faClipboard}/> Run</a>
+        </div>
+        <div class="ms-2 rounded text-light px-2 {PytestTextStyles[test.status]} {PytestBgStyles[test.status]}">
+            {test.status}
+        </div>
+        <div class="ms-2">
+            <button class="btn btn-sm btn-primary" on:click={() => { showDetails = !showDetails; testExpanded = true; }}><Fa icon={showDetails ? faChevronUp : faChevronDown}/></button>
+        </div>
+    </div>
+    <div class="mb-2">
+        {#each test.markers as marker}
+            <button class="btn btn-sm btn-dark me-1" on:click={() => dispatch("markerSelect", { marker: marker })}>{marker}</button>
+        {/each}
+    </div>
+    <div class:show={showDetails} class="rounded overflow-hidden bg-main collapse">
+        {#if test.message}
+            <div class="mb-2 bg-white p-1">
+                <h6 class="mb-1">Message <button class="btn btn-sm btn-success" on:click={() => navigator.clipboard.writeText(test.message)}><Fa icon={faCopy}/></button></h6>
+                <pre class="bg-main code rounded p-2 markdown-body" style="white-space: pre-wrap;">{test.message}</pre>
+            </div>
+        {/if}
+        {#if testExpanded}
+            {#await fetchUserFields(test.name, test.id)}
+                <div class="text-center p-4 text-muted d-flex align-items-center justify-content-center">
+                    <span class="spinner-grow me-2"></span> Loading User Fields...
+                </div>
+            {:then fields}
+                {@const userFields = Object.entries(fields)}
+                {#if userFields.length > 0}
+                    <table class="table table-responsive table-bordered table-striped table-hover">
+                        <thead>
+                            <th>Key</th>
+                            <th>Value</th>
+                        </thead>
+                        <tbody>
+                            {#each userFields as [key, value] (key)}
+                                <tr>
+                                    <td class="key-cell">
+                                        <span class="fw-bold">{key}</span>
+                                        <button class="btn btn-sm btn-dark d-none" on:click={() => dispatch("filterSelect", { filter: key, value: value })}>
+                                            <Fa icon={faFilter} />
+                                        </button>
+                                    </td>
+                                    <td class="user-select-all value-cell">
+                                        {#if value.startsWith("http")}
+                                            <a href="{value}">{value}</a>
+                                        {:else if value.search(/^<a.*>/) != -1}
+                                            {@html value}
+                                        {:else}
+                                            {value}
+                                        {/if}
+                                        <button
+                                            class="btn btn-sm btn-dark d-none"
+                                            on:click={() => navigator.clipboard.writeText(value)}
+                                        >
+                                            <Fa icon={faCopy}/>
+                                        </button>
+                                    </td>
+                                </tr>
+                            {/each}
+                        </tbody>
+                    </table>
+                {:else}
+                    <div class="text-center p-2 rounded bg-light-two text-muted">No User Fields</div>
+                {/if}
+            {/await}
+        {/if}
+    </div>
+</div>
+
+
+<style>
+    td.key-cell:hover button {
+        display: inline !important;
+    }
+
+    td.value-cell:hover button {
+        display: inline !important;
+    }
+
+    div.test-name:hover button {
+        display: inline !important;
+    }
+</style>

--- a/frontend/Views/Widgets/PytestWidget/PytestTableWidget.svelte
+++ b/frontend/Views/Widgets/PytestWidget/PytestTableWidget.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+    import { faSearch } from "@fortawesome/free-solid-svg-icons";
+    import PytestResultRow from "./PytestResultRow.svelte";
+    import { PytestResult } from "./ViewPytestOverview.svelte";
+    import Fa from "svelte-fa";
+    import { createEventDispatcher, onMount } from "svelte";
+
+    export let testData: PytestResult[] = [];
+    export let fetching = false;
+    const dispatch = createEventDispatcher();
+
+    let PAGE_SIZE = 50;
+    let currentPage = 1;
+    export let filterString = "";
+    export let testString = "";
+    let dirty = false;
+    const shouldFilter = function () {
+        dispatch("queryUpdated", { query: filterString} );
+        dirty = false;
+    };
+
+    const shouldSearch = function () {
+        dispatch("testNameUpdated", { test: testString} );
+        dirty = false;
+    };
+
+    const paginateTestData = function(testData: PytestResult[]): PytestResult[][] {
+        if (testData.length == 0) return [];
+        const filtered = testData;
+        const steps = Math.max(parseInt(`${filtered.length / PAGE_SIZE}`) + 1, 1);
+        const pages = Array
+            .from({length: steps}, () => [])
+            .map((_, pageIdx) => {
+                const sliceIdx = pageIdx * PAGE_SIZE;
+                const slice = filtered.slice(sliceIdx, PAGE_SIZE + sliceIdx);
+                return [...slice];
+            });
+        currentPage = 1;
+        return pages;
+    };
+
+    const loadMore = function(pages: PytestResult[][], pageCounter: number) {
+        if (pages.length == 0) return [];
+        let data: PytestResult[] = [];
+        Array.from({ length: Math.min(pageCounter, pages.length) }).forEach((_, idx) => {
+            data = [...data, ...pages[idx]];
+        });
+        return data;
+    };
+
+    $: pagedTests = paginateTestData(testData);
+
+</script>
+
+<div class="rounded bg-light-one p-2">
+    <div class="rounded bg-white p-2 mb-2 input-group">
+        <input class="form-control form-input" type="text" placeholder="Filter test by name" bind:value={testString} on:input={() => dirty = true}>
+        <button class="btn btn-primary" on:click={shouldSearch} disabled={(testString.length == 0 || fetching) && !dirty}><Fa icon={faSearch}/>Search Specific Test</button>
+    </div>
+    <div class="rounded bg-white p-2 mb-2 input-group">
+        <input class="form-control form-input" type="text" placeholder="Filter test body" bind:value={filterString} on:input={() => dirty = true}>
+        <button class="btn btn-primary" on:click={shouldFilter} disabled={(filterString.length == 0 || fetching) && !dirty}><Fa icon={faSearch}/>Search</button>
+    </div>
+    <div class="rounded bg-white p-2">
+        <div class="p-1 rounded bg-light-one">
+            {#each loadMore(pagedTests, currentPage) as item}
+                <PytestResultRow test={item} on:filterSelect on:markerSelect on:testSelect={(e) => {
+                        testString = e.detail;
+                        dispatch("testNameUpdated", { test: e.detail } );
+                    }}/>
+            {:else}
+                <div class="p-4 text-muted text-center">
+                    No data available.
+                </div>
+            {/each}
+        </div>
+    </div>
+
+    {#if pagedTests.length > 1}
+        <div class="my-2">
+                <button class="w-100 btn btn-primary me-1 mb-1" on:click={() => currentPage += 1}>Show more...</button>
+        </div>
+    {/if}
+</div>

--- a/frontend/Views/Widgets/PytestWidget/ViewPytestOverview.svelte
+++ b/frontend/Views/Widgets/PytestWidget/ViewPytestOverview.svelte
@@ -1,0 +1,424 @@
+<script context="module" lang="ts">
+    import { PytestBtnStyles, PytestColors, PytestStatus } from "../../../Common/TestStatus";
+    export interface PytestResult {
+        duration: number;
+        id: string;
+        markers: string[];
+        name: string;
+        release_id: string;
+        run_id: string;
+        session_timestamp: string;
+        status: typeof PytestStatus[keyof typeof PytestStatus];
+        test_id: string;
+        message: string;
+        test_timestamp: string;
+        test_type: string;
+        user_fields: Record<string, string>;
+    }
+
+    export interface IStatusCount {
+        [key: string]: number;
+    }
+
+    export interface ITestStats {
+        [timestamp: string]: {
+            [V in typeof PytestStatus[keyof typeof PytestStatus]]?: number;
+        }
+    }
+
+    export interface IBarChart {
+        labels: string[];
+        datasets: {
+            label: string;
+            data: number[];
+        }[];
+    }
+
+    interface IWidgetState {
+        before: number | null;
+        test: string | null;
+        after: number | null;
+        status: { [V in typeof PytestStatus[keyof typeof PytestStatus]]: boolean },
+        query: string | null;
+        filters: string[];
+        limit: number | null;
+        markers: string[];
+    }
+
+    interface IStatusFilter {
+        [k: string]: boolean;
+    }
+</script>
+
+<script lang="ts">
+    import { Chart } from "chart.js";
+    import { onMount } from "svelte";
+    import { titleCase } from "../../../Common/TextUtils";
+    import PytestTableWidget from "./PytestTableWidget.svelte";
+    import queryString from "query-string";
+    import { faCheck, faCircle, faExclamation, faRefresh, faTimes } from "@fortawesome/free-solid-svg-icons";
+    import Fa from "svelte-fa";
+    import PytestCalendarSelector from "./PytestCalendarSelector.svelte";
+    import dayjs from "dayjs";
+
+    export let dashboardObject: Record<string, unknown>;
+    /**
+     * @type {string}
+     */
+    export let dashboardObjectType: string;
+    export let settings: {
+        enabledStatuses: string[]
+    };
+
+    let pytestBarStatsCanvas: HTMLCanvasElement;
+    let pytestBarChart: Chart<"bar">;
+    let pytestPieChartCanvas: HTMLCanvasElement;
+    let pytestPieChart: Chart<"pie">;
+    let dirty = false;
+    let fetching = false;
+    let total = 0;
+
+    interface IRoutes {
+        [key: string]: string;
+    }
+
+    const ROUTES: IRoutes = {
+        release: "/api/v1/views/widgets/pytest/release/$id/results",
+        view: "/api/v1/views/widgets/pytest/view/$id/results",
+    };
+
+    let testData: PytestResult[] = [];
+
+    const defaultAfterDate = function (days = 30) {
+        return dayjs().subtract(days, "days").unix();
+    };
+
+    const loadStatusState = function(statuses: string[], preset = true): IStatusFilter {
+        const statusFilter = Object.values(PytestStatus).reduce((a, s) => {a[s] = preset; return a;}, {} as IStatusFilter);
+        statuses.forEach(status => statusFilter[status] = true);
+        return statusFilter;
+    };
+
+    const loadPytestDashState = function () {
+        const qs = queryString.parse(document.location.search, { arrayFormat: "bracket" });
+        return {
+            before: qs.pytestBefore ? new Number(qs.pytestBefore) : null,
+            after: qs.pytestAfter ? new Number(qs.pytestAfter) : defaultAfterDate(),
+            status: qs.pytestStatus ? loadStatusState(qs.pytestStatus as string[], false) : loadStatusState(settings.enabledStatuses || [], false),
+            query: qs.pytestQuery || null,
+            test: qs.pytestTest || null,
+            filters: qs.pytestFilters || [],
+            limit: qs.pytestLimit || null,
+            markers: qs.pytestMarkers || [],
+        };
+    };
+
+
+    let widgetState: IWidgetState = loadPytestDashState() as IWidgetState;
+
+    const fetchPytestStats = async function () {
+        try {
+            fetching = true;
+            const qs = {
+                before: widgetState.before,
+                after: widgetState.after,
+                filters: widgetState.filters,
+                test: widgetState.test,
+                markers: widgetState.markers,
+                query: widgetState.query,
+                status: Object.keys(widgetState.status).filter(v => widgetState.status[v]),
+            };
+
+            const res = await fetch(ROUTES[dashboardObjectType].replace("$id", dashboardObject.id as string) + `?${queryString.stringify(qs, { arrayFormat: "bracket" })}`);
+            const json = await res.json();
+
+            if (json.status !== "ok") {
+                dirty = true;
+                throw json;
+            }
+            testData = json.response.hits;
+            total = json.response.total;
+            createBarChar(json.response.barChart);
+            createPieChart(json.response.pieChart);
+            dirty = false;
+        } catch (e) {
+            console.log("Failed fetching stats", e);
+        } finally {
+            fetching = false;
+        }
+    };
+
+    const forceRefresh = async function () {
+        await fetchPytestStats();
+    };
+
+    const handleQueryUpdate = function (event: CustomEvent) {
+        dirty = true;
+        let query = event.detail.query as string;
+        widgetState.query = query;
+        forceRefresh();
+    };
+
+    const handleTestNameUpdate = function (event: CustomEvent) {
+        dirty = true;
+        let test = event.detail.test as string;
+        widgetState.test = test;
+        forceRefresh();
+    };
+
+    const handleMarkerClick = function(event: CustomEvent) {
+        let marker = event.detail.marker as string;
+        if (widgetState.markers.includes(marker)) return;
+        dirty = true;
+        widgetState.markers.push(marker);
+        widgetState.markers = widgetState.markers;
+    };
+
+    const createPieChart = function (counts: IStatusCount) {
+        if (pytestPieChart) {
+            pytestPieChart.destroy();
+        }
+
+        pytestPieChart = new Chart(pytestPieChartCanvas, {
+            type: "pie",
+            data: {
+                labels: Object.keys(counts),
+                datasets: [
+                    {
+                        data: Object.values(counts),
+                        backgroundColor: Object.keys(counts).map((k) => PytestColors[k as keyof typeof PytestColors] || PytestColors.skipped),
+                    },
+                ],
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    title: {
+                        display: false,
+                    },
+                },
+            },
+        });
+    };
+
+    const createBarChar = function (barChart: IBarChart) {
+        if (pytestBarChart) {
+            pytestBarChart.destroy();
+        }
+        pytestBarChart = new Chart(pytestBarStatsCanvas, {
+            type: "bar",
+            data: {
+                labels: barChart.labels,
+                datasets: barChart.datasets.map(set => ({ ...set, backgroundColor: PytestColors[set.label] })),
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: true,
+                plugins: {
+                    legend: {
+                        display: false,
+                    },
+                    title: {
+                        display: true,
+                        text: "Overview",
+                    },
+                    tooltip: {
+                        mode: "index",
+                        intersect: false,
+                        position: "nearest",
+                        callbacks: {
+                            title: (tooltipItems) => {
+                                return tooltipItems[0].label;
+                            },
+                            label: (context) => {
+                                const label = context.dataset.label;
+                                const value = context.parsed.y;
+                                return `${label}: ${value}`;
+                            },
+                        },
+                    },
+                },
+                interaction: {
+                    mode: "index",
+                    intersect: true,
+                    axis: "x",
+                },
+                onHover: (event, chartElements) => {
+                    if (!event?.native?.target) return;
+                    const canvas = event.native.target as HTMLCanvasElement;
+                    canvas.style.cursor = chartElements.length > 0 ? "pointer" : "default";
+                },
+                scales: {
+                    x: {
+                        stacked: true,
+                    },
+                    y: {
+                        stacked: true,
+                    },
+                },
+                onClick: () => {
+                    // empty
+                },
+            },
+        });
+    };
+
+    const parseFilter = function (filter: string): [string, string, boolean] {
+        const rawFilter = filter.replace(/!/, "");
+        const [key, value] = rawFilter.split("=", 2);
+        console.log(key, value, rawFilter);
+        return [key, value, filter[0] == "!"];
+    };
+
+    const alterFilter = function(filter: string) {
+        const idx = widgetState.filters.findIndex(v => v == filter);
+        widgetState.filters[idx] = filter[0] == "!" ? filter.replace(/!/, "") : `!${filter}`;
+        dirty = true;
+    };
+
+    const handleFilterClick = function (event: CustomEvent) {
+        const filter = event.detail.filter as string;
+        const value = event.detail.value as string;
+        const rawFilter = `${filter}=${value}`;
+        if (widgetState.filters.includes(rawFilter)) return;
+        widgetState.filters.push(rawFilter);
+        widgetState = widgetState;
+        dirty = true;
+    };
+
+    $: {
+        const qs = queryString.parse(document.location.search, { arrayFormat: "bracket" });
+        const newQs = {
+            ...qs,
+            pytestBefore: widgetState.before ?? undefined,
+            pytestAfter: widgetState.after ?? undefined,
+            pytestStatus: Object.entries(widgetState.status).filter(([_, state]) => state).map(([status, _]) => status),
+            pytestQuery: widgetState.query ?? undefined,
+            pytestFilters: widgetState.filters.length ? widgetState.filters : undefined,
+            pytestLimit: widgetState.limit ?? undefined,
+            pytestMarkers: widgetState.markers.length ? widgetState.markers : undefined,
+            pytestTest: widgetState.test ? widgetState.test : undefined,
+        };
+        const search = queryString.stringify(newQs, { arrayFormat: "bracket" });
+        window.history.pushState(null, "", `?${search}`);
+    }
+
+    onMount(async () => {
+        //empty
+    });
+</script>
+
+<div>
+    {#await fetchPytestStats()}
+        <div class="text-center p-4 text-muted d-flex align-items-center justify-content-center">
+            <span class="spinner-grow me-2"></span> Loading Test Results...
+        </div>
+    {:then value}
+        <div class="d-flex">
+            <div class="">
+                <h5>Status</h5>
+                <div class="p-1 d-flex flex-wrap w-50">
+                    {#each Object.entries(widgetState.status) as [status, state]}
+                        <button
+                            class="mb-2 ms-2 btn btn-sm {PytestBtnStyles[status] || PytestBtnStyles.skipped}"
+                            on:click={() => {widgetState.status[status] = !state; dirty = true;}}
+                        >
+                            <Fa icon={widgetState.status[status] ? faCheck : faTimes}/>
+                            {status.split(" ").map(v => titleCase(v)).join(" ")}
+                        </button>
+                    {/each}
+                </div>
+            </div>
+            <div class="ms-auto p-2">
+                <PytestCalendarSelector bind:before={widgetState.before} bind:after={widgetState.after} on:setDirty={() => (dirty = true)}/>
+                {#if dirty}
+                    <div class="text-end">
+                        <button class="btn btn-primary" on:click={forceRefresh} disabled={fetching}><span class:fetching><Fa icon={faRefresh}/></span> Refresh</button>
+                    </div>
+                {/if}
+            </div>
+        </div>
+    {/await}
+    <div class="d-flex p-2">
+        <div class="w-25">
+            <canvas bind:this={pytestPieChartCanvas} />
+        </div>
+        <div class="ms-2 w-75">
+            <canvas bind:this={pytestBarStatsCanvas} />
+        </div>
+    </div>
+    <div>
+        {#if widgetState.markers.length > 0}
+        <div class="bg-light-one rounded p-2">
+            <div class="bg-white rounded p-2">
+                <div>Markers</div>
+                <div class="bg-light-one p-1 d-flex flex-wrap rounded">
+                    {#each widgetState.markers as marker}
+                        <div class="btn-group me-1 mb-1">
+                            <button class="btn btn-sm btn-dark">
+                                {marker}
+                            </button>
+                            <button class="btn btn-sm btn-dark" on:click={() => {
+                                widgetState.markers = widgetState.markers.filter(m => m != marker);
+                                dirty = true;
+                            }}>
+                                <Fa icon={faTimes}/>
+                            </button>
+                        </div>
+                    {/each}
+                </div>
+            </div>
+        </div>
+        {/if}
+    </div>
+    <div>
+        {#if widgetState.filters.length > 0}
+            <div class="bg-light-one rounded p-2">
+                <div class="bg-white rounded p-2">
+                    <div>User Fields</div>
+                    <div class="bg-light-one p-1 d-flex flex-wrap rounded">
+                        {#each widgetState.filters as filter}
+                            {@const [filterName, filterValue, negated] = parseFilter(filter)}
+                            <div class="btn-group me-1 mb-1">
+                                <button class="btn btn-sm btn-dark" on:click={() => alterFilter(filter)}>
+                                    {#if negated}
+                                        <Fa icon={faExclamation}/>
+                                    {:else}
+                                        <Fa icon={faCircle} />
+                                    {/if}
+                                </button>
+                                <button class="btn btn-sm btn-dark">
+                                    {filterName} = {filterValue}
+                                </button>
+                                <button class="btn btn-sm btn-dark" on:click={() => {
+                                    widgetState.filters = widgetState.filters.filter(m => m != filter);
+                                    dirty = true;
+                                }}>
+                                    <Fa icon={faTimes}/>
+                                </button>
+                            </div>
+                        {/each}
+                    </div>
+                </div>
+            </div>
+        {/if}
+    </div>
+    <div class="text-muted text-end p-2">
+        Total {total} tests. (Last 500 are shown)
+    </div>
+    <div class="w-100">
+        <PytestTableWidget {testData} {fetching} testString={widgetState.test || ""} filterString={widgetState.query || ""} on:testNameUpdated={handleTestNameUpdate} on:queryUpdated={handleQueryUpdate} on:markerSelect={handleMarkerClick} on:filterSelect={handleFilterClick}/>
+    </div>
+</div>
+
+
+<style>
+    .fetching {
+        animation: rotating 2s linear infinite;
+        display: inline-block;
+    }
+    @keyframes rotating {
+        to { transform: rotate(360deg); }
+    }
+</style>

--- a/scripts/migration/migration_2025-07-18.py
+++ b/scripts/migration/migration_2025-07-18.py
@@ -1,0 +1,63 @@
+import logging
+
+from cassandra.util import datetime_from_uuid1
+from cassandra.query import ConsistencyLevel
+
+from argus.backend.db import ScyllaCluster
+from argus.backend.models.pytest import PytestResultTable, PytestResultTableOld, PytestUserField
+from cassandra.cqlengine.query import BatchQuery
+from argus.backend.models.web import ArgusTest
+from argus.backend.util.common import chunk
+from argus.backend.util.logsetup import setup_application_logging
+
+
+setup_application_logging(log_level=logging.INFO)
+LOGGER = logging.getLogger(__name__)
+DB = ScyllaCluster.get()
+
+
+def migrate():
+    LOGGER.warning("Fetching old data...")
+    rows: list[PytestResultTableOld] = (
+        PytestResultTableOld.consistency(ConsistencyLevel.ONE).filter().fetch_size(5000).limit(None).all()
+    )
+    placeholder_test = ArgusTest.get(build_system_id="scylla-staging/artsiom_mishuta/dtest-release")
+    LOGGER.warning("Migrating results...")
+
+    for batch in chunk(rows, 100):
+        print("Batch", end="")
+        user_fields_to_write: list[PytestUserField] = []
+        with BatchQuery() as b:
+            for row in batch:
+                old = dict(row)
+                uf = old.pop("user_fields", {})
+                ts = datetime_from_uuid1(old.pop("id"))
+                new = PytestResultTable(**old)
+                new.id = ts
+                for key, value in uf.items():
+                    f = PytestUserField()
+                    f.name = new.name
+                    f.id = new.id
+                    f.field_name = key
+                    f.field_value = value
+                    if key == "failure_message" and not new.message:
+                        new.message = value
+                    user_fields_to_write.append(f)
+                if not new.test_id:
+                    new.test_id = placeholder_test.id
+                    new.release_id = placeholder_test.release_id
+                print(".", end="")
+                new.batch(b).save()
+        LOGGER.warning("Migrating user fields... Total to migrate: %s", len(user_fields_to_write))
+        for uf_batch in chunk(user_fields_to_write, 100):
+            print("Batch", end="")
+            with BatchQuery() as b:
+                for uf in uf_batch:
+                    uf.batch(b).save()
+                    print(".", end="")
+
+    LOGGER.warning("Results migrated.")
+
+
+if __name__ == "__main__":
+    migrate()


### PR DESCRIPTION
This commit adds a new View Widget, intended to provide overview into
specific test's pytest results, such as statistics, charts and a
searchable result list. The new widget supports both views and release
pages, supporting both always open and collapsed options.

Widget features:

* Filter tests by cut off date or by range of dates
* Filter by test status
* Filter by test marker
* Filter by test user specified field presence
* Filter by text within the test

Fixes scylladb/qa-tasks#273