### PR TITLE
feature(ProfileJobs): Display planned jobs for user

### DIFF
--- a/argus/backend/controller/api.py
+++ b/argus/backend/controller/api.py
@@ -600,3 +600,14 @@ def user_jobs():
         "status": "ok",
         "response": result
     }
+
+@bp.route("/user/planned_jobs")
+@api_login_required
+def user_planned_jobs():
+    service = ArgusService()
+    result = list(service.get_planned_jobs_for_user(user=g.user))
+
+    return {
+        "status": "ok",
+        "response": result
+    }

--- a/argus/backend/models/plan.py
+++ b/argus/backend/models/plan.py
@@ -22,3 +22,12 @@ class ArgusReleasePlan(Model):
     creation_time = columns.DateTime(default=lambda: datetime.datetime.now(tz=datetime.UTC))
     last_updated = columns.DateTime(default=lambda: datetime.datetime.now(tz=datetime.UTC))
     ends_at = columns.DateTime()
+
+    def __eq__(self, other):
+        if isinstance(other, ArgusReleasePlan):
+            return self.id == other.id
+        else:
+            return super().__eq__(other)
+
+    def __hash__(self):
+        return hash(self.id)

--- a/argus/backend/service/argus_service.py
+++ b/argus/backend/service/argus_service.py
@@ -7,8 +7,11 @@ import datetime
 from types import NoneType
 from uuid import UUID
 from cassandra.util import uuid_from_time
+from cassandra.cqlengine.models import Model
 from flask import current_app
 from argus.backend.db import ScyllaCluster
+from argus.backend.models.plan import ArgusReleasePlan
+from argus.backend.plugins.core import PluginModelBase
 from argus.backend.plugins.loader import AVAILABLE_PLUGINS, all_plugin_models
 from argus.backend.plugins.sct.testrun import SCTTestRun
 from argus.backend.service.notification_manager import NotificationManagerService
@@ -665,6 +668,32 @@ class ArgusService:
             for run in plugin.get_jobs_assigned_to_user(user_id=user.id):
                 if run["start_time"] >= validity_period:
                     yield run
+
+    def get_planned_jobs_for_user(self, user: User):
+        owned_plans = list(ArgusReleasePlan.filter(owner=user.id).allow_filtering().all())
+        participating_plans = list(ArgusReleasePlan.filter(participants__contains=user.id).allow_filtering().all())
+        unique_plans: list[ArgusReleasePlan] = list({plan for plan in [*owned_plans, *participating_plans]})
+
+        user_jobs = []
+        for plan in unique_plans:
+            if plan.owner == user.id:
+                jobs = filter(lambda test: not plan.assignee_mapping.get(test) or plan.assignee_mapping.get(test) == user.id, plan.tests)
+                user_jobs.extend(jobs)
+            if user.id in plan.participants:
+                jobs = filter(lambda test: plan.assignee_mapping.get(test) == user.id, plan.tests)
+                user_jobs.extend(jobs)
+        resolved: list[ArgusTest] = []
+        for batch in chunk(set(user_jobs)):
+            resolved.extend(ArgusTest.filter(id__in=batch).all())
+
+        last_runs: dict[UUID, Model] = {}
+        for test in resolved:
+            try:
+                last_runs[test.id] = AVAILABLE_PLUGINS[test.plugin_name].model.filter(build_id=test.build_system_id).limit(1).get()
+            except PluginModelBase.DoesNotExist:
+                last_runs[test.id] = None
+
+        return [{**dict(test.items()), "last_run": last_runs.get(test.id) } for test in resolved]
 
     def get_schedules_for_user(self, user: User) -> list[dict]:
         all_assigned_schedules = ArgusScheduleAssignee.filter(assignee=user.id).all()

