### PR TITLE
improvement(email_service): Add support for Generic Results API

### DIFF
--- a/argus/backend/template_filters.py
+++ b/argus/backend/template_filters.py
@@ -92,3 +92,14 @@ def nemesis_status_to_emoji(status: str):
         "terminated": "🛑",
     }
     return EMOJI.get(status, EMOJI["terminated"])
+
+@is_filter("result_status_to_table_cell")
+def result_status_to_table_cell(status: str):
+
+    STATUS = {
+        "PASS": "table-success",
+        "ERROR": "table-danger",
+        "WARNING": "table-warning",
+        "NULL": "table-secondary",
+    }
+    return STATUS.get(status, STATUS["NULL"])

--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -161,6 +161,7 @@ Supported sections are:
 | logs| List of links to the log files stored on S3 for this run |
 | cloud| Contains active remaining resources running at the end the test. Table |
 | nemesis| Table of nemeses in the run with their status and durations |
+| generic_results| Generic Result API results, formatted as tables |
 | events| Event block of most recent events sorted by timestamp |
 | screenshots| Grafana screenshot gallery |
 | custom_table| Custom table element. Can be used to display arbitrary tables. HTML in cells is **not** supported |
@@ -180,6 +181,13 @@ The `section` block can be provided as empty array to use the default template.
 |------|----|-----------|
 |amount_per_severity| number | Amount of events per severity to display (default 10)|
 |severity_filter| string[] | Names of severities to include in the email (default [CRITICAL, ERROR]). Available severities: CRITICAL, ERROR, WARNING, NORMAL, DEBUG  (case-sensitive)|
+
+###### Generic Results
+
+|Option|Type|Description|
+|------|----|-----------|
+|table_filter| string[] | Array of regexes to filter tables by. Default: [] - all tables will be shown|
+|section_name| string | Heading value for the results tables|
 
 ###### Nemesis
 

--- a/templates/email/css/styles.css
+++ b/templates/email/css/styles.css
@@ -115,6 +115,23 @@ th {
     border-top-width: 0;
 }
 
+.table-success {
+    color: #000;
+    background-color: #a3cfbb !important;
+}
+.table-danger {
+    color: #000;
+    background-color: #f1aeb5 !important;
+}
+.table-warning {
+    color: #000;
+    background-color: #ffe69c !important;
+}
+.table-secondary {
+    color: #000;
+    background-color: unset !important;
+}
+
 .table-responsive {
     overflow-x: scroll;
     -webkit-overflow-scrolling: touch;

--- a/templates/email/partials/generic_results.html.j2
+++ b/templates/email/partials/generic_results.html.j2
@@ -1,0 +1,46 @@
+{% macro render_partial(options) %}
+<div>
+    <h2><a class="btn-link-dark" href="https://argus.scylladb.com/tests/scylla-cluster-tests/{{ options['run_id' ]}}/results">{{ options["section_name"] }}</a></h2>
+    <div>
+        {% for result in options["results"] %}
+            {% for table_name, table_data in result.items() %}
+                <div>
+                    <h4>{{table_name}}</h4>
+                    <div class="table-responsive">
+                        <table class="table table-responsive table-bordered">
+                            <thead>
+                                <tr>
+                                    <th>    </th>
+                                    {% for col in table_data["columns"] %}
+                                        {% if col["visible"] %}
+                                            <th>{{ col["name"] }}</th>
+                                        {% endif %}
+                                    {% endfor %}
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for row in table_data["rows"] %}
+                                <tr>
+                                    <td>{{ row }}</td>
+                                    {% for col in table_data["columns"] %}
+                                        {% if col["visible"] %}
+                                            <td class="{{ table_data['table_data'][row][col['name']]['status'] | result_status_to_table_cell }}">
+                                                {% if col["type"] == "TEXT" and table_data["table_data"][row][col["name"]]["value"] and table_data["table_data"][row][col["name"]]["value"].startswith("http") %}
+                                                    <a href="{{ table_data['table_data'][row][col['name']]['value'] }}">View</a>
+                                                {% else %}
+                                                    {{ table_data["table_data"][row][col["name"]]["value"] }}
+                                                {% endif %}
+                                            </td>
+                                        {% endif %}
+                                    {% endfor %}
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            {% endfor %}
+        {% endfor %}
+    </div>
+</div>
+{%- endmacro %}


### PR DESCRIPTION
This commit adds support for Generic Result tables inside email reports,
allowing users to show performance, iotune and other results from SCT
tests. Supported options: section_name and table_filter.

Docs are updated with new options.

Fixes #864
