### PR TITLE
docs: add request replay design document

### DIFF
--- a/docs/plans/request_replay.md
+++ b/docs/plans/request_replay.md
@@ -1,0 +1,777 @@
+# Argus Request Replay
+
+## Problem Statement
+
+Argus can go down for various reasons — maintenance windows, infrastructure failures, bugs, database issues. Test results produced by SCT, DTest, driver-matrix-tests, and sirenada are expensive to generate (long-running tests on cloud infrastructure). When Argus is unavailable during a test run, all submitted data is permanently lost.
+
+The current retry mechanism in the Python client (`urllib3.Retry` with `max_retries=3` and `backoff_factor=1`) only handles transient network blips. It cannot recover from extended Argus outages that may last minutes or hours during a multi-hour test run.
+
+**Goal:** Build a replay system that captures every Argus API request in a machine-parseable format, always on by default, so that when Argus recovers, all failed submissions can be replayed to reconstruct the intended system state.
+
+---
+
+## 1. Current Implementation
+
+### 1.1 Client Architecture
+
+All Argus API communication flows through the `ArgusClient` base class in `argus/client/base.py`. Every HTTP request passes through exactly two methods:
+
+- `get()` (line 116) — used for status checks, data retrieval
+- `post()` (line 132) — used for all data submissions
+
+This single chokepoint makes it straightforward to intercept all requests.
+
+**Current logging (DEBUG level):**
+```python
+# base.py line 121
+LOGGER.debug("GET Request: %s, params: %s", url, params)
+# base.py line 128
+LOGGER.debug("GET Response: %s %s", response.status_code, response.url)
+# base.py line 143
+LOGGER.debug("POST Request: %s, params: %s, body: %s", url, params, body)
+# base.py line 151
+LOGGER.debug("POST Response: %s %s", response.status_code, response.url)
+```
+
+These debug logs are human-readable but not machine-parseable. They lack structure, don't include all the fields needed for replay, and are mixed in with all other application logs.
+
+**Retry configuration:**
+```python
+retry_strategy = Retry(
+    total=max_retries,       # default: 3
+    connect=max_retries,
+    read=max_retries,
+    status=0,                # no HTTP status retries
+    backoff_factor=1,
+    status_forcelist=(),     # empty — no status code triggers
+    allowed_methods=["GET", "POST"],
+)
+```
+
+This retries on connection failures and read timeouts only, not on HTTP error status codes. Once retries are exhausted, the exception propagates and data is lost.
+
+### 1.2 Client Types
+
+Four specialized clients extend `ArgusClient`, each with their own test type and routes:
+
+| Client | File | test_type | Routes |
+|--------|------|-----------|--------|
+| `ArgusSCTClient` | `argus/client/sct/client.py` | `scylla-cluster-tests` | 24+ (packages, screenshots, resources, nemesis, events, junit, stress commands, config, email, performance, gemini) |
+| `ArgusGenericClient` | `argus/client/generic/client.py` | `generic` | 3 (submit_run, trigger_jobs, finalize) |
+| `ArgusDriverMatrixClient` | `argus/client/driver_matrix_tests/client.py` | `driver-matrix-tests` | 3 (submit_driver_result, submit_driver_failure, submit_env) |
+| `ArgusSirenadaClient` | `argus/client/sirenada/client.py` | `sirenada` | 1 (submit_sirenada_run — does everything in one call) |
+
+All clients inherit the same `get()` and `post()` methods, so the replay log integration happens once in the base class.
+
+### 1.3 Usage in SCT (scylla-cluster-tests)
+
+SCT is the largest consumer. Key integration points:
+
+- **Client initialization:** `sdcm/utils/argus.py` — `get_argus_client()` creates an `ArgusSCTClient` with credentials from `KeyStore`
+- **Result submission:** `sdcm/argus_results.py` — `submit_results_to_argus()` wraps `client.submit_results()` with error handling
+- **Event pipeline:** `sdcm/sct_events/argus.py` — multi-threaded pipeline: `ArgusEventCollector` → `ArgusEventAggregator` → `ArgusEventPostman`
+- **Error handling pattern:** All argus calls are wrapped in try/except that logs warnings but doesn't fail the test
+
+The event pipeline is particularly relevant because it operates across multiple threads, making sequence ordering critical.
+
+### 1.4 Usage in pytest-argus-reporter
+
+The pytest plugin (`pytest-argus-reporter/pytest_argus_reporter.py`) uses `ArgusGenericClient` and supports configuration via command-line options:
+- `--argus-run-id`
+- `--argus-test-type`
+- `--argus-api-key`
+- `--argus-base-url`
+
+### 1.5 SCT's Existing Self-Healing for Argus Failures
+
+SCT has several mechanisms to handle argus failures. Understanding them is critical because the replay log should complement — not duplicate — these existing patterns.
+
+#### 1.5.1 Graceful Degradation via MagicMock (Production Anti-Pattern)
+
+When argus initialization fails, the client falls back to `unittest.mock.MagicMock` (`sdcm/test_config.py`). All subsequent argus calls silently succeed (no-op). The test continues without argus. This means **no data is captured at all** — it's pure graceful degradation with total data loss.
+
+Using `unittest.mock.MagicMock` as a production fallback is an anti-pattern. It silently swallows every method call on every attribute chain, making it impossible to distinguish "argus is disabled" from "argus call has a bug." It also means the replay log never gets written because the real client was never instantiated.
+
+**Proposed replacement:** If argus client initialization fails (network error, auth error, etc.), the client should either:
+
+1. **Fail the test** — if the team decides argus data is mandatory, the test should not run without it. This is the safest option for preventing silent data loss.
+2. **Switch to replay-only mode** — the `ArgusClient` is still instantiated with a valid `ReplayLog`, but all HTTP calls are skipped. The replay log records every intended request with `"success": false`. When argus recovers, the entire test run can be reconstructed from the JSONL file via `argus replay` or the server-side ingest endpoint (Section 6.4). This gives the same graceful degradation as MagicMock but with **zero data loss**.
+
+The replay-only mode is implemented at the `ArgusClient` level — no changes needed in consumer projects. The client constructor accepts a `replay_only: bool` flag (or detects it from a failed health check), and `get()`/`post()` skip the HTTP call but still write to the replay log.
+
+#### 1.5.2 Heartbeat Thread with Limited Retry
+
+The heartbeat thread (`sdcm/tester.py:466-490`) implements a simple retry:
+
+```python
+fail_count = 0
+while not stop_signal.is_set():
+    if fail_count > 5:
+        break                      # Give up after 5 consecutive failures
+    try:
+        client.sct_heartbeat()
+        fail_count = 0             # Reset on success
+    except Exception:
+        fail_count += 1
+    stop_signal.wait(timeout=30.0) # 30-second interval
+```
+
+After 5 consecutive failures (~2.5 minutes), the heartbeat thread exits permanently. No further heartbeats are sent for the rest of the test run.
+
+#### 1.5.3 Event Pipeline — Fire-and-Forget
+
+The three-stage event pipeline (`sdcm/sct_events/argus.py`) uses `verbose_suppress()` around every operation:
+
+- **ArgusEventCollector** — extracts event data, skips on error
+- **ArgusEventAggregator** — deduplicates within 90-second windows, skips on error
+- **ArgusEventPostman** — calls `client.submit_event()`, suppresses on error
+
+There is **no retry, no buffer, no queue persistence**. If `submit_event()` fails, the event is lost from the real-time pipeline.
+
+#### 1.5.4 Offline Event Recovery (`argus_offline_collect_events`)
+
+This is SCT's primary recovery mechanism (`sdcm/utils/argus.py:94-107`). Called from `store_logs_in_argus()` in `sct.py:1865-1866`:
+
+```python
+# sct.py — after log collection
+if not argus_client.get_run().get("events"):
+    argus_offline_collect_events(client=argus_client)
+```
+
+The function:
+1. Reads the local `~/sct-results/latest/` directory
+2. Reconstructs `EventsProcessesRegistry` from disk
+3. Collects the last 100 events grouped by severity
+4. Submits them as a batch via `client.submit_events()`
+
+**Limitations:**
+- Only recovers **events** — not results, resources, packages, nemesis, configs, or any other data type
+- Only triggered during the `collect-logs` CLI step — if that step doesn't run, no recovery
+- Checks `get_run().get("events")` — if the run itself wasn't submitted (argus was down from the start), `get_run()` will fail and recovery is skipped
+- Limited to 100 most recent events — older events are lost
+- SCT-specific — doesn't help generic, driver-matrix, or sirenada tests
+
+#### 1.5.5 Test Finalization — Single Attempt
+
+`argus_finalize_test_run()` (`sdcm/tester.py:659-683`) submits events, sets status, and finalizes — all in a single try/except. If any call fails, the entire finalization is logged and skipped. No retry.
+
+#### 1.5.6 Node Operations — No Retry
+
+All node-level argus operations (`_add_node_to_argus`, `update_shards_in_argus`, `_terminate_node_in_argus` in `sdcm/cluster.py`) catch exceptions and log them. No retry, no recovery.
+
+#### 1.5.7 Summary of Gaps
+
+| Data Type | Current Recovery | Gap |
+|-----------|-----------------|-----|
+| Events (real-time) | None — fire-and-forget | Lost if argus is down during event |
+| Events (batch) | `argus_offline_collect_events` — last 100 from disk | Only 100 events, only during `collect-logs`, only if run exists in argus |
+| Test run submission | None | If argus is down at test start, nothing works |
+| Test status | None | Lost |
+| Results/performance | None | Lost — most expensive data |
+| Resources (nodes) | None | Lost |
+| Packages | None | Lost |
+| Nemesis records | None | Lost |
+| Logs/screenshots | None | Lost (links only, actual files are on S3) |
+| JUnit reports | None | Lost |
+| Config | None | Lost |
+| Stress commands | None | Lost |
+
+**The replay log addresses all of these gaps** because it records at the HTTP layer — every `get()` and `post()` call is captured regardless of the data type. SCT's existing recovery is event-specific and limited; the replay log is universal.
+
+#### 1.5.8 How the Replay Log Replaces SCT's Self-Healing
+
+With the replay log in place, SCT's custom recovery code becomes redundant and can be removed. The replay log operates at the HTTP layer inside `ArgusClient` itself, so it captures every data type across all test types — something SCT's event-specific recovery never could.
+
+**Code that can be deleted from SCT:**
+
+1. **`argus_offline_collect_events()`** (`sdcm/utils/argus.py:94-107`) — This function reads events from disk and re-submits them. The replay log captures the original `submit_event()` calls with full payloads (not limited to 100), making offline collection redundant.
+
+2. **The `if not argus_client.get_run().get("events")` check** (`sct.py:1865-1866`) — This conditional triggers offline event recovery during `store_logs_in_argus()`. With the replay log, there's no need to check whether events made it to argus and manually re-collect them.
+
+3. **`MagicMock` fallback** (`sdcm/test_config.py`) — Replaced by the client's replay-only mode. The real `ArgusClient` is always instantiated (with replay log), so data is never silently lost.
+
+**Code that remains unchanged in SCT:**
+
+- `verbose_suppress()` wrappers in the event pipeline — still useful for preventing test failures from argus errors
+- `try/except` wrappers around argus calls in `tester.py`, `cluster.py` — still useful for graceful degradation
+- Heartbeat thread — still useful for signaling test liveness to argus
+
+**What changes for other consumers (dtest, driver-matrix, sirenada):**
+
+Nothing. They get the replay log automatically because it's in `ArgusClient`. They never had SCT-style recovery code, so there's nothing to delete — they just gain recovery capability they never had.
+
+---
+
+## 2. Always-On JSONL Replay Log
+
+### 2.1 Design Principles
+
+This is **not** request logging for debugging. This is a **replay journal** — a write-ahead log of every API call that can be used to reconstruct Argus state from scratch.
+
+1. **Always on by default** — we don't know when Argus will start failing, so every request must be recorded
+2. **Independent of request outcome** — captures what *should* be sent to achieve the desired state, not what happened
+3. **Single file per test run** — one test run is always one type, no need for multi-file complexity
+4. **Persistent atomic sequence numbers** — `seq` field uses a lock-protected counter that survives process restarts; this determines the exact replay order even in concurrent environments
+5. **Records success/failure** — so replay can filter to only re-send what failed
+
+### 2.2 New Module: `argus/client/replay_log.py`
+
+A `ReplayLog` class initialized in `ArgusClient.__init__()`, always active. Writes to a single JSONL file.
+
+**File location:** `{log_dir}/argus_replay_{run_id}.jsonl`
+- `log_dir` determined by constructor param or `ARGUS_LOG_DIR` env var, falling back to current working directory
+
+### 2.3 JSONL Record Schema
+
+Each line in the file is a self-contained JSON object:
+
+```json
+{
+  "seq": 1,
+  "ts": "2024-01-15T10:30:00.123456Z",
+  "method": "POST",
+  "endpoint": "/testrun/$type/$id/submit_results",
+  "location_params": {"type": "scylla-cluster-tests", "id": "550e8400-e29b-41d4-a716-446655440000"},
+  "params": null,
+  "body": {
+    "schema_version": "v8",
+    "run_id": "550e8400-e29b-41d4-a716-446655440000",
+    "name": "Performance Results",
+    "description": "Throughput metrics",
+    "columns": [...],
+    "results": [...]
+  },
+  "test_type": "scylla-cluster-tests",
+  "success": true
+}
+```
+
+**Field descriptions:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `seq` | int | Atomic, persistent sequence number. Determines replay order. |
+| `ts` | string | ISO 8601 timestamp of when the request was made. |
+| `method` | string | HTTP method: `"GET"` or `"POST"`. |
+| `endpoint` | string | Route template with `$` placeholders (e.g. `/testrun/$type/$id/submit_results`). Enables replay against any Argus instance. |
+| `location_params` | object | Parameters to resolve the endpoint template into a full path. |
+| `params` | object\|null | URL query parameters. |
+| `body` | object\|null | Full request body as sent to the API. Includes `schema_version` via `generic_body`. |
+| `test_type` | string | The client's test type (redundant with body but useful for filtering). |
+| `success` | bool | `true` if HTTP 200 and response status "ok", `false` otherwise. |
+
+**What is NOT stored (by design):**
+- Auth token — security: tokens are per-user and may rotate
+- HTTP headers — reconstructed at replay time
+- Response body — not needed for replay; success/failure is enough
+- `schema_version` as separate field — already embedded in every `body` via `generic_body`
+
+### 2.4 Persistent Sequence Number
+
+The `seq` counter must survive process restarts. If the log file already exists (e.g. a test process crashed and restarted, or another component writes to the same run's log), the counter resumes from the last recorded value.
+
+```python
+import threading
+import json
+import datetime
+from pathlib import Path
+
+
+class ReplayLog:
+    def __init__(self, log_dir: str, run_id: str, test_type: str):
+        self._lock = threading.Lock()
+        self._path = Path(log_dir) / f"argus_replay_{run_id}.jsonl"
+        self._test_type = test_type
+        self._seq = self._load_last_seq()
+        self._file = open(self._path, "a")
+
+    def _load_last_seq(self) -> int:
+        """Resume sequence from existing file. Reads last line only — O(1)."""
+        if not self._path.exists() or self._path.stat().st_size == 0:
+            return 0
+        with open(self._path, "rb") as f:
+            # Seek backwards from EOF to find the last complete line
+            try:
+                f.seek(-2, 2)
+                while f.read(1) != b"\n":
+                    f.seek(-2, 1)
+            except OSError:
+                # File has only one line
+                f.seek(0)
+            last_line = f.readline().decode()
+        try:
+            return json.loads(last_line)["seq"]
+        except (json.JSONDecodeError, KeyError):
+            return 0
+
+    def record(self, method: str, endpoint: str, location_params: dict | None,
+               params: dict | None, body: dict | None, success: bool):
+        """Record a request to the replay log.
+
+        Only the seq counter is synchronized. File writes happen outside
+        the lock since replay sorts by seq — disk order doesn't matter.
+        """
+        with self._lock:
+            self._seq += 1
+            seq = self._seq
+
+        entry = {
+            "seq": seq,
+            "ts": datetime.datetime.now(datetime.UTC).isoformat(),
+            "method": method,
+            "endpoint": endpoint,
+            "location_params": location_params,
+            "params": params,
+            "body": body,
+            "test_type": self._test_type,
+            "success": success,
+        }
+        # json.dumps + write + flush happen outside the lock.
+        # Lines may interleave on disk but each is a complete JSON line
+        # and replay sorts by seq, so disk order is irrelevant.
+        self._file.write(json.dumps(entry, default=str) + "\n")
+        self._file.flush()
+
+    def close(self):
+        self._file.close()
+```
+
+**Why only lock the counter, not the write:**
+
+The replay tool sorts entries by `seq` before executing, so lines don't need to be ordered on disk. By holding the lock only for the integer increment (nanoseconds), we eliminate contention from JSON serialization and disk I/O. In concurrent systems like SCT's event pipeline (multiple threads submitting events simultaneously), this is a significant performance win.
+
+Python's `file.write()` under the GIL guarantees that individual `write()` calls won't produce interleaved bytes, so concurrent writes of complete JSON lines are safe without a write lock.
+
+### 2.5 Integration into ArgusClient
+
+The replay log is initialized in `ArgusClient.__init__()` and called from `get()` and `post()`:
+
+```python
+class ArgusClient:
+    def __init__(self, auth_token, base_url, ..., log_dir: str | None = None):
+        # ... existing init code ...
+        self._replay_log = ReplayLog(
+            log_dir=log_dir or os.environ.get("ARGUS_LOG_DIR", "."),
+            run_id=getattr(self, "run_id", "unknown"),
+            test_type=getattr(self, "test_type", "unknown"),
+        )
+
+    def post(self, endpoint, location_params=None, params=None, body=None):
+        url = self.get_url_for_endpoint(endpoint=endpoint, location_params=location_params)
+        LOGGER.debug("POST Request: %s, params: %s, body: %s", url, params, body)
+        response = self.session.post(url=url, params=params, json=body,
+                                      headers=self.request_headers, timeout=self._timeout)
+        LOGGER.debug("POST Response: %s %s", response.status_code, response.url)
+
+        # Record to replay log — determine success without raising
+        success = response.status_code == 200
+        if success:
+            try:
+                success = response.json().get("status") == "ok"
+            except Exception:
+                success = False
+        self._replay_log.record(
+            method="POST", endpoint=endpoint,
+            location_params=location_params, params=params,
+            body=body, success=success,
+        )
+
+        return response
+```
+
+The same pattern applies to `get()`. The replay log write happens after the request completes (or fails), before the response is returned to the caller. This ensures we capture the actual success/failure status.
+
+---
+
+## 3. Log Storage Strategy
+
+### 3.1 Problem
+
+Each project using the argus client has different log directories and artifact upload conventions. We need a uniform approach that doesn't require new infrastructure.
+
+### 3.2 Solution: Ride With Existing Artifacts
+
+The JSONL file is placed in each project's existing log directory and uploaded alongside existing test artifacts:
+
+| Project | Log Directory | Upload Mechanism |
+|---------|-------------|-----------------|
+| SCT | `~/sct-results/latest/` | Already uploads to S3 via `sdcm` |
+| DTest (pytest) | pytest `--basetemp` or CWD | CI artifact upload step |
+| Driver Matrix | Jenkins workspace | CI artifact upload step |
+| Sirenada | Test results path (passed to client) | Already uploads to S3 |
+
+### 3.3 Convention
+
+1. Pass `log_dir` to the client constructor, or set `ARGUS_LOG_DIR` environment variable. Falls back to current working directory.
+2. File naming: `argus_replay_{run_id}.jsonl` — one file per test run.
+3. The file is uploaded alongside existing test artifacts — no new upload mechanism needed.
+4. For `pytest-argus-reporter`: add `--argus-log-dir` command-line option that passes through to `ArgusGenericClient`.
+
+---
+
+## 4. `argus replay` CLI Command
+
+The replay mechanism is implemented in the `argus-cli` Go project because it is the official Argus tooling.
+
+### 4.1 Command Interface
+
+```
+argus replay <path-to-jsonl-file> [flags]
+
+Flags:
+  --failed-only       Only replay requests that originally failed (default: true)
+  --filter-endpoint   Only replay requests matching this endpoint pattern (glob)
+  --dry-run           Parse and validate without sending requests
+  --force-all         Ignore idempotency checks, replay everything
+  --target-url        Override the base URL (replay against different Argus instance)
+  --concurrency       Max parallel requests (default: 1 — sequential)
+  --report            Output format for summary: "text" (default) or "json"
+  --run-id            Filter to a specific run_id
+```
+
+**Examples:**
+
+```bash
+# Replay all failed requests from a test run
+argus replay ./argus_replay_550e8400.jsonl
+
+# Dry-run to see what would be replayed
+argus replay ./argus_replay_550e8400.jsonl --dry-run
+
+# Replay against a different Argus instance
+argus replay ./argus_replay_550e8400.jsonl --target-url https://argus-staging.example.com
+
+# Replay everything, including successful requests (full state reconstruction)
+argus replay ./argus_replay_550e8400.jsonl --failed-only=false --force-all
+
+# Batch replay after outage
+find /path/to/logs -name "argus_replay_*.jsonl" | xargs argus replay --failed-only --report json
+```
+
+### 4.2 Go Package Structure
+
+New package: `cli/internal/replay/`
+
+```
+cli/internal/replay/
+├── parser.go       # JSONL file reader → []ReplayEntry
+├── ordering.go     # Sort by seq, group submit/middle/finalize
+├── executor.go     # HTTP replay with idempotency logic
+├── reporter.go     # Summary output (text table or JSON)
+└── *_test.go       # Tests for each component
+```
+
+New command file: `cli/cmd/replay.go` — follows patterns from `cli/cmd/testrun.go`.
+
+### 4.3 Replay Ordering
+
+The `seq` field from the JSONL records determines execution order:
+
+1. **Parse** all entries from the file
+2. **Filter** based on flags (`--failed-only`, `--filter-endpoint`, `--run-id`)
+3. **Sort** by `seq` — the atomic counter guarantees causal ordering even from concurrent producers
+4. **Group** into three phases:
+   - **Phase A (sequential):** `submit_run` / `submit_*_run` entries — must execute first; if the run already exists in Argus, skip
+   - **Phase B (optionally parallel):** All other operations — replay in `seq` order; `--concurrency > 1` enables parallel execution within this group
+   - **Phase C (sequential):** `finalize_run` / `finalize_*_run` entries — must execute last
+5. **Execute** each phase, applying the appropriate idempotency strategy
+
+### 4.4 URL Reconstruction
+
+The replay command reconstructs the full URL from the stored `endpoint` template and `location_params`:
+
+```go
+// Given:
+//   endpoint: "/testrun/$type/$id/submit_results"
+//   location_params: {"type": "scylla-cluster-tests", "id": "uuid"}
+//   target_url: "https://argus.scylladb.com" (from --target-url or config)
+
+url := targetURL + "/api/v1/client" + resolveEndpoint(endpoint, locationParams)
+// Result: "https://argus.scylladb.com/api/v1/client/testrun/scylla-cluster-tests/uuid/submit_results"
+```
+
+This allows replaying against any Argus instance, not just the original target.
+
+---
+
+## 5. Endpoint Idempotency Classification
+
+Each API endpoint is classified into one of four replay strategies. The `argus replay` command uses this classification to determine how to handle each entry.
+
+### 5.1 SAFE — Replay Freely
+
+These endpoints are idempotent or last-write-wins. Replaying them multiple times produces the same result.
+
+| Endpoint | Client Methods |
+|----------|---------------|
+| `/testrun/$type/$id/set_status` | `set_status()`, `set_sct_run_status()`, `set_matrix_status()` |
+| `/testrun/$type/$id/heartbeat` | `heartbeat()`, `sct_heartbeat()` |
+| `/testrun/$type/$id/update_product_version` | `update_product_version()`, `update_scylla_version()` |
+| `/sct/$id/sct_runner/set` | `set_sct_runner()` |
+| `/testrun/$type/$id/logs/submit` | `submit_logs()`, `submit_sct_logs()` |
+| `/sct/$id/screenshots/submit` | `submit_screenshots()` |
+| `/sct/$id/packages/submit` | `submit_packages()` |
+| `/sct/$id/events/submit` | `submit_events()` (batch overwrites) |
+| `/sct/$id/resource/$name/update` | `update_resource()` |
+| `/sct/$id/resource/$name/shards` | `update_shards_for_resource()` |
+| `/$id/config/submit` | `sct_submit_config()` |
+| `/driver_matrix/env/submit` | `submit_env()` |
+| `/testrun/$type/$id/finalize` | `finalize_run()`, `finalize_sct_run()`, `finalize_generic_run()` |
+| `/testrun/$type/$id/submit_results` | `submit_results()` — keyed by table name, overwrites |
+
+### 5.2 CHECK_FIRST — Verify Before Replay
+
+These endpoints create new entities. Replaying when the entity already exists would cause errors or duplicates.
+
+| Endpoint | Check Method | Client Methods |
+|----------|-------------|---------------|
+| `/testrun/$type/submit` | `GET /testrun/$type/$id/get` — if 200, skip | `submit_run()`, `submit_sct_run()`, `submit_generic_run()`, `submit_driver_matrix_run()`, `submit_sirenada_run()` |
+| `/sct/$id/resource/create` | Check by resource name in run data | `create_resource()` |
+
+### 5.3 APPEND — May Create Duplicates
+
+These endpoints add records that may not have natural deduplication keys. The replay command warns the user when replaying these.
+
+| Endpoint | Risk | Client Methods |
+|----------|------|---------------|
+| `/sct/$id/event/submit` | Duplicate events | `submit_event()` |
+| `/sct/$id/nemesis/submit` | Duplicate nemesis records | `submit_nemesis()` |
+| `/sct/$id/nemesis/finalize` | Must pair with submit | `finalize_nemesis()` |
+| `/driver_matrix/result/submit` | Duplicate driver results | `submit_driver_result()` |
+| `/driver_matrix/result/fail` | Duplicate failure records | `submit_driver_failure()` |
+| `/sct/$id/stress_cmd/submit` | Duplicate stress commands | `add_stress_command()` |
+| `/sct/$id/junit/submit` | Duplicate junit reports | `sct_submit_junit_report()` |
+| `/sct/$id/gemini/submit` | Duplicate gemini results | `submit_gemini_results()` |
+| `/sct/$id/performance/submit` | Duplicate perf results | `submit_performance_results()` |
+
+### 5.4 SKIP — Do Not Replay by Default
+
+These endpoints have side effects beyond Argus state. They are skipped unless `--force-all` is passed.
+
+| Endpoint | Side Effect | Client Methods |
+|----------|------------|---------------|
+| `/testrun/report/email` | Sends actual emails | `send_email()` |
+| `/planning/plan/trigger` | Triggers CI jobs | `trigger_jobs()` |
+| `/sct/$id/resource/$name/terminate` | Destructive state change | `terminate_resource()` |
+
+---
+
+## 6. Automation
+
+The goal is full automation without adding new services.
+
+### 6.1 In-Process Retry After Test Completion
+
+Add a `replay_failed()` method to `ReplayLog`:
+
+```python
+def replay_failed(self, client: "ArgusClient") -> dict:
+    """Attempt to replay failed requests. Called after test completion.
+
+    Returns dict with counts: {"total": N, "replayed": N, "succeeded": N, "failed": N}
+    """
+    self._file.flush()
+    stats = {"total": 0, "replayed": 0, "succeeded": 0, "failed": 0}
+
+    with open(self._path, "r") as f:
+        for line in f:
+            entry = json.loads(line)
+            stats["total"] += 1
+            if entry["success"]:
+                continue
+            stats["replayed"] += 1
+            try:
+                if entry["method"] == "POST":
+                    response = client.post(
+                        endpoint=entry["endpoint"],
+                        location_params=entry["location_params"],
+                        params=entry["params"],
+                        body=entry["body"],
+                    )
+                else:
+                    response = client.get(
+                        endpoint=entry["endpoint"],
+                        location_params=entry["location_params"],
+                        params=entry["params"],
+                    )
+                client.check_response(response)
+                stats["succeeded"] += 1
+            except Exception:
+                stats["failed"] += 1
+
+    return stats
+```
+
+This is called automatically in `ArgusClient.finalize_run()` when the replay log is active. It's best-effort — failures are logged but don't affect the test's exit status. Argus may have recovered by the time the test finishes, so this catches many transient outages without any manual intervention.
+
+### 6.2 Manual Replay From S3
+
+For extended outages where the in-process retry also fails:
+
+```bash
+# Download test artifacts (includes JSONL file)
+argus run logs download <run-id>
+
+# Replay only failed requests
+argus replay argus_replay_*.jsonl --failed-only --report
+```
+
+### 6.3 Batch Replay for Outage Recovery
+
+After an extended Argus outage affecting multiple test runs:
+
+```bash
+# Find all replay logs and replay failed requests
+find /path/to/downloaded/logs -name "argus_replay_*.jsonl" \
+  | xargs argus replay --failed-only --report json > replay_report.json
+
+# Review the report
+cat replay_report.json | jq '.[] | select(.failed > 0)'
+```
+
+### 6.4 Server-Side Replay Ingest Endpoint
+
+Instead of requiring external tooling to replay requests one-by-one, Argus itself can accept a JSONL replay file and process it internally. This is the most powerful automation option — Argus heals itself.
+
+**New API endpoint:**
+
+```
+POST /api/v1/client/replay/ingest
+Content-Type: application/octet-stream (or multipart/form-data)
+
+Body: raw JSONL file content
+```
+
+**Query parameters:**
+- `failed_only=true` (default) — only process entries with `"success": false`
+- `dry_run=false` — if true, validate and return what would be replayed without executing
+- `force_all=false` — if true, skip idempotency checks
+
+**How it works:**
+
+1. Argus receives the JSONL file
+2. Parses entries, sorts by `seq`
+3. Applies the same ordering rules as `argus replay` CLI (submit first, finalize last)
+4. Applies idempotency classification (Section 5) — checks existence before creating, skips email/trigger endpoints
+5. Executes each entry against its own internal service layer directly (no HTTP overhead — calls the service functions that the API controller would call)
+6. Returns a summary report:
+
+```json
+{
+  "total": 47,
+  "processed": 12,
+  "succeeded": 11,
+  "failed": 1,
+  "skipped": 35,
+  "errors": [
+    {"seq": 23, "endpoint": "/sct/$id/nemesis/submit", "error": "Duplicate nemesis record"}
+  ]
+}
+```
+
+**Advantages over CLI replay:**
+- **No HTTP round-trip overhead** — Argus processes the replay internally by calling service functions directly, not re-issuing HTTP requests to itself
+- **Argus can self-heal** — After recovering from an outage, Argus can process replay files from S3 without any external tooling
+- **Atomic processing** — Argus can wrap the replay in a database transaction or batch operation
+- **Access control** — The endpoint uses the same `@api_login_required` auth as other client endpoints
+
+**Integration with test artifact storage:**
+
+Since replay JSONL files are uploaded to S3 alongside test logs, Argus can also pull them directly:
+
+```
+POST /api/v1/client/replay/ingest_from_s3
+Body: {"run_id": "uuid", "s3_path": "s3://bucket/path/argus_replay_uuid.jsonl"}
+```
+
+Or even scan for replay files automatically after recovering from downtime, processing any files that contain failed entries. This makes the system fully self-healing — no human intervention required after an outage.
+
+**CLI integration:**
+
+The `argus replay` CLI command can also use this endpoint instead of replaying client-side:
+
+```bash
+# Upload replay file to Argus for server-side processing
+argus replay ./argus_replay_550e8400.jsonl --server-side
+
+# Argus processes internally, returns summary
+```
+
+This is preferred over client-side replay when the JSONL file is large, because the server avoids HTTP round-trip overhead per entry.
+
+---
+
+## 7. Implementation Phases
+
+### Phase 1: Replay Log and Replay-Only Mode (Python Client)
+
+**New file:** `argus/client/replay_log.py`
+- `ReplayLog` class with persistent sequence counter
+- Thread-safe recording with minimal lock contention
+- `replay_failed()` method for in-process retry
+
+**Modify:** `argus/client/base.py`
+- Add `log_dir` parameter to `ArgusClient.__init__()`
+- Initialize `ReplayLog` (always on)
+- Add `replay_only` mode: when `True`, `get()` and `post()` skip the HTTP call but still write to the replay log with `"success": false`
+- Optional health check on init: if argus is unreachable, auto-enter replay-only mode
+- Call `record()` from `get()` and `post()` after each request
+- Call `replay_failed()` from `finalize_run()`
+
+**New file:** `argus/client/tests/test_replay_log.py`
+- Test JSONL format correctness
+- Test sequence number persistence across restarts
+- Test thread safety with concurrent writes
+- Test `replay_failed()` with mock server
+- Test replay-only mode skips HTTP but writes JSONL
+
+### Phase 2: pytest-argus-reporter Integration
+
+**Modify:** `pytest-argus-reporter/pytest_argus_reporter.py`
+- Add `--argus-log-dir` command-line option
+- Pass `log_dir` to `ArgusGenericClient` constructor
+
+### Phase 3: `argus replay` CLI Command (Go)
+
+**New command:** `cli/cmd/replay.go`
+- Cobra command following `testrun.go` patterns
+- Flags for filtering, dry-run, concurrency, reporting
+- `--server-side` flag to upload JSONL to Argus ingest endpoint instead of client-side replay
+
+**New package:** `cli/internal/replay/`
+- `parser.go` — JSONL file reader, deserializes into `ReplayEntry` structs
+- `ordering.go` — Sort by `seq`, group into submit/middle/finalize phases
+- `executor.go` — HTTP replay with idempotency strategy per endpoint
+- `reporter.go` — Text table and JSON summary output
+- `*_test.go` — Unit tests
+
+### Phase 4: Server-Side Replay Ingest (Argus Backend)
+
+**New blueprint:** `argus/backend/controller/replay_api.py`
+- `POST /api/v1/client/replay/ingest` — accepts JSONL file, processes internally
+- `POST /api/v1/client/replay/ingest_from_s3` — pulls JSONL from S3 by run_id
+- Applies ordering rules and idempotency classification
+- Calls service layer directly (no HTTP self-requests)
+- Returns summary report with per-entry status
+
+**New service:** `argus/backend/service/replay.py`
+- Parses JSONL entries
+- Maps endpoints to internal service functions
+- Applies idempotency checks (Section 5)
+- Batch processing with error collection
+
+### Phase 5: Automation and SCT Cleanup
+
+**Modify:** `argus/client/base.py`
+- Wire `replay_failed()` call into `finalize_run()` path
+- Add logging for replay attempt results
+
+**SCT changes (separate PR in scylla-cluster-tests):**
+- Remove `argus_offline_collect_events()` from `sdcm/utils/argus.py`
+- Remove the `if not argus_client.get_run().get("events")` check from `sct.py`
+- Replace `MagicMock` fallback with `replay_only=True` client initialization
+- Pass `log_dir` to `ArgusSCTClient` constructor (use existing `~/sct-results/latest/`)
+
+**Documentation:**
+- Update `docs/api_usage.md` with replay log and ingest endpoint information
+- Add examples for manual, batch, and server-side replay to this document

--- a/docs/plans/request_replay.md
+++ b/docs/plans/request_replay.md
@@ -117,7 +117,7 @@ while not stop_signal.is_set():
 
 After 5 consecutive failures (~2.5 minutes), the heartbeat thread exits permanently. No further heartbeats are sent for the rest of the test run.
 
-#### 1.5.3 Event Pipeline — Fire-and-Forget
+#### 1.5.3 Event Pipeline — Fire-and-Forget with Side-Log
 
 The three-stage event pipeline (`sdcm/sct_events/argus.py`) uses `verbose_suppress()` around every operation:
 
@@ -125,81 +125,60 @@ The three-stage event pipeline (`sdcm/sct_events/argus.py`) uses `verbose_suppre
 - **ArgusEventAggregator** — deduplicates within 90-second windows, skips on error
 - **ArgusEventPostman** — calls `client.submit_event()`, suppresses on error
 
-There is **no retry, no buffer, no queue persistence**. If `submit_event()` fails, the event is lost from the real-time pipeline.
+Events are not lost permanently even when `submit_event()` fails: the underlying `sct_events.log` file on disk contains all raw events and can be re-parsed. However, re-parsing that file requires running the full event-checking logic again. To make replay straightforward, every `submit_event()` call also appends the exact `RawEventPayload` body to a dedicated side-log file (see Section 2.2) **before** the HTTP call is made. This file can be fed directly to the ingest endpoint without any re-parsing.
 
-#### 1.5.4 Offline Event Recovery (`argus_offline_collect_events`)
+#### 1.5.4 Offline Event Recovery — Removed
 
-This is SCT's primary recovery mechanism (`sdcm/utils/argus.py:94-107`). Called from `store_logs_in_argus()` in `sct.py:1865-1866`:
+The previous `argus_offline_collect_events()` function (`sdcm/utils/argus.py:94-107`) was a SCT-specific recovery mechanism that read `EventsProcessesRegistry` from disk and re-submitted the last 100 events via the legacy `submit_events()` (aggregated severity/count) endpoint. It was triggered from `store_logs_in_argus()` in `sct.py:1865-1866`.
 
-```python
-# sct.py — after log collection
-if not argus_client.get_run().get("events"):
-    argus_offline_collect_events(client=argus_client)
-```
+**This mechanism and the `submit_events()` endpoint it depends on are removed.** The replay log (Section 2) replaces this recovery with a universal, data-type-agnostic approach that covers all endpoints, all test types, and is not limited to 100 events.
 
-The function:
+**Code removed from SCT:**
 
-1. Reads the local `~/sct-results/latest/` directory
-2. Reconstructs `EventsProcessesRegistry` from disk
-3. Collects the last 100 events grouped by severity
-4. Submits them as a batch via `client.submit_events()`
+1. `argus_offline_collect_events()` in `sdcm/utils/argus.py`
+2. The `if not argus_client.get_run().get("events"):` conditional in `sct.py:1865-1866`
+3. The one-shot re-fire block in `sdcm/tester.py` that called `submit_events` when the pipeline stage crashed or ended prematurely
 
-**Limitations:**
+**Removed from the Python client:**
 
-- Only recovers **events** — not results, resources, packages, nemesis, configs, or any other data type
-- Only triggered during the `collect-logs` CLI step — if that step doesn't run, no recovery
-- Checks `get_run().get("events")` — if the run itself wasn't submitted (argus was down from the start), `get_run()` will fail and recovery is skipped
-- Limited to 100 most recent events — older events are lost
-- SCT-specific — doesn't help generic, driver-matrix, or sirenada tests
+4. `ArgusSCTClient.submit_events()` (`argus/client/sct/client.py:326`) — legacy aggregated severity/count bulk submit
 
-#### 1.5.5 Test Finalization — Single Attempt
+**Removed from the backend:**
 
-`argus_finalize_test_run()` (`sdcm/tester.py:659-683`) submits events, sets status, and finalizes — all in a single try/except. If any call fails, the entire finalization is logged and skipped. No retry.
+5. `POST /client/sct/<run_id>/events/submit` — the legacy aggregated events endpoint
+
+#### 1.5.5 Test Finalization — Combined with Status
+
+The original `argus_finalize_test_run()` in `sdcm/tester.py:659-683` performed three operations in a single try/except: submit events (legacy), set status, and call finalize. If any call failed, the entire block was skipped.
+
+**This is simplified as follows:**
+
+- The legacy event submission step is removed (covered by the replay log).
+- `finalize_run()` — which only set `end_time` — is removed from the client call path.
+- When the backend receives a **terminal status** (`Failed`, `Aborted`, `Passed`, `Error`, `NotRun`) via `set_status`, it sets `end_time = now()` automatically **if `end_time` is not already set**.
+- The client calls only `set_status(terminal_status)` as the final operation. No separate finalize call is needed.
+- The `POST /client/testrun/:type/:id/finalize` endpoint remains on the backend for manual/forced finalization but is no longer part of the normal client flow.
 
 #### 1.5.6 Node Operations — No Retry
 
-All node-level argus operations (`_add_node_to_argus`, `update_shards_in_argus`, `_terminate_node_in_argus` in `sdcm/cluster.py`) catch exceptions and log them. No retry, no recovery.
+All node-level argus operations (`_add_node_to_argus`, `update_shards_in_argus`, `_terminate_node_in_argus` in `sdcm/cluster.py`) catch exceptions and log them. No retry, no recovery. These calls are captured by the replay log and can be replayed after an outage.
 
-#### 1.5.7 Summary of Gaps
+#### 1.5.7 Summary of Gaps Addressed
 
-| Data Type           | Current Recovery                                    | Gap                                                                      |
-| ------------------- | --------------------------------------------------- | ------------------------------------------------------------------------ |
-| Events (real-time)  | None — fire-and-forget                              | Lost if argus is down during event                                       |
-| Events (batch)      | `argus_offline_collect_events` — last 100 from disk | Only 100 events, only during `collect-logs`, only if run exists in argus |
-| Test run submission | None                                                | If argus is down at test start, nothing works                            |
-| Test status         | None                                                | Lost                                                                     |
-| Results/performance | None                                                | Lost — most expensive data                                               |
-| Resources (nodes)   | None                                                | Lost                                                                     |
-| Packages            | None                                                | Lost                                                                     |
-| Nemesis records     | None                                                | Lost                                                                     |
-| Logs/screenshots    | None                                                | Lost (links only, actual files are on S3)                                |
-| JUnit reports       | None                                                | Lost                                                                     |
-| Config              | None                                                | Lost                                                                     |
-| Stress commands     | None                                                | Lost                                                                     |
-
-**The replay log addresses all of these gaps** because it records at the HTTP layer — every `post()` call is captured regardless of the data type. SCT's existing recovery is event-specific and limited; the replay log is universal.
-
-#### 1.5.8 How the Replay Log Replaces SCT's Self-Healing
-
-With the replay log in place, SCT's custom recovery code becomes redundant and can be removed. The replay log operates at the HTTP layer inside `ArgusClient` itself, so it captures every data type across all test types — something SCT's event-specific recovery never could.
-
-**Code that can be deleted from SCT:**
-
-1. **`argus_offline_collect_events()`** (`sdcm/utils/argus.py:94-107`) — This function reads events from disk and re-submits them. The replay log captures the original `submit_event()` calls with full payloads (not limited to 100), making offline collection redundant.
-
-2. **The `if not argus_client.get_run().get("events")` check** (`sct.py:1865-1866`) — This conditional triggers offline event recovery during `store_logs_in_argus()`. With the replay log, there's no need to check whether events made it to argus and manually re-collect them.
-
-3. **`MagicMock` fallback** (`sdcm/test_config.py`) — Replaced by the client's replay-only mode. The real `ArgusClient` is always instantiated (with replay log), so data is never silently lost.
-
-**Code that remains unchanged in SCT:**
-
-- `verbose_suppress()` wrappers in the event pipeline — still useful for preventing test failures from argus errors
-- `try/except` wrappers around argus calls in `tester.py`, `cluster.py` — still useful for graceful degradation
-- Heartbeat thread — still useful for signaling test liveness to argus
-
-**What changes for other consumers (dtest, driver-matrix, sirenada):**
-
-Nothing. They get the replay log automatically because it's in `ArgusClient`. They never had SCT-style recovery code, so there's nothing to delete — they just gain recovery capability they never had.
+| Data Type           | Previous Recovery                        | With Replay Log                               |
+| ------------------- | ---------------------------------------- | --------------------------------------------- |
+| Events (real-time)  | None — fire-and-forget                   | Captured in JSONL side-log before HTTP call   |
+| Events (batch)      | `argus_offline_collect_events` — removed | Replaced by replay log                        |
+| Test run submission | None                                     | Captured in JSONL                             |
+| Test status         | None                                     | Captured in JSONL                             |
+| Results/performance | None                                     | Captured in JSONL                             |
+| Resources (nodes)   | None                                     | Captured in JSONL                             |
+| Packages            | None                                     | Captured in JSONL                             |
+| Nemesis records     | None                                     | Captured in JSONL                             |
+| Logs/screenshots    | None                                     | Captured in JSONL (links; actual files on S3) |
+| JUnit reports       | None                                     | Captured in JSONL                             |
+| Config              | None                                     | Captured in JSONL                             |
+| Stress commands     | None                                     | Captured in JSONL                             |
 
 ---
 
@@ -210,27 +189,32 @@ Nothing. They get the replay log automatically because it's in `ArgusClient`. Th
 This is **not** request logging for debugging. This is a **replay journal** — a write-ahead log of every API call that can be used to reconstruct Argus state from scratch.
 
 1. **Always on by default** — we don't know when Argus will start failing, so every mutating request must be recorded
-2. **Independent of request outcome** — captures what _should_ be sent to achieve the desired state, not what happened
-3. **Single file per test run** — one test run is always one type, no need for multi-file complexity
-4. **Persistent atomic sequence numbers** — `seq` field uses a lock-protected counter that survives process restarts; this determines the exact replay order even in concurrent environments
-5. **Records success/failure** — so replay can filter to only re-send what failed
+2. **Written before the HTTP call** — the record exists on disk even if the process crashes during the request
+3. **One file per process per run** — timestamp in the filename prevents parallel processes from overwriting each other (see Section 2.2)
+4. **Persistent atomic sequence numbers** — `seq` field uses a lock-protected counter; determines the exact replay order even in concurrent environments
+5. **`request_id` for idempotency** — a UUID generated per record before the HTTP call; the server uses this as the idempotency key, making it safe to replay records that may have succeeded server-side despite a client-side error
 
-### 2.2 New Module: `argus/client/replay_log.py`
+### 2.2 File Naming
 
-A `ReplayLog` class initialized in `ArgusClient.__init__()`, always active. Writes to a single JSONL file.
+```
+{log_dir}/sct_argus_events_{run_id}_{unix_ms}.jsonl
+```
 
-**File location:** `{log_dir}/argus_replay_{run_id}.jsonl`
+- `run_id` scopes the file to one test run.
+- `unix_ms` is Unix epoch time in milliseconds captured once at `ArgusClient.__init__()` time. This disambiguates parallel processes sharing the same `log_dir` and `run_id` (e.g. parallel pytest shards all reporting to the same run — each shard gets its own file).
+- `log_dir` is determined by constructor parameter or `ARGUS_LOG_DIR` env var, falling back to the current working directory.
 
-- `log_dir` determined by constructor param or `ARGUS_LOG_DIR` env var, falling back to current working directory
+**Multiple files per run are expected and supported.** The CLI upload command and backend ingest endpoint both handle multiple JSONL files for the same `run_id` by merging and sorting records by `seq` before execution.
 
 ### 2.3 JSONL Record Schema
 
-Each line in the file is a self-contained JSON object:
+Each line in the file is a self-contained JSON object written **before** the HTTP call:
 
 ```json
 {
+  "request_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
   "seq": 1,
-  "ts": "2024-01-15T10:30:00.123456Z",
+  "ts": 1712345678901,
   "method": "POST",
   "endpoint": "/testrun/$type/$id/submit_results",
   "location_params": {"type": "scylla-cluster-tests", "id": "550e8400-e29b-41d4-a716-446655440000"},
@@ -239,51 +223,70 @@ Each line in the file is a self-contained JSON object:
     "schema_version": "v8",
     "run_id": "550e8400-e29b-41d4-a716-446655440000",
     "name": "Performance Results",
-    "description": "Throughput metrics",
     "columns": [...],
     "results": [...]
   },
   "test_type": "scylla-cluster-tests",
-  "success": true
+  "success": null
 }
