### PR TITLE
fix(ViewDashboard.svelte): Correctly assign and get productVersion

### DIFF
--- a/frontend/Views/ViewDashboard.svelte
+++ b/frontend/Views/ViewDashboard.svelte
@@ -11,10 +11,8 @@
     let clickedTests = {};
     let resolvedTests = [];
     const versionDispatch = {
-        GLOBAL_STATS_KEY: productVersion,
+        [GLOBAL_STATS_KEY]: productVersion,
     };
-
-    console.log(versionDispatch);
 
     const handleTestClick = function (detail) {
         if (detail.start_time == 0) {

--- a/frontend/view-dashboard.js
+++ b/frontend/view-dashboard.js
@@ -1,8 +1,10 @@
+import queryString from "query-string";
 import ViewDashboard from "./Views/ViewDashboard.svelte";
 
 const app = new ViewDashboard({
     target: document.querySelector("div#viewDashboard"),
     props: {
         view: globalThis.ARGUS_VIEW_DATA,
+        productVersion: queryString.parse(document.location.search)?.productVersion,
     }
 });


### PR DESCRIPTION
This commit fixes an issue where productVersion query parameter would be
ignored, but also incorrectly assigned to the widget version filter.

Fixes #751
