### PR TITLE
fix(SelectUtils): Add normalization for non-latin names

### DIFF
--- a/frontend/Common/SelectUtils.js
+++ b/frontend/Common/SelectUtils.js
@@ -1,3 +1,14 @@
+import * as urlSlug from "url-slug";
+
 export const filterUser = function (label, filterText, user) {
-    return `${label ?? ""}${user?.full_name ?? ""}`.toLowerCase().includes(filterText.toLowerCase());
+    const term = `${label ?? ""}${user?.full_name ?? ""}`;
+    const normalizedTerm = urlSlug.convert(term, {
+        separator: " ",
+        transformer: urlSlug.LOWERCASE_TRANSFORMER,
+        dictionary: {
+            Ł: "L",
+            ł: "l",
+        }
+    });
+    return normalizedTerm.includes(filterText.toLowerCase());
 };


### PR DESCRIPTION
This commit adds normalization and removal of diacritic characters from
usernames that contain them, simplyfying filtering for them

Fixes #617
