### PR TITLE
fix(PytestOverview): URI encode tests to prevent resolution errors

### DIFF
--- a/argus/backend/controller/views_widgets/pytest.py
+++ b/argus/backend/controller/views_widgets/pytest.py
@@ -41,7 +41,7 @@ def get_view_pytest_results(view_id: str):
         "response": res
     }
 
-@bp.route("/pytest/<string:test_name>/<string:id>/fields", methods=["GET"])
+@bp.route("/pytest/<path:test_name>/<string:id>/fields", methods=["GET"])
 @api_login_required
 def get_user_fields_for_test(test_name: str, id: str):
     service = PytestViewService()

--- a/frontend/Views/Widgets/PytestWidget/PytestResultRow.svelte
+++ b/frontend/Views/Widgets/PytestWidget/PytestResultRow.svelte
@@ -20,7 +20,7 @@
 
     const fetchUserFields = async function(name: string, id: string): Promise<UserFields> {
         try {
-            const res = await fetch(`/api/v1/views/widgets/pytest/${name}/${id}/fields`);
+            const res = await fetch(`/api/v1/views/widgets/pytest/${encodeURIComponent(name)}/${id}/fields`);
             const json = await res.json();
 
             if (json.status !== "ok") {


### PR DESCRIPTION
This commit fixes an issue where a test with a `/` in its name would
cause the request to return 404 as Flask parses %2F as / before
dispatching the endpoint. For safety, the test names are now also URI
encoded to prevent other kinds of issues. Primary fix is to allow `/`
inside this particular endpoint parameter.
