### PR TITLE
fix(uwsgi.ini): Move socket to /var/lib

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -3,7 +3,7 @@ master = true
 env = PROMETHEUS_MULTIPROC_DIR=/tmp/promdb-argus-metrics
 lazy-apps = true
 enable-threads = true
-socket = /tmp/argus.sock
+socket = /var/lib/argus/argus.sock
 umask = 0007
 wsgi-file = argus_backend.py
 callable = argus_app
@@ -16,4 +16,4 @@ buffer-size = 48000
 listen = 1024
 max-worker-lifetime = 86400
 max-requests = 65535
-stats = /tmp/argus-stats.sock
+stats = /var/lib/argus/argus-stats.sock


### PR DESCRIPTION
This fix resolves a problem where on systems with PrivateTmp=on unit
configuration the argus socket would be inaccessible to other services
due to being in /tmp