+```
+
+After the HTTP call completes (or fails), the record is updated in place with the outcome:
+
+```json
+{ ..., "success": true }
+```
+
+or
+
+```json
+{ ..., "success": false, "error": "ConnectionError: ..." }
 ```
 
 **Field descriptions:**
 
-| Field             | Type         | Description                                                                                                                 |
-| ----------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------- |
-| `seq`             | int          | Atomic, persistent sequence number. Determines replay order.                                                                |
-| `ts`              | string       | ISO 8601 timestamp of when the request was made.                                                                            |
-| `method`          | string       | HTTP method: `"GET"` or `"POST"`.                                                                                           |
-| `endpoint`        | string       | Route template with `$` placeholders (e.g. `/testrun/$type/$id/submit_results`). Enables replay against any Argus instance. |
-| `location_params` | object       | Parameters to resolve the endpoint template into a full path.                                                               |
-| `params`          | object\|null | URL query parameters.                                                                                                       |
-| `body`            | object\|null | Full request body as sent to the API. Includes `schema_version` via `generic_body`.                                         |
-| `test_type`       | string       | The client's test type (redundant with body but useful for filtering).                                                      |
-| `success`         | bool         | `true` if HTTP status is 2xx and the response body does not contain an `"error"` key, `false` otherwise.                    |
+| Field             | Type              | Description                                                                                                                 |
+| ----------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `request_id`      | string (UUID v4)  | Generated before the HTTP call. Server idempotency key — replaying the same `request_id` is a no-op.                        |
+| `seq`             | int               | Atomic, persistent sequence number. Determines replay order across files.                                                   |
+| `ts`              | int               | Unix epoch milliseconds at record write time.                                                                               |
+| `method`          | string            | HTTP method: always `"POST"` (only mutating calls are recorded).                                                            |
+| `endpoint`        | string            | Route template with `$` placeholders (e.g. `/testrun/$type/$id/submit_results`). Enables replay against any Argus instance. |
+| `location_params` | object\|null      | Parameters to resolve the endpoint template into a full path.                                                               |
+| `params`          | object\|null      | URL query parameters.                                                                                                       |
+| `body`            | object\|null      | Full request body as sent to the API.                                                                                       |
+| `test_type`       | string            | The client's test type (redundant with body but useful for filtering).                                                      |
+| `success`         | bool\|null        | `null` before the call. `true` if HTTP 2xx and response body has no `"error"` key. `false` otherwise.                       |
+| `error`           | string (optional) | Present only when `success` is `false`. Human-readable error description.                                                   |
 
 **What is NOT stored (by design):**
 
-- Auth token — security: tokens are per-user and may rotate
-- HTTP headers — reconstructed at replay time
-- Response body — not needed for replay; success/failure is enough
-- `schema_version` as separate field — already embedded in every `body` via `generic_body`
+- Auth token — tokens are per-user and may rotate; reconstructed at replay time
+- HTTP response body — not needed for replay
+- `schema_version` as a separate field — already embedded in every `body`
 
-### 2.4 Persistent Sequence Number
+### 2.4 Why "Failed Only" Replay is Unsafe
 
-The `seq` counter must survive process restarts. If the log file already exists (e.g. a test process crashed and restarted, or another component writes to the same run's log), the counter resumes from the last recorded value.
+A record with `"success": false` does not mean the server-side operation failed. The server may have completed the write and prepared a response, but the connection dropped before the client received it. Additionally, a backend serialization bug (e.g. missing JSON serializer) can cause the response to fail even though the service function completed successfully.
+
+Therefore: **the replay system does not filter by `success` field.** All records are uploaded. The server deduplicates using `request_id` — if a `request_id` has already been processed (and stored in the processed-IDs set), the record is skipped silently. This correctly handles both "actually failed" and "client thought it failed but server succeeded" cases.
+
+### 2.5 Persistent Sequence Number
+
+The `seq` counter resumes from the last recorded value if the file already exists (process restart, crash recovery):
 
 ```python
 import threading
 import json
