### PR TITLE
fix(GithubIssue.svelte): Show correct user for single-issue as well

### DIFF
--- a/argus/backend/service/github_service.py
+++ b/argus/backend/service/github_service.py
@@ -199,7 +199,7 @@ class GithubService:
                 response.append(issue_dict)
 
         else:
-            response = [dict(issue.items()) for issue in resolved_issues]
+            response = [{**dict(issue.items()), **issues[issue.id][0]} for issue in resolved_issues]
         return response
 
     def delete_github_issue(self, issue_id: UUID, run_id: UUID) -> dict:

--- a/frontend/Github/GithubIssue.svelte
+++ b/frontend/Github/GithubIssue.svelte
@@ -74,6 +74,10 @@
     };
 
     const resolveFirstUserForAggregation = function(issue) {
+        if (!issue.links) return {
+            id: issue.user_id,
+            date: issue.added_on,
+        };
         const resolved = issue.links
             .filter(l => !!l.added_on && !!l.user_id)
             .sort((a, b) => {


### PR DESCRIPTION
This fixes an issue where application would crash as `issue.links` is
not populated in non-aggregated widgets.
