### PR TITLE
feature(highlights): added groups to action items

### DIFF
--- a/argus/backend/controller/views_widgets/highlights.py
+++ b/argus/backend/controller/views_widgets/highlights.py
@@ -14,6 +14,7 @@ from argus.backend.service.views_widgets.highlights import (
     CommentUpdate,
     CommentDelete,
     CommentCreate,
+    HighlightGroupCreate,
 )
 from argus.backend.util.common import get_payload
 
@@ -28,6 +29,16 @@ def create_highlight():
     service = HighlightsService()
     highlight = service.create(creator_id, payload)
     return {"status": "ok", "response": asdict(highlight)}
+
+
+@bp.route("/highlights/create_group", methods=["POST"])
+@api_login_required
+def create_highlight_group():
+    creator_id = g.user.id
+    payload = HighlightGroupCreate(**get_payload(request))
+    service = HighlightsService()
+    action_items = service.create_group(creator_id, payload)
+    return {"status": "ok", "response": [asdict(action) for action in action_items]}
 
 
 @bp.route("/highlights", methods=["GET"])

--- a/argus/backend/models/view_widgets.py
+++ b/argus/backend/models/view_widgets.py
@@ -12,6 +12,7 @@ class WidgetHighlights(Model):
     creator_id = columns.UUID()
     assignee_id = columns.UUID()
     content = columns.Text()
+    group = columns.Text()
     completed = columns.Boolean(default=lambda: None)  # None means it's highlight, not an action item
     comments_count = columns.TinyInt()
 

--- a/frontend/Common/ViewTypes.js
+++ b/frontend/Common/ViewTypes.js
@@ -119,6 +119,22 @@ export const WIDGET_TYPES = {
                 default: 0,
                 help: "Index of the highlight (for support multiple highlight widgets in one view)",
                 displayName: "Index"
+            },
+            defaultGroupItems: {
+                type: MultiStringValue,
+                default: [
+                    "dtest - release",
+                    "dtest - debug",
+                    "dtest - release with raft",
+                    "dtest - release with topology changes",
+                    "SCT investigations",
+                    "Drivers",
+                    "SBOM",
+                    "Azure image publish",
+                    "Release Notes"
+                ],
+                help: "List of action items created when new Action Items Group is created",
+                displayName: "Test Filters"
             }
         },
     },

--- a/frontend/Views/Widgets/ViewHighlights/ViewHighlights.svelte
+++ b/frontend/Views/Widgets/ViewHighlights/ViewHighlights.svelte
@@ -3,7 +3,7 @@
 
     import {onMount} from "svelte";
     import Fa from "svelte-fa";
-    import {faPlus, faChevronDown, faChevronUp} from "@fortawesome/free-solid-svg-icons";
+    import {faPlus, faChevronDown, faChevronRight, faChevronUp, faCheck} from "@fortawesome/free-solid-svg-icons";
     import {applicationCurrentUser} from "../../../argus";
     import {userList} from "../../../Stores/UserlistSubscriber";
     import HighlightItem from "./HighlightItem.svelte";
@@ -22,6 +22,7 @@
         content: string;
         creator_id: string;
         createdAt: Date;
+        group: string | null;
         isCompleted?: boolean;
         assignee_id?: string;
         comments_count: number;
@@ -42,13 +43,26 @@
     let highlights: Entry[] = $state([]);
     let actionItems: Entry[] = $state([]);
     let showNewHighlight = $state(false);
-    let showNewActionItem = $state(false);
     let showArchivedHighlights = $state(false);
     let showArchivedActionItems = $state(false);
-    let newHighlight = "";
-    let newActionItem = "";
-    let newActionInput: HTMLInputElement;
+    // let newHighlight = "";
     let newHighlightInput: HTMLInputElement;