-import datetime
+import uuid
+import time
 from pathlib import Path
 
 
 class ReplayLog:
-    def __init__(self, log_dir: str, run_id: str, test_type: str):
+    def __init__(self, log_dir: str, run_id: str, test_type: str, init_ts_ms: int):
         self._lock = threading.Lock()
-        self._path = Path(log_dir) / f"argus_replay_{run_id}.jsonl"
+        self._path = Path(log_dir) / f"sct_argus_events_{run_id}_{init_ts_ms}.jsonl"
         self._test_type = test_type
         self._seq = self._load_last_seq()
         self._file = open(self._path, "a")
@@ -293,13 +296,11 @@ class ReplayLog:
         if not self._path.exists() or self._path.stat().st_size == 0:
             return 0
         with open(self._path, "rb") as f:
-            # Seek backwards from EOF to find the last complete line
             try:
                 f.seek(-2, 2)
                 while f.read(1) != b"\n":
                     f.seek(-2, 1)
             except OSError:
-                # File has only one line
                 f.seek(0)
             last_line = f.readline().decode()
         try:
@@ -307,32 +308,36 @@ class ReplayLog:
         except (json.JSONDecodeError, KeyError):
             return 0
 
-    def record(self, method: str, endpoint: str, location_params: dict | None,
-               params: dict | None, body: dict | None, success: bool):
-        """Record a request to the replay log.
-
-        Only the seq counter is synchronized. File writes happen outside
-        the lock since replay sorts by seq — disk order doesn't matter.
-        """
+    def record_before(self, method: str, endpoint: str, location_params: dict | None,
+                      params: dict | None, body: dict | None) -> tuple[int, str]:
+        """Write the pre-call record (success=null). Returns (seq, request_id)."""
+        request_id = str(uuid.uuid4())
         with self._lock:
             self._seq += 1
             seq = self._seq
 
         entry = {
+            "request_id": request_id,
             "seq": seq,
-            "ts": datetime.datetime.now(datetime.UTC).isoformat(),
+            "ts": int(time.time() * 1000),
             "method": method,
             "endpoint": endpoint,
             "location_params": location_params,
             "params": params,
             "body": body,
             "test_type": self._test_type,
-            "success": success,
+            "success": None,
         }
-        # json.dumps + write + flush happen outside the lock.
-        # Lines may interleave on disk but each is a complete JSON line
-        # and replay sorts by seq, so disk order is irrelevant.
         self._file.write(json.dumps(entry, default=str) + "\n")
+        self._file.flush()
+        return seq, request_id
+
+    def record_after(self, seq: int, success: bool, error: str | None = None):
+        """Append outcome record for an already-written pre-call entry."""
+        outcome = {"seq": seq, "success": success}
+        if error:
+            outcome["error"] = error
+        self._file.write(json.dumps(outcome, default=str) + "\n")
         self._file.flush()
 
     def close(self):
@@ -343,46 +348,53 @@ class ReplayLog:
 
 The replay tool sorts entries by `seq` before executing, so lines don't need to be ordered on disk. By holding the lock only for the integer increment (nanoseconds), we eliminate contention from JSON serialization and disk I/O. In concurrent systems like SCT's event pipeline (multiple threads submitting events simultaneously), this is a significant performance win.
 
-Python's `file.write()` under the GIL guarantees that individual `write()` calls won't produce interleaved bytes, so concurrent writes of complete JSON lines are safe without a write lock.
+Python's `file.write()` under the GIL guarantees that individual `write()` calls won't produce interleaved bytes within a single call, so concurrent writes of complete JSON lines are safe without a write lock.
 
-### 2.5 Integration into ArgusClient
+### 2.6 Integration into ArgusClient
 
-The replay log is initialized in `ArgusClient.__init__()` and called from `post()`:
+The replay log is initialized in `ArgusClient.__init__()` and wraps `post()`:
 
 ```python
 class ArgusClient:
     def __init__(self, auth_token, base_url, ..., log_dir: str | None = None):
         # ... existing init code ...
+        init_ts_ms = int(time.time() * 1000)
         self._replay_log = ReplayLog(
             log_dir=log_dir or os.environ.get("ARGUS_LOG_DIR", "."),
             run_id=getattr(self, "run_id", "unknown"),
             test_type=getattr(self, "test_type", "unknown"),
+            init_ts_ms=init_ts_ms,
         )
 
     def post(self, endpoint, location_params=None, params=None, body=None):
         url = self.get_url_for_endpoint(endpoint=endpoint, location_params=location_params)
         LOGGER.debug("POST Request: %s, params: %s, body: %s", url, params, body)
-        response = self.session.post(url=url, params=params, json=body,
-                                      headers=self.request_headers, timeout=self._timeout)
-        LOGGER.debug("POST Response: %s %s", response.status_code, response.url)
 
-        # Record to replay log — determine success without raising
-        success = 199 < response.status_code < 300
-        if success:
-            try:
-                success = "error" not in response.json()
-            except Exception:
-                success = False
-        self._replay_log.record(
+        # Write pre-call record before the HTTP attempt
+        seq, _request_id = self._replay_log.record_before(
             method="POST", endpoint=endpoint,
-            location_params=location_params, params=params,
-            body=body, success=success,
+            location_params=location_params, params=params, body=body,
         )
+
+        try:
+            response = self.session.post(url=url, params=params, json=body,
+                                          headers=self.request_headers, timeout=self._timeout)
+            LOGGER.debug("POST Response: %s %s", response.status_code, response.url)
+            success = 199 < response.status_code < 300
+            if success:
+                try:
+                    success = "error" not in response.json()
+                except Exception:
+                    success = False
+            self._replay_log.record_after(seq, success=success)
+        except Exception as exc:
+            self._replay_log.record_after(seq, success=False, error=str(exc))
+            raise
 
         return response
 ```
 
