### PR TITLE
fix(TestDashboardGroup.svelte): Add missing style for profile images

### DIFF
--- a/frontend/ReleaseDashboard/TestDashboardGroup.svelte
+++ b/frontend/ReleaseDashboard/TestDashboardGroup.svelte
@@ -97,3 +97,11 @@
         </div>
     </div>
 {/if}
+
+<style>
+    .img-thumb {
+        border-radius: 50%;
+        width: 32px;
+    }
+
+</style>


### PR DESCRIPTION
This fixes an issue where profile pictures for group assignees would be
unstyled.
