### PR TITLE
refactor(plugins/sct): Move nemesis_data to a separate table

### DIFF
--- a/argus/backend/plugins/sct/controller.py
+++ b/argus/backend/plugins/sct/controller.py
@@ -107,6 +107,16 @@ def sct_nemesis_submit(run_id: str):
     }
 
 
+@bp.route("/<string:run_id>/nemesis/get", methods=["GET"])
+@api_login_required
+def sct_nemesis_get(run_id: str):
+    result = SCTService.get_nemesis(run_id=run_id)
+    return {
+        "status": "ok",
+        "response": result
+    }
+
+
 @bp.route("/<string:run_id>/nemesis/finalize", methods=["POST"])
 @api_login_required
 def sct_nemesis_finalize(run_id: str):

--- a/argus/backend/plugins/sct/plugin.py
+++ b/argus/backend/plugins/sct/plugin.py
@@ -1,6 +1,6 @@
 from flask import Blueprint
 
-from argus.backend.plugins.sct.testrun import SCTEvent, SCTJunitReports, SCTTestRun, SCTUnprocessedEvent, StressCommand
+from argus.backend.plugins.sct.testrun import SCTEvent, SCTJunitReports, SCTNemesis, SCTTestRun, SCTUnprocessedEvent, StressCommand
 from argus.backend.plugins.sct.controller import bp as sct_bp
 from argus.backend.plugins.core import PluginInfoBase, PluginModelBase
 from argus.backend.plugins.sct.udt import (
@@ -23,6 +23,7 @@ class PluginInfo(PluginInfoBase):
     all_models = [
         SCTTestRun,
         SCTJunitReports,
+        SCTNemesis,
         SCTEvent,
         SCTUnprocessedEvent,
         StressCommand,

--- a/argus/backend/plugins/sct/service.py
+++ b/argus/backend/plugins/sct/service.py
@@ -14,7 +14,7 @@ from argus.backend.db import ScyllaCluster
 from argus.backend.models.github_issue import GithubIssue, IssueLink
 from argus.backend.models.web import ArgusEventTypes, ErrorEventEmbeddings, CriticalEventEmbeddings
 from argus.backend.models.argus_ai import SCTErrorEventEmbedding, SCTCriticalEventEmbedding
-from argus.backend.plugins.sct.testrun import SCTEvent, SCTEventSeverity, SCTJunitReports, SCTTestRun, SubtestType, SCTUnprocessedEvent, StressCommand
+from argus.backend.plugins.sct.testrun import SCTEvent, SCTEventSeverity, SCTJunitReports, SCTNemesis, SCTTestRun, SubtestType, SCTUnprocessedEvent, StressCommand
 from argus.common.sct_types import GeminiResultsRequest, PerformanceResultsRequest, RawEventPayload, ResourceUpdateRequest
 from argus.backend.plugins.sct.udt import (
     CloudInstanceDetails,
@@ -122,7 +122,8 @@ class SCTService:
                 region=region,
             )
             run.sct_runner_host = details
-            resource = CloudResource(name=name or "sct-runner", resource_type="sct-runner", instance_info=details)
+            resource = CloudResource(
+                name=name or "sct-runner", resource_type="sct-runner", instance_info=details)
             if not any(r.name == resource.name for r in run.allocated_resources):
                 run.allocated_resources.append(resource)
             run.save()
@@ -153,8 +154,10 @@ class SCTService:
             run.subtest_name = SubtestType.GEMINI.value
             run.oracle_nodes_count = gemini_data.get("oracle_nodes_count")
             run.oracle_node_ami_id = gemini_data.get("oracle_node_ami_id")
-            run.oracle_node_instance_type = gemini_data.get("oracle_node_instance_type")
-            run.oracle_node_scylla_version = gemini_data.get("oracle_node_scylla_version")
+            run.oracle_node_instance_type = gemini_data.get(
+                "oracle_node_instance_type")
+            run.oracle_node_scylla_version = gemini_data.get(
+                "oracle_node_scylla_version")
             run.gemini_command = gemini_data.get("gemini_command")
             run.gemini_version = gemini_data.get("gemini_version")
             run.gemini_status = gemini_data.get("gemini_status")
@@ -185,11 +188,16 @@ class SCTService:
         try:
             run: SCTTestRun = SCTTestRun.get(id=run_id)
             run.subtest_name = SubtestType.PERFORMANCE.value
-            run.perf_op_rate_average = performance_results.get("perf_op_rate_average")
-            run.perf_op_rate_total = performance_results.get("perf_op_rate_total")
-            run.perf_avg_latency_99th = performance_results.get("perf_avg_latency_99th")
-            run.perf_avg_latency_mean = performance_results.get("perf_avg_latency_mean")
-            run.perf_total_errors = performance_results.get("perf_total_errors")
+            run.perf_op_rate_average = performance_results.get(
+                "perf_op_rate_average")
+            run.perf_op_rate_total = performance_results.get(
+                "perf_op_rate_total")
+            run.perf_avg_latency_99th = performance_results.get(
+                "perf_avg_latency_99th")
+            run.perf_avg_latency_mean = performance_results.get(
+                "perf_avg_latency_mean")
+            run.perf_total_errors = performance_results.get(
+                "perf_total_errors")
             run.stress_cmd = performance_results.get("stress_cmd")
             run.test_name = performance_results.get("test_name")
             run.save()
@@ -202,7 +210,8 @@ class SCTService:
                 change = int(math.fabs(delta) * 100 / rhs)
                 return change if delta >= 0 else change * -1
 
-            previous_runs = SCTTestRun.get_perf_results_for_test_name(run.build_id, run.start_time, run.test_name)
+            previous_runs = SCTTestRun.get_perf_results_for_test_name(
+                run.build_id, run.start_time, run.test_name)
             metrics_to_check = ["perf_avg_latency_99th",
                                 "perf_avg_latency_mean"] if is_latency_test else ["perf_op_rate_total"]
 
@@ -210,7 +219,8 @@ class SCTService:
             for prev_run in previous_runs:
                 if not older_runs_by_version.get(prev_run["scylla_version"]):
                     older_runs_by_version[prev_run["scylla_version"]] = []
-                older_runs_by_version[prev_run["scylla_version"]].append(prev_run)
+                older_runs_by_version[prev_run["scylla_version"]].append(
+                    prev_run)
 
             regression_found = False
             regression_info = {
@@ -224,11 +234,13 @@ class SCTService:
 
             if performance_results["histograms"]:
                 for histogram in performance_results["histograms"]:
-                    run.histograms = {k: PerformanceHDRHistogram(**v) for k, v in histogram.items()}
+                    run.histograms = {k: PerformanceHDRHistogram(
+                        **v) for k, v in histogram.items()}
 
             for version, runs in older_runs_by_version.items():
                 for metric in metrics_to_check:
-                    best_run = sorted(runs, reverse=(not is_latency_test), key=lambda v: v[metric])[0]
+                    best_run = sorted(runs, reverse=(
+                        not is_latency_test), key=lambda v: v[metric])[0]
                     last_run = runs[0]
 
                     metric_to_best = cmp(run[metric], best_run[metric])
@@ -298,8 +310,10 @@ class SCTService:
 
     @staticmethod
     def create_resource(run_id: str, resource_details: dict) -> str:
-        instance_details = CloudInstanceDetails(**resource_details.pop("instance_details"))
-        resource = CloudResource(**resource_details, instance_info=instance_details)
+        instance_details = CloudInstanceDetails(
+            **resource_details.pop("instance_details"))
+        resource = CloudResource(
+            **resource_details, instance_info=instance_details)
         try:
             run: SCTTestRun = SCTTestRun.get(id=run_id)
             if not any(r.name == resource.name for r in run.get_resources()):
@@ -315,12 +329,15 @@ class SCTService:
     def update_resource_shards(run_id: str, resource_name: str, new_shards: int) -> str:
         try:
             run: SCTTestRun = SCTTestRun.get(id=run_id)
-            resource = next(res for res in run.get_resources() if res.name == resource_name)
+            resource = next(res for res in run.get_resources()
+                            if res.name == resource_name)
             resource.get_instance_info().shards_amount = new_shards
             run.save()
         except StopIteration as exception:
-            LOGGER.error("Resource %s not found in run %s", resource_name, run_id)
-            raise SCTServiceException("Resource not found", resource_name) from exception
+            LOGGER.error("Resource %s not found in run %s",
+                         resource_name, run_id)
+            raise SCTServiceException(
+                "Resource not found", resource_name) from exception
         except SCTTestRun.DoesNotExist as exception:
             LOGGER.error("Run %s not found for SCTTestRun", run_id)
             raise SCTServiceException("Run not found", run_id) from exception
@@ -332,9 +349,11 @@ class SCTService:
         try:
             fields_updated = {}
             run: SCTTestRun = SCTTestRun.get(id=run_id)
-            resource = next(res for res in run.get_resources() if res.name == resource_name)
+            resource = next(res for res in run.get_resources()
+                            if res.name == resource_name)
             instance_info = update_data.pop("instance_info", None)
-            resource.state = ResourceState(update_data.get("state", resource.state)).value
+            resource.state = ResourceState(
+                update_data.get("state", resource.state)).value
             if instance_info:
                 resource_instance_info = resource.get_instance_info()
                 for k, v in instance_info.items():
@@ -343,8 +362,10 @@ class SCTService:
                         fields_updated[k] = v
             run.save()
         except StopIteration as exception:
-            LOGGER.error("Resource %s not found in run %s", resource_name, run_id)
-            raise SCTServiceException("Resource not found", resource_name) from exception
+            LOGGER.error("Resource %s not found in run %s",
+                         resource_name, run_id)
+            raise SCTServiceException(
+                "Resource not found", resource_name) from exception
         except SCTTestRun.DoesNotExist as exception:
             LOGGER.error("Run %s not found for SCTTestRun", run_id)
             raise SCTServiceException("Run not found", run_id) from exception
@@ -359,16 +380,20 @@ class SCTService:
         try:
             run: SCTTestRun = SCTTestRun.get(id=run_id)
             if "sct-runner" in resource_name:  # FIXME: Temp solution until sct-runner name is propagated on submit
-                resource = next(res for res in run.get_resources() if "sct-runner" in res.name)
+                resource = next(res for res in run.get_resources()
+                                if "sct-runner" in res.name)
             else:
-                resource = next(res for res in run.get_resources() if res.name == resource_name)
+                resource = next(res for res in run.get_resources()
+                                if res.name == resource_name)
             resource.get_instance_info().termination_reason = reason
             resource.get_instance_info().termination_time = int(time())
             resource.state = ResourceState.TERMINATED.value
             run.save()
         except StopIteration as exception:
-            LOGGER.error("Resource %s not found in run %s", resource_name, run_id)
-            raise SCTServiceException("Resource not found", resource_name) from exception
+            LOGGER.error("Resource %s not found in run %s",
+                         resource_name, run_id)
+            raise SCTServiceException(
+                "Resource not found", resource_name) from exception
         except SCTTestRun.DoesNotExist as exception:
             LOGGER.error("Run %s not found for SCTTestRun", run_id)
             raise SCTServiceException("Run not found", run_id) from exception
@@ -376,13 +401,25 @@ class SCTService:
         return "terminated"
 
     @staticmethod
+    def get_nemesis(run_id: str) -> list:
+        return list(SCTNemesis.filter(run_id=run_id).all())
+
+    @staticmethod
     def submit_nemesis(run_id: str, nemesis_details: dict) -> str:
         nem_req = NemesisSubmissionRequest(**nemesis_details)
-        node_desc = NodeDescription(name=nem_req.node_name, ip=nem_req.node_ip, shards=nem_req.node_shards)
-        nemesis_info = NemesisRunInfo(
+        try:
+            _ = SCTNemesis.filter(
+                run_id=run_id, start_time=int(nem_req.start_time)).get()
+            return "created"
+        except SCTNemesis.DoesNotExist:
+            pass
+        node_desc = NodeDescription(
+            name=nem_req.node_name, ip=nem_req.node_ip, shards=nem_req.node_shards)
+        nemesis_info = SCTNemesis(
+            run_id=run_id,
+            start_time=int(nem_req.start_time),
             class_name=nem_req.class_name,
             name=nem_req.name,
-            start_time=int(nem_req.start_time),
             end_time=0,
             duration=0,
             stack_trace="",
@@ -391,10 +428,9 @@ class SCTService:
         )
         try:
             run: SCTTestRun = SCTTestRun.get(id=run_id)
-            if not any(nem.name == nem_req.name and nem.start_time == int(nem_req.start_time)
-                       for nem in run.get_nemeses()):
-                run.add_nemesis(nemesis_info)
-                run.save()
+            nemesis_info.save()
+            run.update_nemesis_stats("total")
+            run.save()
         except SCTTestRun.DoesNotExist as exception:
             LOGGER.error("Run %s not found for SCTTestRun", run_id)
             raise SCTServiceException("Run not found", run_id) from exception
@@ -406,21 +442,25 @@ class SCTService:
         nem_req = NemesisFinalizationRequest(**nemesis_details)
         try:
             run: SCTTestRun = SCTTestRun.get(id=run_id)
-            nemesis = next(nem for nem in run.get_nemeses() if nem.name ==
-                           nem_req.name and nem.start_time == nem_req.start_time)
+            nemesis = SCTNemesis.get(
+                run_id=run.id, start_time=int(nem_req.start_time))
             nemesis.status = NemesisStatus(nem_req.status).value
             nemesis.stack_trace = nem_req.message
             nemesis.end_time = int(time())
+            nemesis.duration = nemesis.end_time - nemesis.start_time
+            nemesis.save()
+            run.update_nemesis_stats(NemesisStatus(nem_req.status).value)
             run.save()
-        except StopIteration as exception:
-            LOGGER.error("Nemesis %s (%s) not found for run %s", nem_req.name, nem_req.start_time, run_id)
-            raise SCTServiceException("Nemesis not found", (nem_req.name, nem_req.start_time)) from exception
+        except SCTNemesis.DoesNotExist as exception:
+            LOGGER.error("Nemesis %s (%s) not found for run %s",
+                         nem_req.name, nem_req.start_time, run_id)
+            raise SCTServiceException(
+                "Nemesis not found", (nem_req.name, nem_req.start_time)) from exception
         except SCTTestRun.DoesNotExist as exception:
             LOGGER.error("Run %s not found for SCTTestRun", run_id)
             raise SCTServiceException("Run not found", run_id) from exception
 
         return "updated"
-
 
     @classmethod
     def submit_event(cls, run_id: str, raw_event: RawEventPayload):
@@ -436,7 +476,8 @@ class SCTService:
         # DB related events
         event.node = req.node
         if req.received_timestamp:
-            event.received_timestamp = datetime.fromisoformat(req.received_timestamp)
+            event.received_timestamp = datetime.fromisoformat(
+                req.received_timestamp)
 
         # Nemesis related events
         event.nemesis_name = req.nemesis_name
@@ -453,7 +494,8 @@ class SCTService:
                 run.submit_logs([link])
                 run.save()
         except Exception:
-            LOGGER.warning("Unable to parse event for coredump links.", exc_info=True)
+            LOGGER.warning(
+                "Unable to parse event for coredump links.", exc_info=True)
         # Add to unprocessed events queue for ERROR and CRITICAL events
         if event.severity in (SCTEventSeverity.ERROR.value, SCTEventSeverity.CRITICAL.value):
             try:
@@ -462,12 +504,13 @@ class SCTService:
                 unprocessed_event.severity = event.severity
                 unprocessed_event.ts = event.ts
                 unprocessed_event.save()
-                LOGGER.debug(f"Added event to unprocessed queue: run_id={run_id}, severity={event.severity}, ts={event.ts}")
+                LOGGER.debug(f"Added event to unprocessed queue: run_id={
+                             run_id}, severity={event.severity}, ts={event.ts}")
             except Exception as e:
-                LOGGER.error(f"Failed to add event to unprocessed queue: {e}", exc_info=True)
+                LOGGER.error(f"Failed to add event to unprocessed queue: {
+                             e}", exc_info=True)
 
         return True
-
 
     @staticmethod
     def get_events(run_id: str, limit: int, severities: list[str], before: str | None) -> list[dict]:
@@ -479,7 +522,8 @@ class SCTService:
     @staticmethod
     def count_events_by_severity(run_id: str, severity: SCTEventSeverity) -> int:
         db = ScyllaCluster.get()
-        query = f"SELECT count(*) FROM {SCTEvent.table_name()} WHERE run_id = ? AND severity IN ?"
+        query = f"SELECT count(*) FROM {SCTEvent.table_name()
+                                        } WHERE run_id = ? AND severity IN ?"
         params = [UUID(run_id), [SCTEventSeverity(severity).value]]
 
         prepared = db.prepare(query)
@@ -496,7 +540,8 @@ class SCTService:
                 wrapper = EventsBySeverity(severity=event.severity,
                                            event_amount=event.total_events, last_events=event.messages)
                 run.get_events_legacy().append(wrapper)
-            coredumps = SCTService.locate_coredumps(run, run.get_events_legacy())
+            coredumps = SCTService.locate_coredumps(
+                run, run.get_events_legacy())
             run.submit_logs(coredumps)
             run.save()
         except SCTTestRun.DoesNotExist as exception:
@@ -511,7 +556,8 @@ class SCTService:
         links = []
         for es in events:
             flat_messages.extend(es.last_events)
-        coredump_events = filter(lambda v: "coredumpevent" in v.lower(), flat_messages)
+        coredump_events = filter(
+            lambda v: "coredumpevent" in v.lower(), flat_messages)
         for event in coredump_events:
             if link := cls.create_coredump_link(event):
                 links.append(link)
@@ -523,20 +569,23 @@ class SCTService:
         ts_pattern = r"^(?P<ts>\d{4}-\d{2}-\d{2} ([\d:]*)\.\d{3})"
         node_name_pattern = r"node=(?P<name>.+)$"
         core_url_match = re.search(core_pattern, event_message, re.MULTILINE)
-        node_name_match = re.search(node_name_pattern, event_message, re.MULTILINE)
+        node_name_match = re.search(
+            node_name_pattern, event_message, re.MULTILINE)
         ts_match = re.search(ts_pattern, event_message)
         timestamp = datetime.now(UTC)
         if core_url_match:
             url = core_url_match.group("url")
             ext = url.rsplit(".", maxsplit=1)[-1]
-            ext = ext if len(ext) <= 5 else "zst" # Default to .zst if URL doesn't conform
+            # Default to .zst if URL doesn't conform
+            ext = ext if len(ext) <= 5 else "zst"
             timestamp_component = ""
             if event_ts:
                 timestamp_component = event_ts.strftime("-%Y-%m-%d_%H-%M-%S")
             elif ts_match:
                 try:
                     timestamp = datetime.fromisoformat(ts_match.group("ts"))
-                    timestamp_component = timestamp.strftime("-%Y-%m-%d_%H-%M-%S")
+                    timestamp_component = timestamp.strftime(
+                        "-%Y-%m-%d_%H-%M-%S")
                 except ValueError:
                     pass
             else:
@@ -565,8 +614,10 @@ class SCTService:
         Returns:
             List of dictionaries containing event_index, severity and similars_set for each event
         """
-        error_embeddings = ErrorEventEmbeddings.filter(run_id=run_id).only(["event_index", "similars_map", "duplicates_list"]).all()
-        critical_embeddings = CriticalEventEmbeddings.filter(run_id=run_id).only(["event_index", "similars_map", "duplicates_list"]).all()
+        error_embeddings = ErrorEventEmbeddings.filter(run_id=run_id).only(
+            ["event_index", "similars_map", "duplicates_list"]).all()
+        critical_embeddings = CriticalEventEmbeddings.filter(run_id=run_id).only(
+            ["event_index", "similars_map", "duplicates_list"]).all()
 
         result = []
         # Process ERROR embeddings
@@ -609,9 +660,11 @@ class SCTService:
         try:
             # Convert timestamp to datetime if needed
             event_ts = datetime.fromisoformat(ts)
-            event: SCTEvent = SCTEvent.get(run_id=run_id, severity=severity, ts=event_ts)
+            event: SCTEvent = SCTEvent.get(
+                run_id=run_id, severity=severity, ts=event_ts)
             if event.duplicate_id:
-                real_event: SCTEvent = SCTEvent.get(event_id=event.duplicate_id)
+                real_event: SCTEvent = SCTEvent.get(
+                    event_id=event.duplicate_id)
                 run_id = real_event.run_id
                 severity = real_event.severity
                 event_ts = real_event.ts
@@ -622,13 +675,16 @@ class SCTService:
             elif severity == "CRITICAL":
                 embedding_model = SCTCriticalEventEmbedding
             else:
-                raise SCTServiceException(f"Unsupported severity for similarity search: {severity}")
+                raise SCTServiceException(
+                    f"Unsupported severity for similarity search: {severity}")
 
             # Fetch the embedding for the query event
-            query_embedding_result = embedding_model.filter(run_id=UUID(run_id) if isinstance(run_id, str) else run_id, ts=event_ts).first()
+            query_embedding_result = embedding_model.filter(run_id=UUID(
+                run_id) if isinstance(run_id, str) else run_id, ts=event_ts).first()
 
             if not query_embedding_result:
-                LOGGER.warning(f"No embedding found for event: run_id={run_id}, severity={severity}, ts={event_ts}")
+                LOGGER.warning(f"No embedding found for event: run_id={
+                               run_id}, severity={severity}, ts={event_ts}")
                 return []
 
             query_embedding = query_embedding_result.embedding
@@ -645,7 +701,8 @@ class SCTService:
             """
 
             prepared = db.prepare(query)
-            result_rows = db.session.execute(prepared, parameters=[query_embedding, limit + 1])
+            result_rows = db.session.execute(
+                prepared, parameters=[query_embedding, limit + 1])
 
             similar_events = []
             visited_run_ids = {str(run_id)}  # Skip current run_id
@@ -664,7 +721,8 @@ class SCTService:
 
         except Exception as e:
             LOGGER.error(f"Error fetching similar events: {e}", exc_info=True)
-            raise SCTServiceException(f"Failed to fetch similar events: {str(e)}")
+            raise SCTServiceException(
+                f"Failed to fetch similar events: {str(e)}")
 
     @staticmethod
     def get_similar_runs_info(run_ids: list[str]):
@@ -682,7 +740,8 @@ class SCTService:
         all_issue_links = {}
 
         for batch_run_ids in chunk(run_ids):
-            batch_links = IssueLink.objects.filter(run_id__in=batch_run_ids).all()
+            batch_links = IssueLink.objects.filter(
+                run_id__in=batch_run_ids).all()
 
             for link in batch_links:
                 run_id_str = str(link.run_id)
@@ -713,7 +772,8 @@ class SCTService:
                     test_run = SCTTestRun.get(id=run_id)
                     test_runs[run_id] = test_run
                 except Exception as e:
-                    LOGGER.debug(f"Failed to fetch test run {run_id}: {str(e)}")
+                    LOGGER.debug(f"Failed to fetch test run {
+                                 run_id}: {str(e)}")
 
         # Step 4: Assign run and issue details to result for runs with issues
         for run_id in runs_with_issues:
@@ -723,7 +783,8 @@ class SCTService:
                     continue
 
                 links = all_issue_links.get(run_id, [])
-                issues = [issues_by_id[link.issue_id] for link in links if link.issue_id in issues_by_id]
+                issues = [issues_by_id[link.issue_id]
+                          for link in links if link.issue_id in issues_by_id]
 
                 try:
                     build_number = int(
@@ -756,12 +817,15 @@ class SCTService:
                 }
             except Exception as e:
                 LOGGER.error(f"Error fetching info for run {run_id}: {str(e)}")
-                result[run_id] = {"build_id": None, "start_time": None, "issues": []}
+                result[run_id] = {"build_id": None,
+                                  "start_time": None, "issues": []}
 
         # Step 5: If less than MAX_SIMILARS results, fetch MAX_SIMILARS more run details
         if len(result) < MAX_SIMILARS:
-            remaining_run_ids = [run_id for run_id in run_ids if run_id not in result]
-            additional_needed = min(MAX_SIMILARS - len(result), len(remaining_run_ids))
+            remaining_run_ids = [
+                run_id for run_id in run_ids if run_id not in result]
+            additional_needed = min(
+                MAX_SIMILARS - len(result), len(remaining_run_ids))
 
             if additional_needed > 0:
                 additional_run_ids = remaining_run_ids[:additional_needed]
@@ -772,7 +836,8 @@ class SCTService:
                         test_run = SCTTestRun.get(id=run_id)
                         additional_test_runs[run_id] = test_run
                     except Exception as e:
-                        LOGGER.debug(f"Failed to fetch additional test run {run_id}: {str(e)}")
+                        LOGGER.debug(f"Failed to fetch additional test run {
+                                     run_id}: {str(e)}")
 
                 for run_id in additional_run_ids:
                     try:
@@ -802,26 +867,32 @@ class SCTService:
                             "issues": [],
                         }
                     except Exception as e:
-                        LOGGER.error(f"Error fetching info for run {run_id}: {str(e)}")
-                        result[run_id] = {"build_id": None, "start_time": None, "issues": []}
+                        LOGGER.error(f"Error fetching info for run {
+                                     run_id}: {str(e)}")
+                        result[run_id] = {"build_id": None,
+                                          "start_time": None, "issues": []}
 
         return result
 
     @staticmethod
     def get_scylla_version_kernels_report(release_name: str):
-        all_release_runs = SCTTestRun.get_version_data_for_release(release_name=release_name)
+        all_release_runs = SCTTestRun.get_version_data_for_release(
+            release_name=release_name)
         kernels_by_version = {}
         kernel_metadata = {}
         for run in all_release_runs:
             packages = run["packages"]
             if not packages:
                 continue
-            scylla_pkgs = {p["name"]: p for p in packages if "scylla-server" in p["name"]}
+            scylla_pkgs = {
+                p["name"]: p for p in packages if "scylla-server" in p["name"]}
             scylla_pkg = scylla_pkgs["scylla-server-upgraded"] if scylla_pkgs.get(
                 "scylla-server-upgraded") else scylla_pkgs.get("scylla-server")
-            version = f"{scylla_pkg['version']}-{scylla_pkg['date']}.{scylla_pkg['revision_id']}" if scylla_pkg else "unknown"
+            version = f"{scylla_pkg['version']}-{scylla_pkg['date']
+                                                 }.{scylla_pkg['revision_id']}" if scylla_pkg else "unknown"
             kernel_packages = [p for p in packages if "kernel" in p["name"]]
-            kernel_package = kernel_packages[0] if len(kernel_packages) > 0 else None
+            kernel_package = kernel_packages[0] if len(
+                kernel_packages) > 0 else None
             if not kernel_package:
                 continue
             version_list = set(kernels_by_version.get(version, []))
@@ -847,7 +918,8 @@ class SCTService:
 
     @staticmethod
     def junit_submit(run_id: str, file_name: str, content: str) -> bool:
-        xml_content = str(base64.decodebytes(bytes(content, encoding="utf-8")), encoding="utf-8")
+        xml_content = str(base64.decodebytes(
+            bytes(content, encoding="utf-8")), encoding="utf-8")
         try:
             _ = ElementTree.fromstring(xml_content)
         except Exception:
@@ -873,7 +945,8 @@ class SCTService:
     def add_stress_command(run_id: str, cmd: str, ts: float, loader_name: str, log_name: str):
         try:
             run: SCTTestRun = SCTTestRun.get(id=run_id)
-            run.add_stress_command(cmd=cmd, ts=clamp_ts_to_milliseconds(ts), loader_name=loader_name, log_name=log_name)
+            run.add_stress_command(cmd=cmd, ts=clamp_ts_to_milliseconds(
+                ts), loader_name=loader_name, log_name=log_name)
             run.save()
         except SCTTestRun.DoesNotExist as exception:
             LOGGER.error("Run %s not found for SCTTestRun", run_id)

--- a/argus/backend/plugins/sct/testrun.py
+++ b/argus/backend/plugins/sct/testrun.py
@@ -2,6 +2,7 @@ from enum import Enum
 import logging
 from datetime import UTC, datetime, timezone
 from dataclasses import dataclass, field
+from threading import Lock
 from typing import Optional
 from uuid import UUID, uuid4
 
@@ -17,6 +18,7 @@ from argus.backend.plugins.sct.udt import (
     CloudSetupDetails,
     EventsBySeverity,
     NemesisRunInfo,
+    NodeDescription,
     PackageVersion,
     PerformanceHDRHistogram
 )
@@ -56,7 +58,6 @@ class SCTTestRunSubmissionRequest():
     runner_private_ip: Optional[str] = field(default=None)
 
 
-
 class SCTEventSeverity(str, Enum):
     CRITICAL = "CRITICAL"
     ERROR = "ERROR"
@@ -65,14 +66,13 @@ class SCTEventSeverity(str, Enum):
     DEBUG = "DEBUG"
 
 
-
 class StressCommand(Model):
     run_id = columns.UUID(primary_key=True, partition_key=True)
-    ts = columns.DateTime(primary_key=True, clustering_order="DESC", default=lambda: datetime.now(tz=UTC))
+    ts = columns.DateTime(
+        primary_key=True, clustering_order="DESC", default=lambda: datetime.now(tz=UTC))
     cmd = columns.Text()
     log_name = columns.Text()
     node_name = columns.Text()
-
 
 
 class SCTEvent(Model):
@@ -88,7 +88,7 @@ class SCTEvent(Model):
 
     # DB Log columns
     node = columns.Text()
-    received_timestamp = columns.DateTime() # SCT DB message timestamp
+    received_timestamp = columns.DateTime()  # SCT DB message timestamp
 
     # Nemesis columns
     nemesis_name = columns.Text()
@@ -98,7 +98,6 @@ class SCTEvent(Model):
 
     # Misc
     known_issue = columns.Text()
-
 
     @classmethod
     def table_name(cls):
@@ -114,6 +113,20 @@ class SCTUnprocessedEvent(Model):
     ts = columns.DateTime(primary_key=True, clustering_order="DESC")
 
 
+class SCTNemesis(Model):
+    __table_name__ = "sct_nemesis"
+
+    run_id = columns.UUID(partition_key=True)
+    start_time = columns.Integer(primary_key=True, clustering_order="ASC")
+    class_name = columns.Text()
+    name = columns.Text()
+    duration = columns.Integer()
+    target_node = columns.UserDefinedType(user_type=NodeDescription)
+    status = columns.Text()
+    end_time = columns.Integer()
+    stack_trace = columns.Text()
+
+
 class SCTTestRun(PluginModelBase):
     __table_name__ = "sct_test_run"
     _plugin_name = "scylla-cluster-tests"
@@ -126,7 +139,8 @@ class SCTTestRun(PluginModelBase):
     origin_url = columns.Text()
     started_by = columns.Text()
     config_files = columns.List(value_type=columns.Text())
-    packages = columns.List(value_type=columns.UserDefinedType(user_type=PackageVersion))
+    packages = columns.List(
+        value_type=columns.UserDefinedType(user_type=PackageVersion))
     scylla_version = columns.Text()
     version_source = columns.Text()
     yaml_test_duration = columns.Integer()
@@ -137,11 +151,16 @@ class SCTTestRun(PluginModelBase):
     cloud_setup = columns.UserDefinedType(user_type=CloudSetupDetails)
 
     # Test Runtime Resources
-    allocated_resources = columns.List(value_type=columns.UserDefinedType(user_type=CloudResource))
+    allocated_resources = columns.List(
+        value_type=columns.UserDefinedType(user_type=CloudResource))
 
     # Test Results
-    events = columns.List(value_type=columns.UserDefinedType(user_type=EventsBySeverity))
-    nemesis_data = columns.List(value_type=columns.UserDefinedType(user_type=NemesisRunInfo))
+    events = columns.List(
+        value_type=columns.UserDefinedType(user_type=EventsBySeverity))
+    nemesis_data = columns.List(
+        value_type=columns.UserDefinedType(user_type=NemesisRunInfo))
+    nemesis_stats = columns.Map(
+        key_type=columns.Text(), value_type=columns.Integer())
     screenshots = columns.List(value_type=columns.Text())
 
     # Subtest
@@ -175,8 +194,8 @@ class SCTTestRun(PluginModelBase):
 
     @classmethod
     def _stats_query(cls) -> str:
-        return ("SELECT id, test_id, group_id, release_id, status, start_time, build_job_url, build_id, "
-                f"assignee, end_time, investigation_status, heartbeat, build_number, scylla_version, cloud_setup, allocated_resources, nemesis_data FROM {cls.table_name()} WHERE build_id IN ? PER PARTITION LIMIT 15")
+        return ("SELECT id, test_id, group_id, release_id, status, start_time, build_job_url, build_id, nemesis_stats, "
+                f"assignee, end_time, investigation_status, heartbeat, build_number, scylla_version, cloud_setup, allocated_resources FROM {cls.table_name()} WHERE build_id IN ? PER PARTITION LIMIT 15")
 
     @classmethod
     def load_test_run(cls, run_id: UUID) -> 'SCTTestRun':
@@ -190,9 +209,12 @@ class SCTTestRun(PluginModelBase):
     @classmethod
     def get_distinct_product_versions(cls, release: ArgusRelease) -> list[str]:
         cluster = ScyllaCluster.get()
-        statement = cluster.prepare(f"SELECT scylla_version FROM {cls.table_name()} WHERE release_id = ?")
-        rows = cluster.session.execute(query=statement, parameters=(release.id,))
-        unique_versions = {r["scylla_version"] for r in rows if r["scylla_version"]}
+        statement = cluster.prepare(f"SELECT scylla_version FROM {
+                                    cls.table_name()} WHERE release_id = ?")
+        rows = cluster.session.execute(
+            query=statement, parameters=(release.id,))
+        unique_versions = {r["scylla_version"]
+                           for r in rows if r["scylla_version"]}
 
         return sorted(list(unique_versions), reverse=True)
 
@@ -200,7 +222,8 @@ class SCTTestRun(PluginModelBase):
     def get_version_data_for_release(cls, release_name: str):
         cluster = ScyllaCluster.get()
         release = ArgusRelease.get(name=release_name)
-        query = cluster.prepare(f"SELECT scylla_version, packages, status FROM {cls.table_name()} WHERE release_id = ?")
+        query = cluster.prepare(f"SELECT scylla_version, packages, status FROM {
+                                cls.table_name()} WHERE release_id = ?")
         rows = cluster.session.execute(query=query, parameters=(release.id,))
 
         return list(rows)
@@ -213,8 +236,10 @@ class SCTTestRun(PluginModelBase):
     @classmethod
     def get_distinct_cloud_images_for_release(cls, release: ArgusRelease):
         cluster = ScyllaCluster.get()
-        statement = cluster.prepare(f"SELECT cloud_setup FROM {cls.table_name()} WHERE release_id = ?")
-        rows = cluster.session.execute(query=statement, parameters=(release.id,))
+        statement = cluster.prepare(f"SELECT cloud_setup FROM {
+                                    cls.table_name()} WHERE release_id = ?")
+        rows = cluster.session.execute(
+            query=statement, parameters=(release.id,))
         unique_images = {cls.get_image(r) for r in rows if cls.get_image(r)}
 
         return sorted(list(unique_images), reverse=True)
@@ -222,7 +247,8 @@ class SCTTestRun(PluginModelBase):
     @classmethod
     def get_distinct_cloud_images_for_view(cls, tests: list[ArgusTest]):
         cluster = ScyllaCluster.get()
-        statement = cluster.prepare(f"SELECT cloud_setup FROM {cls.table_name()} WHERE build_id IN ?")
+        statement = cluster.prepare(f"SELECT cloud_setup FROM {
+                                    cls.table_name()} WHERE build_id IN ?")
         futures = []
         for batch in chunk(tests):
             futures.append(cluster.session.execute_async(query=statement,
@@ -241,7 +267,8 @@ class SCTTestRun(PluginModelBase):
         query = cluster.prepare(f"SELECT build_id, packages, scylla_version, test_name, perf_op_rate_average, perf_op_rate_total, "
                                 "perf_avg_latency_99th, perf_avg_latency_mean, perf_total_errors, id, start_time, build_job_url, build_number"
                                 f" FROM {cls.table_name()} WHERE build_id = ? AND start_time < ? AND test_name = ? ALLOW FILTERING")
-        rows = cluster.session.execute(query=query, parameters=(build_id, start_time, test_name))
+        rows = cluster.session.execute(
+            query=query, parameters=(build_id, start_time, test_name))
 
         return list(rows)
 
@@ -278,7 +305,8 @@ class SCTTestRun(PluginModelBase):
             backend = req.sct_config.get("cluster_backend")
             if duration_override := req.sct_config.get("stress_duration"):
                 run.stress_duration = float(duration_override)
-            region_key = SCT_REGION_PROPERTY_MAP.get(backend, SCT_REGION_PROPERTY_MAP["default"])
+            region_key = SCT_REGION_PROPERTY_MAP.get(
+                backend, SCT_REGION_PROPERTY_MAP["default"])
             raw_regions = req.sct_config.get(region_key) or "undefined_region"
             regions = raw_regions.split() if isinstance(raw_regions, str) else raw_regions
             primary_region = regions[0]
@@ -289,7 +317,8 @@ class SCTTestRun(PluginModelBase):
                     provider=backend,
                     region=primary_region,
                 )
-            run.cloud_setup = ResourceSetup.get_resource_setup(backend=backend, sct_config=req.sct_config)
+            run.cloud_setup = ResourceSetup.get_resource_setup(
+                backend=backend, sct_config=req.sct_config)
 
             run.config_files = req.sct_config.get("config_files")
             run.region_name = regions
@@ -301,8 +330,8 @@ class SCTTestRun(PluginModelBase):
     def get_resources(self) -> list[CloudResource]:
         return self.allocated_resources
 
-    def get_nemeses(self) -> list[NemesisRunInfo]:
-        return self.nemesis_data
+    def get_nemeses(self) -> list[SCTNemesis]:
+        return list(SCTNemesis.filter(run_id=self.id).all())
 
     @classmethod
     def get_stress_commands(cls, run_id: str) -> list[StressCommand]:
@@ -319,7 +348,6 @@ class SCTTestRun(PluginModelBase):
         s.save()
         return True
 
-
     def get_events_legacy(self) -> list[EventsBySeverity]:
         """
             Deprecated. To be replaced by new events system.
@@ -332,7 +360,8 @@ class SCTTestRun(PluginModelBase):
     @classmethod
     def get_events_limited(cls, run_id: UUID, before: datetime | None = None, severities: list[SCTEventSeverity] = None, per_partition_limit: int = 100) -> list[dict]:
         db = ScyllaCluster.get()
-        query = f"SELECT * FROM {SCTEvent.table_name()} WHERE run_id = ? AND severity IN ?"
+        query = f"SELECT * FROM {SCTEvent.table_name()
+                                 } WHERE run_id = ? AND severity IN ?"
         params = [run_id]
         if severities:
             severity_filter = [s.value for s in severities]
@@ -381,8 +410,12 @@ class SCTTestRun(PluginModelBase):
     def add_screenshot(self, screenshot_link: str):
         self.screenshots.append(screenshot_link)
 
-    def add_nemesis(self, nemesis: NemesisRunInfo):
-        self.nemesis_data.append(nemesis)
+    def update_nemesis_stats(self, key: str):
+        stats = self.nemesis_stats if self.nemesis_stats else {}
+        val = stats.get(key, 0)
+        val += 1
+        stats[key] = val
+        self.nemesis_stats = stats
 
     def _add_new_event_type(self, event: EventsBySeverity):
         self.events.append(event)
@@ -414,7 +447,8 @@ class SCTTestRun(PluginModelBase):
                          sut_package_name,
                          f"{sut_package_name}-target"
                          ]:
-            scylla_package = next((pkg for pkg in self.packages if pkg.name == sut_name), None)
+            scylla_package = next(
+                (pkg for pkg in self.packages if pkg.name == sut_name), None)
             if scylla_package:
                 break
 
@@ -422,7 +456,8 @@ class SCTTestRun(PluginModelBase):
             return (datetime.strptime(scylla_package.date, '%Y%m%d').replace(tzinfo=timezone.utc).timestamp()
                     + int(scylla_package.revision_id, 16) % 1000000 / 1000000)
         else:
-            raise ValueError(f"{sut_package_name} package not found in packages - cannot determine SUT timestamp")
+            raise ValueError(
+                f"{sut_package_name} package not found in packages - cannot determine SUT timestamp")
 
     @classmethod
     def get_run_response(cls, run_id: UUID) -> dict | None:
@@ -431,7 +466,9 @@ class SCTTestRun(PluginModelBase):
         except cls.DoesNotExist:
             return None
         response = dict(run.items())
-        response["junit_reports"] = list(SCTJunitReports.filter(test_id=run_id).all())
+        response["junit_reports"] = list(
+            SCTJunitReports.filter(test_id=run_id).all())
+        response["nemesis_data"] = list(SCTNemesis.filter(run_id=run.id).all())
         return response
 
 

--- a/argus/backend/plugins/sct/udt.py
+++ b/argus/backend/plugins/sct/udt.py
@@ -61,6 +61,7 @@ class CloudResource(UserType):
     def get_instance_info(self) -> CloudInstanceDetails:
         return self.instance_info
 
+
 class EventsBySeverity(UserType):
     __type_name__ = "EventsBySeverity"
     severity = columns.Text()

--- a/argus/backend/service/email_service.py
+++ b/argus/backend/service/email_service.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from flask import render_template
 import humanize
-from argus.backend.plugins.sct.testrun import SCTEventSeverity, SCTTestRun
+from argus.backend.plugins.sct.testrun import SCTEventSeverity, SCTNemesis, SCTTestRun
 from argus.backend.service.results_service import ResultsService
 from argus.backend.util.send_email import Attachment, Email
 from argus.common.email import RawAttachment, RawReportSendRequest, ReportSection, ReportSectionShortHand
@@ -165,7 +165,7 @@ class Nemesis(Partial):
     TEMPLATE_PATH = "email/partials/nemesis.html.j2"
     def create_context(self, options: dict[str, Any]):
         status_filter = options.get("status_filter") or ["failed", "succeeded"]
-        nemesis = list(filter(lambda nem: nem.status in status_filter, self.test_run.nemesis_data))
+        nemesis = list(filter(lambda nem: nem.status in status_filter, SCTNemesis.filter(run_id=self.test_run.id).all()))
         return {
             **self.default_options(),
             "run_id": self.test_run.id,

--- a/argus/backend/service/stats.py
+++ b/argus/backend/service/stats.py
@@ -506,7 +506,7 @@ class TestStats:
                 "build_job_name": run["build_id"],
                 "start_time": run["start_time"],
                 "end_time": run["end_time"],
-                "nemesis_data": run.get("nemesis_data", []),
+                "nemesis_stats": run.get("nemesis_stats", {}),
                 "assignee": run["assignee"],
                 "issues": [dict(issue.items()) for issue in self.parent_group.parent_release.issues[run["id"]]],
                 "comments": [dict(comment.items()) for comment in self.parent_group.parent_release.comments[run["id"]]],

--- a/argus/backend/service/views_widgets/graphed_stats.py
+++ b/argus/backend/service/views_widgets/graphed_stats.py
@@ -1,9 +1,10 @@
+from collections import defaultdict
 import logging
 from uuid import UUID
 import json
 import re
 from argus.backend.db import ScyllaCluster
-from argus.backend.plugins.sct.testrun import SCTTestRun
+from argus.backend.plugins.sct.testrun import SCTNemesis, SCTTestRun
 from argus.backend.models.github_issue import GithubIssue, IssueLink
 from argus.backend.util.common import chunk
 from argus.backend.util.nemesis_map import get_nemesis_name
@@ -16,16 +17,25 @@ class GraphedStatsService:
         self.cluster = ScyllaCluster.get()
 
     def get_graphed_stats(self, test_id: UUID, filters=None):
-        rows = SCTTestRun.filter(test_id=test_id).only([
+        rows = list(SCTTestRun.filter(test_id=test_id).only([
             "build_id",
             "start_time",
             "end_time",
             "id",
-            "nemesis_data",
             "investigation_status",
             "packages",
             "status"
-        ]).all()
+        ]).all())
+
+        nemesis_rows = []
+        for batch in chunk({r.id for r in rows}):
+            # Typically this should result in <100 runs per test, but
+            # we batch to make sure we don't exceed max cartesian product
+            nemesis_rows.extend(SCTNemesis.filter(run_id__in=batch).all())
+
+        nemesis_data = defaultdict(list)
+        for row in nemesis_rows:
+            nemesis_data[row.run_id].append(row)
 
         release_data = {
             "test_runs": [],
@@ -59,8 +69,8 @@ class GraphedStatsService:
                 "investigation_status": run["investigation_status"]
             })
 
-            if run["nemesis_data"]:
-                for nemesis in [n for n in run["nemesis_data"] if n.status in ("succeeded", "failed")]:
+            if nemeses := nemesis_data.get(run["id"]):
+                for nemesis in [n for n in nemeses if n.status in ("succeeded", "failed")]:
                     release_data["nemesis_data"].append({
                         "version": version,
                         "name": get_nemesis_name(nemesis.name),

--- a/argus/backend/service/views_widgets/nemesis_stats.py
+++ b/argus/backend/service/views_widgets/nemesis_stats.py
@@ -1,8 +1,10 @@
+from collections import defaultdict
 from uuid import UUID
 
 
 from argus.backend.db import ScyllaCluster
-from argus.backend.plugins.sct.testrun import SCTTestRun
+from argus.backend.util.common import chunk
+from argus.backend.plugins.sct.testrun import SCTNemesis, SCTTestRun
 from argus.backend.util.nemesis_map import get_nemesis_name
 
 
@@ -11,16 +13,29 @@ class NemesisStatsService:
         self.cluster = ScyllaCluster.get()
 
     def get_nemesis_data(self, test_id: UUID):
-        rows = SCTTestRun.filter(test_id=test_id).only(["id", "nemesis_data", "investigation_status", "packages"]).all()
+        rows = SCTTestRun.filter(test_id=test_id).only(
+            ["id", "investigation_status", "packages"]).all()
         nemesis_data = []
+
+        nemesis_rows = []
+        for batch in chunk({r.id for r in rows}):
+            # Typically this should result in <100 runs per test, but
+            # we batch to make sure we don't exceed max cartesian product
+            nemesis_rows.extend(SCTNemesis.filter(run_id__in=batch).all())
+
+        nemesis_runs_data = defaultdict(list)
+        for row in nemesis_rows:
+            nemesis_runs_data[row.run_id].append(row)
+
         for run in [row for row in rows if row["investigation_status"].lower() != "ignored"]:
             try:
-                version = [package.version for package in run["packages"] if package.name == "scylla-server"][0]
+                version = [package.version for package in run["packages"]
+                           if package.name == "scylla-server"][0]
             except (IndexError, TypeError):
                 continue
-            if not run["nemesis_data"]:
+            if not (nems := nemesis_runs_data.get(run["id"])):
                 continue
-            for nemesis in [nemesis for nemesis in run["nemesis_data"] if nemesis.status in ("succeeded", "failed")]:
+            for nemesis in [nemesis for nemesis in nems if nemesis.status in ("succeeded", "failed")]:
                 nemesis_data.append(
                     {
                         "version": version,

--- a/argus/backend/tests/sct_api/test_sct_api.py
+++ b/argus/backend/tests/sct_api/test_sct_api.py
@@ -4,7 +4,7 @@ import time
 from uuid import uuid4
 import pytest
 
-from argus.backend.plugins.sct.testrun import SCTTestRun
+from argus.backend.plugins.sct.testrun import SCTNemesis, SCTTestRun
 from argus.common.utils import clamp_ts_to_milliseconds
 
 API_PREFIX = "/api/v1/client/sct"
@@ -226,7 +226,8 @@ def test_nemesis_submit_and_finalize(flask_client, sct_run_id):
 
     # Verify nemesis created
     run = SCTTestRun.get(id=sct_run_id)
-    nem = next(n for n in run.nemesis_data if n.name == "ChaosMonkey" and n.start_time == 123456)
+    nemesis_data = SCTNemesis.filter(run_id=run.id).all()
+    nem = next(n for n in nemesis_data if n.name == "ChaosMonkey" and n.start_time == 123456)
     assert nem.status == "running"
 
     finalize_payload = {
@@ -247,7 +248,8 @@ def test_nemesis_submit_and_finalize(flask_client, sct_run_id):
 
     # Verify nemesis finalized
     run = SCTTestRun.get(id=sct_run_id)
-    nem = next(n for n in run.nemesis_data if n.name == "ChaosMonkey" and n.start_time == 123456)
+    nemesis_data = SCTNemesis.filter(run_id=run.id).all()
+    nem = next(n for n in nemesis_data if n.name == "ChaosMonkey" and n.start_time == 123456)
     assert nem.status == "succeeded"
     assert nem.end_time and nem.end_time > 0
     assert nem.stack_trace == "done"

--- a/argus/client/sct/client.py
+++ b/argus/client/sct/client.py
@@ -26,6 +26,7 @@ class ArgusSCTClient(ArgusClient):
         SUBMIT_GEMINI_RESULTS = "/sct/$id/gemini/submit"
         SUBMIT_PERFORMANCE_RESULTS = "/sct/$id/performance/submit"
         FINALIZE_NEMESIS = "/sct/$id/nemesis/finalize"
+        GET_NEMESIS = "/sct/$id/nemesis/get"
         SUBMIT_EVENTS = "/sct/$id/events/submit"
         SUBMIT_EVENT = "/sct/$id/event/submit"
         SUBMIT_JUNIT_REPORT = "/sct/$id/junit/submit"
@@ -61,7 +62,8 @@ class ArgusSCTClient(ArgusClient):
         """
             Sets an SCT run's status.
         """
-        response = super().set_status(run_type=self.test_type, run_id=self.run_id, new_status=new_status)
+        response = super().set_status(run_type=self.test_type,
+                                      run_id=self.run_id, new_status=new_status)
         self.check_response(response)
 
     def set_sct_runner(self, public_ip: str, private_ip: str, region: str, backend: str, name: str = None) -> None:
@@ -86,7 +88,8 @@ class ArgusSCTClient(ArgusClient):
         """
             Updates scylla server version used for filtering test results by version.
         """
-        response = super().update_product_version(run_type=self.test_type, run_id=self.run_id, product_version=version)
+        response = super().update_product_version(run_type=self.test_type,
+                                                  run_id=self.run_id, product_version=version)
         self.check_response(response)
 
     def submit_event(self, event_data: RawEventPayload | list[RawEventPayload]):
@@ -278,6 +281,17 @@ class ArgusSCTClient(ArgusClient):
             }
         )
         self.check_response(response)
+
+    def get_nemeses(self):
+        """
+            Get a list of all nemeses already submitted to argus
+        """
+        response = self.get(
+            endpoint=self.Routes.GET_NEMESIS,
+            location_params={"id": str(self.run_id)},
+        )
+        self.check_response(response)
+        return response.json()["response"]
 
     def submit_nemesis(self, name: str, class_name: str, start_time: int,
                        target_name: str, target_ip: str, target_shards: int,

--- a/frontend/ReleaseDashboard/TestDashboardTest.svelte
+++ b/frontend/ReleaseDashboard/TestDashboardTest.svelte
@@ -55,8 +55,8 @@
     </div>
     <div class="d-flex flex-fill align-items-end justify-content-end p-1">
         <div class="p-1 me-auto text-small">
-            {#if (lastRun?.nemesis_data ?? []).length}
-                <Fa icon={faSpider} /> {(lastRun?.nemesis_data ?? []).filter((n: {status: string}) => n.status == "failed").length} / {(lastRun?.nemesis_data ?? []).length}
+            {#if ((lastRun?.nemesis_stats ?? {})?.total ?? false)}
+                <Fa icon={faSpider} /> {lastRun?.nemesis_stats?.failed ?? 0} / {lastRun?.nemesis_stats.total}
             {/if}
         </div>
         <div class="p-1 me-2">

--- a/scripts/migration/migration_2026-04-08.py
+++ b/scripts/migration/migration_2026-04-08.py
@@ -1,0 +1,40 @@
+from collections import defaultdict
+import logging
+
+from argus.backend.db import ScyllaCluster
+from argus.backend.plugins.sct.testrun import SCTNemesis, SCTTestRun
+from argus.backend.util.logsetup import setup_application_logging
+
+
+setup_application_logging(log_level=logging.INFO)
+LOGGER = logging.getLogger(__name__)
+DB = ScyllaCluster.get()
+
+
+def migrate():
+    run_count = DB.session.execute("SELECT count(*) FROM sct_test_run", timeout=30.0).one()["count"]
+    runs = SCTTestRun.filter().limit(None).only(["id", "nemesis_data", "build_id", "start_time"]).all()
+    for idx, run in enumerate(runs):
+        nemesis_stats = defaultdict(lambda: 0)
+        LOGGER.info("[%s/%s] Migrating nemeses from run %s...", idx + 1, run_count, run.id)
+        for nemesis in run.nemesis_data:
+            nemesis_stats["total"] += 1
+            nem = SCTNemesis()
+            nem.run_id = run.id
+            nem.start_time = nemesis.start_time
+            nem.end_time = nemesis.end_time
+            nem.status = nemesis.status
+            nem.class_name = nemesis.class_name
+            nem.name = nemesis.name
+            nem.duration = nemesis.duration
+            nem.target_node = nemesis.target_node
+            nem.stack_trace = nemesis.stack_trace
+            nemesis_stats[nem.status] += 1
+            nem.save()
+
+        SCTTestRun.objects(build_id=run.build_id, start_time=run.start_time).update(nemesis_stats=nemesis_stats)
+        LOGGER.info("[%s/%s] Migrated nemeses for run %s.", idx + 1, run_count, run.id)
+
+
+if __name__ == "__main__":
+    migrate()


### PR DESCRIPTION
This commit changes the way nemesis data is stored inside argus,
migrating from a UDT inside SCTTestRun model into a new SCTNemesis table,
while introducing new nemesis_stats field in place to provide nemesis
statistics to TestDashboard component, mitigating the need to fetch data
from this table during stats queries. Finalize and Submit nemesis
endpoints were updated as well as new nemesis_get endpoint was
introduced inside the client in case it wants to look at nemesis data separately.

`get_run_response` was updated to fetch SCTNemesis data as that
particular endpoint only does a single run fetch, negating the need for
updating frontend components.

Fixes ARGUS-7
