### PR TITLE
improvement(review): Add PR review guidelines and /review-pr command

### DIFF
--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,0 +1,98 @@
+---
+description: "Review a PR with project-specific false-positive filtering on top of standard review"
+argument-hint: "[PR number or URL]"
+allowed-tools: ["Bash", "Glob", "Grep", "Read", "Agent"]
+---
+
+# Argus PR Review
+
+Review pull request: "$ARGUMENTS"
+
+This command layers project-specific rules on top of the standard code review workflow. It does NOT replace the built-in review agents — it provides context they need to avoid false positives specific to this codebase.
+
+## Step 1: Gather PR context
+
+Run these in parallel:
+```bash
+gh pr diff "$ARGUMENTS"
+gh pr view "$ARGUMENTS" --json number,title,body,files,baseRefName,headRefOid
+gh api repos/scylladb/argus/issues/$(echo "$ARGUMENTS" | grep -oE '[0-9]+')/comments
+gh api repos/scylladb/argus/pulls/$(echo "$ARGUMENTS" | grep -oE '[0-9]+')/comments
+```
+
+Record:
+- The **exact list of changed files** — this is the review boundary
+- Any **demos, screenshots, or staging URLs** in the PR body or comments
+- Any **existing review comments** from human reviewers
+
+## Step 2: Read project review rules
+
+Read `AGENTS.md` — the "Pull Request Review Guidelines" section contains rules derived from prior false positives in this repo. These rules are mandatory for this review.
+
+## Step 3: Launch the standard code-review agents
+
+Use the `code-review:code-review` skill's methodology but inject these constraints into every agent prompt:
+
+**Scope constraint:** "You may ONLY flag issues in these files: [list from step 1]. Do not read or comment on any other files."
+
+**False-positive filters (from AGENTS.md + historical analysis):**
+
+1. **Diff-only rule.** Only flag issues on changed lines. Pre-existing issues in unchanged code are out of scope.
+2. **3-5 findings max.** If you have more, keep only the highest-confidence ones.
+3. **Concrete bugs only.** "This could theoretically..." is a suggestion, not a bug. Require a realistic reproduction scenario for Critical/High.
+4. **Respect runtime evidence.** If the PR description or comments mention successful manual testing or link staging URLs, factor that into confidence scoring. Qualify static-analysis-only findings accordingly.
+5. **Svelte 5 ≠ Svelte 4.** `$state` creates deeply reactive proxies on native arrays and objects (`.push()` works). Reassigning a `$derived` variable is a bug — flag it.
+6. **CSS color pairs are self-contained.** Severity badges, status indicators, and alert classes set both `background-color` and `color` as a pair. They work in any theme. Only flag color issues when an element relies on the inherited page background.
+7. **3+ occurrences = convention.** If a pattern is used throughout the codebase, it's intentional.
+8. **No duplicating human reviewers.** Check existing comments from step 1 before reporting.
+9. **No migration-period false alarms.** Temporary fallbacks and dual paths during migrations are intentional.
+
+## Step 4: Post-filter all findings
+
+Before presenting results, run each finding through this checklist:
+
+- [ ] Is the flagged file in the PR diff?
+- [ ] Is the flagged line actually changed in this PR?
+- [ ] Did I read the full surrounding context (not just the flagged line)?
+- [ ] Can I describe a concrete, realistic failure scenario?
+- [ ] Does the PR demo/screenshot contradict my finding?
+- [ ] Is this pattern used elsewhere in the codebase (grep for it)?
+- [ ] Has a human reviewer already flagged this?
+- [ ] Am I applying the correct framework version's semantics?
+
+**If any check fails, drop the finding.**
+
+## Step 5: Format output
+
+```markdown
+# PR Review: [title]
+
+**Reviewed files:** [N files from diff]
+**Existing review comments noted:** [count, if any]
+
+## Issues (sorted by confidence)
+1. **[file:line]** (confidence: N/100) — Description.
+   **Reproduction:** How this fails in practice.
+   **Fix:** Concrete suggestion.
+
+[... up to 5 max ...]
+
+## Suggestions (optional, low confidence)
+- Brief one-liners only
+
+## Strengths
+- What the PR does well
+
+## Systemic notes (if any)
+- At most 1-2 one-liners about patterns noticed outside the diff, clearly labeled as future work
+```
+
+If no issues meet the confidence threshold:
+```markdown
+# PR Review: [title]
+
+No significant issues found. Reviewed [N] files from the diff.
+
+## Strengths
+- ...
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,5 +23,17 @@ Tests follow `test_*.py` naming and Pytest markers such as `@pytest.mark.docker_
 ## Commit & Pull Request Guidelines
 Adopt the Conventional Commits style observed in history (`fix(scope): message`, `feature(app): ...`). Compose commits around a single logical change and run lint/tests before pushing. Pull requests should describe intent, outline manual validation steps, and link tracking issues; include screenshots or API payload snippets when UI or API responses change.
 
+## Pull Request Review Guidelines
+- **Scope reviews to the PR diff only.** Only flag issues in files and lines actually changed in the pull request. Do not audit the broader codebase for related issues — that is a separate task, not a PR review. If you notice a broader pattern worth mentioning, note it once as an aside at the end, not as individual findings.
+- **Limit findings to 3-5 maximum.** Prioritize ruthlessly. If unsure whether something is real, omit it. A review with 2 correct findings is more valuable than 2 correct findings buried among 5 false positives.
+- **Verify claims before flagging.** Read the full context (complete CSS rule, surrounding function, component logic) before reporting. Do not flag `color: black` without checking the selector's `background-color`. Do not flag a variable as unused without grepping. Do not flag a function as broken without reading its callers.
+- **Require concrete failure scenarios for bugs.** Only label something "Critical" or "likely a bug" if you can demonstrate a realistic reproduction. Theoretical edge cases involving UUIDs, rare events, or unlikely race conditions are suggestions at best. Use "potential concern" or "worth verifying" for speculative findings.
+- **Respect runtime evidence.** When a PR description or comments mention successful manual testing or link staging URLs, factor that into confidence scoring. Qualify static-analysis-only findings accordingly.
+- **Treat repeated patterns as conventions.** If a pattern appears in 3+ places in the codebase, it is likely a deliberate project convention, not a bug. Do not flag it.
+- **Check existing comments first.** Do not re-report issues already identified by human reviewers in the same PR.
+- **Svelte 5 runes are not Svelte 4.** `$state` creates deeply reactive proxies on native arrays and objects — `.push()` on a `$state` array triggers reactivity (no reassignment needed). Reassigning a `$derived` variable is a bug and should be flagged. Do not apply Svelte 4 mental models to this codebase.
+- **CSS color pairs are self-contained.** Severity badges, status indicators, and alert classes set both `background-color` and `color` as a pair. They work in any theme. Only flag color issues when an element relies on the inherited page background.
+- **Do not flag migration-period code.** Fallbacks, temporary dual paths, and compatibility shims in PRs that are part of an ongoing migration are intentional.
+
 ## Configuration & Security Notes
 Never commit secrets: When testing against Cassandra, use the Docker compose setup in `dev-db/` and tear it down after use. Keep sample data archives outside the repository to avoid leaking production artifacts.


### PR DESCRIPTION
Add project-specific rules to AGENTS.md and a /review-pr slash command to reduce false positives in AI-generated code reviews. Rules derived from analysis of PRs #916, #919, #926, #931, #936, #939 where 70-86% of AI findings were noise.