### PR TITLE
Introduce `MANIFEST.in`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+prune **/tests
+prune **/backend


### PR DESCRIPTION
this is used to exclude files from the `argus-alm` package it was forgotten and wasn't committed during the work on switching to uv