### PR TITLE
fix(argus_service): Do not try to look for jobs if no plugin is set

### DIFF
--- a/argus/backend/service/argus_service.py
+++ b/argus/backend/service/argus_service.py
@@ -696,6 +696,9 @@ class ArgusService:
         last_runs: dict[UUID, Model] = {}
         for test in resolved:
             try:
+                if not test.plugin_name:
+                    last_runs[test.id] = None
+                    continue
                 last_runs[test.id] = AVAILABLE_PLUGINS[test.plugin_name].model.filter(build_id=test.build_system_id).limit(1).get()
             except PluginModelBase.DoesNotExist:
                 last_runs[test.id] = None


### PR DESCRIPTION
This fixes an issue where a planned job for user might not be fully
initialized, leading to being unable to find a corresponding plugin for
the test.

Fixes #792
