### PR TITLE
feat(graphed-stats): enhance test run details with assignees, issue

### DIFF
--- a/argus/backend/controller/views_widgets/graphed_stats.py
+++ b/argus/backend/controller/views_widgets/graphed_stats.py
@@ -30,3 +30,30 @@ def get_graphed_stats():
         "status": "ok",
         "response": response_data
     }
+
+
+@bp.route("/runs_details", methods=["POST"])
+@api_login_required
+def get_runs_details():
+    """Get detailed information for provided test runs including assignee and attached issues."""
+    data = request.get_json()
+    if not data or "run_ids" not in data:
+        return {
+            "status": "error",
+            "response": "Missing run_ids parameter"
+        }, 400
+
+    run_ids = data["run_ids"]
+    if not isinstance(run_ids, list):
+        return {
+            "status": "error",
+            "response": "run_ids must be a list"
+        }, 400
+
+    service = GraphedStatsService()
+    result = service.get_runs_details(run_ids)
+
+    return {
+        "status": "ok",
+        "response": result
+    }

--- a/argus/backend/controller/views_widgets/graphed_stats.py
+++ b/argus/backend/controller/views_widgets/graphed_stats.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+from argus.backend.util.common import get_payload
 from flask import Blueprint, request
 
 from argus.backend.models.web import ArgusUserView
@@ -36,19 +37,13 @@ def get_graphed_stats():
 @api_login_required
 def get_runs_details():
     """Get detailed information for provided test runs including assignee and attached issues."""
-    data = request.get_json()
+    data = get_payload(request)
     if not data or "run_ids" not in data:
-        return {
-            "status": "error",
-            "response": "Missing run_ids parameter"
-        }, 400
+        raise ValueError("Missing run_ids parameter")
 
     run_ids = data["run_ids"]
     if not isinstance(run_ids, list):
-        return {
-            "status": "error",
-            "response": "run_ids must be a list"
-        }, 400
+        raise ValueError("run_ids must be a list")
 
     service = GraphedStatsService()
     result = service.get_runs_details(run_ids)

--- a/argus/backend/service/views_widgets/graphed_stats.py
+++ b/argus/backend/service/views_widgets/graphed_stats.py
@@ -4,6 +4,8 @@ import json
 import re
 from argus.backend.db import ScyllaCluster
 from argus.backend.plugins.sct.testrun import SCTTestRun
+from argus.backend.models.github_issue import GithubIssue, IssueLink
+from argus.backend.util.common import chunk
 
 LOGGER = logging.getLogger(__name__)
 
@@ -70,3 +72,116 @@ class GraphedStatsService:
                     })
 
         return release_data
