### PR TITLE
feature(IssueTab.svelte): Add quick issue link to aggregated issue view

### DIFF
--- a/frontend/Github/GithubIssue.svelte
+++ b/frontend/Github/GithubIssue.svelte
@@ -177,6 +177,9 @@
                 {/if}
                 {#if aggregated}
                     <div class="text-end my-2">
+                        {#if runId}
+                            <button class="btn btn-primary" on:click={() => dispatch("submitToCurrent", issue.url)}>Add to current run</button>
+                        {/if}
                         <button class="btn btn-primary" on:click={() => (showRuns = true)}>View {issue.links.length} runs</button>
                     </div>
                 {/if}

--- a/frontend/Github/GithubIssues.svelte
+++ b/frontend/Github/GithubIssues.svelte
@@ -19,7 +19,7 @@
     let issues = [];
     let fetching = false;
     let showAllLabels = false;
-    const fetchIssues = async function () {
+    export const fetchIssues = async function () {
         issues = [];
         fetching = true;
         try {
@@ -307,7 +307,7 @@
             </div>
             <div class="row">
                 {#each sortedIssues[currentPage] ?? [] as issue (issue.id)}
-                    <GithubIssue {runId} bind:issue={issue} aggregated={aggregateByIssue} deleteEnabled={!submitDisabled} on:issueDeleted={fetchIssues} on:labelClick={(e) => handleLabelClick(e.detail)}/>
+                    <GithubIssue {runId} bind:issue={issue} aggregated={aggregateByIssue} deleteEnabled={!submitDisabled} on:submitToCurrent on:issueDeleted={fetchIssues} on:labelClick={(e) => handleLabelClick(e.detail)}/>
                 {/each}
             </div>
             <div class="d-flex ">

--- a/frontend/TestRun/IssueTab.svelte
+++ b/frontend/TestRun/IssueTab.svelte
@@ -1,11 +1,51 @@
 <script>
     import GithubIssues from "../Github/GithubIssues.svelte";
+    import { sendMessage } from "../Stores/AlertStore";
 
     export let runId;
     export let testInfo;
+
+    let aggregatedIssuesComponent;
+    let runIssuesComponent;
+
+    const submitIssue = async function (url, runId, testId) {
+        try {
+            if (!testId) return;
+            let apiResponse = await fetch(`/api/v1/test/${testId}/run/${runId}/issues/submit`, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    issue_url: url,
+                }),
+            });
+            let apiJson = await apiResponse.json();
+            if (apiJson.status === "ok") {
+                runIssuesComponent.fetchIssues();
+                aggregatedIssuesComponent.fetchIssues();
+            } else {
+                throw apiJson;
+            }
+        } catch (error) {
+            if (error?.status === "error") {
+                sendMessage(
+                    "error",
+                    `API Error while submitting an issue on a test run.\nMessage: ${error.response.arguments[0]}`,
+                    "IssueTab::submit"
+                );
+            } else {
+                sendMessage(
+                    "error",
+                    "A backend error occurred during issue submission.",
+                    "IssueTab::submit"
+                );
+            }
+        }
+    };
 </script>
 
-<GithubIssues {runId} id={runId} testId={testInfo.test.id} pluginName={testInfo.test.plugin_name}/>
+<GithubIssues bind:this={runIssuesComponent} {runId} id={runId} testId={testInfo.test.id} pluginName={testInfo.test.plugin_name}/>
 <div class="accordion accordion-flush border-top" id="allIssuesContainer-{testInfo.test.id}-{runId}">
     <div class="accordion-item">
         <h2 class="accordion-header">
@@ -15,7 +55,7 @@
         </h2>
         <div id="allIssues-{testInfo.test.id}-{runId}" class="accordion-collapse collapse" data-bs-parent="#allIssuesContainer-{testInfo.test.id}-{runId}">
         <div class="accordion-body overflow-scroll" style="max-height: 768px">
-            <GithubIssues {runId} id={testInfo.test.id} testId={testInfo.test.id} filter_key="test_id" aggregateByIssue={true} submitDisabled={true}/>
+            <GithubIssues on:submitToCurrent={(e) => submitIssue(e.detail, runId, testInfo.test.id)} bind:this={aggregatedIssuesComponent} {runId} id={testInfo.test.id} testId={testInfo.test.id} filter_key="test_id" aggregateByIssue={true} submitDisabled={true}/>
         </div>
         </div>
     </div>


### PR DESCRIPTION
This commit adds a feature which allows user to quickly attach an
existing issue shown in "All issues for this test" tab into the current
run.

Fixes #708
