### PR TITLE
fix(results): don't return null for 0 values

### DIFF
--- a/argus/backend/service/results_service.py
+++ b/argus/backend/service/results_service.py
@@ -498,7 +498,7 @@ class ResultsService:
             for cell in cells:
                 column = cell['column']
                 row = cell['row']
-                value = cell.get('value') or cell.get('value_text')
+                value = cell.get('value') if cell.get('value') is not None else cell.get('value_text')
                 status = cell['status']
 
                 if column in column_names and row in table_data['rows']:


### PR DESCRIPTION
Sometimes value sent to results might be 0. This was evaluated to false and considering a cell to be text one.

Fix by verifying if value is not `None`.

fixes: https://github.com/scylladb/argus/issues/687