### PR TITLE
fix(pytest-argus-reporter): pin pytest

### DIFF
--- a/pytest-argus-reporter/pyproject.toml
+++ b/pytest-argus-reporter/pyproject.toml
@@ -46,7 +46,7 @@ argus-reporter  = "pytest_argus_reporter"
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=3.0",
+    "pytest ~= 9.0.0",
     "pre-commit",
     "requests-mock",
     "codecov",


### PR DESCRIPTION
In order to avoid issues when new pytest verion appears, pin it's version.