### PR TITLE
feat(cli): deduplicate events with repeated_at timestamps

### DIFF
--- a/cli/cmd/run_nemeses_events.go
+++ b/cli/cmd/run_nemeses_events.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"sort"
 	"strconv"
 	"time"
 
@@ -121,6 +122,53 @@ func tsFromFlag(s string) int64 {
 	return v
 }
 
+// deduplicateEvents aggregates duplicate events into their originals.
+// Duplicate events (DuplicateID != "") are removed from the output; their
+// timestamps are collected into the RepeatedAt field of the original event.
+//
+// When the original event is absent (e.g. filtered out by a time range), the
+// earliest duplicate is promoted to stand in as the original and the remaining
+// duplicates' timestamps are collected into its RepeatedAt field.
+func deduplicateEvents(events []models.SCTEvent) []models.SCTEvent {
+	idxByEventID := make(map[string]int, len(events))
+	originals := make([]models.SCTEvent, 0, len(events))
+
+	for _, e := range events {
+		if e.DuplicateID == "" {
+			idxByEventID[e.EventID] = len(originals)
+			originals = append(originals, e)
+		}
+	}
+
+	// Group orphaned duplicates (original not in the set) by DuplicateID.
+	orphans := make(map[string][]models.SCTEvent)
+	for _, e := range events {
+		if e.DuplicateID == "" {
+			continue
+		}
+		if idx, ok := idxByEventID[e.DuplicateID]; ok {
+			originals[idx].RepeatedAt = append(originals[idx].RepeatedAt, e.Ts)
+		} else {
+			orphans[e.DuplicateID] = append(orphans[e.DuplicateID], e)
+		}
+	}
+
+	// Promote the earliest orphan in each group; rest become its repeats.
+	for _, group := range orphans {
+		sort.Slice(group, func(i, j int) bool {
+			return group[i].Ts < group[j].Ts
+		})
+		promoted := group[0]
+		promoted.DuplicateID = ""
+		for _, dup := range group[1:] {
+			promoted.RepeatedAt = append(promoted.RepeatedAt, dup.Ts)
+		}
+		originals = append(originals, promoted)
+	}
+
+	return originals
+}
+
 // ---------------------------------------------------------------------------
 // Subcommand: run events
 // ---------------------------------------------------------------------------
@@ -196,8 +244,10 @@ Only SCT runs have per-event records; for other plugin types use
 			allEvents = append(allEvents, severityEvents...)
 		}
 
+		allEvents = deduplicateEvents(allEvents)
+
 		log.Info().Str("run_id", runID).Int("total_events", len(allEvents)).Msg("SCT events fetched successfully")
-		return out.Write(models.NewTabularSlice(allEvents))
+		return out.Write(models.SCTEventsResponse{RunID: runID, Events: allEvents})
 	},
 }
 

