### PR TITLE
fix(cli): trigger cloudflared login flow when cached CF token is missing or expired

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -173,7 +173,9 @@ var rootCmd = &cobra.Command{
 //
 //  1. PAT from keychain
 //  2. Session cookie from keychain
-//  3. Cached Cloudflare Access JWT from cloudflared's local token cache
+//  3. CF Access JWT obtained from cloudflared CLI (`cloudflared access token`);
+//     if the cached token is expired or missing AND interactive mode is allowed,
+//     the full browser-based login flow is triggered automatically.
 //  4. ARGUS_TOKEN env var
 //  5. CF Access service-account credentials from env
 //
@@ -195,11 +197,10 @@ func buildAPIClientRaw(ctx context.Context, cfg *config.Config, extraOpts ...api
 			apiOpts = append(apiOpts, api.WithSession(session))
 		}
 
-		// Attach the cached Cloudflare Access JWT so requests pass through
-		// the CF Access layer that sits in front of the Argus backend.
-		// This is a best-effort read from cloudflared's local token cache
-		// (~/.cloudflared/) — no network call or browser interaction.
-		if cfToken, err := cachedCFToken(ctx, cfg.URL); err == nil {
+		// Obtain a valid Cloudflare Access JWT via the cloudflared CLI.
+		// This is required for every request to pass through CF Access.
+		interactive := !NonInteractiveFrom(ctx)
+		if cfToken, err := ensureCFToken(ctx, cfg.URL, interactive); err == nil {
 			apiOpts = append(apiOpts, api.WithCFToken(cfToken))
 		}
 	}
@@ -224,21 +225,39 @@ func buildAPIClientRaw(ctx context.Context, cfg *config.Config, extraOpts ...api
 	return client, nil
 }
 
-// cachedCFToken attempts to read a valid Cloudflare Access JWT from
-// cloudflared's local token cache.  It locates the cloudflared binary (PATH
-// or managed cache) and delegates to [auth.ArgusService.CachedCFToken].
+// ensureCFToken returns a valid Cloudflare Access JWT. It always uses the
+// cloudflared CLI (`cloudflared access token`) to read from cloudflared's
+// local token cache. If the token is expired/missing/stale and interactive
+// is true, it triggers the full browser-based login flow
+// (`cloudflared access login`) to obtain a fresh one.
 //
-// This is best-effort: if cloudflared is not installed, not on PATH, or the
-// cached token is expired/missing, it returns an error and the caller should
-// proceed without the CF token (the auth-retry mechanism will handle it).
-func cachedCFToken(ctx context.Context, argusURL string) (string, error) {
+// When interactive is false (--non-interactive), it returns whatever the
+// cached token is (if any) without opening a browser.
+func ensureCFToken(ctx context.Context, argusURL string, interactive bool) (string, error) {
 	cfSvc := services.NewCloudflaredService()
 	binPath, err := cfSvc.Ensure(ctx)
 	if err != nil {
 		return "", err
 	}
 	argusSvc := auth.NewArgusService(argusURL, binPath)
-	return argusSvc.CachedCFToken(ctx)
+
+	// Try the fast path: read from cloudflared's local cache.
+	if cfToken, err := argusSvc.CachedCFToken(ctx); err == nil {
+		return cfToken, nil
+	}
+
+	// Cached token is expired/missing/stale. If we can't interact with the
+	// user, return the error — the auth-retry layer will surface it.
+	if !interactive {
+		return "", fmt.Errorf("CF Access token is expired or missing; run `argus auth` or use --non-interactive=false")
+	}
+
+	// Interactive: run the full cloudflared login flow (opens browser).
+	cfToken, loginErr := argusSvc.GetOrFetchCFToken(ctx)
+	if loginErr != nil {
+		return "", loginErr
+	}
+	return cfToken, nil
 }
 
 // isUnauthorizedErr reports whether err is (or wraps) an unauthorized /
@@ -249,7 +268,10 @@ func isUnauthorizedErr(err error) bool {
 
 // runWithAuthRetry wraps fn so that if it returns an unauthorized error and
 // the command context does not have --non-interactive set, it triggers the
-// full login flow and retries fn once with a freshly built API client.
+// full login flow (including obtaining a fresh CF Access token via the
+// cloudflared CLI) and retries fn once with a freshly built API client.
+//
+// If the retry also fails, that error is returned as-is — no further retries.
 func runWithAuthRetry(cmd *cobra.Command, args []string, fn func(*cobra.Command, []string) error) error {
 	err := fn(cmd, args)
 	if err == nil {
@@ -292,11 +314,15 @@ func runWithAuthRetry(cmd *cobra.Command, args []string, fn func(*cobra.Command,
 		return fmt.Errorf("re-auth: locating cloudflared: %w", cfErr)
 	}
 	argusSvc := auth.NewArgusService(cfg.URL, binPath)
+
+	// Full login: obtains a fresh CF token (browser if needed), exchanges
+	// it for an Argus session, then for a durable PAT.
 	if loginErr := argusSvc.Login(ctx); loginErr != nil {
 		return fmt.Errorf("re-auth: login failed: %w", loginErr)
 	}
 
-	// Rebuild client with fresh credentials.
+	// Rebuild client with fresh credentials. Use interactive=true so
+	// ensureCFToken can also obtain a fresh CF token if needed.
 	newClient, buildErr := buildAPIClientRaw(ctx, cfg)
 	if buildErr != nil {
 		return fmt.Errorf("re-auth: building client: %w", buildErr)

--- a/cli/internal/api/api.go
+++ b/cli/internal/api/api.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"net/url"
 	"time"
@@ -136,6 +137,19 @@ func New(rawBaseURL string, opts ...ClientOption) (*Client, error) {
 		o(c)
 	}
 
+	// Install a redirect policy that re-attaches auth credentials on every
+	// hop.  Go's default http.Client strips cookies set via Request.AddCookie
+	// and drops the Authorization header on cross-origin redirects, which
+	// breaks Cloudflare Access: CF responds with a 302 to its interstitial
+	// page, the redirect loses the CF_Authorization cookie / API token, and
+	// the CLI ends up with an HTML login page instead of JSON.
+	//
+	// This must be set after applying opts so that WithHTTPClient (used by
+	// tests) can override the entire http.Client including CheckRedirect.
+	if c.httpClient.CheckRedirect == nil {
+		c.httpClient.CheckRedirect = c.reattachAuthOnRedirect
+	}
+
 	return c, nil
 }
 
@@ -199,6 +213,23 @@ func (c *Client) attachAuth(req *http.Request) {
 	}
 }
 
+// reattachAuthOnRedirect is a [http.Client.CheckRedirect] callback that
+// re-applies the client's authentication credentials to every redirect
+// request.
+//
+// Go's default redirect handling strips cookies set via [http.Request.AddCookie]
+// and drops the Authorization header when the redirect target is on a different
+// origin.  This breaks Cloudflare Access, which sits in front of the Argus
+// backend and may issue same-origin redirects (e.g. to /cdn-cgi/access/…)
+// while requiring the CF_Authorization cookie on every hop.
+func (c *Client) reattachAuthOnRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return errors.New("stopped after 10 redirects")
+	}
+	c.attachAuth(req)
+	return nil
+}
+
 // Do executes req and returns the raw [http.Response].
 // The caller is responsible for closing the response body.
 func (c *Client) Do(req *http.Request) (*http.Response, error) {
@@ -260,19 +291,22 @@ func DoJSON[T any](c *Client, req *http.Request) (T, error) {
 		return zero, fmt.Errorf("server returned %d: %s", resp.StatusCode, http.StatusText(resp.StatusCode))
 	}
 
-	if contentType := resp.Header.Get("Content-Type"); contentType != "application/json" {
-		// Non-JSON response from a non-error status code is almost always a
-		// Cloudflare or reverse-proxy authentication challenge (HTML login
-		// page). Treat it as an authorization failure with an actionable
-		// message so LLM consumers and humans can self-correct by
-		// re-authenticating rather than seeing a confusing decode error.
-		return zero, fmt.Errorf(
-			"%w: server returned Content-Type %q instead of application/json — "+
-				"this usually means authentication failed or the session expired; "+
-				"re-authenticate with `argus auth` or set the ARGUS_TOKEN environment variable",
-			ErrUnauthorized,
-			contentType,
-		)
+	if rawCT := resp.Header.Get("Content-Type"); rawCT != "" {
+		mediaType, _, _ := mime.ParseMediaType(rawCT)
+		if mediaType != "application/json" {
+			// Non-JSON response from a non-error status code is almost always a
+			// Cloudflare or reverse-proxy authentication challenge (HTML login
+			// page). Treat it as an authorization failure with an actionable
+			// message so LLM consumers and humans can self-correct by
+			// re-authenticating rather than seeing a confusing decode error.
+			return zero, fmt.Errorf(
+				"%w: server returned Content-Type %q instead of application/json — "+
+					"this usually means authentication failed or the session expired; "+
+					"re-authenticate with `argus auth` or set the ARGUS_TOKEN environment variable",
+				ErrUnauthorized,
+				rawCT,
+			)
+		}
 	}
 
 	raw, err := io.ReadAll(resp.Body)

--- a/cli/internal/api/api_test.go
+++ b/cli/internal/api/api_test.go
@@ -474,3 +474,203 @@ func TestBaseURL_WithPath(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "https://argus.scylladb.com/some/path", c.BaseURL())
 }
+
+// --------------------------------------------------------------------------
+// DoJSON – Content-Type handling
+// --------------------------------------------------------------------------
+
+// staticHandlerWithContentType returns a handler that writes body with the
+// given HTTP status code and the specified Content-Type header.
+func staticHandlerWithContentType(code int, contentType string, body []byte) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", contentType)
+		w.WriteHeader(code)
+		_, _ = w.Write(body)
+	}
+}
+
+func TestDoJSON_ContentTypeWithCharset(t *testing.T) {
+	t.Parallel()
+
+	want := samplePayload{ID: "ct-1", Name: "charset-test"}
+
+	srv := httptest.NewServer(staticHandlerWithContentType(
+		http.StatusOK,
+		"application/json; charset=utf-8",
+		okEnvelope(t, want),
+	))
+	t.Cleanup(srv.Close)
+
+	c, err := api.New(srv.URL, api.WithHTTPClient(srv.Client()))
+	require.NoError(t, err)
+
+	req, err := c.NewRequest(context.Background(), http.MethodGet, "/", nil)
+	require.NoError(t, err)
+
+	got, err := api.DoJSON[samplePayload](c, req)
+	require.NoError(t, err, "application/json; charset=utf-8 should be accepted")
+	assert.Equal(t, want, got)
+}
+
+func TestDoJSON_HTMLContentType_ReturnsUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(staticHandlerWithContentType(
+		http.StatusOK,
+		"text/html",
+		[]byte("<html><body>Cloudflare Access Login</body></html>"),
+	))
+	t.Cleanup(srv.Close)
+
+	c, err := api.New(srv.URL, api.WithHTTPClient(srv.Client()))
+	require.NoError(t, err)
+
+	req, err := c.NewRequest(context.Background(), http.MethodGet, "/", nil)
+	require.NoError(t, err)
+
+	_, err = api.DoJSON[samplePayload](c, req)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrUnauthorized)
+	assert.Contains(t, err.Error(), "text/html")
+}
+
+func TestDoJSON_HTMLContentTypeWithCharset_ReturnsUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(staticHandlerWithContentType(
+		http.StatusOK,
+		"text/html; charset=utf-8",
+		[]byte("<html><body>Login</body></html>"),
+	))
+	t.Cleanup(srv.Close)
+
+	c, err := api.New(srv.URL, api.WithHTTPClient(srv.Client()))
+	require.NoError(t, err)
+
+	req, err := c.NewRequest(context.Background(), http.MethodGet, "/", nil)
+	require.NoError(t, err)
+
+	_, err = api.DoJSON[samplePayload](c, req)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrUnauthorized)
+}
+
+// --------------------------------------------------------------------------
+// DoJSON – HTTP 401 / 403 status codes
+// --------------------------------------------------------------------------
+
+func TestDoJSON_Status401_ReturnsUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(staticHandler(http.StatusUnauthorized, []byte(`{"error":"not authenticated"}`)))
+	t.Cleanup(srv.Close)
+
+	c, err := api.New(srv.URL, api.WithHTTPClient(srv.Client()))
+	require.NoError(t, err)
+
+	req, err := c.NewRequest(context.Background(), http.MethodGet, "/", nil)
+	require.NoError(t, err)
+
+	_, err = api.DoJSON[samplePayload](c, req)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrUnauthorized)
+	assert.Contains(t, err.Error(), "401")
+}
+
+func TestDoJSON_Status403_ReturnsUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(staticHandler(http.StatusForbidden, []byte(`{"error":"forbidden"}`)))
+	t.Cleanup(srv.Close)
+
+	c, err := api.New(srv.URL, api.WithHTTPClient(srv.Client()))
+	require.NoError(t, err)
+
+	req, err := c.NewRequest(context.Background(), http.MethodGet, "/", nil)
+	require.NoError(t, err)
+
+	_, err = api.DoJSON[samplePayload](c, req)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrUnauthorized)
+	assert.Contains(t, err.Error(), "403")
+}
+
+// --------------------------------------------------------------------------
+// DoJSON – redirect handling (CF Access scenario)
+// --------------------------------------------------------------------------
+
+func TestDoJSON_RedirectPreservesAuth(t *testing.T) {
+	t.Parallel()
+
+	want := samplePayload{ID: "redir-1", Name: "redirect-test"}
+
+	// Mux that redirects / → /final, and /final serves the JSON payload.
+	// The /final handler verifies that the auth credentials survived the
+	// redirect.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		http.Redirect(w, r, "/final", http.StatusFound)
+	})
+	mux.HandleFunc("/final", func(w http.ResponseWriter, r *http.Request) {
+		// Verify auth credentials survived the redirect.
+		assert.Equal(t, "token mytoken", r.Header.Get("Authorization"),
+			"Authorization header must survive redirect")
+
+		cookie, err := r.Cookie("CF_Authorization")
+		require.NoError(t, err, "CF_Authorization cookie must survive redirect")
+		assert.Equal(t, "cf-jwt-123", cookie.Value)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(okEnvelope(t, want))
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	c, err := api.New(srv.URL,
+		api.WithAPIToken("mytoken"),
+		api.WithCFToken("cf-jwt-123"),
+	)
+	require.NoError(t, err)
+
+	req, err := c.NewRequest(context.Background(), http.MethodGet, "/", nil)
+	require.NoError(t, err)
+
+	got, err := api.DoJSON[samplePayload](c, req)
+	require.NoError(t, err, "request through redirect should succeed with auth preserved")
+	assert.Equal(t, want, got)
+}
+
+func TestDoJSON_RedirectToHTMLStillReturnsUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	// Simulates CF Access redirecting to an HTML login page even after
+	// credentials are re-attached (e.g. the token is expired/invalid).
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/run", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/cdn-cgi/access/login", http.StatusFound)
+	})
+	mux.HandleFunc("/cdn-cgi/access/login", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<html><body>Please log in</body></html>"))
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	c, err := api.New(srv.URL, api.WithAPIToken("expired-token"))
+	require.NoError(t, err)
+
+	req, err := c.NewRequest(context.Background(), http.MethodGet, "/api/v1/run", nil)
+	require.NoError(t, err)
+
+	_, err = api.DoJSON[samplePayload](c, req)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, api.ErrUnauthorized)
+}

