### PR TITLE
improvement(ViewsManager): Add drag'n'drop for widget arrangement

### DIFF
--- a/frontend/AdminPanel/ViewWidget.svelte
+++ b/frontend/AdminPanel/ViewWidget.svelte
@@ -13,18 +13,25 @@
      * @typedef {Object} Props
      * @property {Widget} [widgetSettings]
      * @property {any} [items]
+     * @property {} drag
+     * @property {} dragover
+     * @property {} dragend
      */
 
     /** @type {Props} */
-    let { widgetSettings = $bindable({}), items = [] } = $props();
+    let { widgetSettings = $bindable({}), items = [], dragover, drag, dragend } = $props();
 
     let editingSettings = $state(false);
+    let isDragged = $state(false);
     const dispatch = createEventDispatcher();
     let WIDGET_DEF = $state(WIDGET_TYPES[widgetSettings.type]);
     run(() => {
         WIDGET_DEF = WIDGET_TYPES[widgetSettings.type];
     });
 
+    const handleDragStart = function () {
+        isDragged = true;
+    };
 
     const populateWidgetSettings = function() {
         Object
@@ -40,9 +47,24 @@
     });
 </script>
 
-<div class="mb-2 rounded bg-white p-2">
+<div
+    class="mb-2 rounded bg-white p-2"
+    class:is-dragged={isDragged}
+    >
     <div class="d-flex align-items-center">
-        <div class="me-2"><Fa icon={faList}/> <span class="fw-bold">{widgetSettings.position}</span></div>
+        <div
+            class="me-2"
+            role="listitem"
+            draggable="true"
+            style="cursor:grab"
+            ondragstart={() => handleDragStart()}
+            ondrag={() => drag(widgetSettings)}
+            ondragover={() => dragover(widgetSettings)}
+            ondragend={() => {
+                isDragged = false;
+                dragend(widgetSettings);
+            }}
+        ><Fa icon={faList}/> <span class="fw-bold">{widgetSettings.position}</span></div>
         <div class="flex-fill">
             <select class="form-select" bind:value={widgetSettings.type} onchange={() => populateWidgetSettings()}>
                 {#each Object.entries(WIDGET_TYPES) as [type, spec] (type)}
@@ -62,7 +84,7 @@
 {#if editingSettings}
     <div class="widget-settings-modal">
         <div class="d-flex align-items-center justify-content-center p-4">
-            <div class="rounded bg-white p-4 h-50">
+            <div class="rounded bg-white p-4 w-50">
                 <div class="mb-2 d-flex border-bottom pb-2">
                     <h5>Editing <span class="fw-bold">{WIDGET_DEF.friendlyName}</span></h5>
                     <div class="ms-auto">
@@ -103,9 +125,15 @@
     </div>
 {/if}
 <style>
-    .h-50 {
+    .w-50 {
         width: 50%;
     }
+
+    .is-dragged {
+        opacity: 10%;
+        border: dotted 5px black;
+    }
+
     .widget-settings-modal {
         position: fixed;
         top: 0;

--- a/frontend/AdminPanel/ViewsManager.svelte
+++ b/frontend/AdminPanel/ViewsManager.svelte
@@ -31,6 +31,7 @@
     let newView = $state(Object.assign({}, VIEW_CREATE_TEMPLATE));
     let selectedItems = $state([]);
     let lockForm = $state(false);
+    let draggedWidget = $state(null);
     let editingExistingView = $state(false);
     let testSearcherValue = $state();
     let errorPopup = $state(false);
@@ -340,6 +341,25 @@
         sendMessage("error", message, "ViewManager::validateNewView");
     };
 
+    const handleWidgetDrag = function (widgetSettings) {
+        draggedWidget = widgetSettings;
+    };
+
+    const handleWidgetDragOver = function (widgetSettings) {
+        let draggedIndex = newWidgets.findIndex((w) => w.position == draggedWidget.position);
+        let draggedOverIndex = newWidgets.findIndex((w) => w.position == widgetSettings.position);
+        if (draggedIndex == draggedOverIndex) return;
+        let oldWidget = newWidgets[draggedIndex];
+        newWidgets[draggedIndex] = newWidgets[draggedOverIndex];
+        newWidgets[draggedOverIndex] = oldWidget;
+
+    };
+
+    const handleWidgetDragEnd = function (widgetSettings) {
+        draggedWidget = null;
+        reflowWidgetPositions();
+    };
+
     const resetForm = function () {
         newWidgets = [];
         selectedItems = [];
@@ -463,7 +483,14 @@
                             </button>
                         </div>
                         {#each newWidgets as widget, idx (widget.position)}
-                            <ViewWidget bind:widgetSettings={newWidgets[idx]} items={newView.items} on:removeWidget={removeWidget}/>
+                            <ViewWidget
+                                bind:widgetSettings={newWidgets[idx]}
+                                items={newView.items}
+                                on:removeWidget={removeWidget}
+                                drag={(widgetSettings) => handleWidgetDrag(widgetSettings)}
+                                dragover={(widgetSettings) => handleWidgetDragOver(widgetSettings)}
+                                dragend={(widgetSettings) => handleWidgetDragEnd(widgetSettings)}
+                            />
                         {/each}
                     </div>
                 </div>


### PR DESCRIPTION
This commit adds the drag and drop functionality to view manager widget
list window, allowing user to quickly adjust widget settings.

Fixes #794 (Root cause since most users replace that widget with
something else)
