### PR TITLE
improvement(TestRunInfo): Add text-break to Test method

### DIFF
--- a/frontend/TestRun/TestRunInfo.svelte
+++ b/frontend/TestRun/TestRunInfo.svelte
@@ -67,7 +67,7 @@
                     {(test?.pretty_name || test?.name) ?? "#NO_TEST"}
                 </li>
                 {#if test_run.test_method}
-                    <li>
+                    <li class="text-break">
                         <span class="fw-bold">Test Method:</span>
                         {test_run.test_method}
                     </li>


### PR DESCRIPTION
Test methods name can be long, overflowing into other half of the table and overshadowing text there
Example:
https://argus.scylladb.com/tests/scylla-cluster-tests/6624c84b-65a9-4086-8286-312911feeb69
![obrazek](https://github.com/user-attachments/assets/68227668-72ca-43ec-a42e-808613e75f07)
