### PR TITLE
argusAI: deployment use separate dir for argusAI

### DIFF
--- a/argusAI/deployment/argusai_event_similarity_processor.service
+++ b/argusAI/deployment/argusai_event_similarity_processor.service
@@ -6,7 +6,7 @@ After=network.target
 Type=simple
 User=argus
 Group=argus
-WorkingDirectory=/home/argus/app
+WorkingDirectory=/home/argus/argusAI
 Environment="PYTHONPATH=."
 Environment="DAYS_BACK=120"
 ExecStart=/usr/bin/uv --project argusAI/pyproject.toml run argusAI/event_similarity_processor.py


### PR DESCRIPTION
Similar event processor used for simialar events feature was run from argus staging common to argus deployment dir. This causes problems when we test Argus on staging and want to keep prod AI features running intact.

Created separate dir on staging env for argusAI and moved simialarity processor to run from it, so we are detached from changes in Argus staging env.