### PR TITLE
fix(ResultTable.svelte): Resolve promise for individual tables

### DIFF
--- a/frontend/TestRun/Components/ResultTable.svelte
+++ b/frontend/TestRun/Components/ResultTable.svelte
@@ -190,7 +190,7 @@
                     <thead class="thead-dark">
                     <tr>
                         <th>
-                            <button class="btn btn-link p-1" onclick={copyResultTableAsMarkdown}>
+                            <button class="btn btn-link p-1" onclick={async () => await copyResultTableAsMarkdown()}>
                                 <Fa icon={faMarkdown} size="sm"/>
                             </button>
                         </th>


### PR DESCRIPTION
Fixes an issue where a single markdown table couldn't be copied.

Fixes #777
