### PR TITLE
fix(summary_widget): fix limited version

### DIFF
--- a/argus/backend/service/results_service.py
+++ b/argus/backend/service/results_service.py
@@ -612,7 +612,7 @@ class ResultsService:
                 f"""
                 SELECT id, status, investigation_status, test_name, build_id, packages, test_method, started_by
                 FROM {plugin.model.table_name()}
-                WHERE test_id = ? LIMIT 10
+                WHERE test_id = ?
                 """
             )
             rows = self.cluster.session.execute(runs_details_query, parameters=(test_id,)).all()


### PR DESCRIPTION
Because fetch run info was limited to 10, we could see only several recent scylla versions in summary widget.

I don't remember why we needed that. Probably it was just overlooked thing.

fixes: https://github.com/scylladb/argus/issues/701