### PR TITLE
improvement(s3_proxy): Allow configurable mime types for S3 proxy

### DIFF
--- a/argus/backend/controller/api.py
+++ b/argus/backend/controller/api.py
@@ -582,7 +582,7 @@ def resolve_artifact_size():
 @api_login_required
 def s3_generic_proxy(bucket_name: str, bucket_path: str):
     service = TestRunService()
-    result = service.proxy_s3_image(
+    result = service.proxy_s3_file(
         bucket_name=bucket_name,
         bucket_path=bucket_path
     )

--- a/argus/backend/service/testrun.py
+++ b/argus/backend/service/testrun.py
@@ -191,15 +191,15 @@ class TestRunService:
 
         return self.s3.generate_presigned_url(ClientMethod="get_object", Params={"Bucket": match.group("bucket"), "Key": match.group("key")}, ExpiresIn=3600)
 
-    def proxy_s3_image(self, bucket_name: str, bucket_path: str):
+    def proxy_s3_file(self, bucket_name: str, bucket_path: str):
         if bucket_name not in current_app.config.get("S3_ALLOWED_BUCKETS", []):
             raise TestRunServiceException(f"{bucket_name} is not an allowed S3 bucket to pull from")
 
         obj = self.s3.get_object(Bucket=bucket_name, Key=bucket_path)
         header = obj["Body"].read(1024)
         mime = magic.from_buffer(header, mime=True)
-        if "image" not in mime.lower():
-            raise TestRunServiceException(f"Cannot proxy a non-image file: {mime}", mime)
+        if mime.lower() not in current_app.config.get("S3_ALLOWED_MIME", []):
+            raise TestRunServiceException(f"Cannot proxy mime type that is not allowed: {mime}", mime)
 
         return self.s3.generate_presigned_url(ClientMethod="get_object", Params={"Bucket": bucket_name, "Key": bucket_path}, ExpiresIn=600)
 

--- a/argus_web.example.yaml
+++ b/argus_web.example.yaml
@@ -26,6 +26,13 @@ SECRET_KEY: MUSTBEUNIQUE
 # Allowed buckets for S3 proxying
 S3_ALLOWED_BUCKETS:
   - my-bucket-name
+
+# Allowed mime types for S3 proxying
+S3_ALLOWED_MIME:
+  - image/png
+  - application/zstd
+  - application/gzip
+
 # AWS Client ID
 AWS_CLIENT_ID: ABCDE
 # AWS Client Secret


### PR DESCRIPTION
This commit adds a new configuration option to allow user to specify
which file types are allowed to be served via the generic S3 proxy.
