### PR TITLE
feature(EventsTab.svelte): Add quick issue attach to Similar Events

### DIFF
--- a/frontend/TestRun/EventsTab.svelte
+++ b/frontend/TestRun/EventsTab.svelte
@@ -399,6 +399,7 @@
                     similars={event.similars}
                     duplicates={getNumberOfDuplicates(event)}
                     {toggleDuplicates}
+                    on:issueAttach
                 />
             {:else}
                 <RawEvent eventText={event.text} errorMessage={event.error} />

--- a/frontend/TestRun/IssueTab.svelte
+++ b/frontend/TestRun/IssueTab.svelte
@@ -1,14 +1,5 @@
-<script>
-    import GithubIssues from "../Github/GithubIssues.svelte";
-    import { sendMessage } from "../Stores/AlertStore";
-
-    export let runId;
-    export let testInfo;
-
-    let aggregatedIssuesComponent;
-    let runIssuesComponent;
-
-    const submitIssue = async function (url, runId, testId) {
+<script context="module">
+    export const submitIssue = async function (url, runId, testId) {
         try {
             if (!testId) return;
             let apiResponse = await fetch(`/api/v1/test/${testId}/run/${runId}/issues/submit`, {
@@ -22,8 +13,11 @@
             });
             let apiJson = await apiResponse.json();
             if (apiJson.status === "ok") {
-                runIssuesComponent.fetchIssues();
-                aggregatedIssuesComponent.fetchIssues();
+                sendMessage(
+                    "success",
+                    "Issue has been added to the current run!",
+                    "IssueTab::submit"
+                );
             } else {
                 throw apiJson;
             }
@@ -45,6 +39,24 @@
     };
 </script>
 
+<script>
+    import GithubIssues from "../Github/GithubIssues.svelte";
+    import { sendMessage } from "../Stores/AlertStore";
+
+    export let runId;
+    export let testInfo;
+
+    const submitIssueLocal = async function (url, runId, testId) {
+        await submitIssue(url, runId, testId);
+        runIssuesComponent.fetchIssues();
+        aggregatedIssuesComponent.fetchIssues();
+    };
+
+    let aggregatedIssuesComponent;
+    let runIssuesComponent;
+
+</script>
+
 <GithubIssues bind:this={runIssuesComponent} {runId} id={runId} testId={testInfo.test.id} pluginName={testInfo.test.plugin_name}/>
 <div class="accordion accordion-flush border-top" id="allIssuesContainer-{testInfo.test.id}-{runId}">
     <div class="accordion-item">
@@ -55,7 +67,7 @@
         </h2>
         <div id="allIssues-{testInfo.test.id}-{runId}" class="accordion-collapse collapse" data-bs-parent="#allIssuesContainer-{testInfo.test.id}-{runId}">
         <div class="accordion-body overflow-scroll" style="max-height: 768px">
-            <GithubIssues on:submitToCurrent={(e) => submitIssue(e.detail, runId, testInfo.test.id)} bind:this={aggregatedIssuesComponent} {runId} id={testInfo.test.id} testId={testInfo.test.id} filter_key="test_id" aggregateByIssue={true} submitDisabled={true}/>
+            <GithubIssues on:submitToCurrent={(e) => submitIssueLocal(e.detail, runId, testInfo.test.id)} bind:this={aggregatedIssuesComponent} {runId} id={testInfo.test.id} testId={testInfo.test.id} filter_key="test_id" aggregateByIssue={true} submitDisabled={true}/>
         </div>
         </div>
     </div>

--- a/frontend/TestRun/StructuredEvent.svelte
+++ b/frontend/TestRun/StructuredEvent.svelte
@@ -1,16 +1,20 @@
 <script>
-    import {faCopy, faDotCircle, faLink} from "@fortawesome/free-solid-svg-icons";
+    import {faCheckCircle, faCopy, faDotCircle, faLink, faPlus} from "@fortawesome/free-solid-svg-icons";
     import Fa from "svelte-fa";
     import { sendMessage } from "../Stores/AlertStore";
     import ModalWindow from "../Common/ModalWindow.svelte";
+    import { createEventDispatcher } from "svelte";
 
 
     export let event;
     export let similars = [];
     export let duplicates = 0;
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     export let toggleDuplicates = () => {};
     export let display = true;
     export let filterString = "";
+
+    const dispatch = createEventDispatcher();
 
     // Track if duplicates are shown for this event (local state)
     let showingDuplicates = false;
@@ -112,7 +116,7 @@
                     class:btn-info={!showingDuplicates}
                     on:click={() => { showingDuplicates = !showingDuplicates; toggleDuplicates(event); }}>
                     <Fa icon={faCopy} />
-                    <span>{showingDuplicates ? `Hide Duplicates` : `Show ${duplicates} Duplicates`}</span>
+                    <span>{showingDuplicates ? "Hide Duplicates" : `Show ${duplicates} Duplicates`}</span>
                 </button>
             {/if}
             <button
@@ -209,15 +213,24 @@
                                     <td>
                                         {#if similarRunsInfo[runId]?.issues?.length}
                                             {#each similarRunsInfo[runId].issues as issue}
-                                                <div class="issue-item mb-1">
-                                                    <a href={issue.url} target="_blank" class="issue-link">
-                                                        <span
-                                                            class="badge {issue.state === 'open'
-                                                                ? 'issue-open'
-                                                                : 'issue-closed'}">#{issue.number}</span
+                                                <div class="mb-1 d-flex align-items-center">
+                                                    <div class="btn-group" style="width: 128px">
+                                                        <button
+                                                            class:btn-open={issue.state === "open"}
+                                                            class:btn-closed={issue.state !== "open"}
+                                                            class="btn btn-sm"
+                                                            title="Add this issue to the current run"
+                                                            on:click={() => dispatch("issueAttach", { url: issue.url })}
                                                         >
+                                                            <Fa icon={faPlus}/>
+                                                        </button>
+                                                        <a href={issue.url} class:btn-open={issue.state === "open"} class:btn-closed={issue.state !== "open"} target="_blank" class="btn btn-sm">
+                                                            <Fa icon={issue.state === "open" ? faDotCircle : faCheckCircle}/> #{issue.number}
+                                                        </a>
+                                                    </div>
+                                                    <div class="ms-2 overflow-ellipsis text-truncate" style="max-width: 512px" title="{issue.title}">
                                                         {issue.title}
-                                                    </a>
+                                                    </div>
                                                 </div>
                                             {/each}
                                         {:else}
@@ -292,5 +305,39 @@
 
     .date-column {
         width: 100px;
+    }
+
+    .btn-open {
+        --bs-btn-color: #fff;
+        --bs-btn-bg: #347d39;
+        --bs-btn-border-color: #2f5c32;
+        --bs-btn-hover-color: #fff;
+        --bs-btn-hover-bg: #29722e;
+        --bs-btn-hover-border-color: rgb(32, 68, 35);
+        --bs-btn-focus-shadow-rgb: 225, 83, 97;
+        --bs-btn-active-color: #fff;
+        --bs-btn-active-bg: #349b3b;
+        --bs-btn-active-border-color: #3a693d;
+        --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+        --bs-btn-disabled-color: #fff;
+        --bs-btn-disabled-bg: #6fc575;
+        --bs-btn-disabled-border-color: #597e5c;
+    }
+
+    .btn-closed {
+        --bs-btn-color: #fff;
+        --bs-btn-bg: #8256d0;
+        --bs-btn-border-color: #7459a3;
+        --bs-btn-hover-color: #fff;
+        --bs-btn-hover-bg: #6843a8;
+        --bs-btn-hover-border-color: #624496;
+        --bs-btn-focus-shadow-rgb: 225, 83, 97;
+        --bs-btn-active-color: #fff;
+        --bs-btn-active-bg: #9255fa;
+        --bs-btn-active-border-color: #ba95fa;
+        --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+        --bs-btn-disabled-color: #fff;
+        --bs-btn-disabled-bg: #b19cd4;
+        --bs-btn-disabled-border-color: #8e82a1;
     }
 </style>

--- a/frontend/TestRun/TestRun.svelte
+++ b/frontend/TestRun/TestRun.svelte
@@ -31,7 +31,7 @@
     import HeartbeatIndicator from "./HeartbeatIndicator.svelte";
     import EventsTab from "./EventsTab.svelte";
     import ArtifactTab from "./ArtifactTab.svelte";
-    import IssueTab from "./IssueTab.svelte";
+    import IssueTab, { submitIssue } from "./IssueTab.svelte";
     import { SubtestTabBodyComponents, SubtestTabComponents, Subtests } from "./SCTSubTests/Subtest";
     import PackagesInfo from "./PackagesInfo.svelte";
     import JUnitResults from "./jUnitResults.svelte";
@@ -444,7 +444,7 @@
                     role="tabpanel"
                 >
                     {#if visitedTabs["events"]}
-                        <EventsTab {testRun} />
+                        <EventsTab {testRun} on:issueAttach={(e) => submitIssue(e.detail.url, runId, testInfo.test.id)} />
                     {/if}
                 </div>
                 <div


### PR DESCRIPTION
This commit adds an ability to quickly attach issues to runs when
viewing the "Similar Events" tab.

Fixes #708
