### PR TITLE
improvement(jenkins_service): Replace user github token with global one

### DIFF
--- a/argus/backend/controller/api.py
+++ b/argus/backend/controller/api.py
@@ -47,27 +47,6 @@ def app_version():
     })
 
 
-@bp.route("/profile/github/token")
-@api_login_required
-def get_github_oauth_token():
-    user_tokens = UserOauthToken.filter(user_id=g.user.id).all()
-    token = None
-    for tok in user_tokens:
-        if tok.kind == "github":
-            token = tok.token
-            break
-    if not token:
-        raise Exception("Github token not found")
-
-    res = jsonify({
-        "status": "ok",
-        "response": token
-    })
-    res.cache_control.max_age = 300
-
-    return res
-
-
 @bp.route("/releases")
 @api_login_required
 def releases():

--- a/argus/backend/service/jenkins_service.py
+++ b/argus/backend/service/jenkins_service.py
@@ -123,21 +123,14 @@ class JenkinsService:
             repo = git_info["repo"]
             user = git_info["user"]
 
-        user_tokens = UserOauthToken.filter(user_id=g.user.id).all()
-        token = None
-        for tok in user_tokens:
-            if tok.kind == "github":
-                token = tok.token
-                break
-        if not token:
-            raise JenkinsServiceError("Github token not found")
-
+        token = current_app.config.get("GITHUB_ACCESS_TOKEN")
         response = requests.get(
             url=f"https://api.github.com/repos/{user}/{repo}/contents/{new_settings['pipelineFile']}?ref={new_settings['gitBranch']}",
             headers={
                 "Accept": "application/vnd.github+json",
                 "Authorization": f"Bearer {token}",
-            }
+            },
+            timeout=60
         )
 
         if response.status_code == 404:


### PR DESCRIPTION
We don't want to use user tokens to resolve github repositories due to
us switching to a different authorization provider. This commit changes
the user token to the global app token with no changes in functionality.
