### PR TITLE
fix(ReleasePlanCreator): show all missing participants

### DIFF
--- a/frontend/ReleasePlanner/ReleasePlanCreator.svelte
+++ b/frontend/ReleasePlanner/ReleasePlanCreator.svelte
@@ -70,11 +70,16 @@
             soft: false,
             validate: function (plan) {
                 let assignedParticipants = Object.values(plan.assignments);
+                let missing = [];
                 for (const user of plan.participants) {
                     if (!assignedParticipants.find(v => v == user))  {
-                        this.message = `User @${users.find(v => v.id == user).username} is participating but is not assigned.`;
-                        return false;
+                        const username = users.find(v => v.id == user)?.username || user;
+                        missing.push(`@${username}`);
                     }
+                }
+                if (missing.length > 0) {
+                    this.message = `User(s) ${missing.join(", ")} participating but not assigned.`;
+                    return false;
                 }
                 return true;
             }


### PR DESCRIPTION
When several participants are not assigned to tests, Argus shows error message only about one.

Fix by collecting list of unassigned participants and showing all of them in the message.

closes: https://github.com/scylladb/argus/issues/721