### PR TITLE
737 improve duplicate events ux

### DIFF
--- a/frontend/TestRun/StructuredEvent.svelte
+++ b/frontend/TestRun/StructuredEvent.svelte
@@ -18,6 +18,7 @@
         display?: boolean;
         filterString?: string;
         scrollToEvent?: (target: { severity: string; index: number }) => void;
+        registerAnchor?: (node: HTMLElement, key: string) => { destroy?: () => void } | void;
     }
 
     let {
@@ -29,7 +30,8 @@
         duplicateParent = null,
         display = true,
         filterString = "",
-        scrollToEvent = () => {}
+        scrollToEvent = () => {},
+        registerAnchor = (node: HTMLElement, _key: string) => ({ destroy() {} })
     }: Props = $props();
 
     const dispatch = createEventDispatcher();
@@ -89,6 +91,7 @@
 </script>
 
 <div
+    use:registerAnchor={`event-${event.severity}-${event.index}`}
     data-event-key={`event-${event.severity}-${event.index}`}
     class:d-none={!display || shouldFilter(filterString)}
     class="mb-2 p-2 shadow rounded font-monospace"


### PR DESCRIPTION
Added all functionalities requested by https://github.com/scylladb/argus/issues/737:
1. when showing duplicate, clicked event stays on the same spot so user is not disoriented
2. hide/show all duplicates buttons on top
3. hide duplicates button on every duplicated event
4. added 'go to source (<event idx>)' button so user can see duplicate source (parent) 

top button:
<img width="1293" height="247" alt="image" src="https://github.com/user-attachments/assets/eb48e9cb-d037-4538-bc52-4f31bd0b9a06" />

new duplicate buttons:
<img width="1255" height="189" alt="image" src="https://github.com/user-attachments/assets/d5750fe3-4bf7-4824-afd8-4c890013076a" />
