### PR TITLE
fix(release-page.js): Disable shorthand stats

### DIFF
--- a/frontend/release-page.js
+++ b/frontend/release-page.js
@@ -4,12 +4,13 @@ import StatsFetcher from "./Stats/StatsFetcher.svelte";
 const registeredApps = [];
 const releaseElements = document.querySelectorAll("div.release-card");
 
-releaseElements.forEach(el => {
-    let app = new StatsFetcher({
-        target: el.querySelector("div.release-stats"),
-        props: {
-            releaseName: el.dataset.argusReleaseName
-        }
-    });
-    registeredApps.push(app);
-});
+// disabled due to performance overhead
+// releaseElements.forEach(el => {
+//     let app = new StatsFetcher({
+//         target: el.querySelector("div.release-stats"),
+//         props: {
+//             releaseName: el.dataset.argusReleaseName
+//         }
+//     });
+//     registeredApps.push(app);
+// });


### PR DESCRIPTION
This commit disables stat bars found on the "Release" overview page, as
they can be quite costly to run for not much benefit