--- a/cli/cmd/run_nemeses_events_test.go
+++ b/cli/cmd/run_nemeses_events_test.go
@@ -1,0 +1,169 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/scylladb/argus/cli/internal/models"
+)
+
+func TestDeduplicateEvents(t *testing.T) {
+	tests := []struct {
+		name       string
+		events     []models.SCTEvent
+		wantCount  int
+		wantChecks func(t *testing.T, result []models.SCTEvent)
+	}{
+		{
+			name:      "empty input",
+			events:    nil,
+			wantCount: 0,
+		},
+		{
+			name: "no duplicates passthrough",
+			events: []models.SCTEvent{
+				{EventID: "a", Ts: "2024-01-01T00:00:00Z", EventType: "X"},
+				{EventID: "b", Ts: "2024-01-01T01:00:00Z", EventType: "Y"},
+			},
+			wantCount: 2,
+			wantChecks: func(t *testing.T, result []models.SCTEvent) {
+				for _, e := range result {
+					if len(e.RepeatedAt) != 0 {
+						t.Errorf("event %s: expected no RepeatedAt, got %v", e.EventID, e.RepeatedAt)
+					}
+				}
+			},
+		},
+		{
+			name: "simple dedup with original present",
+			events: []models.SCTEvent{
+				{EventID: "orig", Ts: "2024-01-01T00:00:00Z", EventType: "X"},
+				{EventID: "d1", Ts: "2024-01-01T01:00:00Z", DuplicateID: "orig"},
+				{EventID: "d2", Ts: "2024-01-01T02:00:00Z", DuplicateID: "orig"},
+			},
+			wantCount: 1,
+			wantChecks: func(t *testing.T, result []models.SCTEvent) {
+				if result[0].EventID != "orig" {
+					t.Fatalf("expected original event, got %s", result[0].EventID)
+				}
+				if len(result[0].RepeatedAt) != 2 {
+					t.Fatalf("expected 2 repeats, got %d", len(result[0].RepeatedAt))
+				}
+				if result[0].RepeatedAt[0] != "2024-01-01T01:00:00Z" {
+					t.Errorf("repeat[0] = %s, want 2024-01-01T01:00:00Z", result[0].RepeatedAt[0])
+				}
+				if result[0].RepeatedAt[1] != "2024-01-01T02:00:00Z" {
+					t.Errorf("repeat[1] = %s, want 2024-01-01T02:00:00Z", result[0].RepeatedAt[1])
+				}
+			},
+		},
+		{
+			name: "orphaned duplicates promote earliest",
+			events: []models.SCTEvent{
+				{EventID: "d2", Ts: "2024-01-01T03:00:00Z", DuplicateID: "missing-orig", EventType: "X"},
+				{EventID: "d1", Ts: "2024-01-01T01:00:00Z", DuplicateID: "missing-orig", EventType: "X"},
+				{EventID: "d3", Ts: "2024-01-01T05:00:00Z", DuplicateID: "missing-orig", EventType: "X"},
+			},
+			wantCount: 1,
+			wantChecks: func(t *testing.T, result []models.SCTEvent) {
+				promoted := result[0]
+				if promoted.EventID != "d1" {
+					t.Fatalf("expected earliest duplicate d1 promoted, got %s", promoted.EventID)
+				}
+				if promoted.DuplicateID != "" {
+					t.Errorf("promoted event should have DuplicateID cleared, got %q", promoted.DuplicateID)
+				}
+				if len(promoted.RepeatedAt) != 2 {
+					t.Fatalf("expected 2 repeats, got %d", len(promoted.RepeatedAt))
+				}
+				if promoted.RepeatedAt[0] != "2024-01-01T03:00:00Z" {
+					t.Errorf("repeat[0] = %s, want 2024-01-01T03:00:00Z", promoted.RepeatedAt[0])
+				}
+				if promoted.RepeatedAt[1] != "2024-01-01T05:00:00Z" {
+					t.Errorf("repeat[1] = %s, want 2024-01-01T05:00:00Z", promoted.RepeatedAt[1])
+				}
+			},
+		},
+		{
+			name: "single orphaned duplicate promoted as-is",
+			events: []models.SCTEvent{
+				{EventID: "d1", Ts: "2024-01-01T01:00:00Z", DuplicateID: "missing-orig", EventType: "X"},
+			},
+			wantCount: 1,
+			wantChecks: func(t *testing.T, result []models.SCTEvent) {
+				if result[0].DuplicateID != "" {
+					t.Errorf("promoted event should have DuplicateID cleared, got %q", result[0].DuplicateID)
+				}
+				if len(result[0].RepeatedAt) != 0 {
+					t.Errorf("single orphan should have no repeats, got %d", len(result[0].RepeatedAt))
+				}
+			},
+		},
+		{
+			name: "mix of originals, duplicates, and orphans",
+			events: []models.SCTEvent{
+				{EventID: "orig1", Ts: "2024-01-01T00:00:00Z"},
+				{EventID: "d1", Ts: "2024-01-01T01:00:00Z", DuplicateID: "orig1"},
+				{EventID: "orphan2", Ts: "2024-01-01T04:00:00Z", DuplicateID: "gone"},
+				{EventID: "orphan1", Ts: "2024-01-01T02:00:00Z", DuplicateID: "gone"},
+				{EventID: "orig2", Ts: "2024-01-01T05:00:00Z"},
+			},
+			wantCount: 3, // orig1 (with d1 repeat), orig2, promoted orphan1
+			wantChecks: func(t *testing.T, result []models.SCTEvent) {
+				// orig1 should have 1 repeat
+				if result[0].EventID != "orig1" {
+					t.Fatalf("result[0] expected orig1, got %s", result[0].EventID)
+				}
+				if len(result[0].RepeatedAt) != 1 {
+					t.Fatalf("orig1 expected 1 repeat, got %d", len(result[0].RepeatedAt))
+				}
+				// orig2 should have no repeats
+				if result[1].EventID != "orig2" {
+					t.Fatalf("result[1] expected orig2, got %s", result[1].EventID)
+				}
+				if len(result[1].RepeatedAt) != 0 {
+					t.Errorf("orig2 expected 0 repeats, got %d", len(result[1].RepeatedAt))
+				}
+				// promoted orphan
+				promoted := result[2]
+				if promoted.EventID != "orphan1" {
+					t.Fatalf("result[2] expected orphan1 (earliest), got %s", promoted.EventID)
+				}
+				if promoted.DuplicateID != "" {
+					t.Errorf("promoted orphan should have DuplicateID cleared")
+				}
+				if len(promoted.RepeatedAt) != 1 {
+					t.Fatalf("promoted orphan expected 1 repeat, got %d", len(promoted.RepeatedAt))
+				}
+			},
+		},
+		{
+			name: "all events are duplicates of same missing original",
+			events: []models.SCTEvent{
+				{EventID: "d3", Ts: "2024-01-01T03:00:00Z", DuplicateID: "gone"},
+				{EventID: "d1", Ts: "2024-01-01T01:00:00Z", DuplicateID: "gone"},
+				{EventID: "d2", Ts: "2024-01-01T02:00:00Z", DuplicateID: "gone"},
+			},
+			wantCount: 1,
+			wantChecks: func(t *testing.T, result []models.SCTEvent) {
+				if result[0].EventID != "d1" {
+					t.Errorf("expected earliest d1 promoted, got %s", result[0].EventID)
+				}
+				if len(result[0].RepeatedAt) != 2 {
+					t.Errorf("expected 2 repeats, got %d", len(result[0].RepeatedAt))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := deduplicateEvents(tt.events)
+			if len(result) != tt.wantCount {
+				t.Fatalf("got %d events, want %d", len(result), tt.wantCount)
+			}
+			if tt.wantChecks != nil {
+				tt.wantChecks(t, result)
+			}
+		})
+	}
+}

--- a/cli/internal/models/runs.go
+++ b/cli/internal/models/runs.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -207,6 +208,7 @@ type SCTEvent struct {
 	TargetNode        string           `json:"target_node"`
 	NemesisStatus     string           `json:"nemesis_status"`
 	KnownIssue        string           `json:"known_issue"`
+	RepeatedAt        []string         `json:"repeated_at,omitempty"`
 }
 
 // SCTTestRun is the full run response for the scylla-cluster-tests plugin.
@@ -593,7 +595,7 @@ type SCTEventsResponse struct {
 
 // Headers implements output.Tabular for SCTEventsResponse.
 func (SCTEventsResponse) Headers() []string {
-	return []string{"Severity", "Timestamp", "Type", "Node", "Nemesis", "Message"}
+	return []string{"Severity", "Timestamp", "Type", "Node", "Nemesis", "Repeats", "Message"}
 }
 
 // Rows implements output.Tabular for SCTEventsResponse.
@@ -604,12 +606,17 @@ func (r SCTEventsResponse) Rows() [][]string {
 		if len(msg) > 200 {
 			msg = msg[:200] + "..."
 		}
+		repeats := ""
+		if n := len(e.RepeatedAt); n > 0 {
+			repeats = strconv.Itoa(n)
+		}
 		rows = append(rows, []string{
 			string(e.Severity),
 			e.Ts,
 			e.EventType,
 			e.Node,
 			e.NemesisName,
+			repeats,
 			msg,
 		})
 	}


### PR DESCRIPTION
## Summary

- Deduplicate events in CLI output by aggregating duplicates (events with `duplicate_id` set by the backend AI similarity processor) into their original events
- Original events gain a `repeated_at` list containing the timestamps of all their duplicates; duplicate events are removed from output
- Table output includes a new "Repeats" column showing the duplicate count per event

Tested with run `348eae9d-2a41-40ff-976c-0262e8d64ce0`: 37 total events collapsed to 8 unique, with one `DatabaseLogEvent` showing 27 repeats.

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` — all 217 tests pass
- [x] JSON output shows `repeated_at` array with duplicate timestamps
- [x] Table output shows "Repeats" count column (empty when no duplicates)
- [x] Events without duplicates are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)