### PR TITLE
improvement(build_system_monitor): Allow subfolders to act as releases

### DIFF
--- a/argus/backend/controller/main.py
+++ b/argus/backend/controller/main.py
@@ -112,7 +112,7 @@ def alert_debug():
     return render_template("flash_debug.html.j2")
 
 
-@bp.route("/dashboard/<string:release_name>")
+@bp.route("/dashboard/<path:release_name>")
 @login_required
 def release_dashboard(release_name: str):
     service = ArgusService()

--- a/argus/backend/plugins/sct/controller.py
+++ b/argus/backend/plugins/sct/controller.py
@@ -217,7 +217,7 @@ def sct_get_performance_history(run_id: str):
     }
 
 
-@bp.route("/release/<string:release_name>/kernels", methods=["GET"])
+@bp.route("/release/<path:release_name>/kernels", methods=["GET"])
 @api_login_required
 def sct_get_kernel_report(release_name: str):
     result = SCTService.get_scylla_version_kernels_report(release_name=release_name)

--- a/argus/backend/service/build_system_monitor.py
+++ b/argus/backend/service/build_system_monitor.py
@@ -25,7 +25,7 @@ class ArgusTestsMonitor(ABC):
         self._existing_tests = list(ArgusTest.objects().limit(None))
         self._filtered_groups: list[str] = self.BUILD_SYSTEM_FILTERED_PREFIXES
 
-    def create_release(self, release_name):
+    def create_release(self, release_name: str):
         release = ArgusRelease()
         release.name = release_name
         release.save()
@@ -77,6 +77,9 @@ class JenkinsMonitor(ArgusTestsMonitor):
 
     JENKINS_MONITORED_RELEASES = [
         r"^scylla-master$",
+        r"^drivers$",
+        r"^scylla-\d+\.\d+/releng-testing$",
+        r"^enterprise-20\d{2}\.\d+/releng-testing$",
         r"^scylla-staging$",
         r"^scylla-\d+\.\d+$",
         r"^manager-3.\d+$",
@@ -104,13 +107,13 @@ class JenkinsMonitor(ArgusTestsMonitor):
         LOGGER.info("Will collect %s", [f["fullname"] for f in all_monitored_folders])
 
         for release in all_monitored_folders:
-            LOGGER.info("Processing release %s", release["name"])
+            LOGGER.info("Processing release %s", release["fullname"])
             try:
-                saved_release = ArgusRelease.get(name=release["name"])
-                LOGGER.info("Release %s exists", release["name"])
+                saved_release = ArgusRelease.get(name=release["fullname"])
+                LOGGER.info("Release %s exists", release["fullname"])
             except ArgusRelease.DoesNotExist:
-                LOGGER.warning("Release %s does not exist, creating...", release["name"])
-                saved_release = self.create_release(release["name"])
+                LOGGER.warning("Release %s does not exist, creating...", release["fullname"])
+                saved_release = self.create_release(release["fullname"])
                 self._existing_releases.append(saved_release)
 
             try:


### PR DESCRIPTION
This commit adds support for including subfolders of a folder as a
top-level release inside Argus. This means, for example, that a
subfolder of scylla-master, releng-testing, which is usually filtered
due to duplicating structure of that release, can now be scanned as a
separate release with full support. Additional fixes for release
dashboard are included since release names can now contain '/' character
inside them.

Fixes scylladb/qa-tasks#2028