--- a/frontend/Profile/PlannedJob.svelte
+++ b/frontend/Profile/PlannedJob.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+    import Fa from "svelte-fa";
+    import { StatusBackgroundCSSClassMap, TestStatus } from "../Common/TestStatus";
+    import { subUnderscores, titleCase } from "../Common/TextUtils";
+    import { PlannedTest } from "./PlannedJobs.svelte";
+    import { faChevronDown, faChevronUp, faHammer } from "@fortawesome/free-solid-svg-icons";
+    import TestRuns from "../WorkArea/TestRuns.svelte";
+    import { timestampToISODate } from "../Common/DateUtils";
+
+    export let test: PlannedTest;
+    let expanded = false;
+    let status = (test?.last_run?.status ?? TestStatus.NOT_RUN) as keyof typeof StatusBackgroundCSSClassMap;
+</script>
+
+<div class="rounded bg-white overflow-hidden mb-2 d-flex align-items-center">
+    <div class="text-center fw-light p-2 text-light {StatusBackgroundCSSClassMap[status]} me-2" style="width:7%">{subUnderscores(status ?? "Unknown").split(" ").map(v => titleCase(v)).join(" ")}</div>
+    <div>
+        {test.pretty_name || test.name}
+        <div class="text-muted text-sm">
+            {test.build_system_id}
+        </div>
+    </div>
+    <div class="me-2 ms-auto text-sm text-muted">
+        {#if test.last_run}
+            {timestampToISODate(test.last_run.start_time)}
+        {/if}
+    </div>
+    <div class="me-2">
+        <a class="btn btn-sm btn-dark" href="{test.build_system_url}" target="_blank">
+            <Fa icon={faHammer} />
+        </a>
+    </div>
+    <div class="me-2">
+        <button class="btn btn-sm btn-primary" on:click={() => (expanded = !expanded)}>
+            <Fa icon={expanded ? faChevronUp : faChevronDown} /></button>
+    </div>
+
+</div>
+{#if expanded}
+    <div class="mb-2 bg-white rounded overflow-hidden">
+        <TestRuns
+            additionalRuns={[]}
+            removableRuns={false}
+            testId={test.id}
+            tab={""}
+        />
+    </div>
+{/if}
+
+
+<style>
+    .text-sm {
+        font-size: 0.75rem;
+    }
+
+</style>

--- a/frontend/Profile/PlannedJobs.svelte
+++ b/frontend/Profile/PlannedJobs.svelte
@@ -1,0 +1,100 @@
+<script context="module" lang="ts">
+
+    export interface PlannedTest {
+        id: string,
+        name: string,
+        pretty_name: string,
+        build_system_id: string,
+        last_run: LastRun,
+        build_system_url: string,
+    }
+
+    export interface LastRun {
+        status: string,
+        investigation_status: string,
+        build_id: string,
+        start_time: string,
+        assignee: string,
+    }
+
+    export const STATUS_SORT_ORDER = {
+        [TestStatus.NOT_RUN]: 0,
+        [TestStatus.FAILED]: 1,
+        [TestStatus.TEST_ERROR]: 2,
+        [TestStatus.ABORTED]: 3,
+        [TestStatus.PASSED]: 4,
+        [TestStatus.RUNNING]: 5,
+        [TestStatus.CREATED]: 6,
+        [TestStatus.NOT_PLANNED]: 7,
+    };
+</script>
+
+<script lang="ts">
+    import { onMount } from "svelte";
+    import { sendMessage } from "../Stores/AlertStore";
+    import PlannedJob from "./PlannedJob.svelte";
+    import { TestStatus } from "../Common/TestStatus";
+
+    let plannedTests: PlannedTest[] = [];
+    export let jobCount = 0;
+    let fetching = false;
+    let pageSize = 10;
+
+    const sortJobs = function (a: PlannedTest, b: PlannedTest) {
+        const lhs = STATUS_SORT_ORDER[a?.last_run?.status || TestStatus.NOT_RUN];
+        const rhs = STATUS_SORT_ORDER[b?.last_run?.status || TestStatus.NOT_RUN];
+
+        return lhs - rhs;
+    };
+
+    const fetchPlannedJobs = async function() {
+        try {
+            fetching = true;
+            let response = await fetch("/api/v1/user/planned_jobs");
+            if (response.status != 200) throw new Error("HTTP Transport Error");
+            let json = await response.json();
+            if (json.status != "ok") throw new Error(`API Error: ${json.exception.arguments.join(" ")}`);
+
+            plannedTests = json.response.sort(sortJobs);
+            jobCount = plannedTests.filter(t => !t.last_run).length;
+        } catch (e) {
+            if (e instanceof Error) {
+                sendMessage("error", `Error fetching planned user jobs\n${e.message}`, "ProfileJob::testInfo");
+            } else {
+                sendMessage("error", "Error fetching planned user jobs\nUnknown error. Check console for details", "ProfileJobs::testInfo");
+            }
+            console.log(e);
+        } finally {
+            fetching = false;
+        }
+    };
+
+    onMount(async () => {
+        await fetchPlannedJobs();
+    });
+
+</script>
+
+
+<div>
+    {#if !fetching}
+        {#each plannedTests.slice(0, pageSize) as test (test.id)}
+            <PlannedJob test={test} />
+        {:else}
+            <div class="text-muted text-center p-4">
+                No jobs planned.
+            </div>
+        {/each}
+    {:else}
+        <div class="text-center p-4">
+            <span class="spinner-border spinner-border-sm" /> Getting jobs...
+        </div>
+    {/if}
+    {#if plannedTests.length > pageSize}
+        <div>
+            <button class="btn btn-primary d-block w-100" on:click={() => pageSize += pageSize}>
+                Load More...
+            </button>
+        </div>
+    {/if}
+</div>

--- a/frontend/Profile/ProfileJobs.svelte
+++ b/frontend/Profile/ProfileJobs.svelte
@@ -5,12 +5,19 @@
     import { onMount } from "svelte";
     import ProfileJobsTab from "./ProfileJobsTab.svelte";
     import { TestInvestigationStatus } from "../Common/TestStatus";
+    import PlannedJobs from "./PlannedJobs.svelte";
+    import queryString from "query-string";
     export let jobs;
     export let userId;
 
-    let activeTab = "todo";
+    let activeTab = queryString.parse(document.location.search).activeTab ||  "todo";
     let jobsToDo = [];
     let jobsDone = [];
+    let plannedJobIndicator = 0;
+
+    $: {
+        history.pushState(undefined, null, `?${queryString.stringify({ activeTab })}`);
+    }
 
     const fetchUserJobs = async function() {
         if (jobs) {
@@ -91,7 +98,9 @@
                     class:active={activeTab == "planned"}
                     on:click={() => (activeTab = "planned")}
                 >
-                    <Fa icon={faCalendar}/> Planned
+                    <Fa icon={faCalendar}/> Planned {#if plannedJobIndicator > 0}
+                        <div class="d-inline-block bg-danger p-1" style="border-radius: 10%">{plannedJobIndicator}</div>
+                    {/if}
                 </button>
         </div>
         <div class="p-2">
@@ -103,7 +112,7 @@
                     <ProfileJobsTab jobs={jobsDone} on:investigationStatusChange={handleInvestigationStatusChangeDone} on:batchIgnoreDone={handleBatchIgnore}/>
                 </div>
                 <div class:d-none={activeTab != "planned"}>
-                    WIP
+                    <PlannedJobs bind:jobCount={plannedJobIndicator} />
                 </div>
             </div>
         </div>

--- a/templates/partials/nav_bar.html.j2
+++ b/templates/partials/nav_bar.html.j2
@@ -10,7 +10,6 @@
             <a class="{% if request.path == url_for('main.views')%}active{%endif%} nav-link" href="{{ url_for('main.views')}}"><i class="far fa-object-group"></i> Views</a>
             {% if g.user %}
             <a class="{% if request.path == url_for('main.profile_jobs')%}active{%endif%} nav-link" href="{{ url_for('main.profile_jobs')}}"><i class="fas fa-archive"></i> My Jobs</a>
-            <a class="{% if request.path == url_for('main.profile_schedules')%}active{%endif%} nav-link" href="{{ url_for('main.profile_schedules')}}"><i class="fas fa-calendar-week"></i> My Schedule</a>
             <a class="{% if request.path == url_for('main.notifications.index')%}active{%endif%} nav-link position-relative" href="{{ url_for('main.notifications.index') }}"><div class="position-absolute" id="notificationCounter"></div><i class="far fa-bell"></i> Notifications</a>
                 {% if g.user.is_admin() %}
                     <a class="{% if request.path == url_for('admin.index')%}active{%endif%} nav-link" href="{{ url_for('admin.index')}}"><i class="fas fa-wrench"></i> Admin Area</a>


### PR DESCRIPTION
This commit adds a new view that allows users to view their assigned
jobs in the "My Jobs" page. If those include jobs that haven't been run,
the tab will show an indicator with number of these jobs. The tab itself
contains a button to open Jenkins page of the said job and a button that
will load Argus Test Run view for the said job.

Fixes scylladb/qa-tasks#832