+
+    interface GroupState {
+        showNewActionItem: boolean;
+        collapsed: boolean;
+        touched: boolean;
+        isFullyCompleted: boolean;
+    }
+
+    let groupStates = $state<Record<string, GroupState>>({});
+    let groupNames = $state<string[]>(["General"]);
+    let showGroupModal = $state(false);
+    let newGroupName = "";
+    let groupCreationError = "";
+    let isCreatingGroup = $state(false);
+
+    let defaultGroupItems: string[] = settings.defaultGroupItems || [];
 
     run(() => {
         if (Object.keys(users).length === 0 && Object.keys($userList).length > 0) {
@@ -63,17 +77,20 @@
         if (data.status === "ok") {
             highlights = data.response.highlights.map(parseEntry);
             actionItems = data.response.action_items.map(parseEntry);
+            syncGroupStates();
         }
     });
 
     function parseEntry(data): Entry {
+        const isAction = data.completed !== undefined;
         return {
             id: data.created_at.toString(),
             view_id: data.view_id,
-            type: data.completed === undefined ? "highlight" : "action",
+            type: isAction ? "action" : "highlight",
             content: data.content,
             creator_id: data.creator_id,
             createdAt: new Date(data.created_at * 1000),
+            group: isAction ? (data.group ?? "General") : (data.group ?? null),
             isArchived: data.archived_at !== 0,
             isCompleted: data.completed,
             assignee_id: data.assignee_id,
@@ -94,29 +111,138 @@
         };
     }
 
+    function sortGroups(names: Set<string>): string[] {
+        return Array.from(names).sort((a, b) => {
+            if (a === "General") return -1;
+            if (b === "General") return 1;
+            return a.localeCompare(b);
+        });
+    }
 
-    const addEntry = async (type: "highlight" | "action", content: string) => {
+    function isGroupFullyCompleted(name: string): boolean {
+        const items = getGroupItems(name, false);
+        return items.length > 0 && items.every(item => item.isCompleted);
+    }
+
+    function getOrCreateGroupState(name: string): GroupState {
+        if (groupStates[name]) {
+            return groupStates[name];
+        }
+        return {
+            showNewActionItem: false,
+            collapsed: isGroupFullyCompleted(name),
+            touched: false,
+            isFullyCompleted: isGroupFullyCompleted(name),
+        };
+    }
+
+    function syncGroupStates() {
+        const names = new Set(actionItems.map(item => item.group || "General"));
+        names.add("General");
+        const sorted = sortGroups(names);
+        const nextStates: Record<string, GroupState> = {};
+        for (const name of sorted) {
+            const previous = groupStates[name];
+            const shouldCollapse = isGroupFullyCompleted(name);
+            const isCompleted = isGroupFullyCompleted(name);
+
+            if (!previous) {
+                nextStates[name] = {
+                    showNewActionItem: false,
+                    collapsed: shouldCollapse,
+                    touched: false,
+                    isFullyCompleted: isCompleted,
+                };
+                continue;
+            }
+
+            let collapsed = previous.collapsed;
+            let touched = previous.touched;
+
+            if (shouldCollapse) {
+                collapsed = true;
+                touched = false;
+            } else if (!previous.touched) {
+                collapsed = false;
+            }
+
+            nextStates[name] = {
+                showNewActionItem: previous.showNewActionItem,
+                collapsed,
+                touched,
+                isFullyCompleted: isCompleted,
+            };
+        }
+        groupStates = nextStates;
+        groupNames = sorted;
+        redraw++;
+    }
+
+    function getGroupItems(name: string, archived: boolean) {
+        return actionItems.filter(item => (item.group || "General") === name && item.isArchived === archived);
+    }
+
+    function shouldShowActiveGroup(name: string): boolean {
+        if (name === "General") {
+            return true;
+        }
+        return getGroupItems(name, false).length > 0;
+    }
+
+    function toggleGroupEditor(name: string, show: boolean) {
+        const state = getOrCreateGroupState(name);
+        groupStates = {
+            ...groupStates,
+            [name]: {
+                ...state,
+                showNewActionItem: show,
+            },
+        };
+        redraw++;
+    }
+
+    function toggleGroupCollapse(name: string) {
+        const state = getOrCreateGroupState(name);
+        groupStates = {
+            ...groupStates,
+            [name]: {
+                ...state,
+                collapsed: !state.collapsed,
+                touched: true,
+            },
+        };
+        redraw++;
+    }
+
+    function isGroupCollapsed(name: string): boolean {
+        return groupStates[name]?.collapsed ?? isGroupFullyCompleted(name);
+    }
+
+
+    const addEntry = async (type: "highlight" | "action", content: string, group?: string) => {
         if (!content.trim()) return;
+        const payload: Record<string, unknown> = {
+            view_id: dashboardObject.id,
+            index: index,
+            content: content,
+            is_task: type === "action",
+        };
+        if (type === "action") {
+            payload.group = group && group !== "General" ? group : null;
+        }
         const response = await fetch("/api/v1/views/widgets/highlights/create", {
             method: "POST",
             headers: {"Content-Type": "application/json"},
-            body: JSON.stringify({
-                view_id: dashboardObject.id,
-                index: index,
-                content: content,
-                is_task: type === "action",
-            }),
+            body: JSON.stringify(payload),
         });
         const data = await response.json();
         if (data.status === "ok") {
             const newEntry = parseEntry(data.response);
             if (type === "action") {
                 actionItems = [newEntry, ...actionItems];
-                newActionItem = "";
-                showNewActionItem = false;
+                syncGroupStates();
             } else {
                 highlights = [newEntry, ...highlights];
-                newHighlight = "";
                 showNewHighlight = false;
             }
         }
@@ -124,8 +250,15 @@
     const handleHightlightCreate = function (e) {
         addEntry("highlight", e.detail.message);
     };
-    const handleActionItemCreate = function (e) {
-        addEntry("action", e.detail.message);
+
+    const handleGroupActionItemCreate = async (group: string, message: string) => {
+        if (!message.trim()) return;
+        await addEntry("action", message, group);
+        toggleGroupEditor(group, false);
+    };
+
+    const handleGroupActionItemCancel = (group: string) => {
+        toggleGroupEditor(group, false);
     };
 
     const handleToggleArchive = async (event) => {
@@ -143,6 +276,7 @@
         const data = await response.json();
         if (data.status === "ok") {
             entry.isArchived = !entry.isArchived;
+            syncGroupStates();
             redraw++;
         }
     };
@@ -271,13 +405,13 @@
         if (data.status === "ok") {
             actionItem.isCompleted = data.response.completed;
             redraw++;
+            syncGroupStates();
         }
     };
 
     const handleSetAssignee = async (event) => {
-        const actionItem = event.detail.action || event.detail.action;
+        const actionItem = event.detail.action;
         const assignee = event.detail.assignee?.value || undefined;
-        console.log("handling assignee", assignee);
         const response = await fetch("/api/v1/views/widgets/highlights/set_assignee", {
             method: "POST",
             headers: {"Content-Type": "application/json"},
@@ -295,11 +429,49 @@
         }
     };
 
-    run(() => {
-        if (showNewActionItem && newActionInput) {
-            newActionInput.focus();
+    const handleCreateGroup = async () => {
+        groupCreationError = "";
+        const trimmedName = newGroupName.trim();
+        if (!trimmedName) {
+            groupCreationError = "Group name is required";
+            redraw++;
+            return;
         }
-    });
+        if (defaultGroupItems.length === 0) {
+            groupCreationError = "No template items configured. Configure it in Admin Panel.";
+            redraw++;
+            return;
+        }
+        isCreatingGroup = true;
+        try {
+            const response = await fetch("/api/v1/views/widgets/highlights/create_group", {
+                method: "POST",
+                headers: {"Content-Type": "application/json"},
+                body: JSON.stringify({
+                    view_id: dashboardObject.id,
+                    index: index,
+                    name: trimmedName,
+                    items: defaultGroupItems,
+                }),
+            });
+            const data = await response.json();
+            if (data.status === "ok") {
+                const createdItems = data.response.map(parseEntry);
+                actionItems = [...createdItems, ...actionItems];
+                newGroupName = "";
+                showGroupModal = false;
+                syncGroupStates();
+            } else {
+                groupCreationError = data.message || "Failed to create group";
+                redraw++;
+            }
+        } catch (error) {
+            groupCreationError = "Failed to create group";
+            redraw++;
+        } finally {
+            isCreatingGroup = false;
+        }
+    };
 
     run(() => {
         if (showNewHighlight && newHighlightInput) {
@@ -372,40 +544,64 @@
         </div>
 
         <div class="card">
-            <div class="card-header">
+            <div class="card-header d-flex justify-content-between align-items-center">
                 <h2 class="h5 mb-0">Action Items</h2>
+                <button class="btn btn-sm btn-outline-primary" onclick={() => { newGroupName = ""; groupCreationError = ""; showGroupModal = true; }}>
+                    <Fa icon={faPlus}/>
+                    <span class="ms-1">Create Group</span>
+                </button>
             </div>
             <div class="card-body">
                 <ul class="list-group">
-                    {#each actionItems.filter(a => !a.isArchived) as action (action.id)}
-                        <ActionItem {action} currentUserId={applicationCurrentUser.id} {users}
-                                    on:toggleArchive={handleToggleArchive}
-                                    on:loadComments={handleLoadComments}
-                                    on:updateContent={handleUpdateEntry}
-                                    on:addComment={handleAddComment}
-                                    on:deleteComment={handleDeleteComment}
-                                    on:updateCommentContent={handleUpdateComment}
-                                    on:toggleComplete={handleToggleComplete}
-                                    on:assigneeSelected={handleSetAssignee}
-                        />
-                    {/each}
-                    <li class="list-group-item">
-                        {#if showNewActionItem}
-                            <div class="flex-grow-1">
-                                <CommentEditor
-                                        mode="post"
-                                        entryType="action item"
-                                        on:submitComment={handleActionItemCreate}
-                                        on:cancelEditing={() => (showNewActionItem = false)}
-                                />
-                            </div>
-                        {:else}
-                            <button class="btn w-100 text-start text-muted" onclick={() => showNewActionItem = true}>
-                                <Fa icon={faPlus}/>
-                                Add Action Item
-                            </button>
+                    {#each groupNames as groupName (groupName)}
+                        {#if shouldShowActiveGroup(groupName)}
+                            <li class="list-group-item fw-semibold d-flex align-items-center"
+                                class:bg-success-subtle={groupStates[groupName]?.isFullyCompleted}
+                                class:bg-body-secondary={!groupStates[groupName]?.isFullyCompleted}>
+                                <button class="btn btn-link text-decoration-none text-reset d-flex align-items-center p-0 flex-grow-1"
+                                        type="button"
+                                        aria-expanded={!isGroupCollapsed(groupName)}
+                                        onclick={() => toggleGroupCollapse(groupName)}>
+                                    <Fa icon={isGroupCollapsed(groupName) ? faChevronRight : faChevronDown} class="me-2"/>
+                                    <span>{groupName}</span>
+                                </button>
+                                {#if groupStates[groupName]?.isFullyCompleted}
+                                    <Fa icon={faCheck} class="text-success ms-2"/>
+                                {/if}
+                            </li>
+                            {#if !isGroupCollapsed(groupName)}
+                                {#each getGroupItems(groupName, false) as action (action.id)}
+                                    <ActionItem {action} currentUserId={applicationCurrentUser.id} {users}
+                                                on:toggleArchive={handleToggleArchive}
+                                                on:loadComments={handleLoadComments}
+                                                on:updateContent={handleUpdateEntry}
+                                                on:addComment={handleAddComment}
+                                                on:deleteComment={handleDeleteComment}
+                                                on:updateCommentContent={handleUpdateComment}
+                                                on:toggleComplete={handleToggleComplete}
+                                                on:assigneeSelected={handleSetAssignee}
+                                    />
+                                {/each}
+                                <li class="list-group-item">
+                                    {#if groupStates[groupName]?.showNewActionItem}
+                                        <div class="flex-grow-1">
+                                            <CommentEditor
+                                                    mode="post"
+                                                    entryType="action item"
+                                                    on:submitComment={(event) => handleGroupActionItemCreate(groupName, event.detail.message)}
+                                                    on:cancelEditing={() => handleGroupActionItemCancel(groupName)}
+                                            />
+                                        </div>
+                                    {:else}
+                                        <button class="btn w-100 text-start text-muted" onclick={() => toggleGroupEditor(groupName, true)}>
+                                            <Fa icon={faPlus}/>
+                                            Add Action Item
+                                        </button>
+                                    {/if}
+                                </li>
+                            {/if}
                         {/if}
-                    </li>
+                    {/each}
                 </ul>
                 {#if actionItems.some(a => a.isArchived)}
                     <div class="mt-3">
@@ -416,16 +612,36 @@
                         </button>
                         {#if showArchivedActionItems}
                             <ul class="list-group mt-2">
-                                {#each actionItems.filter(a => a.isArchived) as action (action.id)}
-                                    <ActionItem {action} currentUserId={applicationCurrentUser.id} {users}
-                                                on:toggleArchive={handleToggleArchive}
-                                                on:loadComments={handleLoadComments}
-                                                on:updateContent={handleUpdateEntry}
-                                                on:addComment={handleAddComment}
-                                                on:deleteComment={handleDeleteComment}
-                                                on:updateCommentContent={handleUpdateComment}
-                                                on:toggleComplete={handleToggleComplete}
-                                    />
+                                {#each groupNames as groupName (groupName)}
+                                    {#if getGroupItems(groupName, true).length}
+                                        <li class="list-group-item fw-semibold d-flex align-items-center"
+                                            class:bg-success-subtle={groupStates[groupName]?.isFullyCompleted}
+                                            class:bg-body-secondary={!groupStates[groupName]?.isFullyCompleted}>
+                                            <button class="btn btn-link text-decoration-none text-reset d-flex align-items-center p-0 flex-grow-1"
+                                                    type="button"
+                                                    aria-expanded={!isGroupCollapsed(groupName)}
+                                                    onclick={() => toggleGroupCollapse(groupName)}>
+                                                <Fa icon={isGroupCollapsed(groupName) ? faChevronRight : faChevronDown} class="me-2"/>
+                                                <span>{groupName}</span>
+                                            </button>
+                                            {#if groupStates[groupName]?.isFullyCompleted}
+                                                <Fa icon={faCheck} class="text-success ms-2"/>
+                                            {/if}
+                                        </li>
+                                        {#if !isGroupCollapsed(groupName)}
+                                            {#each getGroupItems(groupName, true) as action (action.id)}
+                                                <ActionItem {action} currentUserId={applicationCurrentUser.id} {users}
+                                                            on:toggleArchive={handleToggleArchive}
+                                                            on:loadComments={handleLoadComments}
+                                                            on:updateContent={handleUpdateEntry}
+                                                            on:addComment={handleAddComment}
+                                                            on:deleteComment={handleDeleteComment}
+                                                            on:updateCommentContent={handleUpdateComment}
+                                                            on:toggleComplete={handleToggleComplete}
+                                                />
+                                            {/each}
+                                        {/if}
+                                    {/if}
                                 {/each}
                             </ul>
                         {/if}
@@ -433,6 +649,45 @@
                 {/if}
             </div>
         </div>
+
+        {#if showGroupModal}
+            <div class="modal show d-block" tabindex="-1" role="dialog">
+                <div class="modal-dialog" role="document">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 class="modal-title">Create Action Item Group</h5>
+                            <button type="button" class="btn-close" aria-label="Close"
+                                    onclick={() => { showGroupModal = false; groupCreationError = ""; }}></button>
+                        </div>
+                        <div class="modal-body">
+                            <div class="mb-3">
+                                <label class="form-label" for="group-name-input">Group name</label>
+                                <input id="group-name-input" class="form-control" bind:value={newGroupName}
+                                       placeholder="e.g. 2025.3.3" />
+                            </div>
+                            <p class="mb-1">The following action items will be created:</p>
+                            <ul class="mb-0">
+                                {#each defaultGroupItems as item}
+                                    <li>{item}</li>
+                                {/each}
+                            </ul>
+                            {#if groupCreationError}
+                                <div class="alert alert-danger mt-3" role="alert">{groupCreationError}</div>
+                            {/if}
+                        </div>
+                        <div class="modal-footer">
+                            <button class="btn btn-secondary" onclick={() => { showGroupModal = false; groupCreationError = ""; }}>
+                                Cancel
+                            </button>
+                            <button class="btn btn-primary" onclick={handleCreateGroup} disabled={isCreatingGroup}>
+                                {isCreatingGroup ? "Creating..." : "Create Group"}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-backdrop fade show"></div>
+        {/if}
     {/key}
 </div>
 


### PR DESCRIPTION
In order to precreate tasks (action items) for each new release, introduced 'Groups' concept to Highlights Widget (only for Action Items).

Creating a group (by giving it a name) precreates a list of action items (configured in the widget config) and assigns creator to it (can be changed later).

closes: https://github.com/scylladb/argus/issues/822

<img width="1229" height="593" alt="image" src="https://github.com/user-attachments/assets/3f55467a-2f3b-4fa6-b82d-f20fc4dfbacd" />