-Only `post()` is recorded — `get()` calls are read-only and do not mutate state, so they are not included in the replay log. The replay log write happens after the request completes (or fails), before the response is returned to the caller. This ensures we capture the actual success/failure status.
+Only `post()` is recorded — `get()` calls are read-only and do not mutate state.
 
 ---
 
@@ -390,91 +402,140 @@ Only `post()` is recorded — `get()` calls are read-only and do not mutate stat
 
 ### 3.1 Storage Location
 
-The JSONL replay file is written to the **test's existing log directory**. For now, this is the only supported storage target. How replay files are stored and accessed for other use-cases (e.g. generic CI environments) will be determined in the future.
+The JSONL replay file is written to the **test's existing log directory**. For now, this is the only supported storage target.
 
 - For SCT: `~/sct-results/latest/`
-- For other consumers: pass `log_dir` to the client constructor or set the `ARGUS_LOG_DIR` environment variable. Falls back to the current working directory.
+- For other consumers: pass `log_dir` to the client constructor or set `ARGUS_LOG_DIR`. Falls back to the current working directory.
 
-### 3.2 Convention
+### 3.2 Multiple Files per Run
 
-1. File naming: `argus_replay_{run_id}.jsonl` — one file per test run.
+Because the filename includes `init_ts_ms`, parallel processes using the same `log_dir` and `run_id` each write to their own file:
+
+```
+sct_argus_events_550e8400-..._1712345600000.jsonl   ← shard 0
+sct_argus_events_550e8400-..._1712345600042.jsonl   ← shard 1
+sct_argus_events_550e8400-..._1712345600107.jsonl   ← shard 2
+```
+
+The CLI upload command and backend ingest endpoint accept all files matching `sct_argus_events_{run_id}_*.jsonl` and merge their records by `seq` before processing.
+
+### 3.3 Convention
+
+1. File naming: `sct_argus_events_{run_id}_{unix_ms}.jsonl`
 2. The file is co-located with other test artifacts; no new upload mechanism is needed.
 3. For `pytest-argus-reporter`: add `--argus-log-dir` command-line option that passes through to `ArgusGenericClient`.
 
 ---
 
-## 4. `argus replay` CLI Command
+## 4. Backend — Terminal Status Auto-Finalize
 
-The `argus replay` CLI command is a thin uploader. It reads the local JSONL file and POSTs it to the Argus server-side ingest endpoint (`POST /api/v1/client/replay/ingest`). All replay logic — ordering, idempotency, execution — runs on the server.
+When `set_status` receives a terminal status (`Failed`, `Aborted`, `Passed`, `Error`, `NotRun`):
 
-### 4.1 Command Interface
+- The backend sets `end_time = now()` **if `end_time` is not already set**.
+- No separate `finalize` call is needed from the client.
+- The `POST /client/testrun/:type/:id/finalize` endpoint remains on the backend for manual or forced finalization but is removed from the normal client flow.
+
+This simplifies finalization from a two-step sequence (`set_status` → `finalize`) to a single call.
+
+---
+
+## 5. `argus replay` CLI Command
+
+The `argus replay` CLI command collects all matching JSONL files, bundles them into a `tar.zst` archive, and uploads the archive to the Argus server-side ingest endpoint. All replay logic — ordering, idempotency, execution — runs on the server.
+
+### 5.1 Command Interface
 
 ```
-argus replay <path-to-jsonl-file> [flags]
+argus replay [flags]
 
 Flags:
-  --failed-only       Only replay requests that originally failed (default: true)
-  --dry-run           Validate on the server without executing
-  --force-all         Ignore idempotency checks, replay everything
-  --target-url        Override the base URL (replay against different Argus instance)
-  --report            Output format for summary: "text" (default) or "json"
+  --dir <path>         Directory to scan for sct_argus_events_*.jsonl files
+  --run-id <uuid>      Filter files by run ID (used with --dir)
+  --file <path>        Explicit file path (repeatable; mutually exclusive with --dir)
+  --dry-run            Validate on the server without executing
+  --target-url         Override the base URL (replay against a different Argus instance)
+  --report             Output format for summary: "text" (default) or "json"
 ```
 
 **Examples:**
 
 ```bash
-# Upload replay file to Argus for server-side processing
-argus replay ./argus_replay_550e8400.jsonl
+# Replay all files for a specific run in the SCT results directory
+argus replay --dir ~/sct-results/latest --run-id 550e8400-e29b-41d4-a716-446655440000
 
-# Dry-run to see what would be replayed
-argus replay ./argus_replay_550e8400.jsonl --dry-run
+# Replay explicit files
+argus replay --file sct_argus_events_550e8400-..._1712345600000.jsonl \
+             --file sct_argus_events_550e8400-..._1712345600042.jsonl
+
+# Dry-run to preview what would be replayed
+argus replay --dir ~/sct-results/latest --run-id 550e8400-... --dry-run
 
 # Replay against a different Argus instance
-argus replay ./argus_replay_550e8400.jsonl --target-url https://argus-staging.example.com
+argus replay --dir ~/sct-results/latest --target-url https://argus-staging.example.com
 ```
 
-### 4.2 Go Package Structure
+### 5.2 Upload Format
+
+All collected JSONL files are bundled into a **`tar.zst` archive** and uploaded as a single POST:
+
+- Uses `archive/tar` + `github.com/klauspost/compress/zstd` — both already in `go.mod`
+- `Content-Type: application/x-tar-zstd`
+- Single round-trip; server handles decompression, merging, and ordering
+
+The archive contains one entry per JSONL file, preserving original filenames so the server can associate files with their `run_id` via the filename convention.
+
+### 5.3 No `--failed-only` Flag
+
+There is no `--failed-only` flag. All records are uploaded unconditionally. The server handles deduplication via `request_id`. See Section 2.4 for the rationale.
+
+### 5.4 Go Package Structure
 
 New package: `cli/internal/replay/`
 
 ```
 cli/internal/replay/
-├── uploader.go     # Reads JSONL file, POSTs to ingest endpoint
+├── collector.go    # Scans directory or accepts explicit file list
+├── archiver.go     # Builds tar.zst archive from collected files
+├── uploader.go     # POSTs archive to ingest endpoint
 ├── reporter.go     # Formats and prints server summary response
-└── *_test.go       # Tests for each component
+└── *_test.go
 ```
 
 New command file: `cli/cmd/replay.go` — follows patterns from `cli/cmd/testrun.go`.
 
+New route constant in `cli/internal/api/routes.go`:
+
+```go
+ReplayIngest = "/api/v1/client/replay/ingest"  // POST – upload tar.zst archive of JSONL files
+```
+
 ---
 
-## 5. Endpoint Idempotency Classification
+## 6. Endpoint Idempotency Classification
 
-Each API endpoint is classified into one of four replay strategies. The server-side ingest endpoint uses this classification to determine how to handle each entry.
+Each API endpoint is classified into one of four replay strategies. The server-side ingest service uses this classification when processing each JSONL entry.
 
-### 5.1 SAFE — Replay Freely
+### 6.1 SAFE — Replay Freely
 
 These endpoints are idempotent or last-write-wins. Replaying them multiple times produces the same result.
 
-| Endpoint                                    | Client Methods                                                   |
-| ------------------------------------------- | ---------------------------------------------------------------- |
-| `/testrun/$type/$id/set_status`             | `set_status()`, `set_sct_run_status()`, `set_matrix_status()`    |
-| `/testrun/$type/$id/update_product_version` | `update_product_version()`, `update_scylla_version()`            |
-| `/sct/$id/sct_runner/set`                   | `set_sct_runner()`                                               |
-| `/testrun/$type/$id/logs/submit`            | `submit_logs()`, `submit_sct_logs()`                             |
-| `/sct/$id/screenshots/submit`               | `submit_screenshots()`                                           |
-| `/sct/$id/packages/submit`                  | `submit_packages()`                                              |
-| `/sct/$id/events/submit`                    | `submit_events()` (batch overwrites)                             |
-| `/sct/$id/resource/$name/update`            | `update_resource()`                                              |
-| `/sct/$id/resource/$name/shards`            | `update_shards_for_resource()`                                   |
-| `/$id/config/submit`                        | `sct_submit_config()`                                            |
-| `/driver_matrix/env/submit`                 | `submit_env()`                                                   |
-| `/testrun/$type/$id/finalize`               | `finalize_run()`, `finalize_sct_run()`, `finalize_generic_run()` |
-| `/testrun/$type/$id/submit_results`         | `submit_results()` — keyed by table name, overwrites             |
+| Endpoint                                    | Client Methods                                                |
+| ------------------------------------------- | ------------------------------------------------------------- |
+| `/testrun/$type/$id/set_status`             | `set_status()`, `set_sct_run_status()`, `set_matrix_status()` |
+| `/testrun/$type/$id/update_product_version` | `update_product_version()`, `update_scylla_version()`         |
+| `/sct/$id/sct_runner/set`                   | `set_sct_runner()`                                            |
+| `/testrun/$type/$id/logs/submit`            | `submit_logs()`, `submit_sct_logs()`                          |
+| `/sct/$id/screenshots/submit`               | `submit_screenshots()`                                        |
+| `/sct/$id/packages/submit`                  | `submit_packages()`                                           |
+| `/sct/$id/resource/$name/update`            | `update_resource()`                                           |
+| `/sct/$id/resource/$name/shards`            | `update_shards_for_resource()`                                |
+| `/$id/config/submit`                        | `sct_submit_config()`                                         |
+| `/driver_matrix/env/submit`                 | `submit_env()`                                                |
+| `/testrun/$type/$id/submit_results`         | `submit_results()` — keyed by table name, overwrites          |
 
 > **Note:** Heartbeat calls (`/testrun/$type/$id/heartbeat`) are **not replayed**. They serve only to signal live test activity and have no value after the test has finished.
 
-### 5.2 CHECK_FIRST — Verify Before Replay
+### 6.2 CHECK_FIRST — Verify Before Replay
 
 These endpoints create new entities. Replaying when the entity already exists would cause errors or duplicates.
 
@@ -483,9 +544,9 @@ These endpoints create new entities. Replaying when the entity already exists wo
 | `/testrun/$type/submit`    | `GET /testrun/$type/$id/get` — if 200, skip | `submit_run()`, `submit_sct_run()`, `submit_generic_run()`, `submit_driver_matrix_run()`, `submit_sirenada_run()` |
 | `/sct/$id/resource/create` | Check by resource name in run data          | `create_resource()`                                                                                               |
 
-### 5.3 APPEND — Safe to Replay
+### 6.3 APPEND_IDEMPOTENT — Deduplicate via `request_id`
 
-These endpoints append records. All inserts are safe — replaying them is idempotent from a data-integrity standpoint because duplicate entries are acceptable.
+These endpoints append records. Duplicate detection uses `request_id` — the server stores processed `request_id` values and silently skips any record whose `request_id` has already been processed.
 
 | Endpoint                       | Client Methods                 |
 | ------------------------------ | ------------------------------ |
@@ -499,9 +560,9 @@ These endpoints append records. All inserts are safe — replaying them is idemp
 | `/sct/$id/gemini/submit`       | `submit_gemini_results()`      |
 | `/sct/$id/performance/submit`  | `submit_performance_results()` |
 
-### 5.4 SKIP — Do Not Replay by Default
+### 6.4 SKIP — Do Not Replay
 
-These endpoints have side effects beyond Argus state. They are skipped unless `--force-all` is passed.
+These endpoints have side effects beyond Argus state. They are always skipped during replay.
 
 | Endpoint                 | Side Effect         | Client Methods   |
 | ------------------------ | ------------------- | ---------------- |
@@ -510,48 +571,29 @@ These endpoints have side effects beyond Argus state. They are skipped unless `-
 
 ---
 
-## 6. Automation
-
-The goal is full automation without adding new services.
-
-### 6.1 Manual Replay via CLI
-
-After an outage, download the replay JSONL file from the test log directory and upload it to Argus for server-side processing:
-
-```bash
-# Upload replay file to Argus for server-side processing
-argus replay ./argus_replay_550e8400.jsonl --server-side
-```
-
-The CLI's only job is to upload the file. All replay logic runs server-side.
-
-### 6.2 Server-Side Replay Ingest Endpoint
-
-Argus itself accepts a JSONL replay file and processes it internally. This is the only supported replay path — Argus heals itself.
-
-**New API endpoint:**
+## 7. Server-Side Replay Ingest Endpoint
 
 ```
 POST /api/v1/client/replay/ingest
-Content-Type: multipart/form-data
-
-Body: JSONL file upload
+Content-Type: application/x-tar-zstd
 ```
 
 **Query parameters:**
 
-- `failed_only=true` (default) — only process entries with `"success": false`
 - `dry_run=false` — if true, validate and return what would be replayed without executing
-- `force_all=false` — if true, skip idempotency checks
 
 **How it works:**
 
-1. Argus receives the JSONL file
-2. Parses entries, sorts by `seq`
-3. Applies ordering rules (submit first, finalize last)
-4. Applies idempotency classification (Section 5) — checks existence before creating, skips email/trigger endpoints
-5. Executes each entry against its own internal service layer directly (no HTTP overhead — calls the service functions that the API controller would call)
-6. Returns a summary report:
+1. Flask receives the `tar.zst` body and decompresses it using `zstandard`
+2. Extracts all JSONL files from the archive
+3. Parses all records, merges across files, sorts by `seq`
+4. Applies ordering rules: `submit_run` first, terminal `set_status` / finalize last
+5. For each record:
+    - Apply idempotency classification (Section 6)
+    - Check processed `request_id` set — skip duplicates silently
+    - Call the corresponding internal service function directly (no HTTP self-requests)
+    - Record outcome (success or error with detail)
+6. Returns a summary:
 
 ```json
 {
@@ -559,79 +601,117 @@ Body: JSONL file upload
     "processed": 12,
     "succeeded": 11,
     "failed": 1,
-    "skipped": 35,
-    "errors": [{ "seq": 23, "endpoint": "/sct/$id/nemesis/submit", "error": "Duplicate nemesis record" }]
+    "skipped_duplicate": 30,
+    "skipped_no_replay": 4,
+    "errors": [{ "seq": 23, "request_id": "...", "endpoint": "/sct/$id/nemesis/submit", "error": "..." }]
 }
 ```
 
-**Advantages:**
-
-- **No HTTP round-trip overhead** — Argus processes the replay internally by calling service functions directly, not re-issuing HTTP requests to itself
-- **Argus can self-heal** — upload the file and Argus does the rest
-- **Atomic processing** — Argus can wrap the replay in a database transaction or batch operation
-- **Access control** — The endpoint uses the same `@api_login_required` auth as other client endpoints
+**Idempotency key storage:** Processed `request_id` values are stored per `run_id`. The storage mechanism (a Cassandra set column on the run record, a dedicated table, or an in-memory set for the duration of the ingest request) is an implementation detail decided during Phase 4.
 
 ---
 
-## 7. Implementation Phases
+## 8. Implementation Phases
 
-### Phase 1: Replay Log and Replay-Only Mode (Python Client)
+### Phase 1: Replay Log (Python Client)
 
 **New file:** `argus/client/replay_log.py`
 
-- `ReplayLog` class with persistent sequence counter
-- Thread-safe recording with minimal lock contention
-- `replay_failed()` method for in-process retry
+- `ReplayLog` class with `record_before()` and `record_after()` methods
+- Persistent sequence counter (resume from last `seq` in existing file)
+- Thread-safe counter increment with minimal lock contention
+- Filename convention: `sct_argus_events_{run_id}_{unix_ms}.jsonl`
 
 **Modify:** `argus/client/base.py`
 
 - Add `log_dir` parameter to `ArgusClient.__init__()`
+- Capture `init_ts_ms` at construction time; pass to `ReplayLog`
 - Initialize `ReplayLog` (always on)
-- Add `replay_only` mode: when `True`, `get()` and `post()` skip the HTTP call but still write to the replay log with `"success": false`
-- Optional health check on init: if argus is unreachable, auto-enter replay-only mode
-- Call `record()` from `post()` after each request
+- Add `replay_only` mode: `get()` and `post()` skip the HTTP call but still write to the replay log
+- Wrap `post()` to call `record_before()` then `record_after()`
+
+**Remove from `argus/client/sct/client.py`:**
+
+- `submit_events()` method (legacy aggregated severity/count)
 
 **New file:** `argus/client/tests/test_replay_log.py`
 
-- Test JSONL format correctness
-- Test sequence number persistence across restarts
-- Test thread safety with concurrent writes
-- Test replay-only mode skips HTTP but writes JSONL
+- JSONL format correctness
+- Sequence number persistence across restarts
+- Thread safety with concurrent writes
+- `replay_only` mode: no HTTP calls, JSONL written with `success=false`
+- Multiple files for the same run do not interfere
 
-### Phase 2: pytest-argus-reporter Integration
+### Phase 2: Backend Terminal Status Auto-Finalize
+
+**Modify:** `argus/backend/service/client_service.py`
+
+- In `update_run_status()`: if status is terminal, set `end_time = now()` when not already set
+
+**Remove from backend:**
+
+- `POST /client/sct/<run_id>/events/submit` legacy endpoint
+
+### Phase 3: Remove SCT Self-Healing Code
+
+**Modify `sdcm/utils/argus.py`:**
+
+- Remove `argus_offline_collect_events()`
+
+**Modify `sct.py`:**
+
+- Remove the `if not argus_client.get_run().get("events"):` block at line 1865-1866
+
+**Modify `sdcm/tester.py`:**
+
+- Remove the one-shot `submit_events` re-fire block in `argus_finalize_test_run()`
+- Replace separate `set_status` + `finalize_run` calls with a single `set_status(terminal_status)` call
+
+**Modify `sdcm/test_config.py`:**
+
+- Replace `MagicMock` fallback with replay-only mode client instantiation
+
+### Phase 4: pytest-argus-reporter Integration
 
 **Modify:** `pytest-argus-reporter/pytest_argus_reporter.py`
 
 - Add `--argus-log-dir` command-line option
 - Pass `log_dir` to `ArgusGenericClient` constructor
 
-### Phase 3: `argus replay` CLI Command (Go)
+### Phase 5: `argus replay` CLI Command (Go)
 
 **New command:** `cli/cmd/replay.go`
 
-- Cobra command following `testrun.go` patterns
-- Uploads the JSONL file to the Argus server-side ingest endpoint (`POST /api/v1/client/replay/ingest`)
-- Flags: `--failed-only`, `--dry-run`, `--force-all`, `--target-url`
-- Prints the summary report returned by the server
+- Cobra command; flags: `--dir`, `--run-id`, `--file` (repeatable), `--dry-run`, `--target-url`, `--report`
+- No `--failed-only` flag
 
 **New package:** `cli/internal/replay/`
 
-- `uploader.go` — reads the JSONL file and POSTs it to the ingest endpoint
+- `collector.go` — scans directory matching `sct_argus_events_*.jsonl`; optionally filters by `run_id`
+- `archiver.go` — builds in-memory `tar.zst` from collected files using `archive/tar` + `github.com/klauspost/compress/zstd`
+- `uploader.go` — POSTs archive to `POST /api/v1/client/replay/ingest`
 - `reporter.go` — formats and prints the server summary response
-- `*_test.go` — Unit tests
+- `*_test.go` — unit tests for each component
 
-### Phase 4: Server-Side Replay Ingest (Argus Backend)
+**Add to `cli/internal/api/routes.go`:**
+
+```go
+ReplayIngest = "/api/v1/client/replay/ingest"  // POST – tar.zst archive of JSONL replay files
+```
+
+### Phase 6: Server-Side Replay Ingest (Argus Backend)
 
 **New blueprint:** `argus/backend/controller/replay_api.py`
 
-- `POST /api/v1/client/replay/ingest` — accepts JSONL file upload, processes internally
-- Applies ordering rules and idempotency classification
-- Calls service layer directly (no HTTP self-requests)
-- Returns summary report with per-entry status
+- `POST /api/v1/client/replay/ingest`
+- Decompresses `tar.zst` body with `zstandard`
+- Delegates to `ReplayService`
 
-**New service:** `argus/backend/service/replay.py`
+**New service:** `argus/backend/service/replay_service.py`
 
-- Parses JSONL entries
-- Maps endpoints to internal service functions
-- Applies idempotency checks (Section 5)
-- Batch processing with error collection
+- Extracts and merges JSONL files from archive
+- Sorts records by `seq`, applies ordering rules
+- Maps endpoint templates to internal service functions
+- Checks and stores processed `request_id` values for deduplication
+- Applies idempotency classification (Section 6)
+- Collects per-record outcomes; returns summary

--- a/docs/plans/request_replay.md
+++ b/docs/plans/request_replay.md
@@ -117,7 +117,7 @@ while not stop_signal.is_set():
 
 After 5 consecutive failures (~2.5 minutes), the heartbeat thread exits permanently. No further heartbeats are sent for the rest of the test run.
 
-#### 1.5.3 Event Pipeline — Fire-and-Forget with Side-Log
+#### 1.5.3 Event Pipeline — Fire-and-Forget
 
 The three-stage event pipeline (`sdcm/sct_events/argus.py`) uses `verbose_suppress()` around every operation:
 
@@ -125,29 +125,7 @@ The three-stage event pipeline (`sdcm/sct_events/argus.py`) uses `verbose_suppre
 - **ArgusEventAggregator** — deduplicates within 90-second windows, skips on error
 - **ArgusEventPostman** — calls `client.submit_event()`, suppresses on error
 
