### PR TITLE
fix(stats): include group data in quick select events

### DIFF
--- a/frontend/ReleaseDashboard/ReleaseDashboard.svelte
+++ b/frontend/ReleaseDashboard/ReleaseDashboard.svelte
@@ -40,14 +40,16 @@
     };
 
     const handleQuickSelect = function (e) {
-        let tests = e.detail.tests;
+        let tests = e.detail.tests ?? [];
+        const detailGroups = e.detail.groups ?? {};
         tests.forEach((v) => {
-            let group = stats.groups[v.test.group_id];
+            const groupStats = detailGroups[v.test.group_id] ?? stats?.groups?.[v.test.group_id];
+            const groupName = groupStats?.group?.name ?? v.test.group?.name ?? v.test.group_id ?? "Unknown group";
             handleTestClick({
                 name: v.test.name,
                 id: v.test.id,
                 assignees: [],
-                group: group.group.name,
+                group: groupName,
                 status: v.status,
                 start_time: v.start_time,
                 last_runs: v.last_runs,

--- a/frontend/ReleaseDashboard/TestDashboard.svelte
+++ b/frontend/ReleaseDashboard/TestDashboard.svelte
@@ -311,14 +311,17 @@
     };
 
     const handleQuickSelect = function (e) {
-        let tests = e.detail.tests;
+        let tests = e.detail.tests ?? [];
+        const detailGroups = e.detail.groups ?? {};
         tests.forEach((v) => {
-            let group = stats.groups[v.test.group_id];
+            const groupStats = detailGroups[v.test.group_id] ?? stats?.groups?.[v.test.group_id];
+            const groupId = groupStats?.group?.id ?? v.test.group_id;
+            const groupAssignees = groupId ? assigneeList.groups?.[groupId] ?? [] : [];
             dispatch("testClick", {
                 name: v.test.name,
                 id: v.test.id,
-                assignees: [...(assigneeList.tests?.[v.test.id] ?? []), ...(assigneeList.groups?.[group.group.id] ?? [])],
-                group: group.group.name,
+                assignees: [...(assigneeList.tests?.[v.test.id] ?? []), ...groupAssignees],
+                group: groupStats?.group?.name ?? v.test.group?.name ?? groupId ?? "Unknown group",
                 status: v.status,
                 start_time: v.start_time,
                 last_runs: v.last_runs,
@@ -333,7 +336,7 @@
      */
     const quickTestFilter = function(stats, key) {
         let allTests = Object.values(stats.groups).reduce((tests, group) => [...tests, ...Object.values(group.tests)], []);
-        let evt = new CustomEvent("quickSelect", { detail: { tests: allTests.filter(key) } });
+        let evt = new CustomEvent("quickSelect", { detail: { tests: allTests.filter(key), groups: stats.groups } });
         handleQuickSelect(evt);
     };
 

--- a/frontend/Stats/NumberStats.svelte
+++ b/frontend/Stats/NumberStats.svelte
@@ -151,7 +151,11 @@
                                                 <button
                                                     class="btn btn-sm btn-light mb-1"
                                                     onclick={() => {
-                                                        dispatch("quickSelect", { tests: getTestsForStatus(stats, investigationStatus, status) });
+                                                        const groups = stats.groups ?? (stats.group?.id ? { [stats.group.id]: stats } : undefined);
+                                                        dispatch("quickSelect", {
+                                                            tests: getTestsForStatus(stats, investigationStatus, status),
+                                                            groups
+                                                        });
                                                     }}
                                                 >
                                                     <Fa icon={faChevronRight} />

--- a/frontend/Views/ViewDashboard.svelte
+++ b/frontend/Views/ViewDashboard.svelte
@@ -79,15 +79,32 @@
         }
     };
 
+    const resolveGroupStats = function (groupId, detailGroups) {
+        if (detailGroups?.[groupId]) {
+            return detailGroups[groupId];
+        }
+        if (stats?.groups?.[groupId]) {
+            return stats.groups[groupId];
+        }
+        for (const stat of Object.values(stats ?? {})) {
+            if (stat?.groups?.[groupId]) {
+                return stat.groups[groupId];
+            }
+        }
+        return null;
+    };
+
     const handleQuickSelect = function (e) {
-        let tests = e.detail.tests;
+        let tests = e.detail.tests ?? [];
+        const detailGroups = e.detail.groups;
         tests.forEach((v) => {
-            let group = stats.groups[v.test.group_id];
+            const groupStats = resolveGroupStats(v.test.group_id, detailGroups);
+            const groupName = groupStats?.group?.name ?? v.test.group?.name ?? v.test.group_id ?? "Unknown group";
             handleTestClick({
                 name: v.test.name,
                 id: v.test.id,
                 assignees: [],
-                group: group.group.name,
+                group: groupName,
                 status: v.status,
                 start_time: v.start_time,
                 last_runs: v.last_runs,


### PR DESCRIPTION
- Root cause: NumberStats only dispatched tests, so the view dashboard (which stores widget stats in a keyed map without a top-level groups) tried to resolve stats.groups[...] and crashed on undefined.
- Fix: include the relevant group stats in the quick-select event payload and teach all handlers to use the provided map (or fall back to their local stats) before selecting tests, keeping existing release dashboard behavior intact.

fixes: https://github.com/scylladb/argus/issues/826