### PR TITLE
feat: prioritize runs with issues in similar events display

### DIFF
--- a/argus/backend/tests/view_widgets/test_highlights_api.py
+++ b/argus/backend/tests/view_widgets/test_highlights_api.py
@@ -1,4 +1,5 @@
 import json
+import time
 from datetime import datetime, UTC
 from unittest.mock import patch
 from uuid import uuid4, UUID
@@ -77,6 +78,9 @@ def test_get_highlights_should_return_highlights_and_action_items(flask_client):
         comments_count=0,
     )
     action_item_entry.save()
+
+    # Add small delay to ensure can be read (test was flaky)
+    time.sleep(0.05)  # 50ms delay
 
     response = flask_client.get(f"/api/v1/views/widgets/highlights?view_id={view_id}&index=0")
 

--- a/argusAI/event_similarity_processor.py
+++ b/argusAI/event_similarity_processor.py
@@ -22,7 +22,7 @@ from argusAI.utils.scylla_connection import ScyllaConnection
 
 SLEEP_INTERVAL: int = 300  # 5 minutes
 SIMILARITY_THRESHOLD: float = 0.90
-MAX_SIMILARS: int = 20
+MAX_SIMILARS: int = 200
 DAYS_BACK: int = int(os.getenv("DAYS_BACK", "120"))
 
 logging.basicConfig(

--- a/frontend/TestRun/StructuredEvent.svelte
+++ b/frontend/TestRun/StructuredEvent.svelte
@@ -136,70 +136,73 @@
 {#if showSimilars}
     <ModalWindow widthClass="w-75" on:modalClose={closeSimilarModal}>
         <svelte:fragment slot="title">
-            Similar Events ({similars.length})
+            Similar Events ({Object.keys(similarRunsInfo).length})
         </svelte:fragment>
         <svelte:fragment slot="body">
-            <div class="table-responsive">
-                <table class="table table-striped table-hover">
-                    <thead>
-                        <tr>
-                            <th>Build ID</th>
-                            <th>Start Time</th>
-                            <th>Version</th>
-
-                            <th>Issues</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {#each similars as runId}
+            {#if fetchingIssues}
+                <div class="d-flex justify-content-center align-items-center" style="min-height: 200px;">
+                    <div class="spinner-border" role="status">
+                        <span class="visually-hidden">Loading similar runs information...</span>
+                    </div>
+                    <span class="ms-3">Loading similar runs information...</span>
+                </div>
+            {:else}
+                <div class="table-responsive">
+                    <table class="table table-striped table-hover">
+                        <thead>
                             <tr>
-                                <td>
-                                    <a href="/tests/scylla-cluster-tests/{runId}" target="_blank" title={runId}>
-                                        {similarRunsInfo[runId]?.build_id || runId}
-                                    </a>
-                                </td>
-
-                                <td class="date-column">
-                                    {#if similarRunsInfo[runId]?.start_time}
-                                        {new Date(similarRunsInfo[runId].start_time).toLocaleDateString("en-CA")}
-                                    {:else}
-                                        -
-                                    {/if}
-                                </td>
-                                <td>
-                                    {#if similarRunsInfo[runId]?.version}
-                                        {similarRunsInfo[runId].version}
-                                    {:else}
-                                        -
-                                    {/if}
-                                </td>
-                                <td>
-                                    {#if fetchingIssues}
-                                        <div class="spinner-border spinner-border-sm" role="status">
-                                            <span class="visually-hidden">Loading...</span>
-                                        </div>
-                                    {:else if similarRunsInfo[runId]?.issues?.length}
-                                        {#each similarRunsInfo[runId].issues as issue}
-                                            <div class="issue-item mb-1">
-                                                <a href={issue.url} target="_blank" class="issue-link">
-                                                    <span
-                                                        class="badge {issue.state === 'open'
-                                                            ? 'issue-open'
-                                                            : 'issue-closed'}">#{issue.number}</span
-                                                    >
-                                                    {issue.title}
-                                                </a>
-                                            </div>
-                                        {/each}
-                                    {:else}
-                                        <span class="text-muted">No issues</span>
-                                    {/if}
-                                </td>
+                                <th>Build ID</th>
+                                <th>Start Time</th>
+                                <th>Version</th>
+                                <th>Issues</th>
                             </tr>
-                        {/each}
-                    </tbody>
-                </table>
-            </div>
+                        </thead>
+                        <tbody>
+                            {#each similars.filter(runId => similarRunsInfo[runId]) as runId}
+                                <tr>
+                                    <td>
+                                        <a href="/tests/scylla-cluster-tests/{runId}" target="_blank" title={runId}>
+                                            {similarRunsInfo[runId]?.build_id || runId}
+                                        </a>
+                                    </td>
+                                    <td class="date-column">
+                                        {#if similarRunsInfo[runId]?.start_time}
+                                            {new Date(similarRunsInfo[runId].start_time).toLocaleDateString("en-CA")}
+                                        {:else}
+                                            -
+                                        {/if}
+                                    </td>
+                                    <td>
+                                        {#if similarRunsInfo[runId]?.version}
+                                            {similarRunsInfo[runId].version}
+                                        {:else}
+                                            -
+                                        {/if}
+                                    </td>
+                                    <td>
+                                        {#if similarRunsInfo[runId]?.issues?.length}
+                                            {#each similarRunsInfo[runId].issues as issue}
+                                                <div class="issue-item mb-1">
+                                                    <a href={issue.url} target="_blank" class="issue-link">
+                                                        <span
+                                                            class="badge {issue.state === 'open'
+                                                                ? 'issue-open'
+                                                                : 'issue-closed'}">#{issue.number}</span
+                                                        >
+                                                        {issue.title}
+                                                    </a>
+                                                </div>
+                                            {/each}
+                                        {:else}
+                                            <span class="text-muted">No issues</span>
+                                        {/if}
+                                    </td>
+                                </tr>
+                            {/each}
+                        </tbody>
+                    </table>
+                </div>
+            {/if}
         </svelte:fragment>
     </ModalWindow>
 {/if}


### PR DESCRIPTION
- Refactor get_similar_runs_info to fetch issue links first for all runs
- Fetch and display runs with attached issues before others
- Ensure up to 20 similar runs are shown by backfilling with additional runs
- Optimize database queries by batching issue links and run fetches
- Add loading spinner to similar events modal for better UX

This ensures users see the most relevant similar runs (those with issues) first while maintaining the target of 20 results for comprehensive analysis.

refs: https://github.com/scylladb/qa-tasks/issues/1850