-Events are not lost permanently even when `submit_event()` fails: the underlying `sct_events.log` file on disk contains all raw events and can be re-parsed. However, re-parsing that file requires running the full event-checking logic again. To make replay straightforward, every `submit_event()` call also appends the exact `RawEventPayload` body to a dedicated side-log file (see Section 2.2) **before** the HTTP call is made. This file can be fed directly to the ingest endpoint without any re-parsing.
-
-#### 1.5.4 Offline Event Recovery — Removed
-
-The previous `argus_offline_collect_events()` function (`sdcm/utils/argus.py:94-107`) was a SCT-specific recovery mechanism that read `EventsProcessesRegistry` from disk and re-submitted the last 100 events via the legacy `submit_events()` (aggregated severity/count) endpoint. It was triggered from `store_logs_in_argus()` in `sct.py:1865-1866`.
-
-**This mechanism and the `submit_events()` endpoint it depends on are removed.** The replay log (Section 2) replaces this recovery with a universal, data-type-agnostic approach that covers all endpoints, all test types, and is not limited to 100 events.
-
-**Code removed from SCT:**
-
-1. `argus_offline_collect_events()` in `sdcm/utils/argus.py`
-2. The `if not argus_client.get_run().get("events"):` conditional in `sct.py:1865-1866`
-3. The one-shot re-fire block in `sdcm/tester.py` that called `submit_events` when the pipeline stage crashed or ended prematurely
-
-**Removed from the Python client:**
-
-4. `ArgusSCTClient.submit_events()` (`argus/client/sct/client.py:326`) — legacy aggregated severity/count bulk submit
-
-**Removed from the backend:**
-
-5. `POST /client/sct/<run_id>/events/submit` — the legacy aggregated events endpoint
-
-#### 1.5.5 Test Finalization — Combined with Status
+#### 1.5.4 Test Finalization — Combined with Status
 
 The original `argus_finalize_test_run()` in `sdcm/tester.py:659-683` performed three operations in a single try/except: submit events (legacy), set status, and call finalize. If any call failed, the entire block was skipped.
 
@@ -159,15 +137,15 @@ The original `argus_finalize_test_run()` in `sdcm/tester.py:659-683` performed t
 - The client calls only `set_status(terminal_status)` as the final operation. No separate finalize call is needed.
 - The `POST /client/testrun/:type/:id/finalize` endpoint remains on the backend for manual/forced finalization but is no longer part of the normal client flow.
 
-#### 1.5.6 Node Operations — No Retry
+#### 1.5.5 Node Operations — No Retry
 
 All node-level argus operations (`_add_node_to_argus`, `update_shards_in_argus`, `_terminate_node_in_argus` in `sdcm/cluster.py`) catch exceptions and log them. No retry, no recovery. These calls are captured by the replay log and can be replayed after an outage.
 
-#### 1.5.7 Summary of Gaps Addressed
+#### 1.5.6 Summary of Gaps Addressed
 
 | Data Type           | Previous Recovery                        | With Replay Log                               |
 | ------------------- | ---------------------------------------- | --------------------------------------------- |
-| Events (real-time)  | None — fire-and-forget                   | Captured in JSONL side-log before HTTP call   |
+| Events (real-time)  | None — fire-and-forget                   | Captured in JSONL replay log                  |
 | Events (batch)      | `argus_offline_collect_events` — removed | Replaced by replay log                        |
 | Test run submission | None                                     | Captured in JSONL                             |
 | Test status         | None                                     | Captured in JSONL                             |
