### PR TITLE
fix(generic_result): Add missing init params to StaticGenericResultTable

### DIFF
--- a/argus/client/generic_result.py
+++ b/argus/client/generic_result.py
@@ -155,7 +155,7 @@ class StaticGenericResultTable(GenericResultTable):
     """Results class for static results metainformation, defined in Meta class."""
 
     def __init__(
-        self, name=None, description=None, columns=None, sut_package_name=None, validation_rules=None
+        self, name=None, description=None, columns=None, sut_package_name=None, validation_rules=None, results=None, sut_timestamp=0
     ):
         meta = getattr(self.__class__, "Meta")
         super().__init__(
@@ -165,4 +165,9 @@ class StaticGenericResultTable(GenericResultTable):
             sut_package_name=sut_package_name or getattr(meta, "sut_package_name", ""),
             validation_rules=validation_rules or getattr(
                 meta, "ValidationRules", getattr(meta, "validation_rules", {})),
+            results=results or [],
+            sut_timestamp=sut_timestamp
         )
+
+    class Meta:
+        pass

--- a/argus/client/tests/test_results.py
+++ b/argus/client/tests/test_results.py
@@ -6,7 +6,7 @@ from argus.client.generic_result import (
     ColumnMetadata,
     ResultType,
     ValidationRule,
-    GenericResultTable,
+    GenericResultTable, Cell,
 )
 
 
@@ -222,3 +222,33 @@ def test_text_rule():
 
     with pytest.raises(ValueError, match="TEXT"):
         TextType()
+
+
+@pytest.mark.parametrize("clazz", [
+    pytest.param(GenericResultTable, id="GenericResultTable"),
+    pytest.param(StaticGenericResultTable, id="StaticGenericResultTable"),
+])
+def test_all_parameters(clazz):
+    """
+    Tests that all parameters can be passed through constructor
+    """
+    results = clazz(name="test",
+                    description="test",
+                    columns=[
+                        ColumnMetadata(name="column2", unit="unit1", type=ResultType.INTEGER, higher_is_better=True),
+                    ],
+                    validation_rules={"column2": ValidationRule(best_pct=10, best_abs=20, fixed_limit=30)},
+                    sut_timestamp=10,
+                    results=[
+                        Cell(column='column2', row="1", value=2.86, status=Status.UNSET)
+                    ],
+                    sut_package_name="test package")
+
+    serialized = results.as_dict()
+
+    assert serialized["meta"]["name"] == "test"
+    assert serialized["meta"]["description"] == "test"
+    assert len(serialized["meta"]["rows_meta"]) == 1
+    assert len(serialized["meta"]["columns_meta"]) == 1
+    assert len(serialized["meta"]["validation_rules"]) == 1
+    assert len(serialized["results"]) == 1


### PR DESCRIPTION
This makes it on par with GenericResultTable in terms of init parameters