### PR TITLE
feature(artifacts): download all artifacts button

### DIFF
--- a/frontend/TestRun/ArtifactRow.svelte
+++ b/frontend/TestRun/ArtifactRow.svelte
@@ -4,11 +4,16 @@
     let { artifactName, artifactLink, originalLink } = $props();
 
     let artifactSize = $state();
+    let downloadLinkElement: HTMLAnchorElement;
 
     const showArtifactSize = function (bytesCount) {
         if (!bytesCount) return "(N/A)";
 
         return `(${pretty(bytesCount)})`;
+    };
+
+    export const triggerDownload = () => {
+        downloadLinkElement?.click();
     };
 
     onMount(async () => {
@@ -33,6 +38,7 @@
     <td>{artifactName} <span class="fw-bold">{showArtifactSize(artifactSize)}</span></td>
     <td
         ><a
+            bind:this={downloadLinkElement}
             class="btn btn-primary"
             href={artifactLink}>Download</a
         ></td


### PR DESCRIPTION
Added "Download all" button on artifact page.
Clicking it triggers download of all artifacts one by one with slight delay of 800ms to avoid cancelling by web browser.

closes: https://github.com/scylladb/argus/issues/769

<img width="1165" height="236" alt="image" src="https://github.com/user-attachments/assets/3752e8d1-9d55-4ec3-8e40-3e8417db0b91" />