+
+    def get_runs_details(self, run_ids: list[str]):
+        """Get detailed information for provided test runs including assignee and attached issues.
+
+        Args:
+            run_ids: List of run IDs to fetch detailed information for
+
+        Returns:
+            Dictionary mapping run IDs to their detailed information (build_id, start_time, assignee, version, and issues)
+        """
+        result = {}
+
+        if not run_ids:
+            return result
+
+        # Step 1: Get issue links for all run_ids in batches
+        all_issue_links = {}
+        for batch_run_ids in chunk(run_ids):
+            batch_links = IssueLink.objects.filter(run_id__in=batch_run_ids).only(["run_id", "issue_id"]).all()
+
+            for link in batch_links:
+                run_id_str = str(link.run_id)
+                if run_id_str not in all_issue_links:
+                    all_issue_links[run_id_str] = []
+                all_issue_links[run_id_str].append(link.issue_id)
+
+        # Step 2: Fetch all unique issue details
+        all_issue_ids = set()
+        for links in all_issue_links.values():
+            all_issue_ids.update(links)
+
+        issues_by_id = {}
+        if all_issue_ids:
+            for batch_issue_ids in chunk(list(all_issue_ids)):
+                batch_issues = GithubIssue.filter(id__in=batch_issue_ids).only(
+                    ["id", "state", "title", "number", "url"]).all()
+
+                for issue in batch_issues:
+                    issues_by_id[issue.id] = issue
+
+        # Step 3: Fetch test runs for all provided run_ids
+        test_runs = {}
+        for run_id in run_ids:
+            try:
+                test_run = SCTTestRun.filter(id=run_id).only(
+                    ["id", "status", "build_id", "start_time", "assignee", "investigation_status", "packages", "build_job_url"]).get()
+                test_runs[run_id] = test_run
+            except Exception as e:
+                LOGGER.error(f"Failed to fetch test run {run_id}: {str(e)}")
+
+        # Step 4: Build result with run and issue details
+        for run_id in run_ids:
+            try:
+                test_run = test_runs.get(run_id)
+                if not test_run:
+                    result[run_id] = {
+                        "build_id": None,
+                        "start_time": None,
+                        "assignee": None,
+                        "version": "unknown",
+                        "issues": []
+                    }
+                    continue
+
+                links = all_issue_links.get(run_id, [])
+                issues = [issues_by_id[issue_id] for issue_id in links if issue_id in issues_by_id]
+
+                try:
+                    build_number = int(
+                        test_run.build_job_url[:-1].split("/")[-1]
+                    )
+                except Exception as e:
+                    LOGGER.error(
+                        f"Error parsing build number for run {run_id}: {test_run.build_job_url[:-1].split('/')} - {str(e)}")
+                    build_number = -1
+
+                # Get Scylla version from packages
+                for pkg_name in ["scylla-server-upgraded", "scylla-server", "scylla-server-target"]:
+                    sut_version = next(
+                        (f"{pkg.version}-{pkg.date}" for pkg in test_run.packages if pkg.name == pkg_name), None)
+                    if sut_version:
+                        break
+                else:
+                    sut_version = "unknown"
+
+                result[run_id] = {
+                    "build_id": f"{test_run.build_id}#{build_number}",
+                    "status": test_run.status,
+                    "start_time": test_run.start_time.isoformat(),
+                    "assignee": test_run.assignee,
+                    "version": sut_version,
+                    "investigation_status": test_run.investigation_status,
+                    "issues": [
+                        {
+                            "number": issue.number,
+                            "state": issue.state,
+                            "title": issue.title,
+                            "url": issue.url,
+                        }
+                        for issue in issues
+                    ],
+                }
+            except Exception as e:
+                LOGGER.error(f"Error fetching details for run {run_id}: {str(e)}")
+                result[run_id] = {
+                    "build_id": None,
+                    "start_time": None,
+                    "assignee": None,
+                    "version": "unknown",
+                    "issues": []
+                }
+
+        return result

--- a/frontend/Common/TestStatus.js
+++ b/frontend/Common/TestStatus.js
@@ -164,3 +164,8 @@ export const ResultCellStatusStyleMap = {
     "WARNING": "table-warning",
     "NULL": "table-secondary"
 };
+
+export const NemesisStatusToTestStatus = {
+  "skipped": "aborted",
+  "succeeded": "passed",
+}

--- a/frontend/Github/GithubIssue.svelte
+++ b/frontend/Github/GithubIssue.svelte
@@ -285,16 +285,6 @@
         color: white !important;
     }
 
-    .issue-open {
-        color: #f4faff;
-        background-color: #347d39;
-    }
-
-    .issue-closed {
-        color: #f4faff;
-        background-color: #8256d0;
-    }
-
     .h-50 {
         width: 50%;
     }

--- a/frontend/TestRun/StructuredEvent.svelte
+++ b/frontend/TestRun/StructuredEvent.svelte
@@ -259,14 +259,7 @@
     .issue-link:hover {
         text-decoration: underline;
     }
-    .issue-open {
-        color: #f4faff;
-        background-color: #347d39;
-    }
-    .issue-closed {
-        color: #f4faff;
-        background-color: #8256d0;
-    }
+
     .date-column {
         width: 100px;
     }

--- a/frontend/Views/Widgets/ViewGraphedStats.svelte
+++ b/frontend/Views/Widgets/ViewGraphedStats.svelte
@@ -359,10 +359,26 @@
                 plugins: {
                     title: { display: true, text: "Nemesis Success and Failure Counts" },
                     legend: { position: "bottom" },
+                    tooltip: {
+                        mode: "index",
+                        intersect: false,
+                        position: "nearest",
+                        callbacks: {
+                            title: (tooltipItems) => {
+                                return tooltipItems[0].label;
+                            },
+                            label: (context) => {
+                                const label = context.dataset.label;
+                                const value = context.parsed.y;
+                                return `${label}: ${value}`;
+                            },
+                        },
+                    },
                 },
                 onClick: (event, elements) => {
                     if (elements.length) onClick(nemesisNames[elements[0].index]);
                 },