@@ -186,34 +164,31 @@ All node-level argus operations (`_add_node_to_argus`, `update_shards_in_argus`,
 
 ### 2.1 Design Principles
 
-This is **not** request logging for debugging. This is a **replay journal** — a write-ahead log of every API call that can be used to reconstruct Argus state from scratch.
+This is **not** request logging for debugging. This is a **replay journal** of every API call that can be used to reconstruct Argus state from scratch.
 
 1. **Always on by default** — we don't know when Argus will start failing, so every mutating request must be recorded
-2. **Written before the HTTP call** — the record exists on disk even if the process crashes during the request
+2. **Written after the HTTP call completes (or fails)** — each record is a single, complete JSONL line with the final outcome. If the process crashes mid-HTTP-call, that one record is lost — the same behavior as today, and not worth the complexity of a write-ahead approach since the server may or may not have processed the request anyway.
 3. **One file per process per run** — timestamp in the filename prevents parallel processes from overwriting each other (see Section 2.2)
-4. **Persistent atomic sequence numbers** — `seq` field uses a lock-protected counter; determines the exact replay order even in concurrent environments
-5. **`request_id` for idempotency** — a UUID generated per record before the HTTP call; the server uses this as the idempotency key, making it safe to replay records that may have succeeded server-side despite a client-side error
+4. **Queue + writer thread** — request threads enqueue complete records onto a `queue.Queue`; a single background thread drains the queue and writes to disk. This eliminates file I/O contention from the request hot path entirely.
 
 ### 2.2 File Naming
 
 ```
-{log_dir}/sct_argus_events_{run_id}_{unix_ms}.jsonl
+{log_dir}/argus_replay_log_{run_id}_{unix_ms}.jsonl
 ```
 
 - `run_id` scopes the file to one test run.
-- `unix_ms` is Unix epoch time in milliseconds captured once at `ArgusClient.__init__()` time. This disambiguates parallel processes sharing the same `log_dir` and `run_id` (e.g. parallel pytest shards all reporting to the same run — each shard gets its own file).
-- `log_dir` is determined by constructor parameter or `ARGUS_LOG_DIR` env var, falling back to the current working directory.
+- `unix_ms` is Unix epoch time in milliseconds captured once at `ArgusClient.__init__()` time. This disambiguates parallel processes sharing the same `log_dir` and `run_id` (e.g. parallel pytest workers all reporting to the same run — each worker gets its own file).
+- `log_dir` is the test's existing log directory, passed by each consumer at client construction time. There is no `ARGUS_LOG_DIR` env var or fallback — each test framework is responsible for providing its own log directory.
 
-**Multiple files per run are expected and supported.** The CLI upload command and backend ingest endpoint both handle multiple JSONL files for the same `run_id` by merging and sorting records by `seq` before execution.
+**Multiple files per run are expected and supported.** The CLI upload command and backend ingest endpoint both handle multiple JSONL files for the same `run_id` by merging and sorting records by `ts` before execution.
 
 ### 2.3 JSONL Record Schema
 
-Each line in the file is a self-contained JSON object written **before** the HTTP call:
+Each line in the file is a single, self-contained JSON object written **after** the HTTP call completes (or fails):
 
 ```json
 {
-  "request_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
-  "seq": 1,
   "ts": 1712345678901,
   "method": "POST",
   "endpoint": "/testrun/$type/$id/submit_results",
@@ -227,36 +202,40 @@ Each line in the file is a self-contained JSON object written **before** the HTT
     "results": [...]
   },
   "test_type": "scylla-cluster-tests",
-  "success": null
+  "success": true
 }
 ```
 
-After the HTTP call completes (or fails), the record is updated in place with the outcome:
+On failure:
 
 ```json
-{ ..., "success": true }
+{
+  "ts": 1712345679100,
+  "method": "POST",
+  "endpoint": "/sct/$id/event/submit",
+  "location_params": {"id": "550e8400-e29b-41d4-a716-446655440000"},
+  "params": null,
+  "body": { ... },
+  "test_type": "scylla-cluster-tests",
+  "success": false,
+  "error": "ConnectionError: Connection refused"
+}
 ```
 
-or
-
-```json
-{ ..., "success": false, "error": "ConnectionError: ..." }
-```
+One line per request — no pre-call/post-call pairs, no merging needed.
 
 **Field descriptions:**
 
 | Field             | Type              | Description                                                                                                                 |
 | ----------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `request_id`      | string (UUID v4)  | Generated before the HTTP call. Server idempotency key — replaying the same `request_id` is a no-op.                        |
-| `seq`             | int               | Atomic, persistent sequence number. Determines replay order across files.                                                   |
-| `ts`              | int               | Unix epoch milliseconds at record write time.                                                                               |
+| `ts`              | int               | Unix epoch milliseconds at record write time. Used for ordering during replay.                                              |
 | `method`          | string            | HTTP method: always `"POST"` (only mutating calls are recorded).                                                            |
 | `endpoint`        | string            | Route template with `$` placeholders (e.g. `/testrun/$type/$id/submit_results`). Enables replay against any Argus instance. |
 | `location_params` | object\|null      | Parameters to resolve the endpoint template into a full path.                                                               |
 | `params`          | object\|null      | URL query parameters.                                                                                                       |
 | `body`            | object\|null      | Full request body as sent to the API.                                                                                       |
 | `test_type`       | string            | The client's test type (redundant with body but useful for filtering).                                                      |
-| `success`         | bool\|null        | `null` before the call. `true` if HTTP 2xx and response body has no `"error"` key. `false` otherwise.                       |
+| `success`         | bool              | `true` if HTTP 2xx and response body has no `"error"` key. `false` otherwise.                                               |
 | `error`           | string (optional) | Present only when `success` is `false`. Human-readable error description.                                                   |
 
 **What is NOT stored (by design):**
@@ -269,98 +248,126 @@ or
 
 A record with `"success": false` does not mean the server-side operation failed. The server may have completed the write and prepared a response, but the connection dropped before the client received it. Additionally, a backend serialization bug (e.g. missing JSON serializer) can cause the response to fail even though the service function completed successfully.
 
-Therefore: **the replay system does not filter by `success` field.** All records are uploaded. The server deduplicates using `request_id` — if a `request_id` has already been processed (and stored in the processed-IDs set), the record is skipped silently. This correctly handles both "actually failed" and "client thought it failed but server succeeded" cases.
+Therefore: **the replay system does not filter by `success` field.** All records are uploaded. The server applies idempotency classification (Section 6) to handle duplicates — SAFE endpoints are last-write-wins, CHECK_FIRST endpoints verify existence before creating, and APPEND endpoints rely on natural deduplication (matching on payload content). This correctly handles both "actually failed" and "client thought it failed but server succeeded" cases.
 
-### 2.5 Persistent Sequence Number
+### 2.5 ReplayLog Implementation
 
-The `seq` counter resumes from the last recorded value if the file already exists (process restart, crash recovery):
+The `ReplayLog` uses a context manager API and a background writer thread. Request threads build the record in memory, execute the HTTP call, set the outcome, and enqueue the complete record. A single background thread drains the queue and writes to disk.
 
 ```python
-import threading
+import atexit
 import json
-import uuid
+import queue
+import threading
 import time
+from contextlib import contextmanager
 from pathlib import Path
+
+
+class ReplayRecord:
+    """Mutable record populated during the HTTP call, written after completion."""
+    __slots__ = ("ts", "method", "endpoint",
+                 "location_params", "params", "body", "test_type",
+                 "success", "error")
+
+    def __init__(self, *, method: str, endpoint: str,
+                 location_params: dict | None, params: dict | None,
+                 body: dict | None, test_type: str):
+        self.ts = int(time.time() * 1000)
+        self.method = method
+        self.endpoint = endpoint
+        self.location_params = location_params
+        self.params = params
+        self.body = body
+        self.test_type = test_type
+        self.success: bool = False
+        self.error: str | None = None
+
+    def to_dict(self) -> dict:
+        d = {
+            "ts": self.ts,
+            "method": self.method,
+            "endpoint": self.endpoint,
+            "location_params": self.location_params,
+            "params": self.params,
+            "body": self.body,
+            "test_type": self.test_type,
+            "success": self.success,
+        }
+        if self.error:
+            d["error"] = self.error
+        return d
+
+
+_SENTINEL = object()
 
 
 class ReplayLog:
     def __init__(self, log_dir: str, run_id: str, test_type: str, init_ts_ms: int):
-        self._lock = threading.Lock()
-        self._path = Path(log_dir) / f"sct_argus_events_{run_id}_{init_ts_ms}.jsonl"
+        self._path = Path(log_dir) / f"argus_replay_log_{run_id}_{init_ts_ms}.jsonl"
         self._test_type = test_type
-        self._seq = self._load_last_seq()
-        self._file = open(self._path, "a")
+        self._queue: queue.Queue = queue.Queue()
+        self._writer_thread = threading.Thread(
+            target=self._writer_loop, daemon=True, name="replay-log-writer",
+        )
+        self._writer_thread.start()
+        atexit.register(self.close)
 
-    def _load_last_seq(self) -> int:
-        """Resume sequence from existing file. Reads last line only — O(1)."""
-        if not self._path.exists() or self._path.stat().st_size == 0:
-            return 0
-        with open(self._path, "rb") as f:
-            try:
-                f.seek(-2, 2)
-                while f.read(1) != b"\n":
-                    f.seek(-2, 1)
-            except OSError:
-                f.seek(0)
-            last_line = f.readline().decode()
+    def _writer_loop(self):
+        """Background thread: drain queue, write JSONL lines to disk."""
+        with open(self._path, "a") as f:
+            while True:
+                item = self._queue.get()
+                if item is _SENTINEL:
+                    break
+                f.write(json.dumps(item, default=str) + "\n")
+                f.flush()
+
+    @contextmanager
+    def record(self, method: str, endpoint: str, location_params: dict | None,
+               params: dict | None, body: dict | None):
+        """Context manager: yields a ReplayRecord, enqueues it on exit."""
+        rec = ReplayRecord(
+            method=method,
+            endpoint=endpoint,
+            location_params=location_params,
+            params=params,
+            body=body,
+            test_type=self._test_type,
+        )
         try:
-            return json.loads(last_line)["seq"]
-        except (json.JSONDecodeError, KeyError):
-            return 0
-
-    def record_before(self, method: str, endpoint: str, location_params: dict | None,
-                      params: dict | None, body: dict | None) -> tuple[int, str]:
-        """Write the pre-call record (success=null). Returns (seq, request_id)."""
-        request_id = str(uuid.uuid4())
-        with self._lock:
-            self._seq += 1
-            seq = self._seq
-
-        entry = {
-            "request_id": request_id,
-            "seq": seq,
-            "ts": int(time.time() * 1000),
-            "method": method,
-            "endpoint": endpoint,
-            "location_params": location_params,
-            "params": params,
-            "body": body,
-            "test_type": self._test_type,
-            "success": None,
-        }
-        self._file.write(json.dumps(entry, default=str) + "\n")
-        self._file.flush()
-        return seq, request_id
-
-    def record_after(self, seq: int, success: bool, error: str | None = None):
-        """Append outcome record for an already-written pre-call entry."""
-        outcome = {"seq": seq, "success": success}
-        if error:
-            outcome["error"] = error
-        self._file.write(json.dumps(outcome, default=str) + "\n")
-        self._file.flush()
+            yield rec
+        except Exception as exc:
+            rec.success = False
+            rec.error = str(exc)
+            raise
+        finally:
+            self._queue.put(rec.to_dict())
 
     def close(self):
-        self._file.close()
+        """Signal the writer thread to flush and exit."""
+        self._queue.put(_SENTINEL)
+        self._writer_thread.join(timeout=5.0)
 ```
 
-**Why only lock the counter, not the write:**
+**Key design choices:**
 
-The replay tool sorts entries by `seq` before executing, so lines don't need to be ordered on disk. By holding the lock only for the integer increment (nanoseconds), we eliminate contention from JSON serialization and disk I/O. In concurrent systems like SCT's event pipeline (multiple threads submitting events simultaneously), this is a significant performance win.
-
-Python's `file.write()` under the GIL guarantees that individual `write()` calls won't produce interleaved bytes within a single call, so concurrent writes of complete JSON lines are safe without a write lock.
+- **`queue.Queue` + writer thread** — request threads never touch the file. The writer thread is the sole consumer, so no file locking is needed.
+- **`daemon=True`** — the writer thread won't prevent process exit. `atexit` + `close()` ensures a clean drain on normal shutdown. On hard kills (`SIGKILL`), in-flight queue items are lost — acceptable since those records were from requests that just completed (the data is either already on the server or genuinely lost).
+- **Context manager** — the record is built before the HTTP call (in memory only), the caller executes the request inside the `with` block, and the final record is enqueued on `__exit__` regardless of success or failure.
+- **Ordering by `ts`** — records are sorted by timestamp during replay. In multithreaded environments, two requests within the same millisecond may have identical `ts` values, but since all endpoints are idempotent, replay order between same-ms records does not affect correctness.
 
 ### 2.6 Integration into ArgusClient
 
-The replay log is initialized in `ArgusClient.__init__()` and wraps `post()`:
+The replay log is initialized in `ArgusClient.__init__()` and used via context manager in `post()`:
 
 ```python
 class ArgusClient:
-    def __init__(self, auth_token, base_url, ..., log_dir: str | None = None):
+    def __init__(self, auth_token, base_url, ..., log_dir: str):
         # ... existing init code ...
         init_ts_ms = int(time.time() * 1000)
         self._replay_log = ReplayLog(
-            log_dir=log_dir or os.environ.get("ARGUS_LOG_DIR", "."),
+            log_dir=log_dir,
             run_id=getattr(self, "run_id", "unknown"),
             test_type=getattr(self, "test_type", "unknown"),
             init_ts_ms=init_ts_ms,
@@ -370,13 +377,7 @@ class ArgusClient:
         url = self.get_url_for_endpoint(endpoint=endpoint, location_params=location_params)
         LOGGER.debug("POST Request: %s, params: %s, body: %s", url, params, body)
 
-        # Write pre-call record before the HTTP attempt
-        seq, _request_id = self._replay_log.record_before(
-            method="POST", endpoint=endpoint,
-            location_params=location_params, params=params, body=body,
-        )
-
-        try:
+        with self._replay_log.record("POST", endpoint, location_params, params, body) as rec:
             response = self.session.post(url=url, params=params, json=body,
                                           headers=self.request_headers, timeout=self._timeout)
             LOGGER.debug("POST Response: %s %s", response.status_code, response.url)
@@ -386,10 +387,7 @@ class ArgusClient:
                     success = "error" not in response.json()
                 except Exception:
                     success = False
-            self._replay_log.record_after(seq, success=success)
-        except Exception as exc:
-            self._replay_log.record_after(seq, success=False, error=str(exc))
-            raise
+            rec.success = success
 
         return response
 ```
@@ -402,26 +400,25 @@ Only `post()` is recorded — `get()` calls are read-only and do not mutate stat
 
 ### 3.1 Storage Location
 
-The JSONL replay file is written to the **test's existing log directory**. For now, this is the only supported storage target.
+The JSONL replay file is written to the **test's existing log directory**. Each consumer passes its log directory at client construction time. There is no separate env var or fallback — the replay log is co-located with other test artifacts.
 
 - For SCT: `~/sct-results/latest/`
-- For other consumers: pass `log_dir` to the client constructor or set `ARGUS_LOG_DIR`. Falls back to the current working directory.
 
 ### 3.2 Multiple Files per Run
 
 Because the filename includes `init_ts_ms`, parallel processes using the same `log_dir` and `run_id` each write to their own file:
 
 ```
-sct_argus_events_550e8400-..._1712345600000.jsonl   ← shard 0
-sct_argus_events_550e8400-..._1712345600042.jsonl   ← shard 1
-sct_argus_events_550e8400-..._1712345600107.jsonl   ← shard 2
+argus_replay_log_550e8400-..._1712345600000.jsonl   ← worker 0
+argus_replay_log_550e8400-..._1712345600042.jsonl   ← worker 1
+argus_replay_log_550e8400-..._1712345600107.jsonl   ← worker 2
 ```
 
-The CLI upload command and backend ingest endpoint accept all files matching `sct_argus_events_{run_id}_*.jsonl` and merge their records by `seq` before processing.
+The CLI upload command and backend ingest endpoint accept all files matching `argus_replay_log_{run_id}_*.jsonl` and merge their records by `ts` before processing.
 
 ### 3.3 Convention
 
-1. File naming: `sct_argus_events_{run_id}_{unix_ms}.jsonl`
+1. File naming: `argus_replay_log_{run_id}_{unix_ms}.jsonl`
 2. The file is co-located with other test artifacts; no new upload mechanism is needed.
 3. For `pytest-argus-reporter`: add `--argus-log-dir` command-line option that passes through to `ArgusGenericClient`.
 
@@ -449,7 +446,7 @@ The `argus replay` CLI command collects all matching JSONL files, bundles them i
 argus replay [flags]
 
 Flags:
-  --dir <path>         Directory to scan for sct_argus_events_*.jsonl files
+  --dir <path>         Directory to scan for argus_replay_log_*.jsonl files
   --run-id <uuid>      Filter files by run ID (used with --dir)
   --file <path>        Explicit file path (repeatable; mutually exclusive with --dir)
   --dry-run            Validate on the server without executing
@@ -464,8 +461,8 @@ Flags:
 argus replay --dir ~/sct-results/latest --run-id 550e8400-e29b-41d4-a716-446655440000
 
 # Replay explicit files
-argus replay --file sct_argus_events_550e8400-..._1712345600000.jsonl \
-             --file sct_argus_events_550e8400-..._1712345600042.jsonl
+argus replay --file argus_replay_log_550e8400-..._1712345600000.jsonl \
+             --file argus_replay_log_550e8400-..._1712345600042.jsonl
 
 # Dry-run to preview what would be replayed
 argus replay --dir ~/sct-results/latest --run-id 550e8400-... --dry-run
@@ -486,28 +483,9 @@ The archive contains one entry per JSONL file, preserving original filenames so 
 
 ### 5.3 No `--failed-only` Flag
 
-There is no `--failed-only` flag. All records are uploaded unconditionally. The server handles deduplication via `request_id`. See Section 2.4 for the rationale.
+There is no `--failed-only` flag. All records are uploaded unconditionally. The server handles idempotency per endpoint classification (Section 6). See Section 2.4 for the rationale.
 
-### 5.4 Go Package Structure
-
-New package: `cli/internal/replay/`
-
-```
-cli/internal/replay/
-├── collector.go    # Scans directory or accepts explicit file list
-├── archiver.go     # Builds tar.zst archive from collected files
-├── uploader.go     # POSTs archive to ingest endpoint
-├── reporter.go     # Formats and prints server summary response
-└── *_test.go
-```
-
-New command file: `cli/cmd/replay.go` — follows patterns from `cli/cmd/testrun.go`.
-
-New route constant in `cli/internal/api/routes.go`:
-
-```go
-ReplayIngest = "/api/v1/client/replay/ingest"  // POST – upload tar.zst archive of JSONL files
-```
+The CLI implementation details (package structure, command wiring) are handled in the CLI repository separately.
 
 ---
 
@@ -533,7 +511,7 @@ These endpoints are idempotent or last-write-wins. Replaying them multiple times
 | `/driver_matrix/env/submit`                 | `submit_env()`                                                |
 | `/testrun/$type/$id/submit_results`         | `submit_results()` — keyed by table name, overwrites          |
 
-> **Note:** Heartbeat calls (`/testrun/$type/$id/heartbeat`) are **not replayed**. They serve only to signal live test activity and have no value after the test has finished.
+> **Note:** For heartbeat calls (`/testrun/$type/$id/heartbeat`), only the **last** heartbeat record is replayed. This sets the heartbeat timestamp to the expected final value without replaying every intermediate heartbeat (which would serve no purpose after the test has finished).
 
 ### 6.2 CHECK_FIRST — Verify Before Replay
 
@@ -544,9 +522,9 @@ These endpoints create new entities. Replaying when the entity already exists wo
 | `/testrun/$type/submit`    | `GET /testrun/$type/$id/get` — if 200, skip | `submit_run()`, `submit_sct_run()`, `submit_generic_run()`, `submit_driver_matrix_run()`, `submit_sirenada_run()` |
 | `/sct/$id/resource/create` | Check by resource name in run data          | `create_resource()`                                                                                               |
 
-### 6.3 APPEND_IDEMPOTENT — Deduplicate via `request_id`
+### 6.3 APPEND — Naturally Idempotent
 
-These endpoints append records. Duplicate detection uses `request_id` — the server stores processed `request_id` values and silently skips any record whose `request_id` has already been processed.
+These endpoints append records. The backend endpoints are inherently idempotent — duplicate submissions with identical payloads are handled gracefully (either ignored or produce the same result).
 
 | Endpoint                       | Client Methods                 |
 | ------------------------------ | ------------------------------ |
@@ -586,11 +564,10 @@ Content-Type: application/x-tar-zstd
 
 1. Flask receives the `tar.zst` body and decompresses it using `zstandard`
 2. Extracts all JSONL files from the archive
-3. Parses all records, merges across files, sorts by `seq`
+3. Parses all records, merges across files, sorts by `ts`
 4. Applies ordering rules: `submit_run` first, terminal `set_status` / finalize last
 5. For each record:
     - Apply idempotency classification (Section 6)
-    - Check processed `request_id` set — skip duplicates silently
     - Call the corresponding internal service function directly (no HTTP self-requests)
     - Record outcome (success or error with detail)
 6. Returns a summary:
@@ -598,16 +575,13 @@ Content-Type: application/x-tar-zstd
 ```json
 {
     "total": 47,
-    "processed": 12,
-    "succeeded": 11,
+    "processed": 42,
+    "succeeded": 41,
     "failed": 1,
-    "skipped_duplicate": 30,
     "skipped_no_replay": 4,
-    "errors": [{ "seq": 23, "request_id": "...", "endpoint": "/sct/$id/nemesis/submit", "error": "..." }]
+    "errors": [{ "ts": 1712345679100, "endpoint": "/sct/$id/nemesis/submit", "error": "..." }]
 }
 ```
-
-**Idempotency key storage:** Processed `request_id` values are stored per `run_id`. The storage mechanism (a Cassandra set column on the run record, a dedicated table, or an in-memory set for the duration of the ingest request) is an implementation detail decided during Phase 4.
 
 ---
 
@@ -617,18 +591,17 @@ Content-Type: application/x-tar-zstd
 
 **New file:** `argus/client/replay_log.py`
 
-- `ReplayLog` class with `record_before()` and `record_after()` methods
-- Persistent sequence counter (resume from last `seq` in existing file)
-- Thread-safe counter increment with minimal lock contention
-- Filename convention: `sct_argus_events_{run_id}_{unix_ms}.jsonl`
+- `ReplayRecord` data class and `ReplayLog` class with context manager `record()` method
+- `queue.Queue` + background writer thread for contention-free disk I/O
+- Filename convention: `argus_replay_log_{run_id}_{unix_ms}.jsonl`
 
 **Modify:** `argus/client/base.py`
 
-- Add `log_dir` parameter to `ArgusClient.__init__()`
+- Add `log_dir` parameter to `ArgusClient.__init__()` (required, no fallback — each consumer provides its test log directory)
 - Capture `init_ts_ms` at construction time; pass to `ReplayLog`
 - Initialize `ReplayLog` (always on)
 - Add `replay_only` mode: `get()` and `post()` skip the HTTP call but still write to the replay log
-- Wrap `post()` to call `record_before()` then `record_after()`
+- Wrap `post()` with `self._replay_log.record(...)` context manager
 
 **Remove from `argus/client/sct/client.py`:**
 
@@ -636,21 +609,17 @@ Content-Type: application/x-tar-zstd
 
 **New file:** `argus/client/tests/test_replay_log.py`
 
-- JSONL format correctness
-- Sequence number persistence across restarts
-- Thread safety with concurrent writes
+- JSONL format correctness (single line per request, all fields present)
+- Thread safety with concurrent writes via queue
 - `replay_only` mode: no HTTP calls, JSONL written with `success=false`
 - Multiple files for the same run do not interfere
+- Writer thread clean shutdown via `close()`
 
 ### Phase 2: Backend Terminal Status Auto-Finalize
 
 **Modify:** `argus/backend/service/client_service.py`
 
 - In `update_run_status()`: if status is terminal, set `end_time = now()` when not already set
-
-**Remove from backend:**
-
-- `POST /client/sct/<run_id>/events/submit` legacy endpoint
 
 ### Phase 3: Remove SCT Self-Healing Code
 
@@ -678,26 +647,9 @@ Content-Type: application/x-tar-zstd
 - Add `--argus-log-dir` command-line option
 - Pass `log_dir` to `ArgusGenericClient` constructor
 
-### Phase 5: `argus replay` CLI Command (Go)
+### Phase 5: `argus replay` CLI Command
 
-**New command:** `cli/cmd/replay.go`
-
-- Cobra command; flags: `--dir`, `--run-id`, `--file` (repeatable), `--dry-run`, `--target-url`, `--report`
-- No `--failed-only` flag
-
-**New package:** `cli/internal/replay/`
-
-- `collector.go` — scans directory matching `sct_argus_events_*.jsonl`; optionally filters by `run_id`
-- `archiver.go` — builds in-memory `tar.zst` from collected files using `archive/tar` + `github.com/klauspost/compress/zstd`
-- `uploader.go` — POSTs archive to `POST /api/v1/client/replay/ingest`
-- `reporter.go` — formats and prints the server summary response
-- `*_test.go` — unit tests for each component
-
-**Add to `cli/internal/api/routes.go`:**
-
-```go
-ReplayIngest = "/api/v1/client/replay/ingest"  // POST – tar.zst archive of JSONL replay files
-```
+Add an `argus replay` command to the CLI that collects JSONL files, bundles them into a `tar.zst` archive, and uploads to the Argus ingest endpoint. Supports `--dir`, `--run-id`, `--file`, `--dry-run`, `--target-url`, and `--report` flags. Implementation details handled in the CLI repository.
 
 ### Phase 6: Server-Side Replay Ingest (Argus Backend)
 
@@ -710,8 +662,7 @@ ReplayIngest = "/api/v1/client/replay/ingest"  // POST – tar.zst archive of JS
 **New service:** `argus/backend/service/replay_service.py`
 
 - Extracts and merges JSONL files from archive
-- Sorts records by `seq`, applies ordering rules
+- Sorts records by `ts`, applies ordering rules
 - Maps endpoint templates to internal service functions
-- Checks and stores processed `request_id` values for deduplication
 - Applies idempotency classification (Section 6)
 - Collects per-record outcomes; returns summary

--- a/docs/plans/request_replay.md
+++ b/docs/plans/request_replay.md
@@ -19,14 +19,11 @@ All Argus API communication flows through the `ArgusClient` base class in `argus
 - `get()` (line 116) — used for status checks, data retrieval
 - `post()` (line 132) — used for all data submissions
 
-This single chokepoint makes it straightforward to intercept all requests.
+This single chokepoint makes it straightforward to intercept all state-mutating requests.
 
 **Current logging (DEBUG level):**
+
 ```python
-# base.py line 121
-LOGGER.debug("GET Request: %s, params: %s", url, params)
-# base.py line 128
-LOGGER.debug("GET Response: %s %s", response.status_code, response.url)
 # base.py line 143
 LOGGER.debug("POST Request: %s, params: %s, body: %s", url, params, body)
 # base.py line 151
@@ -36,6 +33,7 @@ LOGGER.debug("POST Response: %s %s", response.status_code, response.url)
 These debug logs are human-readable but not machine-parseable. They lack structure, don't include all the fields needed for replay, and are mixed in with all other application logs.
 
 **Retry configuration:**
+
 ```python
 retry_strategy = Retry(
     total=max_retries,       # default: 3
@@ -54,12 +52,12 @@ This retries on connection failures and read timeouts only, not on HTTP error st
 
 Four specialized clients extend `ArgusClient`, each with their own test type and routes:
 
-| Client | File | test_type | Routes |
-|--------|------|-----------|--------|
-| `ArgusSCTClient` | `argus/client/sct/client.py` | `scylla-cluster-tests` | 24+ (packages, screenshots, resources, nemesis, events, junit, stress commands, config, email, performance, gemini) |
-| `ArgusGenericClient` | `argus/client/generic/client.py` | `generic` | 3 (submit_run, trigger_jobs, finalize) |
-| `ArgusDriverMatrixClient` | `argus/client/driver_matrix_tests/client.py` | `driver-matrix-tests` | 3 (submit_driver_result, submit_driver_failure, submit_env) |
-| `ArgusSirenadaClient` | `argus/client/sirenada/client.py` | `sirenada` | 1 (submit_sirenada_run — does everything in one call) |
+| Client                    | File                                         | test_type              | Routes                                                                                                              |
+| ------------------------- | -------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `ArgusSCTClient`          | `argus/client/sct/client.py`                 | `scylla-cluster-tests` | 24+ (packages, screenshots, resources, nemesis, events, junit, stress commands, config, email, performance, gemini) |
+| `ArgusGenericClient`      | `argus/client/generic/client.py`             | `generic`              | 3 (submit_run, trigger_jobs, finalize)                                                                              |
+| `ArgusDriverMatrixClient` | `argus/client/driver_matrix_tests/client.py` | `driver-matrix-tests`  | 3 (submit_driver_result, submit_driver_failure, submit_env)                                                         |
+| `ArgusSirenadaClient`     | `argus/client/sirenada/client.py`            | `sirenada`             | 1 (submit_sirenada_run — does everything in one call)                                                               |
 
 All clients inherit the same `get()` and `post()` methods, so the replay log integration happens once in the base class.
 
@@ -77,6 +75,7 @@ The event pipeline is particularly relevant because it operates across multiple 
 ### 1.4 Usage in pytest-argus-reporter
 
 The pytest plugin (`pytest-argus-reporter/pytest_argus_reporter.py`) uses `ArgusGenericClient` and supports configuration via command-line options:
+
 - `--argus-run-id`
 - `--argus-test-type`
 - `--argus-api-key`
@@ -139,12 +138,14 @@ if not argus_client.get_run().get("events"):
 ```
 
 The function:
+
 1. Reads the local `~/sct-results/latest/` directory
 2. Reconstructs `EventsProcessesRegistry` from disk
 3. Collects the last 100 events grouped by severity
 4. Submits them as a batch via `client.submit_events()`
 
 **Limitations:**
+
 - Only recovers **events** — not results, resources, packages, nemesis, configs, or any other data type
 - Only triggered during the `collect-logs` CLI step — if that step doesn't run, no recovery
 - Checks `get_run().get("events")` — if the run itself wasn't submitted (argus was down from the start), `get_run()` will fail and recovery is skipped
@@ -161,22 +162,22 @@ All node-level argus operations (`_add_node_to_argus`, `update_shards_in_argus`,
 
 #### 1.5.7 Summary of Gaps
 
-| Data Type | Current Recovery | Gap |
-|-----------|-----------------|-----|
-| Events (real-time) | None — fire-and-forget | Lost if argus is down during event |
-| Events (batch) | `argus_offline_collect_events` — last 100 from disk | Only 100 events, only during `collect-logs`, only if run exists in argus |
-| Test run submission | None | If argus is down at test start, nothing works |
-| Test status | None | Lost |
-| Results/performance | None | Lost — most expensive data |
-| Resources (nodes) | None | Lost |
-| Packages | None | Lost |
-| Nemesis records | None | Lost |
-| Logs/screenshots | None | Lost (links only, actual files are on S3) |
-| JUnit reports | None | Lost |
-| Config | None | Lost |
-| Stress commands | None | Lost |
+| Data Type           | Current Recovery                                    | Gap                                                                      |
+| ------------------- | --------------------------------------------------- | ------------------------------------------------------------------------ |
+| Events (real-time)  | None — fire-and-forget                              | Lost if argus is down during event                                       |
+| Events (batch)      | `argus_offline_collect_events` — last 100 from disk | Only 100 events, only during `collect-logs`, only if run exists in argus |
+| Test run submission | None                                                | If argus is down at test start, nothing works                            |
+| Test status         | None                                                | Lost                                                                     |
+| Results/performance | None                                                | Lost — most expensive data                                               |
+| Resources (nodes)   | None                                                | Lost                                                                     |
+| Packages            | None                                                | Lost                                                                     |
+| Nemesis records     | None                                                | Lost                                                                     |
+| Logs/screenshots    | None                                                | Lost (links only, actual files are on S3)                                |
+| JUnit reports       | None                                                | Lost                                                                     |
+| Config              | None                                                | Lost                                                                     |
+| Stress commands     | None                                                | Lost                                                                     |
 
-**The replay log addresses all of these gaps** because it records at the HTTP layer — every `get()` and `post()` call is captured regardless of the data type. SCT's existing recovery is event-specific and limited; the replay log is universal.
+**The replay log addresses all of these gaps** because it records at the HTTP layer — every `post()` call is captured regardless of the data type. SCT's existing recovery is event-specific and limited; the replay log is universal.
 
 #### 1.5.8 How the Replay Log Replaces SCT's Self-Healing
 
@@ -208,8 +209,8 @@ Nothing. They get the replay log automatically because it's in `ArgusClient`. Th
 
 This is **not** request logging for debugging. This is a **replay journal** — a write-ahead log of every API call that can be used to reconstruct Argus state from scratch.
 
-1. **Always on by default** — we don't know when Argus will start failing, so every request must be recorded
-2. **Independent of request outcome** — captures what *should* be sent to achieve the desired state, not what happened
+1. **Always on by default** — we don't know when Argus will start failing, so every mutating request must be recorded
+2. **Independent of request outcome** — captures what _should_ be sent to achieve the desired state, not what happened
 3. **Single file per test run** — one test run is always one type, no need for multi-file complexity
 4. **Persistent atomic sequence numbers** — `seq` field uses a lock-protected counter that survives process restarts; this determines the exact replay order even in concurrent environments
 5. **Records success/failure** — so replay can filter to only re-send what failed
@@ -219,6 +220,7 @@ This is **not** request logging for debugging. This is a **replay journal** — 
 A `ReplayLog` class initialized in `ArgusClient.__init__()`, always active. Writes to a single JSONL file.
 
 **File location:** `{log_dir}/argus_replay_{run_id}.jsonl`
+
 - `log_dir` determined by constructor param or `ARGUS_LOG_DIR` env var, falling back to current working directory
 
 ### 2.3 JSONL Record Schema
@@ -248,19 +250,20 @@ Each line in the file is a self-contained JSON object:
 
 **Field descriptions:**
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `seq` | int | Atomic, persistent sequence number. Determines replay order. |
-| `ts` | string | ISO 8601 timestamp of when the request was made. |
-| `method` | string | HTTP method: `"GET"` or `"POST"`. |
-| `endpoint` | string | Route template with `$` placeholders (e.g. `/testrun/$type/$id/submit_results`). Enables replay against any Argus instance. |
-| `location_params` | object | Parameters to resolve the endpoint template into a full path. |
-| `params` | object\|null | URL query parameters. |
-| `body` | object\|null | Full request body as sent to the API. Includes `schema_version` via `generic_body`. |
-| `test_type` | string | The client's test type (redundant with body but useful for filtering). |
-| `success` | bool | `true` if HTTP 200 and response status "ok", `false` otherwise. |
+| Field             | Type         | Description                                                                                                                 |
+| ----------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| `seq`             | int          | Atomic, persistent sequence number. Determines replay order.                                                                |
+| `ts`              | string       | ISO 8601 timestamp of when the request was made.                                                                            |
+| `method`          | string       | HTTP method: `"GET"` or `"POST"`.                                                                                           |
+| `endpoint`        | string       | Route template with `$` placeholders (e.g. `/testrun/$type/$id/submit_results`). Enables replay against any Argus instance. |
+| `location_params` | object       | Parameters to resolve the endpoint template into a full path.                                                               |
+| `params`          | object\|null | URL query parameters.                                                                                                       |
+| `body`            | object\|null | Full request body as sent to the API. Includes `schema_version` via `generic_body`.                                         |
+| `test_type`       | string       | The client's test type (redundant with body but useful for filtering).                                                      |
+| `success`         | bool         | `true` if HTTP status is 2xx and the response body does not contain an `"error"` key, `false` otherwise.                    |
 
 **What is NOT stored (by design):**
+
 - Auth token — security: tokens are per-user and may rotate
 - HTTP headers — reconstructed at replay time
 - Response body — not needed for replay; success/failure is enough
@@ -344,7 +347,7 @@ Python's `file.write()` under the GIL guarantees that individual `write()` calls
 
 ### 2.5 Integration into ArgusClient
 
-The replay log is initialized in `ArgusClient.__init__()` and called from `get()` and `post()`:
+The replay log is initialized in `ArgusClient.__init__()` and called from `post()`:
 
 ```python
 class ArgusClient:
@@ -364,10 +367,10 @@ class ArgusClient:
         LOGGER.debug("POST Response: %s %s", response.status_code, response.url)
 
         # Record to replay log — determine success without raising
-        success = response.status_code == 200
+        success = 199 < response.status_code < 300
         if success:
             try:
-                success = response.json().get("status") == "ok"
+                success = "error" not in response.json()
             except Exception:
                 success = False
         self._replay_log.record(
@@ -379,39 +382,30 @@ class ArgusClient:
         return response
 ```
 
-The same pattern applies to `get()`. The replay log write happens after the request completes (or fails), before the response is returned to the caller. This ensures we capture the actual success/failure status.
+Only `post()` is recorded — `get()` calls are read-only and do not mutate state, so they are not included in the replay log. The replay log write happens after the request completes (or fails), before the response is returned to the caller. This ensures we capture the actual success/failure status.
 
 ---
 
 ## 3. Log Storage Strategy
 
-### 3.1 Problem
+### 3.1 Storage Location
 
-Each project using the argus client has different log directories and artifact upload conventions. We need a uniform approach that doesn't require new infrastructure.
+The JSONL replay file is written to the **test's existing log directory**. For now, this is the only supported storage target. How replay files are stored and accessed for other use-cases (e.g. generic CI environments) will be determined in the future.
 
-### 3.2 Solution: Ride With Existing Artifacts
+- For SCT: `~/sct-results/latest/`
+- For other consumers: pass `log_dir` to the client constructor or set the `ARGUS_LOG_DIR` environment variable. Falls back to the current working directory.
 
-The JSONL file is placed in each project's existing log directory and uploaded alongside existing test artifacts:
+### 3.2 Convention
 
-| Project | Log Directory | Upload Mechanism |
-|---------|-------------|-----------------|
-| SCT | `~/sct-results/latest/` | Already uploads to S3 via `sdcm` |
-| DTest (pytest) | pytest `--basetemp` or CWD | CI artifact upload step |
-| Driver Matrix | Jenkins workspace | CI artifact upload step |
-| Sirenada | Test results path (passed to client) | Already uploads to S3 |
-
-### 3.3 Convention
-
-1. Pass `log_dir` to the client constructor, or set `ARGUS_LOG_DIR` environment variable. Falls back to current working directory.
-2. File naming: `argus_replay_{run_id}.jsonl` — one file per test run.
-3. The file is uploaded alongside existing test artifacts — no new upload mechanism needed.
-4. For `pytest-argus-reporter`: add `--argus-log-dir` command-line option that passes through to `ArgusGenericClient`.
+1. File naming: `argus_replay_{run_id}.jsonl` — one file per test run.
+2. The file is co-located with other test artifacts; no new upload mechanism is needed.
+3. For `pytest-argus-reporter`: add `--argus-log-dir` command-line option that passes through to `ArgusGenericClient`.
 
 ---
 
 ## 4. `argus replay` CLI Command
 
-The replay mechanism is implemented in the `argus-cli` Go project because it is the official Argus tooling.
+The `argus replay` CLI command is a thin uploader. It reads the local JSONL file and POSTs it to the Argus server-side ingest endpoint (`POST /api/v1/client/replay/ingest`). All replay logic — ordering, idempotency, execution — runs on the server.
 
 ### 4.1 Command Interface
 
@@ -420,19 +414,16 @@ argus replay <path-to-jsonl-file> [flags]
 
 Flags:
   --failed-only       Only replay requests that originally failed (default: true)
-  --filter-endpoint   Only replay requests matching this endpoint pattern (glob)
-  --dry-run           Parse and validate without sending requests
+  --dry-run           Validate on the server without executing
   --force-all         Ignore idempotency checks, replay everything
   --target-url        Override the base URL (replay against different Argus instance)
-  --concurrency       Max parallel requests (default: 1 — sequential)
   --report            Output format for summary: "text" (default) or "json"
-  --run-id            Filter to a specific run_id
 ```
 
 **Examples:**
 
 ```bash
-# Replay all failed requests from a test run
+# Upload replay file to Argus for server-side processing
 argus replay ./argus_replay_550e8400.jsonl
 
 # Dry-run to see what would be replayed
@@ -440,12 +431,6 @@ argus replay ./argus_replay_550e8400.jsonl --dry-run
 
 # Replay against a different Argus instance
 argus replay ./argus_replay_550e8400.jsonl --target-url https://argus-staging.example.com
-
-# Replay everything, including successful requests (full state reconstruction)
-argus replay ./argus_replay_550e8400.jsonl --failed-only=false --force-all
-
-# Batch replay after outage
-find /path/to/logs -name "argus_replay_*.jsonl" | xargs argus replay --failed-only --report json
 ```
 
 ### 4.2 Go Package Structure
@@ -454,105 +439,74 @@ New package: `cli/internal/replay/`
 
 ```
 cli/internal/replay/
-├── parser.go       # JSONL file reader → []ReplayEntry
-├── ordering.go     # Sort by seq, group submit/middle/finalize
-├── executor.go     # HTTP replay with idempotency logic
-├── reporter.go     # Summary output (text table or JSON)
+├── uploader.go     # Reads JSONL file, POSTs to ingest endpoint
+├── reporter.go     # Formats and prints server summary response
 └── *_test.go       # Tests for each component
 ```
 
 New command file: `cli/cmd/replay.go` — follows patterns from `cli/cmd/testrun.go`.
 
-### 4.3 Replay Ordering
-
-The `seq` field from the JSONL records determines execution order:
-
-1. **Parse** all entries from the file
-2. **Filter** based on flags (`--failed-only`, `--filter-endpoint`, `--run-id`)
-3. **Sort** by `seq` — the atomic counter guarantees causal ordering even from concurrent producers
-4. **Group** into three phases:
-   - **Phase A (sequential):** `submit_run` / `submit_*_run` entries — must execute first; if the run already exists in Argus, skip
-   - **Phase B (optionally parallel):** All other operations — replay in `seq` order; `--concurrency > 1` enables parallel execution within this group
-   - **Phase C (sequential):** `finalize_run` / `finalize_*_run` entries — must execute last
-5. **Execute** each phase, applying the appropriate idempotency strategy
-
-### 4.4 URL Reconstruction
-
-The replay command reconstructs the full URL from the stored `endpoint` template and `location_params`:
-
-```go
-// Given:
-//   endpoint: "/testrun/$type/$id/submit_results"
-//   location_params: {"type": "scylla-cluster-tests", "id": "uuid"}
-//   target_url: "https://argus.scylladb.com" (from --target-url or config)
-
-url := targetURL + "/api/v1/client" + resolveEndpoint(endpoint, locationParams)
-// Result: "https://argus.scylladb.com/api/v1/client/testrun/scylla-cluster-tests/uuid/submit_results"
-```
-
-This allows replaying against any Argus instance, not just the original target.
-
 ---
 
 ## 5. Endpoint Idempotency Classification
 
-Each API endpoint is classified into one of four replay strategies. The `argus replay` command uses this classification to determine how to handle each entry.
+Each API endpoint is classified into one of four replay strategies. The server-side ingest endpoint uses this classification to determine how to handle each entry.
 
 ### 5.1 SAFE — Replay Freely
 
 These endpoints are idempotent or last-write-wins. Replaying them multiple times produces the same result.
 
-| Endpoint | Client Methods |
-|----------|---------------|
-| `/testrun/$type/$id/set_status` | `set_status()`, `set_sct_run_status()`, `set_matrix_status()` |
-| `/testrun/$type/$id/heartbeat` | `heartbeat()`, `sct_heartbeat()` |
-| `/testrun/$type/$id/update_product_version` | `update_product_version()`, `update_scylla_version()` |
-| `/sct/$id/sct_runner/set` | `set_sct_runner()` |
-| `/testrun/$type/$id/logs/submit` | `submit_logs()`, `submit_sct_logs()` |
-| `/sct/$id/screenshots/submit` | `submit_screenshots()` |
-| `/sct/$id/packages/submit` | `submit_packages()` |
-| `/sct/$id/events/submit` | `submit_events()` (batch overwrites) |
-| `/sct/$id/resource/$name/update` | `update_resource()` |
-| `/sct/$id/resource/$name/shards` | `update_shards_for_resource()` |
-| `/$id/config/submit` | `sct_submit_config()` |
-| `/driver_matrix/env/submit` | `submit_env()` |
-| `/testrun/$type/$id/finalize` | `finalize_run()`, `finalize_sct_run()`, `finalize_generic_run()` |
-| `/testrun/$type/$id/submit_results` | `submit_results()` — keyed by table name, overwrites |
+| Endpoint                                    | Client Methods                                                   |
+| ------------------------------------------- | ---------------------------------------------------------------- |
+| `/testrun/$type/$id/set_status`             | `set_status()`, `set_sct_run_status()`, `set_matrix_status()`    |
+| `/testrun/$type/$id/update_product_version` | `update_product_version()`, `update_scylla_version()`            |
+| `/sct/$id/sct_runner/set`                   | `set_sct_runner()`                                               |
+| `/testrun/$type/$id/logs/submit`            | `submit_logs()`, `submit_sct_logs()`                             |
+| `/sct/$id/screenshots/submit`               | `submit_screenshots()`                                           |
+| `/sct/$id/packages/submit`                  | `submit_packages()`                                              |
+| `/sct/$id/events/submit`                    | `submit_events()` (batch overwrites)                             |
+| `/sct/$id/resource/$name/update`            | `update_resource()`                                              |
+| `/sct/$id/resource/$name/shards`            | `update_shards_for_resource()`                                   |
+| `/$id/config/submit`                        | `sct_submit_config()`                                            |
+| `/driver_matrix/env/submit`                 | `submit_env()`                                                   |
+| `/testrun/$type/$id/finalize`               | `finalize_run()`, `finalize_sct_run()`, `finalize_generic_run()` |
+| `/testrun/$type/$id/submit_results`         | `submit_results()` — keyed by table name, overwrites             |
+
+> **Note:** Heartbeat calls (`/testrun/$type/$id/heartbeat`) are **not replayed**. They serve only to signal live test activity and have no value after the test has finished.
 
 ### 5.2 CHECK_FIRST — Verify Before Replay
 
 These endpoints create new entities. Replaying when the entity already exists would cause errors or duplicates.
 
-| Endpoint | Check Method | Client Methods |
-|----------|-------------|---------------|
-| `/testrun/$type/submit` | `GET /testrun/$type/$id/get` — if 200, skip | `submit_run()`, `submit_sct_run()`, `submit_generic_run()`, `submit_driver_matrix_run()`, `submit_sirenada_run()` |
-| `/sct/$id/resource/create` | Check by resource name in run data | `create_resource()` |
+| Endpoint                   | Check Method                                | Client Methods                                                                                                    |
+| -------------------------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `/testrun/$type/submit`    | `GET /testrun/$type/$id/get` — if 200, skip | `submit_run()`, `submit_sct_run()`, `submit_generic_run()`, `submit_driver_matrix_run()`, `submit_sirenada_run()` |
+| `/sct/$id/resource/create` | Check by resource name in run data          | `create_resource()`                                                                                               |
 
-### 5.3 APPEND — May Create Duplicates
+### 5.3 APPEND — Safe to Replay
 
-These endpoints add records that may not have natural deduplication keys. The replay command warns the user when replaying these.
+These endpoints append records. All inserts are safe — replaying them is idempotent from a data-integrity standpoint because duplicate entries are acceptable.
 
-| Endpoint | Risk | Client Methods |
-|----------|------|---------------|
-| `/sct/$id/event/submit` | Duplicate events | `submit_event()` |
-| `/sct/$id/nemesis/submit` | Duplicate nemesis records | `submit_nemesis()` |
-| `/sct/$id/nemesis/finalize` | Must pair with submit | `finalize_nemesis()` |
-| `/driver_matrix/result/submit` | Duplicate driver results | `submit_driver_result()` |
-| `/driver_matrix/result/fail` | Duplicate failure records | `submit_driver_failure()` |
-| `/sct/$id/stress_cmd/submit` | Duplicate stress commands | `add_stress_command()` |
-| `/sct/$id/junit/submit` | Duplicate junit reports | `sct_submit_junit_report()` |
-| `/sct/$id/gemini/submit` | Duplicate gemini results | `submit_gemini_results()` |
-| `/sct/$id/performance/submit` | Duplicate perf results | `submit_performance_results()` |
+| Endpoint                       | Client Methods                 |
+| ------------------------------ | ------------------------------ |
+| `/sct/$id/event/submit`        | `submit_event()`               |
+| `/sct/$id/nemesis/submit`      | `submit_nemesis()`             |
+| `/sct/$id/nemesis/finalize`    | `finalize_nemesis()`           |
+| `/driver_matrix/result/submit` | `submit_driver_result()`       |
+| `/driver_matrix/result/fail`   | `submit_driver_failure()`      |
+| `/sct/$id/stress_cmd/submit`   | `add_stress_command()`         |
+| `/sct/$id/junit/submit`        | `sct_submit_junit_report()`    |
+| `/sct/$id/gemini/submit`       | `submit_gemini_results()`      |
+| `/sct/$id/performance/submit`  | `submit_performance_results()` |
 
 ### 5.4 SKIP — Do Not Replay by Default
 
 These endpoints have side effects beyond Argus state. They are skipped unless `--force-all` is passed.
 
-| Endpoint | Side Effect | Client Methods |
-|----------|------------|---------------|
-| `/testrun/report/email` | Sends actual emails | `send_email()` |
-| `/planning/plan/trigger` | Triggers CI jobs | `trigger_jobs()` |
-| `/sct/$id/resource/$name/terminate` | Destructive state change | `terminate_resource()` |
+| Endpoint                 | Side Effect         | Client Methods   |
+| ------------------------ | ------------------- | ---------------- |
+| `/testrun/report/email`  | Sends actual emails | `send_email()`   |
+| `/planning/plan/trigger` | Triggers CI jobs    | `trigger_jobs()` |
 
 ---
 
@@ -560,89 +514,32 @@ These endpoints have side effects beyond Argus state. They are skipped unless `-
 
 The goal is full automation without adding new services.
 
-### 6.1 In-Process Retry After Test Completion
+### 6.1 Manual Replay via CLI
 
-Add a `replay_failed()` method to `ReplayLog`:
-
-```python
-def replay_failed(self, client: "ArgusClient") -> dict:
-    """Attempt to replay failed requests. Called after test completion.
-
-    Returns dict with counts: {"total": N, "replayed": N, "succeeded": N, "failed": N}
-    """
-    self._file.flush()
-    stats = {"total": 0, "replayed": 0, "succeeded": 0, "failed": 0}
-
-    with open(self._path, "r") as f:
-        for line in f:
-            entry = json.loads(line)
-            stats["total"] += 1
-            if entry["success"]:
-                continue
-            stats["replayed"] += 1
-            try:
-                if entry["method"] == "POST":
-                    response = client.post(
-                        endpoint=entry["endpoint"],
-                        location_params=entry["location_params"],
-                        params=entry["params"],
-                        body=entry["body"],
-                    )
-                else:
-                    response = client.get(
-                        endpoint=entry["endpoint"],
-                        location_params=entry["location_params"],
-                        params=entry["params"],
-                    )
-                client.check_response(response)
-                stats["succeeded"] += 1
-            except Exception:
-                stats["failed"] += 1
-
-    return stats
-```
-
-This is called automatically in `ArgusClient.finalize_run()` when the replay log is active. It's best-effort — failures are logged but don't affect the test's exit status. Argus may have recovered by the time the test finishes, so this catches many transient outages without any manual intervention.
-
-### 6.2 Manual Replay From S3
-
-For extended outages where the in-process retry also fails:
+After an outage, download the replay JSONL file from the test log directory and upload it to Argus for server-side processing:
 
 ```bash
-# Download test artifacts (includes JSONL file)
-argus run logs download <run-id>
-
-# Replay only failed requests
-argus replay argus_replay_*.jsonl --failed-only --report
+# Upload replay file to Argus for server-side processing
+argus replay ./argus_replay_550e8400.jsonl --server-side
 ```
 
-### 6.3 Batch Replay for Outage Recovery
+The CLI's only job is to upload the file. All replay logic runs server-side.
 
-After an extended Argus outage affecting multiple test runs:
+### 6.2 Server-Side Replay Ingest Endpoint
 
-```bash
-# Find all replay logs and replay failed requests
-find /path/to/downloaded/logs -name "argus_replay_*.jsonl" \
-  | xargs argus replay --failed-only --report json > replay_report.json
-
-# Review the report
-cat replay_report.json | jq '.[] | select(.failed > 0)'
-```
-
-### 6.4 Server-Side Replay Ingest Endpoint
-
-Instead of requiring external tooling to replay requests one-by-one, Argus itself can accept a JSONL replay file and process it internally. This is the most powerful automation option — Argus heals itself.
+Argus itself accepts a JSONL replay file and processes it internally. This is the only supported replay path — Argus heals itself.
 
 **New API endpoint:**
 
 ```
 POST /api/v1/client/replay/ingest
-Content-Type: application/octet-stream (or multipart/form-data)
+Content-Type: multipart/form-data
 
-Body: raw JSONL file content
+Body: JSONL file upload
 ```
 
 **Query parameters:**
+
 - `failed_only=true` (default) — only process entries with `"success": false`
 - `dry_run=false` — if true, validate and return what would be replayed without executing
 - `force_all=false` — if true, skip idempotency checks
@@ -651,53 +548,28 @@ Body: raw JSONL file content
 
 1. Argus receives the JSONL file
 2. Parses entries, sorts by `seq`
-3. Applies the same ordering rules as `argus replay` CLI (submit first, finalize last)
+3. Applies ordering rules (submit first, finalize last)
 4. Applies idempotency classification (Section 5) — checks existence before creating, skips email/trigger endpoints
 5. Executes each entry against its own internal service layer directly (no HTTP overhead — calls the service functions that the API controller would call)
 6. Returns a summary report:
 
 ```json
 {
-  "total": 47,
-  "processed": 12,
-  "succeeded": 11,
-  "failed": 1,
-  "skipped": 35,
-  "errors": [
-    {"seq": 23, "endpoint": "/sct/$id/nemesis/submit", "error": "Duplicate nemesis record"}
-  ]
+    "total": 47,
+    "processed": 12,
+    "succeeded": 11,
+    "failed": 1,
+    "skipped": 35,
+    "errors": [{ "seq": 23, "endpoint": "/sct/$id/nemesis/submit", "error": "Duplicate nemesis record" }]
 }
 ```
 
-**Advantages over CLI replay:**
+**Advantages:**
+
 - **No HTTP round-trip overhead** — Argus processes the replay internally by calling service functions directly, not re-issuing HTTP requests to itself
-- **Argus can self-heal** — After recovering from an outage, Argus can process replay files from S3 without any external tooling
+- **Argus can self-heal** — upload the file and Argus does the rest
 - **Atomic processing** — Argus can wrap the replay in a database transaction or batch operation
 - **Access control** — The endpoint uses the same `@api_login_required` auth as other client endpoints
-
-**Integration with test artifact storage:**
-
-Since replay JSONL files are uploaded to S3 alongside test logs, Argus can also pull them directly:
-
-```
-POST /api/v1/client/replay/ingest_from_s3
-Body: {"run_id": "uuid", "s3_path": "s3://bucket/path/argus_replay_uuid.jsonl"}
-```
-
-Or even scan for replay files automatically after recovering from downtime, processing any files that contain failed entries. This makes the system fully self-healing — no human intervention required after an outage.
-
-**CLI integration:**
-
-The `argus replay` CLI command can also use this endpoint instead of replaying client-side:
-
-```bash
-# Upload replay file to Argus for server-side processing
-argus replay ./argus_replay_550e8400.jsonl --server-side
-
-# Argus processes internally, returns summary
-```
-
-This is preferred over client-side replay when the JSONL file is large, because the server avoids HTTP round-trip overhead per entry.
 
 ---
 
@@ -706,72 +578,60 @@ This is preferred over client-side replay when the JSONL file is large, because 
 ### Phase 1: Replay Log and Replay-Only Mode (Python Client)
 
 **New file:** `argus/client/replay_log.py`
+
 - `ReplayLog` class with persistent sequence counter
 - Thread-safe recording with minimal lock contention
 - `replay_failed()` method for in-process retry
 
 **Modify:** `argus/client/base.py`
+
 - Add `log_dir` parameter to `ArgusClient.__init__()`
 - Initialize `ReplayLog` (always on)
 - Add `replay_only` mode: when `True`, `get()` and `post()` skip the HTTP call but still write to the replay log with `"success": false`
 - Optional health check on init: if argus is unreachable, auto-enter replay-only mode
-- Call `record()` from `get()` and `post()` after each request
-- Call `replay_failed()` from `finalize_run()`
+- Call `record()` from `post()` after each request
 
 **New file:** `argus/client/tests/test_replay_log.py`
+
 - Test JSONL format correctness
 - Test sequence number persistence across restarts
 - Test thread safety with concurrent writes
-- Test `replay_failed()` with mock server
 - Test replay-only mode skips HTTP but writes JSONL
 
 ### Phase 2: pytest-argus-reporter Integration
 
 **Modify:** `pytest-argus-reporter/pytest_argus_reporter.py`
+
 - Add `--argus-log-dir` command-line option
 - Pass `log_dir` to `ArgusGenericClient` constructor
 
 ### Phase 3: `argus replay` CLI Command (Go)
 
 **New command:** `cli/cmd/replay.go`
+
 - Cobra command following `testrun.go` patterns
-- Flags for filtering, dry-run, concurrency, reporting
-- `--server-side` flag to upload JSONL to Argus ingest endpoint instead of client-side replay
+- Uploads the JSONL file to the Argus server-side ingest endpoint (`POST /api/v1/client/replay/ingest`)
+- Flags: `--failed-only`, `--dry-run`, `--force-all`, `--target-url`
+- Prints the summary report returned by the server
 
 **New package:** `cli/internal/replay/`
-- `parser.go` — JSONL file reader, deserializes into `ReplayEntry` structs
-- `ordering.go` — Sort by `seq`, group into submit/middle/finalize phases
-- `executor.go` — HTTP replay with idempotency strategy per endpoint
-- `reporter.go` — Text table and JSON summary output
+
+- `uploader.go` — reads the JSONL file and POSTs it to the ingest endpoint
+- `reporter.go` — formats and prints the server summary response
 - `*_test.go` — Unit tests
 
 ### Phase 4: Server-Side Replay Ingest (Argus Backend)
 
 **New blueprint:** `argus/backend/controller/replay_api.py`
-- `POST /api/v1/client/replay/ingest` — accepts JSONL file, processes internally
-- `POST /api/v1/client/replay/ingest_from_s3` — pulls JSONL from S3 by run_id
+
+- `POST /api/v1/client/replay/ingest` — accepts JSONL file upload, processes internally
 - Applies ordering rules and idempotency classification
 - Calls service layer directly (no HTTP self-requests)
 - Returns summary report with per-entry status
 
 **New service:** `argus/backend/service/replay.py`
+
 - Parses JSONL entries
 - Maps endpoints to internal service functions
 - Applies idempotency checks (Section 5)
 - Batch processing with error collection
-
-### Phase 5: Automation and SCT Cleanup
-
-**Modify:** `argus/client/base.py`
-- Wire `replay_failed()` call into `finalize_run()` path
-- Add logging for replay attempt results
-
-**SCT changes (separate PR in scylla-cluster-tests):**
-- Remove `argus_offline_collect_events()` from `sdcm/utils/argus.py`
-- Remove the `if not argus_client.get_run().get("events")` check from `sct.py`
-- Replace `MagicMock` fallback with `replay_only=True` client initialization
-- Pass `log_dir` to `ArgusSCTClient` constructor (use existing `~/sct-results/latest/`)
-
-**Documentation:**
-- Update `docs/api_usage.md` with replay log and ingest endpoint information
-- Add examples for manual, batch, and server-side replay to this document

--- a/docs/plans/request_replay.md
+++ b/docs/plans/request_replay.md
@@ -94,7 +94,7 @@ Using `unittest.mock.MagicMock` as a production fallback is an anti-pattern. It 
 **Proposed replacement:** If argus client initialization fails (network error, auth error, etc.), the client should either:
 
 1. **Fail the test** — if the team decides argus data is mandatory, the test should not run without it. This is the safest option for preventing silent data loss.
-2. **Switch to replay-only mode** — the `ArgusClient` is still instantiated with a valid `ReplayLog`, but all HTTP calls are skipped. The replay log records every intended request with `"success": false`. When argus recovers, the entire test run can be reconstructed from the JSONL file via `argus replay` or the server-side ingest endpoint (Section 6.4). This gives the same graceful degradation as MagicMock but with **zero data loss**.
+2. **Switch to replay-only mode** — the `ArgusClient` is still instantiated with a valid `ReplayLog`, but all HTTP calls are skipped. The replay log records every intended request with `"success": false`. When argus recovers, the entire test run can be reconstructed from the JSONL file via `argus replay` or the server-side ingest endpoint (Section 7). This gives the same graceful degradation as MagicMock but with **zero data loss**.
 
 The replay-only mode is implemented at the `ArgusClient` level — no changes needed in consumer projects. The client constructor accepts a `replay_only: bool` flag (or detects it from a failed health check), and `get()`/`post()` skip the HTTP call but still write to the replay log.
 
@@ -146,7 +146,7 @@ All node-level argus operations (`_add_node_to_argus`, `update_shards_in_argus`,
 | Data Type           | Previous Recovery                        | With Replay Log                               |
 | ------------------- | ---------------------------------------- | --------------------------------------------- |
 | Events (real-time)  | None — fire-and-forget                   | Captured in JSONL replay log                  |
-| Events (batch)      | `argus_offline_collect_events` — removed | Replaced by replay log                        |
+| Events (batch)      | `argus_offline_collect_events`           | Replaced by replay log                        |
 | Test run submission | None                                     | Captured in JSONL                             |
 | Test status         | None                                     | Captured in JSONL                             |
 | Results/performance | None                                     | Captured in JSONL                             |
@@ -491,38 +491,33 @@ The CLI implementation details (package structure, command wiring) are handled i
 
 ## 6. Endpoint Idempotency Classification
 
-Each API endpoint is classified into one of four replay strategies. The server-side ingest service uses this classification when processing each JSONL entry.
+Each API endpoint is classified into one of three replay strategies. The server-side ingest service uses this classification when processing each JSONL entry.
 
 ### 6.1 SAFE — Replay Freely
 
 These endpoints are idempotent or last-write-wins. Replaying them multiple times produces the same result.
 
-| Endpoint                                    | Client Methods                                                |
-| ------------------------------------------- | ------------------------------------------------------------- |
-| `/testrun/$type/$id/set_status`             | `set_status()`, `set_sct_run_status()`, `set_matrix_status()` |
-| `/testrun/$type/$id/update_product_version` | `update_product_version()`, `update_scylla_version()`         |
-| `/sct/$id/sct_runner/set`                   | `set_sct_runner()`                                            |
-| `/testrun/$type/$id/logs/submit`            | `submit_logs()`, `submit_sct_logs()`                          |
-| `/sct/$id/screenshots/submit`               | `submit_screenshots()`                                        |
-| `/sct/$id/packages/submit`                  | `submit_packages()`                                           |
-| `/sct/$id/resource/$name/update`            | `update_resource()`                                           |
-| `/sct/$id/resource/$name/shards`            | `update_shards_for_resource()`                                |
-| `/$id/config/submit`                        | `sct_submit_config()`                                         |
-| `/driver_matrix/env/submit`                 | `submit_env()`                                                |
-| `/testrun/$type/$id/submit_results`         | `submit_results()` — keyed by table name, overwrites          |
+| Endpoint                                    | Client Methods                                                                                                    |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `/testrun/$type/$id/set_status`             | `set_status()`, `set_sct_run_status()`, `set_matrix_status()`                                                     |
+| `/testrun/$type/$id/update_product_version` | `update_product_version()`, `update_scylla_version()`                                                             |
+| `/testrun/$type/submit`                     | `submit_run()`, `submit_sct_run()`, `submit_generic_run()`, `submit_driver_matrix_run()`, `submit_sirenada_run()` |
+| `/sct/$id/sct_runner/set`                   | `set_sct_runner()`                                                                                                |
+| `/testrun/$type/$id/logs/submit`            | `submit_logs()`, `submit_sct_logs()`                                                                              |
+| `/sct/$id/screenshots/submit`               | `submit_screenshots()`                                                                                            |
+| `/sct/$id/packages/submit`                  | `submit_packages()`                                                                                               |
+| `/sct/$id/resource/create`                  | `create_resource()` — deduplicates by resource name                                                               |
+| `/sct/$id/resource/$name/update`            | `update_resource()`                                                                                               |
+| `/sct/$id/resource/$name/shards`            | `update_shards_for_resource()`                                                                                    |
+| `/$id/config/submit`                        | `sct_submit_config()`                                                                                             |
+| `/driver_matrix/env/submit`                 | `submit_env()`                                                                                                    |
+| `/testrun/$type/$id/submit_results`         | `submit_results()` — keyed by table name, overwrites                                                              |
 
 > **Note:** For heartbeat calls (`/testrun/$type/$id/heartbeat`), only the **last** heartbeat record is replayed. This sets the heartbeat timestamp to the expected final value without replaying every intermediate heartbeat (which would serve no purpose after the test has finished).
 
-### 6.2 CHECK_FIRST — Verify Before Replay
+> **Sirenada bug:** `submit_sirenada_run` (`argus/backend/plugins/sirenada/model.py`) appends to `run.results` without dedup when the run already exists — replaying it duplicates results. The other list fields (`sirenada_test_ids`, `browsers`, `clusters`, `s3_folder_ids`) already have `not in` guards. Fix: add the same `not in` guard to `results` before appending. This should be done as a prerequisite in Phase 2.
 
-These endpoints create new entities. Replaying when the entity already exists would cause errors or duplicates.
-
-| Endpoint                   | Check Method                                | Client Methods                                                                                                    |
-| -------------------------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `/testrun/$type/submit`    | `GET /testrun/$type/$id/get` — if 200, skip | `submit_run()`, `submit_sct_run()`, `submit_generic_run()`, `submit_driver_matrix_run()`, `submit_sirenada_run()` |
-| `/sct/$id/resource/create` | Check by resource name in run data          | `create_resource()`                                                                                               |
-
-### 6.3 APPEND — Naturally Idempotent
+### 6.2 APPEND — Naturally Idempotent
 
 These endpoints append records. The backend endpoints are inherently idempotent — duplicate submissions with identical payloads are handled gracefully (either ignored or produce the same result).
 
@@ -538,7 +533,7 @@ These endpoints append records. The backend endpoints are inherently idempotent 
 | `/sct/$id/gemini/submit`       | `submit_gemini_results()`      |
 | `/sct/$id/performance/submit`  | `submit_performance_results()` |
 
-### 6.4 SKIP — Do Not Replay
+### 6.3 SKIP — Do Not Replay
 
 These endpoints have side effects beyond Argus state. They are always skipped during replay.
 
@@ -603,10 +598,6 @@ Content-Type: application/x-tar-zstd
 - Add `replay_only` mode: `get()` and `post()` skip the HTTP call but still write to the replay log
 - Wrap `post()` with `self._replay_log.record(...)` context manager
 
-**Remove from `argus/client/sct/client.py`:**
-
-- `submit_events()` method (legacy aggregated severity/count)
-
 **New file:** `argus/client/tests/test_replay_log.py`
 
 - JSONL format correctness (single line per request, all fields present)
@@ -615,11 +606,15 @@ Content-Type: application/x-tar-zstd
 - Multiple files for the same run do not interfere
 - Writer thread clean shutdown via `close()`
 
-### Phase 2: Backend Terminal Status Auto-Finalize
+### Phase 2: Backend Changes
 
 **Modify:** `argus/backend/service/client_service.py`
 
 - In `update_run_status()`: if status is terminal, set `end_time = now()` when not already set
+
+**Fix:** `argus/backend/plugins/sirenada/model.py`
+
+- In `submit_sirenada_run()`: add dedup guard on `run.results` before appending (same `not in` pattern already used for `sirenada_test_ids`, `browsers`, `clusters`, `s3_folder_ids`)
 
 ### Phase 3: Remove SCT Self-Healing Code
 


### PR DESCRIPTION
Design document for an always-on JSONL replay log in the Python client and an `argus replay` CLI command to recover lost data when Argus is unavailable during test runs.

Closes QAINFRA-43