### PR TITLE
feature(plugins/sct): SCT Events Rework

### DIFF
--- a/argus/backend/plugins/sct/plugin.py
+++ b/argus/backend/plugins/sct/plugin.py
@@ -1,6 +1,6 @@
 from flask import Blueprint
 
-from argus.backend.plugins.sct.testrun import SCTJunitReports, SCTTestRun
+from argus.backend.plugins.sct.testrun import SCTEvent, SCTJunitReports, SCTTestRun
 from argus.backend.plugins.sct.controller import bp as sct_bp
 from argus.backend.plugins.core import PluginInfoBase, PluginModelBase
 from argus.backend.plugins.sct.udt import (
@@ -23,6 +23,7 @@ class PluginInfo(PluginInfoBase):
     all_models = [
         SCTTestRun,
         SCTJunitReports,
+        SCTEvent,
     ]
     all_types = [
         NemesisRunInfo,

--- a/argus/backend/tests/conftest.py
+++ b/argus/backend/tests/conftest.py
@@ -5,9 +5,11 @@ from unittest.mock import patch
 
 from cassandra.auth import PlainTextAuthProvider
 from docker import DockerClient
-from flask import g
+from flask import g, Flask
+from flask.testing import FlaskClient
 
 from argus.backend.plugins.loader import all_plugin_types
+from argus.backend.plugins.sct.service import SCTService
 from argus.backend.service.testrun import TestRunService
 from argus.backend.service.views_widgets.pytest import PytestViewService
 from argus.backend.util.config import Config
@@ -121,7 +123,7 @@ def app_context(argus_db, argus_app):
 
 
 @fixture(scope='session')
-def flask_client(argus_app):
+def flask_client(argus_app: Flask) -> FlaskClient:
     return argus_app.test_client()
 
 
@@ -138,6 +140,11 @@ def client_service(argus_db):
 @fixture(scope='session')
 def pv_service(argus_db) -> PytestViewService:
     return PytestViewService()
+
+
+@fixture(scope='session')
+def sct_service(argus_db) -> SCTService:
+    return SCTService()
 
 
 @fixture(scope='session')

--- a/argus/backend/tests/sct_events/test_sct_events.py
+++ b/argus/backend/tests/sct_events/test_sct_events.py
@@ -1,0 +1,383 @@
+from dataclasses import asdict
+from datetime import datetime, UTC
+import json
+import logging
+
+import pytest
+from flask.testing import FlaskClient
+
+from argus.backend.models.web import ArgusRelease, ArgusGroup, ArgusTest
+from argus.backend.plugins.sct.testrun import SCTEventSeverity, SCTTestRun
+from argus.backend.service.client_service import ClientService
+from argus.backend.plugins.sct.service import SCTService
+from argus.backend.service.testrun import TestRunService
+from argus.backend.tests.conftest import get_fake_test_run
+from argus.backend.util.encoders import ArgusJSONEncoder
+from argus.common.sct_types import RawEventPayload
+
+LOGGER = logging.getLogger(__name__)
+
+def test_submit_event(client_service: ClientService, sct_service: SCTService, testrun_service: TestRunService, fake_test: ArgusTest):
+    run_type, run_req = get_fake_test_run(fake_test)
+    client_service.submit_run(run_type, asdict(run_req))
+    run: SCTTestRun = testrun_service.get_run(run_type, run_req.run_id)
+
+    event_data: RawEventPayload = {
+        "duration": 30.0,
+        "event_type": "end",
+        "known_issue": None,
+        "message": "Sample event - body contains\nmultiple lines.",
+        "nemesis_name": None,
+        "nemesis_status": None,
+        "node": None,
+        "received_timestamp": None,
+        "run_id": run.id,
+        "severity": SCTEventSeverity.CRITICAL.value,
+        "target_node": None,
+        "ts": datetime.now(tz=UTC).timestamp()
+    }
+
+    _ = sct_service.submit_event(str(run.id), event_data)
+
+    all_events = run.get_all_events()
+    assert len(all_events) == 1, "Event not found"
+
+
+def test_get_events_by_severity(client_service: ClientService, sct_service: SCTService, testrun_service: TestRunService, fake_test: ArgusTest):
+    run_type, run_req = get_fake_test_run(fake_test)
+    client_service.submit_run(run_type, asdict(run_req))
+    run: SCTTestRun = testrun_service.get_run(run_type, run_req.run_id)
+
+    event_template: RawEventPayload = {
+        "duration": 30.0,
+        "event_type": "end",
+        "known_issue": None,
+        "message": "Sample event - body contains\nmultiple lines.",
+        "nemesis_name": None,
+        "nemesis_status": None,
+        "node": None,
+        "received_timestamp": None,
+        "run_id": run.id,
+        "severity": None,
+        "target_node": None,
+        "ts": None
+    }
+
+    events = []
+    for i in range(3):
+        raw_event = dict(event_template)
+        raw_event["ts"] = datetime.now(tz=UTC).timestamp() - i
+        raw_event["severity"] = SCTEventSeverity.CRITICAL.value
+        events.append(raw_event)
+
+    for i in range(10):
+        raw_event = dict(event_template)
+        raw_event["ts"] = datetime.now(tz=UTC).timestamp() - i
+        raw_event["severity"] = SCTEventSeverity.NORMAL.value
+        events.append(raw_event)
+
+    for event in events:
+        _ = sct_service.submit_event(str(run.id), event)
+
+    all_events = run.get_all_events()
+    assert len(all_events) == 13, "Event not found"
+
+    events_by_severity = run.get_events_by_severity(SCTEventSeverity.CRITICAL)
+    assert len(events_by_severity) == 3, "Not all events were added or count mismatch"
+
+
+def test_submit_event_sparse_fields(client_service: ClientService, sct_service: SCTService, testrun_service: TestRunService, fake_test: ArgusTest):
+    run_type, run_req = get_fake_test_run(fake_test)
+    client_service.submit_run(run_type, asdict(run_req))
+    run: SCTTestRun = testrun_service.get_run(run_type, run_req.run_id)
+
+    event_data: RawEventPayload = {
+        "message": "Sample event - body contains\nmultiple lines.",
+        "run_id": run.id,
+        "severity": SCTEventSeverity.CRITICAL.value,
+        "ts": datetime.now(tz=UTC).timestamp(),
+        "event_type": "DatabaseEvent"
+    }
+
+    _ = sct_service.submit_event(str(run.id), event_data)
+
+    all_events = run.get_all_events()
+    assert len(all_events) == 1, "Event not found"
+
+
+def test_submit_event_ordering(client_service: ClientService, sct_service: SCTService, testrun_service: TestRunService, fake_test: ArgusTest):
+    run_type, run_req = get_fake_test_run(fake_test)
+    client_service.submit_run(run_type, asdict(run_req))
+    run: SCTTestRun = testrun_service.get_run(run_type, run_req.run_id)
+
+    event_template: RawEventPayload = {
+        "message": None,
+        "run_id": run.id,
+        "severity": SCTEventSeverity.CRITICAL.value,
+        "ts": None,
+        "event_type": "DatabaseEvent"
+    }
+
+    for i in range(100):
+        event_data = dict(event_template)
+        event_data["ts"] = datetime.now(tz=UTC).timestamp() - 1
+        event_data["message"] = f"This is event {i}"
+        _ = sct_service.submit_event(str(run.id), event_data)
+
+
+    all_events = run.get_all_events()
+    assert len(all_events) > 0 and all_events[0]["message"] == "This is event 99", "Incorrect event in set!"
+
+    # Insert more
+    for i in range(100):
+        event_data = dict(event_template)
+        event_data["ts"] = datetime.now(tz=UTC).timestamp() + 1
+        event_data["message"] = f"This is event r{i}"
+        _ = sct_service.submit_event(str(run.id), event_data)
+
+    all_events = run.get_all_events()
+    assert len(all_events) > 0 and all_events[0]["message"] == "This is event r99", "Incorrect event in set!"
+
+
+def test_fetch_partition_limit(client_service: ClientService, sct_service: SCTService, testrun_service: TestRunService, fake_test: ArgusTest):
+    run_type, run_req = get_fake_test_run(fake_test)
+    client_service.submit_run(run_type, asdict(run_req))
+    run: SCTTestRun = testrun_service.get_run(run_type, run_req.run_id)
+
+    event_template: RawEventPayload = {
+        "message": None,
+        "run_id": run.id,
+        "severity": SCTEventSeverity.CRITICAL.value,
+        "ts": None,
+        "event_type": "DatabaseEvent"
+    }
+
+    for i in range(200):
+        event_data = dict(event_template)
+        event_data["ts"] = datetime.now(tz=UTC).timestamp() - 1
+        event_data["message"] = f"This is event {i}"
+        _ = sct_service.submit_event(str(run.id), event_data)
+
+    for i in range(200):
+        event_data = dict(event_template)
+        event_data["severity"] = SCTEventSeverity.NORMAL.value
+        event_data["ts"] = datetime.now(tz=UTC).timestamp() - 1
+        event_data["message"] = f"This is event {i}"
+        _ = sct_service.submit_event(str(run.id), event_data)
+
+    all_events = run.get_events_limited(run.id)
+    assert len(all_events) == 200, "Incorrect event in set!"
+
+
+def test_fetch_custom_limit(client_service: ClientService, sct_service: SCTService, testrun_service: TestRunService, fake_test: ArgusTest):
+    run_type, run_req = get_fake_test_run(fake_test)
+    client_service.submit_run(run_type, asdict(run_req))
+    run: SCTTestRun = testrun_service.get_run(run_type, run_req.run_id)
+
+    event_template: RawEventPayload = {
+        "message": None,
+        "run_id": run.id,
+        "severity": SCTEventSeverity.CRITICAL.value,
+        "ts": None,
+        "event_type": "DatabaseEvent"
+    }
+
+    for i in range(50):
+        event_data = dict(event_template)
+        event_data["ts"] = datetime.now(tz=UTC).timestamp() - 1
+        event_data["message"] = f"This is event {i}"
+        _ = sct_service.submit_event(str(run.id), event_data)
+
+    for i in range(50):
+        event_data = dict(event_template)
+        event_data["severity"] = SCTEventSeverity.NORMAL.value
+        event_data["ts"] = datetime.now(tz=UTC).timestamp() - 1
+        event_data["message"] = f"This is event {i}"
+        _ = sct_service.submit_event(str(run.id), event_data)
+
+    all_events = run.get_events_limited(run.id, per_partition_limit=10, severities=[SCTEventSeverity.CRITICAL])
+    assert len(all_events) == 10, "Incorrect events in set!"
+
+
+def test_submit_event_with_nemesis_data(client_service: ClientService, sct_service: SCTService, testrun_service: TestRunService, fake_test: ArgusTest):
+    run_type, run_req = get_fake_test_run(fake_test)
+    client_service.submit_run(run_type, asdict(run_req))
+    run: SCTTestRun = testrun_service.get_run(run_type, run_req.run_id)
+
+    event_data: RawEventPayload = {
+        "duration": 30.0,
+        "event_type": "NemesisEvent",
+        "known_issue": "http://example.com/yes/1",
+        "message": "Sample event - body contains\nmultiple lines.",
+        "nemesis_name": "NemesisName",
+        "nemesis_status": "passed",
+        "run_id": run.id,
+        "severity": SCTEventSeverity.CRITICAL.value,
+        "target_node": "127.0.0.1",
+        "ts": datetime.now(tz=UTC).timestamp()
+    }
+
+    _ = sct_service.submit_event(str(run.id), event_data)
+
+    all_events = run.get_all_events()
+    assert len(all_events) == 1, "Event not found"
+
+
+def test_submit_event_db_event(client_service: ClientService, sct_service: SCTService, testrun_service: TestRunService, fake_test: ArgusTest):
+    run_type, run_req = get_fake_test_run(fake_test)
+    client_service.submit_run(run_type, asdict(run_req))
+    run: SCTTestRun = testrun_service.get_run(run_type, run_req.run_id)
+
+    event_data: RawEventPayload = {
+        "duration": 30.0,
+        "event_type": "DatabaseEvent",
+        "message": "Sample event - body contains\nmultiple lines.",
+        "node": "127.0.0.1",
+        "received_timestamp": "2025-05-01T19:30:21.666Z",
+        "run_id": run.id,
+        "severity": SCTEventSeverity.CRITICAL.value,
+        "ts": datetime.now(tz=UTC).timestamp()
+    }
+
+    _ = sct_service.submit_event(str(run.id), event_data)
+
+    all_events = run.get_all_events()
+    assert len(all_events) == 1, "Event not found"
+
+
+def test_controller_submit_event(flask_client: FlaskClient, fake_test: ArgusTest, client_service: ClientService, testrun_service: TestRunService):
+    run_type, run_req = get_fake_test_run(fake_test)
+    client_service.submit_run(run_type, asdict(run_req))
+    run: SCTTestRun = testrun_service.get_run(run_type, run_req.run_id)
+
+    body: RawEventPayload = {
+        "duration": 30.0,
+        "event_type": "DatabaseEvent",
+        "message": "Sample event - body contains\nmultiple lines.",
+        "node": "127.0.0.1",
+        "received_timestamp": "2025-05-01T19:30:21.666Z",
+        "run_id": run.id,
+        "severity": SCTEventSeverity.CRITICAL.value,
+        "ts": datetime.now(tz=UTC).timestamp()
+    }
+
+    response = flask_client.post(
+        f"/api/v1/client/sct/{run.id}/event/submit",
+        data=json.dumps({
+            "data": body,
+            "schema_version": "v8",
+        }, cls=ArgusJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    assert response.content_type == "application/json"
+    assert response.json["status"] == "ok"
+    assert response.json["response"]
+
+
+
+def test_controller_submit_multiple_events(flask_client: FlaskClient, fake_test: ArgusTest, client_service: ClientService, testrun_service: TestRunService):
+    run_type, run_req = get_fake_test_run(fake_test)
+    client_service.submit_run(run_type, asdict(run_req))
+    run: SCTTestRun = testrun_service.get_run(run_type, run_req.run_id)
+
+    body: RawEventPayload = {
+        "duration": 30.0,
+        "event_type": "DatabaseEvent",
+        "message": "Sample event - body contains\nmultiple lines.",
+        "node": "127.0.0.1",
+        "received_timestamp": "2025-05-01T19:30:21.666Z",
+        "run_id": run.id,
+        "severity": SCTEventSeverity.CRITICAL.value,
+        "ts": datetime.now(tz=UTC).timestamp()
+    }
+
+    events = []
+    for i in range(10):
+        event = dict(body)
+        event["ts"] += i
+        events.append(event)
+
+    response = flask_client.post(
+        f"/api/v1/client/sct/{run.id}/event/submit",
+        data=json.dumps({
+            "data": events,
+            "schema_version": "v8",
+        }, cls=ArgusJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    assert response.content_type == "application/json"
+    assert response.json["status"] == "ok"
+    assert response.json["response"]
+
+
+
+def test_controller_submit_events_and_get_by_severity(flask_client: FlaskClient, fake_test: ArgusTest, client_service: ClientService, testrun_service: TestRunService):
+    run_type, run_req = get_fake_test_run(fake_test)
+    client_service.submit_run(run_type, asdict(run_req))
+    run: SCTTestRun = testrun_service.get_run(run_type, run_req.run_id)
+
+    body: RawEventPayload = {
+        "duration": 30.0,
+        "event_type": "DatabaseEvent",
+        "message": "Sample event - body contains\nmultiple lines.",
+        "node": "127.0.0.1",
+        "received_timestamp": "2025-05-01T19:30:21.666Z",
+        "run_id": run.id,
+        "severity": SCTEventSeverity.CRITICAL.value,
+        "ts": datetime.now(tz=UTC).timestamp()
+    }
+
+    events = []
+    for i in range(100):
+        event = dict(body)
+        event["ts"] += i
+        events.append(event)
+
+
+    events = []
+    for i in range(1000):
+        event = dict(body)
+        event["ts"] += i
+        event["severity"] = SCTEventSeverity.NORMAL.value
+        events.append(event)
+
+
+    response = flask_client.post(
+        f"/api/v1/client/sct/{run.id}/event/submit",
+        data=json.dumps({
+            "data": events,
+            "schema_version": "v8",
+        }, cls=ArgusJSONEncoder),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    assert response.content_type == "application/json"
+    assert response.json["status"] == "ok"
+    assert response.json["response"]
+
+
+    response = flask_client.get(
+        f"/api/v1/client/sct/{run.id}/events/{SCTEventSeverity.NORMAL.value}/get?limit=50",
+    )
+
+    assert response.status_code == 200
+    assert response.content_type == "application/json"
+    assert response.json["status"] == "ok"
+    assert len(response.json["response"]) == 50
+
+
+    only_normal = [e for e in events if e["severity"] == "NORMAL"]
+    ev = only_normal[25]
+    response = flask_client.get(
+        f"/api/v1/client/sct/{run.id}/events/{SCTEventSeverity.NORMAL.value}/get?limit=50&before={int(ev["ts"])}",
+    )
+
+    assert response.status_code == 200
+    assert response.content_type == "application/json"
+    assert response.json["status"] == "ok"
+    assert len(response.json["response"]) == 25

--- a/argus/client/sct/client.py
+++ b/argus/client/sct/client.py
@@ -2,7 +2,7 @@ import base64
 from typing import Any
 from uuid import UUID
 from dataclasses import asdict
-from argus.common.sct_types import GeminiResultsRequest, PerformanceResultsRequest
+from argus.common.sct_types import GeminiResultsRequest, PerformanceResultsRequest, RawEventPayload
 from argus.common.enums import ResourceState, TestStatus
 from argus.client.base import ArgusClient
 from argus.client.sct.types import EventsInfo, LogLink, Package
@@ -25,6 +25,7 @@ class ArgusSCTClient(ArgusClient):
         SUBMIT_PERFORMANCE_RESULTS = "/sct/$id/performance/submit"
         FINALIZE_NEMESIS = "/sct/$id/nemesis/finalize"
         SUBMIT_EVENTS = "/sct/$id/events/submit"
+        SUBMIT_EVENT = "/sct/$id/event/submit"
         SUBMIT_JUNIT_REPORT = "/sct/$id/junit/submit"
 
     def __init__(self, run_id: UUID, auth_token: str, base_url: str, api_version="v1", extra_headers: dict | None = None) -> None:
@@ -79,6 +80,17 @@ class ArgusSCTClient(ArgusClient):
             Updates scylla server version used for filtering test results by version.
         """
         response = super().update_product_version(run_type=self.test_type, run_id=self.run_id, product_version=version)
+        self.check_response(response)
+
+    def submit_event(self, event_data: RawEventPayload | list[RawEventPayload]):
+        response = self.post(
+            endpoint=self.Routes.SUBMIT_EVENT,
+            location_params={"id": str(self.run_id)},
+            body={
+                **self.generic_body,
+                "data": event_data,
+            }
+        )
         self.check_response(response)
 
     def submit_sct_logs(self, logs: list[LogLink]) -> None:

--- a/argus/common/sct_types.py
+++ b/argus/common/sct_types.py
@@ -1,6 +1,21 @@
 from typing import TypedDict
 
 
+class RawEventPayload(TypedDict):
+    run_id: str
+    severity: str
+    ts: float
+    message: str
+    event_type: str
+    received_timestamp: str | None
+    nemesis_name: str | None
+    duration: float | None
+    node: str | None
+    target_node: str | None
+    known_issue: str | None
+    nemesis_status: str | None
+
+
 class RawHDRHistogram(TypedDict):
     start_time: int
     percentile_90: float


### PR DESCRIPTION
This commit reworks the way SCT Events are stored by argus, by adding
several endpoints to store and get events separately from the usual
SCTTestRun entity, allowing quicker lookups, indexing and better
structure for events themselves. Previously, events were strings stored
on a collection of objects (severity, events), this commit replaces that
with a new table called SCTEvent.

Current endpoints:
 * submit
     * Supports both single and multiple event submits
 * get
     * Supports per partition limit to return limited amount of events
       per severity

Tests are included in argus/backend/tests/sct_events/

Fixes #786 
