### PR TITLE
fix(ViewDashboard.svelte): Propagate widgetId property to NumberStats

### DIFF
--- a/frontend/Stats/NumberStats.svelte
+++ b/frontend/Stats/NumberStats.svelte
@@ -6,6 +6,7 @@
     import { createEventDispatcher } from "svelte";
     import { faChevronRight } from "@fortawesome/free-solid-svg-icons";
     interface Props {
+        widgetId?: number;
         displayNumber?: boolean;
         displayPercentage?: boolean;
         displayInvestigations?: boolean;
@@ -18,6 +19,7 @@
         displayPercentage = false,
         displayInvestigations = false,
         hiddenStatuses = [],
+        widgetId = -1,
         stats = {
         created: 0,
         running: 0,
@@ -151,7 +153,7 @@
                                                 <button
                                                     class="btn btn-sm btn-light mb-1"
                                                     onclick={() => {
-                                                        dispatch("quickSelect", { tests: getTestsForStatus(stats, investigationStatus, status) });
+                                                        dispatch("quickSelect", { tests: getTestsForStatus(stats, investigationStatus, status), widgetId: widgetId });
                                                     }}
                                                 >
                                                     <Fa icon={faChevronRight} />

--- a/frontend/Stats/ReleaseStats.svelte
+++ b/frontend/Stats/ReleaseStats.svelte
@@ -9,6 +9,7 @@
         hiddenStatuses?: any;
         displayExtendedStats?: boolean;
         releaseStats?: any;
+        widgetId?: number;
     }
 
     let {
@@ -19,6 +20,7 @@
         hiddenStatuses = [],
         displayExtendedStats = false,
         releaseStats,
+        widgetId,
     }: Props = $props();
 
     const releaseStatsDefault = {
@@ -41,7 +43,7 @@
     {#if releaseStats?.total > 0}
         {#if showReleaseStats}
             <div class="w-100 mb-2">
-                <DisplayItem stats={releaseStats} displayNumber={displayExtendedStats} displayInvestigations={displayExtendedStats} {hiddenStatuses} on:quickSelect/>
+                <DisplayItem stats={releaseStats} displayNumber={displayExtendedStats} displayInvestigations={displayExtendedStats} {hiddenStatuses} {widgetId} on:quickSelect/>
             </div>
         {/if}
     {:else if releaseStats?.total == -1}

--- a/frontend/Views/ViewDashboard.svelte
+++ b/frontend/Views/ViewDashboard.svelte
@@ -81,8 +81,10 @@
 
     const handleQuickSelect = function (e) {
         let tests = e.detail.tests;
+        let widget = view.widget_settings.find(v => v.position == e.detail.widgetId);
+        const key = calculateWidgetStatsKey(widget);
         tests.forEach((v) => {
-            let group = stats.groups[v.test.group_id];
+            let group = stats[key].groups[v.test.group_id];
             handleTestClick({
                 name: v.test.name,
                 id: v.test.id,

--- a/frontend/Views/Widgets/ViewReleaseStats.svelte
+++ b/frontend/Views/Widgets/ViewReleaseStats.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
     import ReleaseStats from "../../Stats/ReleaseStats.svelte";
-    let { settings, stats = $bindable() } = $props();
+    let { widgetId, settings, stats = $bindable() } = $props();
 
 </script>
 
 <div class="row mb-2">
     <div class="col">
         <ReleaseStats
+            widgetId={widgetId}
             horizontal={settings.horizontal}
             displayExtendedStats={settings.displayExtendedStats}
             hiddenStatuses={settings.hiddenStatuses}


### PR DESCRIPTION
This commit fixes an issue where NumberStats would dispatch quick
selection for underlying view without providing its widgetId and the
view quick select logic itself wasn't updated to correctly handle
changes in #833, hence quick select would fail for top level
ReleaseStats widget (but still works for one inside ViewTestDashboard).
This change propagates widgetId for ViewReleaseStats family of widgets
and also adds a key calculation inside handleQuickSelect of
ViewDashboard.

Fixes #826
Closes #833
