### PR TITLE
feature(plugins/sct): Add instance_type to CloudInstanceDetails

### DIFF
--- a/argus/backend/plugins/sct/udt.py
+++ b/argus/backend/plugins/sct/udt.py
@@ -22,6 +22,7 @@ class PackageVersion(UserType):
 class CloudInstanceDetails(UserType):
     __type_name__ = "CloudInstanceDetails_v3"
     provider = columns.Text()
+    instance_type = columns.Text()
     region = columns.Text()
     public_ip = columns.Text()
     private_ip = columns.Text()

--- a/argus/client/sct/client.py
+++ b/argus/client/sct/client.py
@@ -152,7 +152,7 @@ class ArgusSCTClient(ArgusClient):
         )
         self.check_response(response)
 
-    def create_resource(self, name: str, resource_type: str, public_ip: str, private_ip: str,
+    def create_resource(self, name: str, resource_type: str, public_ip: str, private_ip: str, instance_type: str,
                         region: str, provider: str, dc_name: str, rack_name: str, shards_amount: int, state=ResourceState.RUNNING) -> None:
         """
             Creates a cloud resource record in argus.
@@ -167,6 +167,7 @@ class ArgusSCTClient(ArgusClient):
                     "state": state,
                     "resource_type": resource_type,
                     "instance_details": {
+                        "instance_type": instance_type,
                         "provider": provider,
                         "region": region,
                         "dc_name": dc_name,

--- a/frontend/TestRun/ResourcesInfo.svelte
+++ b/frontend/TestRun/ResourcesInfo.svelte
@@ -20,6 +20,7 @@
         provider: ["instance_info", "provider"],
         state: "state",
         name: "name",
+        type: ["instance_info", "instance_type"],
         shards: ["instance_info", "shards_amount"],
         publicIp: ["instance_info", "public_ip"],
         privateIp: ["instance_info", "private_ip"],
@@ -135,6 +136,25 @@
                 </span>
             {/if}
             Provider
+        </th>
+        <th
+            role="button"
+            scope="col"
+            class="text-center align-middle"
+            on:click={() => {
+                sortHeader = "type";
+                sortAscending = !sortAscending;
+            }}
+        >
+            {#if sortHeader == "type"}
+                <span
+                    class="d-inline-block"
+                    class:invertArrow={sortAscending}
+                >
+                    &#x25B2;
+                </span>
+            {/if}
+            Instance Type
         </th>
         <th
             role="button"
@@ -350,6 +370,7 @@
         {#each sortResourcesByKey(resources, sortHeader, sortAscending) as resource (resource.name)}
             <tr class:d-none={filterResource(resource)}>
                 <td>{resource.instance_info.provider}</td>
+                <td>{resource.instance_info.instance_type || "N/A"}</td>
                 <td>{resource.name}</td>
                 <td>{resource.instance_info.region}</td>
                 <td>{resource.instance_info.dc_name ?? ""}</td>


### PR DESCRIPTION
This commit adds a new field to the CloudInstanceDetails UDT, which
allows specifying individual resource instance type (as opposed to
providing config-specified instance type) and adds necessary code to
show it in the resource table on SCT run.

Task: #618
