### PR TITLE
feature(runs-assign): default job assignment based on priority

### DIFF
--- a/argus/backend/plugins/core.py
+++ b/argus/backend/plugins/core.py
@@ -17,7 +17,8 @@ from argus.backend.models.web import (
     ArgusScheduleGroup,
     ArgusSchedule,
     ArgusScheduleTest,
-    ArgusScheduleAssignee
+    ArgusScheduleAssignee,
+    User,
 )
 from argus.backend.util.common import chunk
 from argus.common.enums import TestInvestigationStatus, TestStatus
@@ -87,6 +88,20 @@ class PluginModelBase(Model):
 
     def get_scheduled_assignee(self) -> UUID:
         return self.get_assignment()
+
+    def get_initial_assignee(self, started_by: str | None = None) -> UUID | None:
+        try:
+            investigation_assignee = self.get_scheduled_assignee()
+            if investigation_assignee:
+                return investigation_assignee
+        except Model.DoesNotExist:
+            pass
+
+        if not started_by:
+            return None
+
+        trigger_user = User.exists_by_name(started_by)
+        return trigger_user.id if trigger_user else None
 
     def _legacy_get_scheduled_assignee(self, associated_test: ArgusTest, associated_release: ArgusRelease) -> UUID:
         """

--- a/argus/backend/plugins/core.py
+++ b/argus/backend/plugins/core.py
@@ -20,10 +20,13 @@ from argus.backend.models.web import (
     ArgusScheduleAssignee,
     User,
 )
-from argus.backend.util.common import chunk
+from argus.backend.util.common import chunk, get_build_number
 from argus.common.enums import TestInvestigationStatus, TestStatus
+from argus.backend.service.jenkins_service import JenkinsService
 
 LOGGER = logging.getLogger(__name__)
+# Jenkins stores the requester as the email local part only (see JenkinsService.build_job)
+JENKINS_USER_EMAIL_DOMAIN = "scylladb.com"
 
 
 class PluginModelBase(Model):
@@ -86,22 +89,46 @@ class PluginModelBase(Model):
         # FIXME: Legacy fallback until we fully migrate to new plans
         return self._legacy_get_scheduled_assignee(associated_test=associated_test, associated_release=associated_release)
 
-    def get_scheduled_assignee(self) -> UUID:
-        return self.get_assignment()
-
-    def get_initial_assignee(self, started_by: str | None = None) -> UUID | None:
+    def get_assignee(self, started_by: str | None = None) -> UUID | None:
         try:
-            investigation_assignee = self.get_scheduled_assignee()
+            investigation_assignee = self.get_assignment()
             if investigation_assignee:
                 return investigation_assignee
         except Model.DoesNotExist:
             pass
 
-        if not started_by:
+        if started_by:
+            trigger_user = User.exists_by_name(started_by)
+            if trigger_user:
+                return trigger_user.id
+
+        jenkins_username = self._get_jenkins_requested_by_user()
+        if jenkins_username:
+            jenkins_user = User.exists_by_email(f"{jenkins_username}@{JENKINS_USER_EMAIL_DOMAIN}")
+            if jenkins_user:
+                return jenkins_user.id
+
+        return None
+
+    def _get_jenkins_requested_by_user(self) -> str | None:
+        if not self.build_job_url or not self.build_id:
             return None
 
-        trigger_user = User.exists_by_name(started_by)
-        return trigger_user.id if trigger_user else None
+        build_number = get_build_number(self.build_job_url)
+        if not build_number:
+            return None
+
+        try:
+            service = JenkinsService()
+            return service.get_requested_by_user(build_id=self.build_id, build_number=build_number)
+        except Exception:  # noqa: BLE001 – Jenkins may be unreachable; do not fail run submission
+            LOGGER.warning(
+                "Could not fetch REQUESTED_BY_USER from Jenkins for build %s #%s",
+                self.build_id,
+                build_number,
+                exc_info=True,
+            )
+            return None
 
     def _legacy_get_scheduled_assignee(self, associated_test: ArgusTest, associated_release: ArgusRelease) -> UUID:
         """

