### PR TITLE
fix(GithubIssue): Display correct user for each page

### DIFF
--- a/argus/backend/models/github_issue.py
+++ b/argus/backend/models/github_issue.py
@@ -58,3 +58,5 @@ class IssueLink(Model):
     release_id = columns.UUID(index=True)
     group_id = columns.UUID(index=True)
     test_id = columns.UUID(index=True)
+    user_id = columns.UUID(index=True)
+    added_on = columns.DateTime(default=datetime.utcnow)

--- a/argus/backend/service/github_service.py
+++ b/argus/backend/service/github_service.py
@@ -138,6 +138,7 @@ class GithubService:
 
         link = IssueLink()
         link.run_id = run.id
+        link.user_id = g.user.id
         link.issue_id = issue.id
         link.release_id = test.release_id
         link.test_id = test.id

--- a/frontend/Github/GithubIssue.svelte
+++ b/frontend/Github/GithubIssue.svelte
@@ -73,6 +73,22 @@
         return data.response.runs;
     };
 
+    const resolveFirstUserForAggregation = function(issue) {
+        const resolved = issue.links
+            .filter(l => !!l.added_on && !!l.user_id)
+            .sort((a, b) => {
+                const lhs = Date.parse(a.added_on);
+                const rhs = Date.parse(b.added_on);
+
+                return lhs > rhs ? 1 : rhs > lhs ? -1 : 0;
+            });
+
+        return {
+            id: resolved?.[0]?.user_id ?? issue.user_id,
+            date: resolved?.[0]?.added_on ?? issue.added_on,
+        };
+    };
+
     const deleteIssue = async function () {
         deleting = true;
         try {
@@ -149,7 +165,7 @@
                         class="text-muted d-flex align-items-center"
                         title={new Date(issue.added_on).toISOString()}
                     >
-                        <div>Added by <span class="fw-bold">@{users?.[issue.user_id]?.username ?? "ghost"}</span> on {timestampToISODate(new Date(issue.added_on))}</div>
+                        <div>Added by <span class="fw-bold">@{users?.[resolveFirstUserForAggregation(issue).id]?.username ?? "ghost"}</span> on {timestampToISODate(new Date(resolveFirstUserForAggregation(issue).date))}</div>
                         {#if deleteEnabled && !aggregated}
                             <div class="ms-2 text-muted">
                                 {#if deleting}


### PR DESCRIPTION
This commit fixes an issue where user displayed on issue overview would
show first user who submitted the issue ever, instead of whichever user
submitted this issue to this specific view. For example, previously, an
issue added on scylla-staging by user1 would be displayed as added by
user1 on scylla-master, even though it was added by user2 to that
release. Previous issues are not migrated but the new ones will use
correct behaviour.

Fixes #697