--- a/cli/internal/auth/argus.go
+++ b/cli/internal/auth/argus.go
@@ -153,7 +153,7 @@ func (s *ArgusService) CachedCFToken(ctx context.Context) (string, error) {
 // credentials first (e.g. by making a lightweight API call) and only call
 // Login when those credentials are known to be invalid.
 func (s *ArgusService) Login(ctx context.Context) error {
-	cfToken, err := s.getOrFetchCFToken(ctx)
+	cfToken, err := s.GetOrFetchCFToken(ctx)
 	if err != nil {
 		return err
 	}
@@ -219,12 +219,12 @@ func (s *ArgusService) fetchPAT(ctx context.Context, session, cfToken string) (s
 	return result.Token, nil
 }
 
-// getOrFetchCFToken returns a valid CF Access JWT.  It first tries
+// GetOrFetchCFToken returns a valid CF Access JWT.  It first tries
 // `cloudflared access token --app <url>` which reads the token from
 // cloudflared's local token cache (~/.cloudflared/) without any network call
 // or browser interaction.  If that fails or the token is expired / too old,
 // it falls back to `cloudflared access login` which opens a browser.
-func (s *ArgusService) getOrFetchCFToken(ctx context.Context) (string, error) {
+func (s *ArgusService) GetOrFetchCFToken(ctx context.Context) (string, error) {
 	// Try the fast, local-only `access token` subcommand first.
 	if cached, err := s.runCFAccessToken(ctx); err == nil {
 		expired, jwtErr := jwt.IsExpired(cached)


### PR DESCRIPTION
## Summary

The CLI's Cloudflare Access authentication was broken: when the cached CF Access JWT was expired or missing, `cloudflared` never triggered the browser-based login flow, leaving the user stuck with opaque unauthorized errors. Additionally, Go's default HTTP redirect handling stripped auth credentials on 302 hops issued by CF Access, causing requests to land on an HTML login page instead of receiving JSON.

## Changes

### Auth flow: cache-then-login (`cmd/root.go`, `internal/auth/argus.go`)

- Replace the read-only `cachedCFToken()` helper with `ensureCFToken()`, which first attempts the fast local cache read (`cloudflared access token`) and, if that fails and the session is interactive, falls back to the full browser-based login (`cloudflared access login`).
- In non-interactive mode (`--non-interactive`), return a clear error instead of silently proceeding without a token.
- Export `GetOrFetchCFToken` from the auth package so the root command can invoke the full token-fetch flow directly.

### Redirect auth preservation (`internal/api/api.go`)

- Install a custom `CheckRedirect` policy (`reattachAuthOnRedirect`) on the HTTP client that re-attaches the `Authorization` header and `CF_Authorization` cookie on every redirect hop.
- This fixes the scenario where CF Access responds with a 302 to its interstitial page and Go's default client strips the credentials, resulting in an HTML login page instead of JSON.

### Content-Type detection fix (`internal/api/api.go`)

- Switch from exact string comparison to `mime.ParseMediaType` when checking the response `Content-Type` in `DoJSON`.
- `application/json; charset=utf-8` is now correctly accepted instead of being misclassified as an unauthorized HTML response.

### Tests (`internal/api/api_test.go`)

- Content-Type with charset parameter is accepted as valid JSON.
- HTML Content-Type (with and without charset) is detected as unauthorized.
- HTTP 401 and 403 status codes return `ErrUnauthorized`.
- Auth credentials (Authorization header + CF_Authorization cookie) survive a same-origin 302 redirect.
- Redirect to an HTML login page still surfaces as `ErrUnauthorized`.