--- a/argus/backend/plugins/driver_matrix_tests/model.py
+++ b/argus/backend/plugins/driver_matrix_tests/model.py
@@ -168,10 +168,7 @@ class DriverTestRun(PluginModelBase):
         run.build_job_url = req.job_url
         run.start_time = datetime.utcnow()
         run.assign_categories()
-        try:
-            run.assignee = run.get_scheduled_assignee()
-        except Exception:
-            run.assignee = None
+        run.assignee = run.get_assignee()
 
         run.status = TestStatus.CREATED.value
         run.save()
@@ -347,10 +344,7 @@ class DriverTestRun(PluginModelBase):
         run.build_id = req.job_name
         run.build_job_url = req.job_url
         run.assign_categories()
-        try:
-            run.assignee = run.get_scheduled_assignee()
-        except Exception:
-            run.assignee = None
+        run.assignee = run.get_assignee()
         for key, value in req.test_environment.items():
             env_info = EnvironmentInfo()
             env_info.key = key

--- a/argus/backend/plugins/generic/model.py
+++ b/argus/backend/plugins/generic/model.py
@@ -68,10 +68,7 @@ class GenericRun(PluginModelBase):
         run.build_job_url = request_data["build_url"]
         run.sub_type = request_data.get("sub_type")
         run.assign_categories()
-        try:
-            run.assignee = run.get_scheduled_assignee()
-        except Model.DoesNotExist:
-            run.assignee = None
+        run.assignee = run.get_initial_assignee(request_data.get("started_by"))
         if version := request_data.get("scylla_version"):
             run.submit_product_version(version)
         run.status = TestStatus.RUNNING.value

--- a/argus/backend/plugins/generic/model.py
+++ b/argus/backend/plugins/generic/model.py
@@ -63,12 +63,12 @@ class GenericRun(PluginModelBase):
         run = cls()
         run.start_time = datetime.utcnow()
         run.build_id = request_data["build_id"]
+        run.build_job_url = request_data["build_url"]
         run.started_by = request_data["started_by"]
         run.id = request_data["run_id"]
-        run.build_job_url = request_data["build_url"]
         run.sub_type = request_data.get("sub_type")
         run.assign_categories()
-        run.assignee = run.get_initial_assignee(request_data.get("started_by"))
+        run.assignee = run.get_assignee(request_data.get("started_by"))
         if version := request_data.get("scylla_version"):
             run.submit_product_version(version)
         run.status = TestStatus.RUNNING.value

--- a/argus/backend/plugins/sct/testrun.py
+++ b/argus/backend/plugins/sct/testrun.py
@@ -249,10 +249,7 @@ class SCTTestRun(PluginModelBase):
         run = cls()
         run.build_id = req.job_name
         run.assign_categories()
-        try:
-            run.assignee = run.get_scheduled_assignee()
-        except _DoesNotExist:
-            run.assignee = None
+        run.assignee = run.get_initial_assignee(req.started_by)
         run.start_time = datetime.now(timezone.utc)
         run.id = UUID(req.run_id)
         run.scm_revision_id = req.commit_id

--- a/argus/backend/plugins/sct/testrun.py
+++ b/argus/backend/plugins/sct/testrun.py
@@ -248,8 +248,9 @@ class SCTTestRun(PluginModelBase):
     def init_sct_run(cls, req: SCTTestRunSubmissionRequest):
         run = cls()
         run.build_id = req.job_name
+        run.build_job_url = req.job_url
         run.assign_categories()
-        run.assignee = run.get_initial_assignee(req.started_by)
+        run.assignee = run.get_assignee(req.started_by)
         run.start_time = datetime.now(timezone.utc)
         run.id = UUID(req.run_id)
         run.scm_revision_id = req.commit_id
@@ -257,7 +258,6 @@ class SCTTestRun(PluginModelBase):
             run.origin_url = req.origin_url
             run.branch_name = req.branch_name
         run.started_by = req.started_by
-        run.build_job_url = req.job_url
 
         return run
 

--- a/argus/backend/plugins/sirenada/model.py
+++ b/argus/backend/plugins/sirenada/model.py
@@ -86,14 +86,11 @@ class SirenadaRun(PluginModelBase):
             run.id = request_data["run_id"]  # FIXME: Validate pls
             run.build_id = request_data["build_id"]
             run.start_time = datetime.utcnow()
