### PR TITLE
fix(PlannedJobs.svelte): Do not display disabled jobs

### DIFF
--- a/argus/backend/service/argus_service.py
+++ b/argus/backend/service/argus_service.py
@@ -695,6 +695,8 @@ class ArgusService:
 
         last_runs: dict[UUID, Model] = {}
         for test in resolved:
+            if not test.enabled:
+                continue
             try:
                 last_runs[test.id] = AVAILABLE_PLUGINS[test.plugin_name].model.filter(build_id=test.build_system_id).limit(1).get()
             except PluginModelBase.DoesNotExist:


### PR DESCRIPTION
This fixes an issue where old disabled jobs would show up in Planned Tab
on my jobs page.
