### PR TITLE
fix(readme): Add missing link to pypi to badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Argus
-![PyPI - Version](https://img.shields.io/pypi/v/argus-alm)
+[![PyPI - Version](https://img.shields.io/pypi/v/argus-alm)](https://pypi.python.org/pypi/argus-alm)
 
 ## Description
 


### PR DESCRIPTION
Badge was working, but the link was not added.