-            run.assign_categories()
             run.build_job_url = request_data["build_job_url"]
+            run.assign_categories()
             run.region = request_data["region"]
             run.status = TestStatus.PASSED.value
-            try:
-                run.assignee = run.get_scheduled_assignee()
-            except Model.DoesNotExist:
-                run.assignee = None
+            run.assignee = run.get_assignee()
 
         for raw_case in request_data["results"]:
             case = SirenadaTest(**raw_case)

--- a/argus/backend/service/jenkins_service.py
+++ b/argus/backend/service/jenkins_service.py
@@ -260,3 +260,21 @@ class JenkinsService:
                 "inQueueSince": build_info["inQueueSince"],
                 "taskUrl": build_info["task"]["url"],
             }
+
+    def get_requested_by_user(self, build_id: str, build_number: int) -> str | None:
+        """Return the value of the REQUESTED_BY_USER parameter for a specific build, or None."""
+        try:
+            build_info = self._jenkins.get_build_info(name=build_id, number=build_number)
+        except jenkins.JenkinsException:
+            LOGGER.warning("Could not retrieve build info for %s #%s", build_id, build_number)
+            return None
+        params_action = next(
+            (a for a in build_info.get("actions", []) if a.get("_class") == "hudson.model.ParametersAction"),
+            None,
+        )
+        if not params_action:
+            return None
+        for param in params_action.get("parameters", []):
+            if param.get("name") == self.RESERVED_PARAMETER_NAME:
+                return param.get("value") or None
+        return None

--- a/argus/backend/tests/test_assignee.py
+++ b/argus/backend/tests/test_assignee.py
@@ -1,11 +1,12 @@
 import json
 import uuid
+from datetime import datetime, timedelta, UTC
 from unittest.mock import patch
 
 import pytest
 from flask import g
 
-from argus.backend.models.web import User, UserRoles
+from argus.backend.models.web import ArgusSchedule, ArgusScheduleAssignee, ArgusScheduleTest, User, UserRoles
 from argus.backend.plugins.sct.testrun import SCTTestRun
 from argus.backend.service.testrun import TestRunService
 
