### PR TITLE
fix(tests/highlights): Shift created_at timestamp by one second

### DIFF
--- a/argus/backend/tests/view_widgets/test_highlights_api.py
+++ b/argus/backend/tests/view_widgets/test_highlights_api.py
@@ -154,6 +154,7 @@ def test_get_highlights_should_return_highlights_and_action_items(flask_client):
 def test_archive_highlight_should_mark_highlight_as_archived(flask_client):
     view_id = str(uuid4())
     created_at = datetime.now(UTC)
+    created_at = created_at - timedelta(seconds=1)
     creator_id = g.user.id
     highlight_entry = WidgetHighlights(
         view_id=UUID(view_id),


### PR DESCRIPTION
This commit fixes test flakiness resulting from having test run too fast
and scylla or python-driver truncating nanoseconds, resulting in same
nanosecond value.
