### PR TITLE
fix(pytest-reporter): enable sending the message on it's own

### DIFF
--- a/pytest-argus-reporter/pytest_argus_reporter.py
+++ b/pytest-argus-reporter/pytest_argus_reporter.py
@@ -297,7 +297,7 @@ class ArgusReporter(object):  # pylint: disable=too-many-instance-attributes
 
                 request_data["test_type"] = self.test_type
                 request_data["run_id"] = self.run_id
-
+                request_data["message"] = test_data.pop("failure_message", None)
                 request_data["status"] = test_data.pop("outcome")
                 request_data["duration"] = test_data.pop("duration")
                 request_data["timestamp"] = test_data.pop("timestamp")

--- a/pytest-argus-reporter/tests/conftest.py
+++ b/pytest-argus-reporter/tests/conftest.py
@@ -34,7 +34,7 @@ def configure_needed_env_vars():
 
 @pytest.fixture(scope="function", autouse=True)
 def configure_argus_mock(requests_mock):  # pylint: disable=redefined-outer-name
-    matcher = re.compile(r"http://argus.scylladb.com:443/api/v1/client/testrun/pytest/result/.*")
+    matcher = re.compile(r"https://argus.scylladb.com/api/v1/client/testrun/pytest/result/.*")
 
     requests_mock.post(matcher, status_code=201)
 

--- a/pytest-argus-reporter/tests/test_argus_reporter.py
+++ b/pytest-argus-reporter/tests/test_argus_reporter.py
@@ -94,6 +94,19 @@ def test_failures(testdir, requests_mock):  # pylint: disable=redefined-outer-na
     # make sure that we get a '1' exit code for the testsuite
     assert result.ret == 1
 
+    for req in requests_mock.request_history:
+        req_json = req.json()
+        assert "status" in req_json
+        assert "name" in req_json
+        assert "user_fields" in req_json
+        assert "test_type" in req_json
+        assert "session_timestamp" in req_json
+        assert "duration" in req_json
+
+        # Ensure that for failed tests (excluding xpass tests), the "message" field is populated with an error message.
+        if "message" in req_json and "xpass" not in req_json["name"] and req_json["status"] != "passed":
+            assert req_json["message"] is not None, f"message should not be None {req_json}"
+
 
 def test_argus_configuration(testdir):
     """Make sure that pytest accepts our argus configuration."""


### PR DESCRIPTION
this field was missing and been send over via `user-fields` by mistake