+
             },
         }) as ChartType;
     }

--- a/frontend/Views/Widgets/ViewGraphedStats.svelte
+++ b/frontend/Views/Widgets/ViewGraphedStats.svelte
@@ -500,7 +500,7 @@
                                 <div>
                                     <TestRunTable
                                         testRuns={$state.filteredData.test_runs}
-                                        onClose={() => ($state.currentBuildLevel = "")}
+                                        onClose={zoomOut}
                                     />
                                 </div>
                             {:else}

--- a/frontend/Views/Widgets/ViewGraphedStats/AssigneeCell.svelte
+++ b/frontend/Views/Widgets/ViewGraphedStats/AssigneeCell.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+    import { getUser, getPicture } from "../../../Common/UserUtils";
+    import { userList } from "../../../Stores/UserlistSubscriber";
+    import type { TestRun } from "./Interfaces";
+
+    export let run: TestRun;
+
+    let users = {};
+    $: users = $userList;
+
+    const assignee = run.assignee;
+    $: user = assignee && assignee !== "Unassigned" ? getUser(assignee, users) : null;
+    $: pictureUrl = user ? getPicture(user.picture_id) : "";
+</script>
+
+{#if !assignee || assignee === "Unassigned"}
+    <span class="text-muted">Unassigned</span>
+{:else}
+    <div class="d-flex align-items-center" title={user ? (user.full_name || user.username || assignee) : ""}>
+        <div class="img-profile me-2" style="background-image: url({pictureUrl});"></div>
+    </div>
+{/if}
+
+<style>
+    .img-profile {
+        width: 24px;
+        height: 24px;
+        border-radius: 50%;
+        background-size: cover;
+        background-position: center;
+        background-repeat: no-repeat;
+        flex-shrink: 0;
+    }
+</style>

--- a/frontend/Views/Widgets/ViewGraphedStats/Interfaces.ts
+++ b/frontend/Views/Widgets/ViewGraphedStats/Interfaces.ts
@@ -8,6 +8,25 @@ export interface TestRun {
     start_time: number;
     stack_trace?: string;
     investigation_status: string;
+    assignee?: string;
+    issues?: Issue[];
+}
+
+export interface Issue {
+    number: number;
+    state: string;
+    title: string;
+    url: string;
+}
+
+export interface RunDetails {
+    build_id: string;
+    status: string;
+    start_time: string;
+    assignee: string;
+    version: string;
+    investigation_status: string;
+    issues: Issue[];
 }
 
 export interface NemesisData {

--- a/frontend/Views/Widgets/ViewGraphedStats/InvestigationStatusCell.svelte
+++ b/frontend/Views/Widgets/ViewGraphedStats/InvestigationStatusCell.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+    import {
+        InvestigationBackgroundCSSClassMap,
+        TestInvestigationStatusStrings
+    } from "../../../Common/TestStatus";
+    import type { TestRun } from "./Interfaces";
+
+    export let run: TestRun;
+
+    const status = run.investigation_status;
+    const statusText = TestInvestigationStatusStrings[status as keyof typeof TestInvestigationStatusStrings] || status;
+    const badgeClass = InvestigationBackgroundCSSClassMap[status as keyof typeof InvestigationBackgroundCSSClassMap] || "bg-secondary";
+</script>
+
+<span
+    class="badge {badgeClass} investigation-status-badge"
+    title={statusText}
+>
+    <span class="visually-hidden">{statusText}</span>
+</span>
+
+<style>
+    .investigation-status-badge {
+        width: 40px;
+        height: 12px;
+        border-radius: 10%;
+        display: inline-block;
+        cursor: help;
+    }
+</style>

--- a/frontend/Views/Widgets/ViewGraphedStats/IssuesCell.svelte
+++ b/frontend/Views/Widgets/ViewGraphedStats/IssuesCell.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+    import type { TestRun } from "./Interfaces";
+
+    export let run: TestRun;
+
+    const issues = run.issues || [];
+    const hasIssues = issues.length > 0;
+</script>
+
+{#if !hasIssues}
+    <span class="text-muted">No issues</span>
+{:else}
+    <div class="issues-container">
+        {#each issues as issue (issue.number)}
+            <a
+                href={issue.url}
+                target="_blank"
+                class="badge me-1 {issue.state === 'open' ? 'issue-open' : 'issue-closed'}"
+                title={issue.title}
+            >
+                #{issue.number}
+            </a>
+        {/each}
+    </div>
+{/if}
+
+<style>
+    .issues-container {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 2px;
+    }
+
+    .issue-open {
+        background-color: #dc3545;
+        color: white;
+    }
+
+    .issue-closed {
+        background-color: #6c757d;
+        color: white;
+    }
+
+    .badge {
+        text-decoration: none;
+    }
+
+    .badge:hover {
+        opacity: 0.8;
+    }
+</style>

--- a/frontend/Views/Widgets/ViewGraphedStats/NemesisTable.svelte
+++ b/frontend/Views/Widgets/ViewGraphedStats/NemesisTable.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import PaginatedTable from "./PaginatedTable.svelte";
     import StackTracePreview from "./StackTracePreview.svelte";
+    import StatusBadge from "./StatusBadge.svelte";
     import type { NemesisData } from "./Interfaces";
 
     export let nemesisName: string | null;
@@ -20,16 +21,13 @@
                     ? 1
                     : a.run_id.localeCompare(b.run_id),
             width: "120px",
-            render: (item: NemesisData) =>
-                `<span class="badge bg-${item.status === "failed" ? "danger" : "success"}">${
-                    item.status === "failed" ? "Failed" : "Succeeded"
-                }</span>`,
+            component: StatusBadge,
         },
         {
             key: "start_time",
             label: "Start Time",
             sort: (a: NemesisData, b: NemesisData) => a.start_time - b.start_time,
-            width: "130px",
+            width: "150px",
         },
         {
             key: "duration",

--- a/frontend/Views/Widgets/ViewGraphedStats/PaginatedTable.svelte
+++ b/frontend/Views/Widgets/ViewGraphedStats/PaginatedTable.svelte
@@ -126,6 +126,7 @@
                             <th
                                 class:sortable={column.sort !== undefined}
                                 on:click={() => column.sort && toggleSort(column.key)}
+                                title={column.label}
                                 style={column.width
                                     ? `width: ${column.width}; min-width: ${column.width};`
                                     : i === columns.length - 1

--- a/frontend/Views/Widgets/ViewGraphedStats/StatusBadge.svelte
+++ b/frontend/Views/Widgets/ViewGraphedStats/StatusBadge.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+    import { NemesisStatusToTestStatus, StatusBackgroundCSSClassMap } from "../../../Common/TestStatus";
+    import { subUnderscores, titleCase } from "../../../Common/TextUtils";
+    import { TestRun } from "./Interfaces";
+
+    export let run: TestRun;
+
+    const status = run?.status || "";
+</script>
+
+<span class="badge {StatusBackgroundCSSClassMap[NemesisStatusToTestStatus[status] || status]}"
+    >{subUnderscores(status)
+        .split(" ")
+        .map((v) => titleCase(v))
+        .join(" ")}</span
+>

--- a/frontend/Views/Widgets/ViewGraphedStats/StatusCell.svelte
+++ b/frontend/Views/Widgets/ViewGraphedStats/StatusCell.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+    import { StatusBackgroundCSSClassMap } from "../../../Common/TestStatus";
+    import type { TestRun } from "./Interfaces";
+
+    export let run: TestRun;
+
+    const status = run.status?.toLowerCase();
+    const badgeClass = getBadgeClass(status);
+    const statusText = getStatusText(status);
+
+    function getBadgeClass(status: string | undefined): string {
+        const baseClass =
+            StatusBackgroundCSSClassMap[status as keyof typeof StatusBackgroundCSSClassMap] || "bg-secondary";
+        // Special case for running status to ensure text readability
+        return status === "running" ? `${baseClass} text-dark` : baseClass;
+    }
+
+    function getStatusText(status: string | undefined): string {
+        return status ? status.charAt(0).toUpperCase() + status.slice(1) : "Unknown";
+    }
+</script>
+
+<span class="badge {badgeClass}">{statusText}</span>

--- a/frontend/Views/Widgets/ViewGraphedStats/TestRunTable.svelte
+++ b/frontend/Views/Widgets/ViewGraphedStats/TestRunTable.svelte
@@ -1,25 +1,121 @@
 <script lang="ts">
     import PaginatedTable from "./PaginatedTable.svelte";
-    import type { TestRun } from "./Interfaces";
+    import type { TestRun, RunDetails } from "./Interfaces";
+    import { getUser, getPicture } from "../../../Common/UserUtils";
+    import { userList } from "../../../Stores/UserlistSubscriber";
+    import {
+        InvestigationBackgroundCSSClassMap,
+        TestInvestigationStatusStrings
+    } from "../../../Common/TestStatus";
 
     export let testRuns: TestRun[];
     export let onClose: () => void;
+
+    let users = {};
+    $: users = $userList;
+
+    let enrichedTestRuns: TestRun[] = [];
+    let loading = true;
+    let error = "";
+
+    /**
+     * Fetches detailed information for test runs including assignees and issues
+     */
+    async function fetchRunDetails() {
+        if (!testRuns || testRuns.length === 0) {
+            enrichedTestRuns = [];
+            loading = false;
+            return;
+        }
+
+        try {
+            loading = true;
+            error = "";
+
+            const runIds = testRuns.map(run => run.run_id);
+            const response = await fetch('/api/v1/views/widgets/runs_details', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ run_ids: runIds }),
+            });
+
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+
+            const data = await response.json();
+            if (data.status !== "ok") {
+                throw new Error(data.response || "Failed to fetch run details");
+            }
+
+            const runDetailsMap: Record<string, RunDetails> = data.response;
+
+            // Merge the run details with the test runs
+            enrichedTestRuns = testRuns.map(run => ({
+                ...run,
+                // Use status from run details if available, otherwise keep original
+                status: runDetailsMap[run.run_id]?.status || run.status,
+                assignee: runDetailsMap[run.run_id]?.assignee || "Unassigned",
+                issues: runDetailsMap[run.run_id]?.issues || [],
+            }));
+        } catch (err) {
+            error = `Failed to load run details: ${(err as Error).message}`;
+            // Fallback to original data without enrichment
+            enrichedTestRuns = testRuns.map(run => ({
+                ...run,
+                assignee: "Unknown",
+                issues: [],
+            }));
+        } finally {
+            loading = false;
+        }
+    }
 
     const columns = [
         {
             key: "status",
             label: "Status",
-            sort: (a: TestRun, b: TestRun) =>
-                a.status === "failed" && b.status !== "failed"
-                    ? -1
-                    : a.status !== "failed" && b.status === "failed"
-                    ? 1
-                    : a.run_id.localeCompare(b.run_id),
+            sort: (a: TestRun, b: TestRun) => {
+                const statusOrder = { failed: 0, 'test-error': 1, aborted: 2, running: 3, passed: 4 };
+                const aOrder = statusOrder[a.status?.toLowerCase()] ?? 5;
+                const bOrder = statusOrder[b.status?.toLowerCase()] ?? 5;
+                return aOrder - bOrder || a.run_id.localeCompare(b.run_id);
+            },
             width: "120px",
-            render: (item: TestRun) =>
-                `<span class="badge bg-${item.status === "failed" ? "danger" : "success"}">${
-                    item.status === "failed" ? "Failed" : "Succeeded"
-                }</span>`,
+            render: (item: TestRun) => {
+                const status = item.status?.toLowerCase();
+                let badgeClass = "bg-secondary";
+                let statusText = "Unknown";
+
+                switch (status) {
+                    case "failed":
+                        badgeClass = "bg-danger";
+                        statusText = "Failed";
+                        break;
+                    case "test-error":
+                        badgeClass = "bg-warning";
+                        statusText = "Test Error";
+                        break;
+                    case "passed":
+                        badgeClass = "bg-success";
+                        statusText = "Passed";
+                        break;
+                    case "aborted":
+                        badgeClass = "bg-dark";
+                        statusText = "Aborted";
+                        break;
+                    case "running":
+                        badgeClass = "bg-warning text-dark";
+                        statusText = "Running";
+                        break;
+                    default:
+                        statusText = status ? status.charAt(0).toUpperCase() + status.slice(1) : "Unknown";
+                }
+
+                return `<span class="badge ${badgeClass}">${statusText}</span>`;
+            },
         },
         {
             key: "start_time",
@@ -40,13 +136,86 @@
             width: "130px",
         },
         {
+            key: "assignee",
+            label: "Assignee",
+            sort: (a: TestRun, b: TestRun) => (a.assignee || "").localeCompare(b.assignee || ""),
+            width: "120px",
+            render: (item: TestRun) => {
+                const assignee = item.assignee;
+                if (!assignee || assignee === "Unassigned") {
+                    return '<span class="text-muted">Unassigned</span>';
+                }
+
+                const user = getUser(assignee, users);
+                const pictureUrl = getPicture(user.picture_id);
+                const fullName = user.full_name || user.username || assignee;
+
+                return `
+                    <div class="d-flex align-items-center" title="${fullName}">
+                        <div class="img-profile me-2" style="background-image: url(${pictureUrl});"></div>
+                        <span class="text-truncate">${fullName}</span>
+                    </div>
+                `;
+            },
+        },
+        {
+            key: "issues",
+            label: "Issues",
+            sort: (a: TestRun, b: TestRun) => (a.issues?.length || 0) - (b.issues?.length || 0),
+            width: "200px",
+            render: (item: TestRun) => {
+                if (!item.issues || item.issues.length === 0) {
+                    return '<span class="text-muted">No issues</span>';
+                }
+                return item.issues.map(issue => {
+                    const issueClass = issue.state === 'open' ? 'issue-open' : 'issue-closed';
+                    return `<a href="${issue.url}" target="_blank" class="badge ${issueClass} me-1" title="${issue.title}">
+                        #${issue.number}
+                    </a>`;
+                }).join('');
+            },
+        },
+        {
             key: "investigation_status",
-            label: "Investigation Status",
+            label: "Investigation",
             sort: (a: TestRun, b: TestRun) => a.investigation_status.localeCompare(b.investigation_status),
+            width: "70px",
+            render: (item: TestRun) => {
+                const status = item.investigation_status;
+                const statusText = TestInvestigationStatusStrings[status] || status;
+                const badgeClass = InvestigationBackgroundCSSClassMap[status] || "bg-secondary";
+
+                return `
+                    <span class="badge ${badgeClass}" title="${statusText}" style="width: 12px; height: 12px; border-radius: 50%; display: inline-block; cursor: help;">
+                        <span class="visually-hidden">${statusText}</span>
+                    </span>
+
+                `;
+            },
         },
     ];
     const sortField = "start_time";
     const sortDirection = "desc";
+
+    // Reactive statement to fetch details when testRuns change
+    $: if (testRuns) {
+        fetchRunDetails();
+    }
 </script>
 
-<PaginatedTable items={testRuns} title="Test Runs" {columns} {sortField} {sortDirection} {onClose} />
+{#if error}
+    <div class="alert alert-warning mb-3">
+        {error}
+    </div>
+{/if}
+
+{#if loading}
+    <div class="text-center my-3">
+        <div class="spinner-border spinner-border-sm" role="status">
+            <span class="visually-hidden">Loading run details...</span>
+        </div>
+        <span class="ms-2">Loading run details...</span>
+    </div>
+{/if}
+
+<PaginatedTable items={enrichedTestRuns} title="Test Runs" {columns} {sortField} {sortDirection} {onClose} />

--- a/frontend/argus.css
+++ b/frontend/argus.css
@@ -164,3 +164,13 @@ div#notificationCounter {
     background-position: center;
     background-size: cover;
 }
+
+.issue-open {
+    color: #f4faff;
+    background-color: #347d39;
+}
+
+.issue-closed {
+    color: #f4faff;
+    background-color: #8256d0;
+}


### PR DESCRIPTION
- Add new backend endpoint `/widgets/runs_details` for fetching detailed test run information
- Implement batched data fetching for issue links, GitHub issues, and test run metadata
- Enhance TestRunTable component with user avatars, hover tooltips, and assignee display
- Add support for all test status types (FAILED, TEST-ERROR, PASSED, ABORTED, RUNNING) with appropriate colors
- Implement GitHub issue badges with open/closed state styling
- Add investigation status indicators as colored circles with hover text
- Include column header tooltips for better UX when names are truncated
- Update type definitions for enhanced test run data structure

Backend changes:
- New GraphedStatsService.get_runs_details() method with error handling

Frontend changes:
- Enhanced TestRunTable with async data loading and enriched display
- Improved status column with comprehensive status type support
- User avatar integration with UserUtils and picture display
- CSS styling for avatars, GitHub issues, and investigation status

refs: https://github.com/scylladb/argus/issues/645