@@ -138,3 +139,136 @@ def test_assign_testrun_to_other(flask_client, sct_run_for_assignee, test_user, 
         # Verify notification was sent when assigning to someone else
         mock_notify.assert_called_once()
         assert mock_notify.call_args.kwargs["receiver"] == test_user.id
+
+
+def test_run_auto_assigned_to_triggerer(flask_client, fake_test):
+    triggerer = User(
+        id=uuid.uuid4(),
+        username=f"triggerer_{uuid.uuid4().hex[:8]}",
+        full_name="Triggerer User",
+        email=f"trigger_{uuid.uuid4().hex[:8]}@scylladb.com",
+        password="test_password",
+        roles=[UserRoles.User.value],
+    )
+    triggerer.save()
+
+    run_id = str(uuid.uuid4())
+    payload = {
+        "run_id": run_id,
+        "job_name": fake_test.build_system_id,
+        "job_url": "http://example.com/job/auto",
+        "started_by": triggerer.username,
+        "commit_id": "cafebabe",
+        "origin_url": "http://example.com/repo.git",
+        "branch_name": "main",
+        "sct_config": {"cluster_backend": "aws"},
+        "schema_version": "v8",
+    }
+    resp = flask_client.post(
+        "/api/v1/client/testrun/scylla-cluster-tests/submit",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200, resp.json
+    assert resp.json["status"] == "ok"
+
+    run = SCTTestRun.get(id=run_id)
+    assert run.assignee == triggerer.id, "run should be assigned to the person who triggered it"
+
+
+def test_run_unassigned_when_triggerer_unknown(flask_client, fake_test):
+    run_id = str(uuid.uuid4())
+    payload = {
+        "run_id": run_id,
+        "job_name": fake_test.build_system_id,
+        "job_url": "http://example.com/job/unknown",
+        "started_by": "ghost_user_that_does_not_exist",
+        "commit_id": "00000000",
+        "origin_url": "http://example.com/repo.git",
+        "branch_name": "main",
+        "sct_config": {"cluster_backend": "aws"},
+        "schema_version": "v8",
+    }
+    resp = flask_client.post(
+        "/api/v1/client/testrun/scylla-cluster-tests/submit",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200, resp.json
+    assert resp.json["status"] == "ok"
+
+    run = SCTTestRun.get(id=run_id)
+    assert run.assignee is None, "run should remain unassigned when started_by user does not exist"
+
+
+def test_investigation_assignee_takes_priority_over_triggerer(flask_client, fake_test):
+    investigator = User(
+        id=uuid.uuid4(),
+        username=f"investigator_{uuid.uuid4().hex[:8]}",
+        full_name="Investigator User",
+        email=f"inv_{uuid.uuid4().hex[:8]}@scylladb.com",
+        password="test_password",
+        roles=[UserRoles.User.value],
+    )
+    investigator.save()
+
+    triggerer = User(
+        id=uuid.uuid4(),
+        username=f"just_triggerer_{uuid.uuid4().hex[:8]}",
+        full_name="Just Triggerer",
+        email=f"justtrigger_{uuid.uuid4().hex[:8]}@scylladb.com",
+        password="test_password",
+        roles=[UserRoles.User.value],
+    )
+    triggerer.save()
+
+    now = datetime.now(UTC)
+    schedule = ArgusSchedule(
+        release_id=fake_test.release_id,
+        period_start=now - timedelta(days=1),
+        period_end=now + timedelta(days=1),
+    )
+    schedule.save()
+
+    schedule_test = ArgusScheduleTest(
+        release_id=fake_test.release_id,
+        test_id=fake_test.id,
+        schedule_id=schedule.id,
+    )
+    schedule_test.save()
+
+    schedule_assignee = ArgusScheduleAssignee(
+        assignee=investigator.id,
+        release_id=fake_test.release_id,
+        schedule_id=schedule.id,
+    )
+    schedule_assignee.save()
+
+    try:
+        run_id = str(uuid.uuid4())
+        payload = {
+            "run_id": run_id,
+            "job_name": fake_test.build_system_id,
+            "job_url": "http://example.com/job/investigation",
+            "started_by": triggerer.username,
+            "commit_id": "deadc0de",
+            "origin_url": "http://example.com/repo.git",
+            "branch_name": "main",
+            "sct_config": {"cluster_backend": "aws"},
+            "schema_version": "v8",
+        }
+        resp = flask_client.post(
+            "/api/v1/client/testrun/scylla-cluster-tests/submit",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200, resp.json
+        assert resp.json["status"] == "ok"
+
+        run = SCTTestRun.get(id=run_id)
+        assert run.assignee == investigator.id, "run should be assigned to the investigation duty person, not the triggerer"
+        assert run.assignee != triggerer.id
+    finally:
+        schedule_assignee.delete()
+        schedule_test.delete()
+        schedule.delete()

--- a/argus/backend/tests/test_assignee.py
+++ b/argus/backend/tests/test_assignee.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+from contextlib import contextmanager
 from datetime import datetime, timedelta, UTC
 from unittest.mock import patch
 
@@ -10,20 +11,41 @@ from argus.backend.models.web import ArgusSchedule, ArgusScheduleAssignee, Argus
 from argus.backend.plugins.sct.testrun import SCTTestRun
 from argus.backend.service.testrun import TestRunService
 
+SUBMIT_ENDPOINT = "/api/v1/client/testrun/scylla-cluster-tests/submit"
+NOTIFICATION_TARGET = "argus.backend.service.notification_manager.NotificationManagerService.send_notification"
+JENKINS_TARGET = "argus.backend.plugins.core.JenkinsService"
+
+
+@contextmanager
+def jenkins_returns(requested_by_user: str | None):
+    """Patch the whole JenkinsService class, because its constructor needs app config the tests do not set"""
+    with patch(JENKINS_TARGET) as service_class:
+        service_class.return_value.get_requested_by_user.return_value = requested_by_user
+        yield service_class.return_value.get_requested_by_user
+
 
 @pytest.fixture
-def test_user():
+def make_user():
+    """Return a factory that creates and saves an Argus user with a unique username and email"""
+    def _make_user(prefix: str = "user") -> User:
+        suffix = uuid.uuid4().hex[:8]
+        user = User(
+            id=uuid.uuid4(),
+            username=f"{prefix}_{suffix}",
+            full_name=f"{prefix} test user",
+            email=f"{prefix}_{suffix}@scylladb.com",
+            password="test_password",
+            roles=[UserRoles.User.value],
+        )
+        user.save()
+        return user
+    return _make_user
+
+
+@pytest.fixture
+def test_user(make_user):
     """Create and save a test user for assignee tests"""
-    user = User(
-        id=uuid.uuid4(),
-        username=f"assignee_user_{uuid.uuid4().hex[:8]}",
-        full_name="Assignee Test User",
-        email=f"assignee_{uuid.uuid4().hex[:8]}@scylladb.com",
-        password="test_password",
-        roles=[UserRoles.User.value],
-    )
-    user.save()
-    return user
+    return make_user("assignee_user")
 
 
 @pytest.fixture
@@ -37,28 +59,66 @@ def saved_g_user():
 
 
 @pytest.fixture
-def sct_run_for_assignee(flask_client, fake_test):
+def submit_sct_run(flask_client, fake_test):
+    """Return a factory that submits an SCT run for the fake test and returns its run id"""
+    def _submit(started_by: str = "test_user", job_url: str = "http://example.com/job/1") -> str:
+        run_id = str(uuid.uuid4())
+        payload = {
+            "run_id": run_id,
+            "job_name": fake_test.build_system_id,
+            "job_url": job_url,
+            "started_by": started_by,
+            "commit_id": "deadbeef",
+            "origin_url": "http://example.com/repo.git",
+            "branch_name": "main",
+            "sct_config": {"cluster_backend": "aws"},
+            "schema_version": "v8",
+        }
+        resp = flask_client.post(SUBMIT_ENDPOINT, data=json.dumps(payload), content_type="application/json")
+        assert resp.status_code == 200, resp.json
+        assert resp.json["status"] == "ok"
+        return run_id
+    return _submit
+
+
+@pytest.fixture
+def sct_run_for_assignee(submit_sct_run, fake_test):
     """Create an SCT run that can be used for assignee tests"""
-    run_id = str(uuid.uuid4())
-    payload = {
-        "run_id": run_id,
-        "job_name": fake_test.build_system_id,
-        "job_url": "http://example.com/job/1",
-        "started_by": "test_user",
-        "commit_id": "deadbeef",
-        "origin_url": "http://example.com/repo.git",
-        "branch_name": "main",
-        "sct_config": {"cluster_backend": "aws"},
-        "schema_version": "v8",
-    }
-    resp = flask_client.post(
-        "/api/v1/client/testrun/scylla-cluster-tests/submit",
-        data=json.dumps(payload),
-        content_type="application/json",
+    return submit_sct_run(), fake_test.id
+
+
+@pytest.fixture
+def scheduled_investigator(make_user, fake_test):
+    """Put a user on investigation duty for the fake test and remove the schedule afterwards"""
+    investigator = make_user("investigator")
+    now = datetime.now(UTC)
+
+    schedule = ArgusSchedule(
+        release_id=fake_test.release_id,
+        period_start=now - timedelta(days=1),
+        period_end=now + timedelta(days=1),
     )
-    assert resp.status_code == 200
-    assert resp.json["status"] == "ok"
-    return run_id, fake_test.id
+    schedule.save()
+
+    schedule_test = ArgusScheduleTest(
+        release_id=fake_test.release_id,
+        test_id=fake_test.id,
+        schedule_id=schedule.id,
+    )
+    schedule_test.save()
+
+    schedule_assignee = ArgusScheduleAssignee(
+        assignee=investigator.id,
+        release_id=fake_test.release_id,
+        schedule_id=schedule.id,
+    )
+    schedule_assignee.save()
+
+    yield investigator
+
+    schedule_assignee.delete()
+    schedule_test.delete()
+    schedule.delete()
 
 
 def test_unassign_testrun(flask_client, sct_run_for_assignee, test_user):
@@ -66,7 +126,7 @@ def test_unassign_testrun(flask_client, sct_run_for_assignee, test_user):
     run_id, test_id = sct_run_for_assignee
 
     # First, assign to a user
-    with patch('argus.backend.service.notification_manager.NotificationManagerService.send_notification'):
+    with patch(NOTIFICATION_TARGET):
         assign_payload = {"assignee": str(test_user.id)}
         resp = flask_client.post(
             f"/api/v1/test/{test_id}/run/{run_id}/assignee/set",
@@ -82,7 +142,7 @@ def test_unassign_testrun(flask_client, sct_run_for_assignee, test_user):
     assert run.assignee == test_user.id
 
     # Now unassign (this is what was causing the error)
-    with patch('argus.backend.service.notification_manager.NotificationManagerService.send_notification') as mock_notify:
+    with patch(NOTIFICATION_TARGET) as mock_notify:
         unassign_payload = {"assignee": TestRunService.ASSIGNEE_PLACEHOLDER}
         resp = flask_client.post(
             f"/api/v1/test/{test_id}/run/{run_id}/assignee/set",
@@ -105,8 +165,7 @@ def test_assign_testrun_to_self(flask_client, sct_run_for_assignee, saved_g_user
     """Test that assigning a testrun to yourself doesn't send notification"""
     run_id, test_id = sct_run_for_assignee
 
-    # Assign to self (g.user from conftest)
-    with patch('argus.backend.service.notification_manager.NotificationManagerService.send_notification') as mock_notify:
+    with patch(NOTIFICATION_TARGET) as mock_notify:
         assign_payload = {"assignee": str(g.user.id)}
         resp = flask_client.post(
             f"/api/v1/test/{test_id}/run/{run_id}/assignee/set",
@@ -116,7 +175,6 @@ def test_assign_testrun_to_self(flask_client, sct_run_for_assignee, saved_g_user
         assert resp.status_code == 200, f"Assign to self failed: {resp.json}"
         assert resp.json["status"] == "ok"
 
-        # Verify no notification was sent when assigning to self
         mock_notify.assert_not_called()
 
 
@@ -124,8 +182,7 @@ def test_assign_testrun_to_other(flask_client, sct_run_for_assignee, test_user, 
     """Test that assigning a testrun to someone else sends notification"""
     run_id, test_id = sct_run_for_assignee
 
-    # Assign to another user
-    with patch('argus.backend.service.notification_manager.NotificationManagerService.send_notification') as mock_notify:
+    with patch(NOTIFICATION_TARGET) as mock_notify:
         assign_payload = {"assignee": str(test_user.id)}
         resp = flask_client.post(
             f"/api/v1/test/{test_id}/run/{run_id}/assignee/set",
@@ -136,139 +193,92 @@ def test_assign_testrun_to_other(flask_client, sct_run_for_assignee, test_user, 
         assert resp.json["status"] == "ok"
         assert resp.json["response"]["assignee"] == str(test_user.id)
 
-        # Verify notification was sent when assigning to someone else
         mock_notify.assert_called_once()
         assert mock_notify.call_args.kwargs["receiver"] == test_user.id
 
 
-def test_run_auto_assigned_to_triggerer(flask_client, fake_test):
-    triggerer = User(
-        id=uuid.uuid4(),
-        username=f"triggerer_{uuid.uuid4().hex[:8]}",
-        full_name="Triggerer User",
-        email=f"trigger_{uuid.uuid4().hex[:8]}@scylladb.com",
-        password="test_password",
-        roles=[UserRoles.User.value],
-    )
-    triggerer.save()
+def test_run_auto_assigned_to_triggerer(submit_sct_run, make_user):
+    """A submitted run is assigned to the started_by user when that user exists in Argus."""
+    triggerer = make_user("triggerer")
 
-    run_id = str(uuid.uuid4())
-    payload = {
-        "run_id": run_id,
-        "job_name": fake_test.build_system_id,
-        "job_url": "http://example.com/job/auto",
-        "started_by": triggerer.username,
-        "commit_id": "cafebabe",
-        "origin_url": "http://example.com/repo.git",
-        "branch_name": "main",
-        "sct_config": {"cluster_backend": "aws"},
-        "schema_version": "v8",
-    }
-    resp = flask_client.post(
-        "/api/v1/client/testrun/scylla-cluster-tests/submit",
-        data=json.dumps(payload),
-        content_type="application/json",
-    )
-    assert resp.status_code == 200, resp.json
-    assert resp.json["status"] == "ok"
+    run_id = submit_sct_run(started_by=triggerer.username, job_url="http://example.com/job/auto")
 
     run = SCTTestRun.get(id=run_id)
     assert run.assignee == triggerer.id, "run should be assigned to the person who triggered it"
 
 
-def test_run_unassigned_when_triggerer_unknown(flask_client, fake_test):
-    run_id = str(uuid.uuid4())
-    payload = {
-        "run_id": run_id,
-        "job_name": fake_test.build_system_id,
-        "job_url": "http://example.com/job/unknown",
-        "started_by": "ghost_user_that_does_not_exist",
-        "commit_id": "00000000",
-        "origin_url": "http://example.com/repo.git",
-        "branch_name": "main",
-        "sct_config": {"cluster_backend": "aws"},
-        "schema_version": "v8",
-    }
-    resp = flask_client.post(
-        "/api/v1/client/testrun/scylla-cluster-tests/submit",
-        data=json.dumps(payload),
-        content_type="application/json",
-    )
-    assert resp.status_code == 200, resp.json
-    assert resp.json["status"] == "ok"
+def test_run_unassigned_when_triggerer_unknown(submit_sct_run):
+    """A run stays unassigned when started_by matches no Argus user and Jenkins returns nothing."""
+    with jenkins_returns(None):
+        run_id = submit_sct_run(started_by="ghost_user_that_does_not_exist",
+                                job_url="http://example.com/job/unknown")
 
     run = SCTTestRun.get(id=run_id)
     assert run.assignee is None, "run should remain unassigned when started_by user does not exist"
 
 
-def test_investigation_assignee_takes_priority_over_triggerer(flask_client, fake_test):
-    investigator = User(
-        id=uuid.uuid4(),
-        username=f"investigator_{uuid.uuid4().hex[:8]}",
-        full_name="Investigator User",
-        email=f"inv_{uuid.uuid4().hex[:8]}@scylladb.com",
-        password="test_password",
-        roles=[UserRoles.User.value],
-    )
-    investigator.save()
+def test_investigation_assignee_takes_priority_over_triggerer(submit_sct_run, make_user, scheduled_investigator):
+    """The investigation duty person wins over the started_by user."""
+    triggerer = make_user("just_triggerer")
 
-    triggerer = User(
-        id=uuid.uuid4(),
-        username=f"just_triggerer_{uuid.uuid4().hex[:8]}",
-        full_name="Just Triggerer",
-        email=f"justtrigger_{uuid.uuid4().hex[:8]}@scylladb.com",
-        password="test_password",
-        roles=[UserRoles.User.value],
-    )
-    triggerer.save()
+    run_id = submit_sct_run(started_by=triggerer.username, job_url="http://example.com/job/investigation")
 
-    now = datetime.now(UTC)
-    schedule = ArgusSchedule(
-        release_id=fake_test.release_id,
-        period_start=now - timedelta(days=1),
-        period_end=now + timedelta(days=1),
-    )
-    schedule.save()
+    run = SCTTestRun.get(id=run_id)
+    assert run.assignee == scheduled_investigator.id, \
+        "run should be assigned to the investigation duty person, not the triggerer"
+    assert run.assignee != triggerer.id
 
-    schedule_test = ArgusScheduleTest(
-        release_id=fake_test.release_id,
-        test_id=fake_test.id,
-        schedule_id=schedule.id,
-    )
-    schedule_test.save()
 
-    schedule_assignee = ArgusScheduleAssignee(
-        assignee=investigator.id,
-        release_id=fake_test.release_id,
-        schedule_id=schedule.id,
-    )
-    schedule_assignee.save()
+def test_run_assigned_via_jenkins_fallback_when_started_by_unknown(submit_sct_run, make_user, fake_test):
+    """When started_by doesn't match any Argus user, fall back to REQUESTED_BY_USER from Jenkins."""
+    jenkins_user = make_user("jenkins_user")
+    # Jenkins holds the email local part only, so the lookup appends the scylladb.com domain
+    requested_by_user = jenkins_user.email.split("@")[0]
 
-    try:
-        run_id = str(uuid.uuid4())
-        payload = {
-            "run_id": run_id,
-            "job_name": fake_test.build_system_id,
-            "job_url": "http://example.com/job/investigation",
-            "started_by": triggerer.username,
-            "commit_id": "deadc0de",
-            "origin_url": "http://example.com/repo.git",
-            "branch_name": "main",
-            "sct_config": {"cluster_backend": "aws"},
-            "schema_version": "v8",
-        }
-        resp = flask_client.post(
-            "/api/v1/client/testrun/scylla-cluster-tests/submit",
-            data=json.dumps(payload),
-            content_type="application/json",
+    with jenkins_returns(requested_by_user):
+        run_id = submit_sct_run(
+            started_by="ghost_user_not_in_argus",
+            job_url=f"http://example.com/job/{fake_test.build_system_id}/99/",
         )
-        assert resp.status_code == 200, resp.json
-        assert resp.json["status"] == "ok"
 
-        run = SCTTestRun.get(id=run_id)
-        assert run.assignee == investigator.id, "run should be assigned to the investigation duty person, not the triggerer"
-        assert run.assignee != triggerer.id
-    finally:
-        schedule_assignee.delete()
-        schedule_test.delete()
-        schedule.delete()
+    run = SCTTestRun.get(id=run_id)
+    assert run.assignee == jenkins_user.id, "run should be assigned to the user returned by Jenkins REQUESTED_BY_USER"
+
+
+def test_run_unassigned_when_jenkins_fallback_returns_unknown_user(submit_sct_run, fake_test):
+    """When REQUESTED_BY_USER from Jenkins doesn't match any Argus user either, leave the run unassigned."""
+    with jenkins_returns("also_unknown_jenkins_user"):
+        run_id = submit_sct_run(
+            started_by="ghost_user_not_in_argus",
+            job_url=f"http://example.com/job/{fake_test.build_system_id}/100/",
+        )
+
+    run = SCTTestRun.get(id=run_id)
+    assert run.assignee is None, "run should remain unassigned when Jenkins user is also not in Argus"
+
+
+def test_run_unassigned_when_jenkins_fallback_fails(submit_sct_run, fake_test):
+    """When Jenkins is unreachable, silently fall through and leave the run unassigned."""
+    with patch(JENKINS_TARGET, side_effect=Exception("Jenkins unreachable")):
+        run_id = submit_sct_run(
+            started_by="ghost_user_not_in_argus",
+            job_url=f"http://example.com/job/{fake_test.build_system_id}/101/",
+        )
+
+    run = SCTTestRun.get(id=run_id)
+    assert run.assignee is None, "run should remain unassigned when Jenkins fallback raises"
+
+
+def test_started_by_takes_priority_over_jenkins_fallback(submit_sct_run, make_user, fake_test):
+    """started_by should be used when it resolves to a known user; Jenkins is not queried."""
+    triggerer = make_user("real_triggerer")
+
+    with jenkins_returns("should_not_be_used") as mock_jenkins:
+        run_id = submit_sct_run(
+            started_by=triggerer.username,
+            job_url=f"http://example.com/job/{fake_test.build_system_id}/102/",
+        )
+
+    run = SCTTestRun.get(id=run_id)
+    assert run.assignee == triggerer.id, "run should be assigned to the started_by user"
+    mock_jenkins.assert_not_called()


### PR DESCRIPTION
In argus, when you start a job, that job gets unassigned. This means that runner (or in special cases, one who needs to investigate the job) does not get the notification about the job. This changes to the priority list of assigning. This feature places the current job in the views when opening argus

Priority Assignment List:
1. Scheduled Assignee (one who will investigate in argus terms)
2. User who triggered run gets assigned
3. Some error happened -> unassigned as previous