### PR TITLE
fix: Add horizontal scrolling to result tables in ResultsTab

### DIFF
--- a/frontend/TestRun/ResultsTab.svelte
+++ b/frontend/TestRun/ResultsTab.svelte
@@ -99,6 +99,9 @@
         list-style-type: none;
         padding: 0;
         margin: 0;
+        overflow-x: auto;
+        white-space: nowrap;
+        display: block;
     }
 
     .filters-container {


### PR DESCRIPTION
- Updated `.result-list` container to allow horizontal scrolling when ResultTable components are too wide.
- Ensures all table content remains accessible regardless of width.

fixes: https://github.com/scylladb/argus/issues/689