### PR TITLE
improvement(TestDashboardTest): Add triage information to test

### DIFF
--- a/argus/backend/plugins/sct/testrun.py
+++ b/argus/backend/plugins/sct/testrun.py
@@ -117,7 +117,7 @@ class SCTTestRun(PluginModelBase):
     @classmethod
     def _stats_query(cls) -> str:
         return ("SELECT id, test_id, group_id, release_id, status, start_time, build_job_url, build_id, "
-                f"assignee, end_time, investigation_status, heartbeat, scylla_version, cloud_setup, allocated_resources FROM {cls.table_name()} WHERE build_id IN ? PER PARTITION LIMIT 15")
+                f"assignee, end_time, investigation_status, heartbeat, scylla_version, cloud_setup, allocated_resources, nemesis_data FROM {cls.table_name()} WHERE build_id IN ? PER PARTITION LIMIT 15")
 
     @classmethod
     def load_test_run(cls, run_id: UUID) -> 'SCTTestRun':

--- a/argus/backend/service/stats.py
+++ b/argus/backend/service/stats.py
@@ -505,6 +505,8 @@ class TestStats:
                 "build_number": get_build_number(run["build_job_url"]),
                 "build_job_name": run["build_id"],
                 "start_time": run["start_time"],
+                "end_time": run["end_time"],
+                "nemesis_data": run.get("nemesis_data", []),
                 "assignee": run["assignee"],
                 "issues": [dict(issue.items()) for issue in self.parent_group.parent_release.issues[run["id"]]],
                 "comments": [dict(comment.items()) for comment in self.parent_group.parent_release.comments[run["id"]]],


### PR DESCRIPTION
This commit adds extra information to test blocks on a TestDashboard,
namely:

* The amount of passed/failed nemesis is now reflected for SCT runs
* The time taken is displayed under the test

Fixes #597
