### PR TITLE
refactor(plugins/sct): Move allocated_resources to a separate table

### DIFF
--- a/argus/backend/plugins/sct/controller.py
+++ b/argus/backend/plugins/sct/controller.py
@@ -52,6 +52,27 @@ def sct_set_runner(run_id: str):
     }
 
 
+
+@bp.route("/<string:run_id>/resource/all", methods=["GET"])
+@api_login_required
+def sct_resource_all(run_id: str):
+    result = SCTService.get_resources(run_id=run_id)
+    return {
+        "status": "ok",
+        "response": result
+    }
+
+
+@bp.route("/<string:run_id>/resource/<string:name>/get", methods=["GET"])
+@api_login_required
+def sct_resource_get(run_id: str, name: str):
+    result = SCTService.get_resource(run_id=run_id, name=name)
+    return {
+        "status": "ok",
+        "response": result
+    }
+
+
 @bp.route("/<string:run_id>/resource/create", methods=["POST"])
 @api_login_required
 def sct_resource_create(run_id: str):

--- a/argus/backend/plugins/sct/plugin.py
+++ b/argus/backend/plugins/sct/plugin.py
@@ -1,6 +1,6 @@
 from flask import Blueprint
 
-from argus.backend.plugins.sct.testrun import SCTEvent, SCTJunitReports, SCTTestRun, SCTUnprocessedEvent, StressCommand
+from argus.backend.plugins.sct.testrun import SCTEvent, SCTJunitReports, SCTResource, SCTTestRun, SCTUnprocessedEvent, StressCommand
 from argus.backend.plugins.sct.controller import bp as sct_bp
 from argus.backend.plugins.core import PluginInfoBase, PluginModelBase
 from argus.backend.plugins.sct.udt import (
@@ -26,6 +26,7 @@ class PluginInfo(PluginInfoBase):
         SCTEvent,
         SCTUnprocessedEvent,
         StressCommand,
+        SCTResource,
     ]
     all_types = [
         NemesisRunInfo,

--- a/argus/backend/plugins/sct/plugin.py
+++ b/argus/backend/plugins/sct/plugin.py
@@ -1,6 +1,6 @@
 from flask import Blueprint
 
-from argus.backend.plugins.sct.testrun import SCTEvent, SCTJunitReports, SCTNemesis, SCTTestRun, SCTUnprocessedEvent, StressCommand
+from argus.backend.plugins.sct.testrun import SCTEvent, SCTJunitReports, SCTResource, SCTNemesis, SCTTestRun, SCTUnprocessedEvent, StressCommand
 from argus.backend.plugins.sct.controller import bp as sct_bp
 from argus.backend.plugins.core import PluginInfoBase, PluginModelBase
 from argus.backend.plugins.sct.udt import (
@@ -27,6 +27,7 @@ class PluginInfo(PluginInfoBase):
         SCTEvent,
         SCTUnprocessedEvent,
         StressCommand,
+        SCTResource,
     ]
     all_types = [
         NemesisRunInfo,

--- a/argus/backend/plugins/sct/service.py
+++ b/argus/backend/plugins/sct/service.py
@@ -14,11 +14,10 @@ from argus.backend.db import ScyllaCluster
 from argus.backend.models.github_issue import GithubIssue, IssueLink
 from argus.backend.models.web import ArgusEventTypes, ErrorEventEmbeddings, CriticalEventEmbeddings
 from argus.backend.models.argus_ai import SCTErrorEventEmbedding, SCTCriticalEventEmbedding
-from argus.backend.plugins.sct.testrun import SCTEvent, SCTEventSeverity, SCTJunitReports, SCTNemesis, SCTTestRun, SubtestType, SCTUnprocessedEvent, StressCommand
+from argus.backend.plugins.sct.testrun import SCTEvent, SCTEventSeverity, SCTJunitReports, SCTResource, SCTNemesis, SCTTestRun, SubtestType, SCTUnprocessedEvent, StressCommand
 from argus.common.sct_types import GeminiResultsRequest, PerformanceResultsRequest, RawEventPayload, ResourceUpdateRequest
 from argus.backend.plugins.sct.udt import (
     CloudInstanceDetails,
-    CloudResource,
     EventsBySeverity,
     NemesisRunInfo,
     NodeDescription,
@@ -122,11 +121,15 @@ class SCTService:
                 region=region,
             )
             run.sct_runner_host = details
-            resource = CloudResource(
-                name=name or "sct-runner", resource_type="sct-runner", instance_info=details)
-            if not any(r.name == resource.name for r in run.allocated_resources):
-                run.allocated_resources.append(resource)
             run.save()
+            resource_name = name or "sct-runner"
+            if not SCTResource.objects(run_id=UUID(run_id), name=resource_name).count():
+                SCTResource.create(
+                    run_id=UUID(run_id),
+                    name=resource_name,
+                    resource_type="sct-runner",
+                    instance_info=details,
+                )
         except SCTTestRun.DoesNotExist as exception:
             LOGGER.error("Run %s not found for SCTTestRun", run_id)
             raise SCTServiceException("Run not found", run_id) from exception
@@ -309,16 +312,29 @@ class SCTService:
             raise SCTServiceException("Run not found", run_id) from exception
 
     @staticmethod
+    def get_resources(run_id: str):
+        return list(SCTResource.filter(run_id=run_id).all())
+
+    @staticmethod
+    def get_resource(run_id: str, name: str):
+        return SCTResource.get(run_id=run_id, name=name)
+
+    @staticmethod
     def create_resource(run_id: str, resource_details: dict) -> str:
         instance_details = CloudInstanceDetails(
             **resource_details.pop("instance_details"))
-        resource = CloudResource(
-            **resource_details, instance_info=instance_details)
+        resource_name = resource_details.get("name")
         try:
-            run: SCTTestRun = SCTTestRun.get(id=run_id)
-            if not any(r.name == resource.name for r in run.get_resources()):
-                run.get_resources().append(resource)
-                run.save()
+            SCTTestRun.get(id=run_id)
+            if not SCTResource.objects(run_id=UUID(run_id), name=resource_name).count():
+                SCTResource.create(
+                    run_id=UUID(run_id),
+                    name=resource_name,
+                    state=resource_details.get(
+                        "state", ResourceState.RUNNING.value),
+                    resource_type=resource_details.get("resource_type"),
+                    instance_info=instance_details,
+                )
         except SCTTestRun.DoesNotExist as exception:
             LOGGER.error("Run %s not found for SCTTestRun", run_id)
             raise SCTServiceException("Run not found", run_id) from exception
@@ -328,19 +344,18 @@ class SCTService:
     @staticmethod
     def update_resource_shards(run_id: str, resource_name: str, new_shards: int) -> str:
         try:
-            run: SCTTestRun = SCTTestRun.get(id=run_id)
-            resource = next(res for res in run.get_resources()
-                            if res.name == resource_name)
-            resource.get_instance_info().shards_amount = new_shards
-            run.save()
-        except StopIteration as exception:
+            resource = SCTResource.get(run_id=UUID(run_id), name=resource_name)
+            info = CloudInstanceDetails(**resource.instance_info)
+            if not info:
+                info = CloudInstanceDetails()
+            info.shards_amount = new_shards
+            resource.instance_info = info
+            resource.save()
+        except SCTResource.DoesNotExist as exception:
             LOGGER.error("Resource %s not found in run %s",
                          resource_name, run_id)
             raise SCTServiceException(
                 "Resource not found", resource_name) from exception
-        except SCTTestRun.DoesNotExist as exception:
-            LOGGER.error("Run %s not found for SCTTestRun", run_id)
-            raise SCTServiceException("Run not found", run_id) from exception
 
         return "updated"
 
@@ -348,27 +363,24 @@ class SCTService:
     def update_resource(run_id: str, resource_name: str, update_data: ResourceUpdateRequest) -> str:
         try:
             fields_updated = {}
-            run: SCTTestRun = SCTTestRun.get(id=run_id)
-            resource = next(res for res in run.get_resources()
-                            if res.name == resource_name)
+            resource = SCTResource.get(run_id=UUID(run_id), name=resource_name)
             instance_info = update_data.pop("instance_info", None)
             resource.state = ResourceState(
                 update_data.get("state", resource.state)).value
             if instance_info:
-                resource_instance_info = resource.get_instance_info()
+                resource_instance_info = CloudInstanceDetails(
+                    **resource.instance_info)
                 for k, v in instance_info.items():
                     if k in resource_instance_info.keys():
                         resource_instance_info[k] = v
                         fields_updated[k] = v
-            run.save()
-        except StopIteration as exception:
+                resource.update(instance_info=resource_instance_info)
+            resource.save()
+        except SCTResource.DoesNotExist as exception:
             LOGGER.error("Resource %s not found in run %s",
                          resource_name, run_id)
             raise SCTServiceException(
                 "Resource not found", resource_name) from exception
-        except SCTTestRun.DoesNotExist as exception:
-            LOGGER.error("Run %s not found for SCTTestRun", run_id)
-            raise SCTServiceException("Run not found", run_id) from exception
 
         return {
             "state": "updated",
@@ -378,25 +390,24 @@ class SCTService:
     @staticmethod
     def terminate_resource(run_id: str, resource_name: str, reason: str) -> str:
         try:
-            run: SCTTestRun = SCTTestRun.get(id=run_id)
             if "sct-runner" in resource_name:  # FIXME: Temp solution until sct-runner name is propagated on submit
-                resource = next(res for res in run.get_resources()
-                                if "sct-runner" in res.name)
+                resources = list(SCTResource.filter(run_id=UUID(run_id)).all())
+                resource = next(
+                    res for res in resources if "sct-runner" in res.name)
             else:
-                resource = next(res for res in run.get_resources()
-                                if res.name == resource_name)
-            resource.get_instance_info().termination_reason = reason
-            resource.get_instance_info().termination_time = int(time())
+                resource = SCTResource.get(
+                    run_id=UUID(run_id), name=resource_name)
+            info = CloudInstanceDetails(**resource.instance_info)
+            info.termination_reason = reason
+            info.termination_time = int(time())
             resource.state = ResourceState.TERMINATED.value
-            run.save()
-        except StopIteration as exception:
+            resource.update(instance_info=info)
+            resource.save()
+        except (StopIteration, SCTResource.DoesNotExist) as exception:
             LOGGER.error("Resource %s not found in run %s",
                          resource_name, run_id)
             raise SCTServiceException(
                 "Resource not found", resource_name) from exception
-        except SCTTestRun.DoesNotExist as exception:
-            LOGGER.error("Run %s not found for SCTTestRun", run_id)
-            raise SCTServiceException("Run not found", run_id) from exception
 
         return "terminated"
 
@@ -514,8 +525,10 @@ class SCTService:
 
     @staticmethod
     def get_events(run_id: str, limit: int, severities: list[str], before: str | None, after: str | None = None) -> list[dict]:
-        before_dt = datetime.fromtimestamp(int(before), tz=UTC) if before else None
-        after_dt = datetime.fromtimestamp(int(after), tz=UTC) if after else None
+        before_dt = datetime.fromtimestamp(
+            int(before), tz=UTC) if before else None
+        after_dt = datetime.fromtimestamp(
+            int(after), tz=UTC) if after else None
 
         return SCTTestRun.get_events_limited(run_id=UUID(run_id), before=before_dt, after=after_dt, severities=severities, per_partition_limit=limit)
 

--- a/argus/backend/plugins/sct/service.py
+++ b/argus/backend/plugins/sct/service.py
@@ -14,11 +14,10 @@ from argus.backend.db import ScyllaCluster
 from argus.backend.models.github_issue import GithubIssue, IssueLink
 from argus.backend.models.web import ArgusEventTypes, ErrorEventEmbeddings, CriticalEventEmbeddings
 from argus.backend.models.argus_ai import SCTErrorEventEmbedding, SCTCriticalEventEmbedding
-from argus.backend.plugins.sct.testrun import SCTEvent, SCTEventSeverity, SCTJunitReports, SCTTestRun, SubtestType, SCTUnprocessedEvent, StressCommand
+from argus.backend.plugins.sct.testrun import SCTEvent, SCTEventSeverity, SCTJunitReports, SCTResource, SCTTestRun, SubtestType, SCTUnprocessedEvent, StressCommand
 from argus.common.sct_types import GeminiResultsRequest, PerformanceResultsRequest, RawEventPayload, ResourceUpdateRequest
 from argus.backend.plugins.sct.udt import (
     CloudInstanceDetails,
-    CloudResource,
     EventsBySeverity,
     NemesisRunInfo,
     NodeDescription,
@@ -122,10 +121,15 @@ class SCTService:
                 region=region,
             )
             run.sct_runner_host = details
-            resource = CloudResource(name=name or "sct-runner", resource_type="sct-runner", instance_info=details)
-            if not any(r.name == resource.name for r in run.allocated_resources):
-                run.allocated_resources.append(resource)
             run.save()
+            resource_name = name or "sct-runner"
+            if not SCTResource.objects(run_id=UUID(run_id), name=resource_name).count():
+                SCTResource.create(
+                    run_id=UUID(run_id),
+                    name=resource_name,
+                    resource_type="sct-runner",
+                    instance_info=details,
+                )
         except SCTTestRun.DoesNotExist as exception:
             LOGGER.error("Run %s not found for SCTTestRun", run_id)
             raise SCTServiceException("Run not found", run_id) from exception
@@ -153,8 +157,10 @@ class SCTService:
             run.subtest_name = SubtestType.GEMINI.value
             run.oracle_nodes_count = gemini_data.get("oracle_nodes_count")
             run.oracle_node_ami_id = gemini_data.get("oracle_node_ami_id")
-            run.oracle_node_instance_type = gemini_data.get("oracle_node_instance_type")
-            run.oracle_node_scylla_version = gemini_data.get("oracle_node_scylla_version")
+            run.oracle_node_instance_type = gemini_data.get(
+                "oracle_node_instance_type")
+            run.oracle_node_scylla_version = gemini_data.get(
+                "oracle_node_scylla_version")
             run.gemini_command = gemini_data.get("gemini_command")
             run.gemini_version = gemini_data.get("gemini_version")
             run.gemini_status = gemini_data.get("gemini_status")
@@ -185,11 +191,16 @@ class SCTService:
         try:
             run: SCTTestRun = SCTTestRun.get(id=run_id)
             run.subtest_name = SubtestType.PERFORMANCE.value
-            run.perf_op_rate_average = performance_results.get("perf_op_rate_average")
-            run.perf_op_rate_total = performance_results.get("perf_op_rate_total")
-            run.perf_avg_latency_99th = performance_results.get("perf_avg_latency_99th")
-            run.perf_avg_latency_mean = performance_results.get("perf_avg_latency_mean")
-            run.perf_total_errors = performance_results.get("perf_total_errors")
+            run.perf_op_rate_average = performance_results.get(
+                "perf_op_rate_average")
+            run.perf_op_rate_total = performance_results.get(
+                "perf_op_rate_total")
+            run.perf_avg_latency_99th = performance_results.get(
+                "perf_avg_latency_99th")
+            run.perf_avg_latency_mean = performance_results.get(
+                "perf_avg_latency_mean")
+            run.perf_total_errors = performance_results.get(
+                "perf_total_errors")
             run.stress_cmd = performance_results.get("stress_cmd")
             run.test_name = performance_results.get("test_name")
             run.save()
@@ -202,7 +213,8 @@ class SCTService:
                 change = int(math.fabs(delta) * 100 / rhs)
                 return change if delta >= 0 else change * -1
 
-            previous_runs = SCTTestRun.get_perf_results_for_test_name(run.build_id, run.start_time, run.test_name)
+            previous_runs = SCTTestRun.get_perf_results_for_test_name(
+                run.build_id, run.start_time, run.test_name)
             metrics_to_check = ["perf_avg_latency_99th",
                                 "perf_avg_latency_mean"] if is_latency_test else ["perf_op_rate_total"]
 
@@ -210,7 +222,8 @@ class SCTService:
             for prev_run in previous_runs:
                 if not older_runs_by_version.get(prev_run["scylla_version"]):
                     older_runs_by_version[prev_run["scylla_version"]] = []
-                older_runs_by_version[prev_run["scylla_version"]].append(prev_run)
+                older_runs_by_version[prev_run["scylla_version"]].append(
+                    prev_run)
 
             regression_found = False
             regression_info = {
@@ -224,11 +237,13 @@ class SCTService:
 
             if performance_results["histograms"]:
                 for histogram in performance_results["histograms"]:
-                    run.histograms = {k: PerformanceHDRHistogram(**v) for k, v in histogram.items()}
+                    run.histograms = {k: PerformanceHDRHistogram(
+                        **v) for k, v in histogram.items()}
 
             for version, runs in older_runs_by_version.items():
                 for metric in metrics_to_check:
-                    best_run = sorted(runs, reverse=(not is_latency_test), key=lambda v: v[metric])[0]
+                    best_run = sorted(runs, reverse=(
+                        not is_latency_test), key=lambda v: v[metric])[0]
                     last_run = runs[0]
 
                     metric_to_best = cmp(run[metric], best_run[metric])
@@ -297,14 +312,29 @@ class SCTService:
             raise SCTServiceException("Run not found", run_id) from exception
 
     @staticmethod
+    def get_resources(run_id: str):
+        return list(SCTResource.filter(run_id=run_id).all())
+
+    @staticmethod
+    def get_resource(run_id: str, name: str):
+        return SCTResource.get(run_id=run_id, name=name)
+
+    @staticmethod
     def create_resource(run_id: str, resource_details: dict) -> str:
-        instance_details = CloudInstanceDetails(**resource_details.pop("instance_details"))
-        resource = CloudResource(**resource_details, instance_info=instance_details)
+        instance_details = CloudInstanceDetails(
+            **resource_details.pop("instance_details"))
+        resource_name = resource_details.get("name")
         try:
-            run: SCTTestRun = SCTTestRun.get(id=run_id)
-            if not any(r.name == resource.name for r in run.get_resources()):
-                run.get_resources().append(resource)
-                run.save()
+            SCTTestRun.get(id=run_id)
+            if not SCTResource.objects(run_id=UUID(run_id), name=resource_name).count():
+                SCTResource.create(
+                    run_id=UUID(run_id),
+                    name=resource_name,
+                    state=resource_details.get(
+                        "state", ResourceState.RUNNING.value),
+                    resource_type=resource_details.get("resource_type"),
+                    instance_info=instance_details,
+                )
         except SCTTestRun.DoesNotExist as exception:
             LOGGER.error("Run %s not found for SCTTestRun", run_id)
             raise SCTServiceException("Run not found", run_id) from exception
@@ -314,16 +344,18 @@ class SCTService:
     @staticmethod
     def update_resource_shards(run_id: str, resource_name: str, new_shards: int) -> str:
         try:
-            run: SCTTestRun = SCTTestRun.get(id=run_id)
-            resource = next(res for res in run.get_resources() if res.name == resource_name)
-            resource.get_instance_info().shards_amount = new_shards
-            run.save()
-        except StopIteration as exception:
-            LOGGER.error("Resource %s not found in run %s", resource_name, run_id)
-            raise SCTServiceException("Resource not found", resource_name) from exception
-        except SCTTestRun.DoesNotExist as exception:
-            LOGGER.error("Run %s not found for SCTTestRun", run_id)
-            raise SCTServiceException("Run not found", run_id) from exception
+            resource = SCTResource.get(run_id=UUID(run_id), name=resource_name)
+            info = CloudInstanceDetails(**resource.instance_info)
+            if not info:
+                info = CloudInstanceDetails()
+            info.shards_amount = new_shards
+            resource.instance_info = info
+            resource.save()
+        except SCTResource.DoesNotExist as exception:
+            LOGGER.error("Resource %s not found in run %s",
+                         resource_name, run_id)
+            raise SCTServiceException(
+                "Resource not found", resource_name) from exception
 
         return "updated"
 
@@ -331,23 +363,24 @@ class SCTService:
     def update_resource(run_id: str, resource_name: str, update_data: ResourceUpdateRequest) -> str:
         try:
             fields_updated = {}
-            run: SCTTestRun = SCTTestRun.get(id=run_id)
-            resource = next(res for res in run.get_resources() if res.name == resource_name)
+            resource = SCTResource.get(run_id=UUID(run_id), name=resource_name)
             instance_info = update_data.pop("instance_info", None)
-            resource.state = ResourceState(update_data.get("state", resource.state)).value
+            resource.state = ResourceState(
+                update_data.get("state", resource.state)).value
             if instance_info:
-                resource_instance_info = resource.get_instance_info()
+                resource_instance_info = CloudInstanceDetails(
+                    **resource.instance_info)
                 for k, v in instance_info.items():
                     if k in resource_instance_info.keys():
                         resource_instance_info[k] = v
                         fields_updated[k] = v
-            run.save()
-        except StopIteration as exception:
-            LOGGER.error("Resource %s not found in run %s", resource_name, run_id)
-            raise SCTServiceException("Resource not found", resource_name) from exception
-        except SCTTestRun.DoesNotExist as exception:
-            LOGGER.error("Run %s not found for SCTTestRun", run_id)
-            raise SCTServiceException("Run not found", run_id) from exception
+                resource.update(instance_info=resource_instance_info)
+            resource.save()
+        except SCTResource.DoesNotExist as exception:
+            LOGGER.error("Resource %s not found in run %s",
+                         resource_name, run_id)
+            raise SCTServiceException(
+                "Resource not found", resource_name) from exception
 
         return {
             "state": "updated",
@@ -357,28 +390,32 @@ class SCTService:
     @staticmethod
     def terminate_resource(run_id: str, resource_name: str, reason: str) -> str:
         try:
-            run: SCTTestRun = SCTTestRun.get(id=run_id)
             if "sct-runner" in resource_name:  # FIXME: Temp solution until sct-runner name is propagated on submit
-                resource = next(res for res in run.get_resources() if "sct-runner" in res.name)
+                resources = list(SCTResource.filter(run_id=UUID(run_id)).all())
+                resource = next(
+                    res for res in resources if "sct-runner" in res.name)
             else:
-                resource = next(res for res in run.get_resources() if res.name == resource_name)
-            resource.get_instance_info().termination_reason = reason
-            resource.get_instance_info().termination_time = int(time())
+                resource = SCTResource.get(
+                    run_id=UUID(run_id), name=resource_name)
+            info = CloudInstanceDetails(**resource.instance_info)
+            info.termination_reason = reason
+            info.termination_time = int(time())
             resource.state = ResourceState.TERMINATED.value
-            run.save()
-        except StopIteration as exception:
-            LOGGER.error("Resource %s not found in run %s", resource_name, run_id)
-            raise SCTServiceException("Resource not found", resource_name) from exception
-        except SCTTestRun.DoesNotExist as exception:
-            LOGGER.error("Run %s not found for SCTTestRun", run_id)
-            raise SCTServiceException("Run not found", run_id) from exception
+            resource.update(instance_info=info)
+            resource.save()
+        except (StopIteration, SCTResource.DoesNotExist) as exception:
+            LOGGER.error("Resource %s not found in run %s",
+                         resource_name, run_id)
+            raise SCTServiceException(
+                "Resource not found", resource_name) from exception
 
         return "terminated"
 
     @staticmethod
     def submit_nemesis(run_id: str, nemesis_details: dict) -> str:
         nem_req = NemesisSubmissionRequest(**nemesis_details)
-        node_desc = NodeDescription(name=nem_req.node_name, ip=nem_req.node_ip, shards=nem_req.node_shards)
+        node_desc = NodeDescription(
+            name=nem_req.node_name, ip=nem_req.node_ip, shards=nem_req.node_shards)
         nemesis_info = NemesisRunInfo(
             class_name=nem_req.class_name,
             name=nem_req.name,
@@ -413,14 +450,15 @@ class SCTService:
             nemesis.end_time = int(time())
             run.save()
         except StopIteration as exception:
-            LOGGER.error("Nemesis %s (%s) not found for run %s", nem_req.name, nem_req.start_time, run_id)
-            raise SCTServiceException("Nemesis not found", (nem_req.name, nem_req.start_time)) from exception
+            LOGGER.error("Nemesis %s (%s) not found for run %s",
+                         nem_req.name, nem_req.start_time, run_id)
+            raise SCTServiceException(
+                "Nemesis not found", (nem_req.name, nem_req.start_time)) from exception
         except SCTTestRun.DoesNotExist as exception:
             LOGGER.error("Run %s not found for SCTTestRun", run_id)
             raise SCTServiceException("Run not found", run_id) from exception
 
         return "updated"
-
 
     @classmethod
     def submit_event(cls, run_id: str, raw_event: RawEventPayload):
@@ -436,7 +474,8 @@ class SCTService:
         # DB related events
         event.node = req.node
         if req.received_timestamp:
-            event.received_timestamp = datetime.fromisoformat(req.received_timestamp)
+            event.received_timestamp = datetime.fromisoformat(
+                req.received_timestamp)
 
         # Nemesis related events
         event.nemesis_name = req.nemesis_name
@@ -453,7 +492,8 @@ class SCTService:
                 run.submit_logs([link])
                 run.save()
         except Exception:
-            LOGGER.warning("Unable to parse event for coredump links.", exc_info=True)
+            LOGGER.warning(
+                "Unable to parse event for coredump links.", exc_info=True)
         # Add to unprocessed events queue for ERROR and CRITICAL events
         if event.severity in (SCTEventSeverity.ERROR.value, SCTEventSeverity.CRITICAL.value):
             try:
@@ -462,24 +502,28 @@ class SCTService:
                 unprocessed_event.severity = event.severity
                 unprocessed_event.ts = event.ts
                 unprocessed_event.save()
-                LOGGER.debug(f"Added event to unprocessed queue: run_id={run_id}, severity={event.severity}, ts={event.ts}")
+                LOGGER.debug(f"Added event to unprocessed queue: run_id={
+                             run_id}, severity={event.severity}, ts={event.ts}")
             except Exception as e:
-                LOGGER.error(f"Failed to add event to unprocessed queue: {e}", exc_info=True)
+                LOGGER.error(f"Failed to add event to unprocessed queue: {
+                             e}", exc_info=True)
 
         return True
 
-
     @staticmethod
     def get_events(run_id: str, limit: int, severities: list[str], before: str | None, after: str | None = None) -> list[dict]:
-        before_dt = datetime.fromtimestamp(int(before), tz=UTC) if before else None
-        after_dt = datetime.fromtimestamp(int(after), tz=UTC) if after else None
+        before_dt = datetime.fromtimestamp(
+            int(before), tz=UTC) if before else None
+        after_dt = datetime.fromtimestamp(
+            int(after), tz=UTC) if after else None
 
         return SCTTestRun.get_events_limited(run_id=UUID(run_id), before=before_dt, after=after_dt, severities=severities, per_partition_limit=limit)
 
     @staticmethod
     def count_events_by_severity(run_id: str, severity: SCTEventSeverity) -> int:
         db = ScyllaCluster.get()
-        query = f"SELECT count(*) FROM {SCTEvent.table_name()} WHERE run_id = ? AND severity IN ?"
+        query = f"SELECT count(*) FROM {SCTEvent.table_name()
+                                        } WHERE run_id = ? AND severity IN ?"
         params = [UUID(run_id), [SCTEventSeverity(severity).value]]
 
         prepared = db.prepare(query)
@@ -496,7 +540,8 @@ class SCTService:
                 wrapper = EventsBySeverity(severity=event.severity,
                                            event_amount=event.total_events, last_events=event.messages)
                 run.get_events_legacy().append(wrapper)
-            coredumps = SCTService.locate_coredumps(run, run.get_events_legacy())
+            coredumps = SCTService.locate_coredumps(
+                run, run.get_events_legacy())
             run.submit_logs(coredumps)
             run.save()
         except SCTTestRun.DoesNotExist as exception:
@@ -511,7 +556,8 @@ class SCTService:
         links = []
         for es in events:
             flat_messages.extend(es.last_events)
-        coredump_events = filter(lambda v: "coredumpevent" in v.lower(), flat_messages)
+        coredump_events = filter(
+            lambda v: "coredumpevent" in v.lower(), flat_messages)
         for event in coredump_events:
             if link := cls.create_coredump_link(event):
                 links.append(link)
@@ -523,20 +569,23 @@ class SCTService:
         ts_pattern = r"^(?P<ts>\d{4}-\d{2}-\d{2} ([\d:]*)\.\d{3})"
         node_name_pattern = r"node=(?P<name>.+)$"
         core_url_match = re.search(core_pattern, event_message, re.MULTILINE)
-        node_name_match = re.search(node_name_pattern, event_message, re.MULTILINE)
+        node_name_match = re.search(
+            node_name_pattern, event_message, re.MULTILINE)
         ts_match = re.search(ts_pattern, event_message)
         timestamp = datetime.now(UTC)
         if core_url_match:
             url = core_url_match.group("url")
             ext = url.rsplit(".", maxsplit=1)[-1]
-            ext = ext if len(ext) <= 5 else "zst" # Default to .zst if URL doesn't conform
+            # Default to .zst if URL doesn't conform
+            ext = ext if len(ext) <= 5 else "zst"
             timestamp_component = ""
             if event_ts:
                 timestamp_component = event_ts.strftime("-%Y-%m-%d_%H-%M-%S")
             elif ts_match:
                 try:
                     timestamp = datetime.fromisoformat(ts_match.group("ts"))
-                    timestamp_component = timestamp.strftime("-%Y-%m-%d_%H-%M-%S")
+                    timestamp_component = timestamp.strftime(
+                        "-%Y-%m-%d_%H-%M-%S")
                 except ValueError:
                     pass
             else:
@@ -565,8 +614,10 @@ class SCTService:
         Returns:
             List of dictionaries containing event_index, severity and similars_set for each event
         """
-        error_embeddings = ErrorEventEmbeddings.filter(run_id=run_id).only(["event_index", "similars_map", "duplicates_list"]).all()
-        critical_embeddings = CriticalEventEmbeddings.filter(run_id=run_id).only(["event_index", "similars_map", "duplicates_list"]).all()
+        error_embeddings = ErrorEventEmbeddings.filter(run_id=run_id).only(
+            ["event_index", "similars_map", "duplicates_list"]).all()
+        critical_embeddings = CriticalEventEmbeddings.filter(run_id=run_id).only(
+            ["event_index", "similars_map", "duplicates_list"]).all()
 
         result = []
         # Process ERROR embeddings
@@ -609,9 +660,11 @@ class SCTService:
         try:
             # Convert timestamp to datetime if needed
             event_ts = datetime.fromisoformat(ts)
-            event: SCTEvent = SCTEvent.get(run_id=run_id, severity=severity, ts=event_ts)
+            event: SCTEvent = SCTEvent.get(
+                run_id=run_id, severity=severity, ts=event_ts)
             if event.duplicate_id:
-                real_event: SCTEvent = SCTEvent.get(event_id=event.duplicate_id)
+                real_event: SCTEvent = SCTEvent.get(
+                    event_id=event.duplicate_id)
                 run_id = real_event.run_id
                 severity = real_event.severity
                 event_ts = real_event.ts
@@ -622,13 +675,16 @@ class SCTService:
             elif severity == "CRITICAL":
                 embedding_model = SCTCriticalEventEmbedding
             else:
-                raise SCTServiceException(f"Unsupported severity for similarity search: {severity}")
+                raise SCTServiceException(
+                    f"Unsupported severity for similarity search: {severity}")
 
             # Fetch the embedding for the query event
-            query_embedding_result = embedding_model.filter(run_id=UUID(run_id) if isinstance(run_id, str) else run_id, ts=event_ts).first()
+            query_embedding_result = embedding_model.filter(run_id=UUID(
+                run_id) if isinstance(run_id, str) else run_id, ts=event_ts).first()
 
             if not query_embedding_result:
-                LOGGER.warning(f"No embedding found for event: run_id={run_id}, severity={severity}, ts={event_ts}")
+                LOGGER.warning(f"No embedding found for event: run_id={
+                               run_id}, severity={severity}, ts={event_ts}")
                 return []
 
             query_embedding = query_embedding_result.embedding
@@ -645,7 +701,8 @@ class SCTService:
             """
 
             prepared = db.prepare(query)
-            result_rows = db.session.execute(prepared, parameters=[query_embedding, limit + 1])
+            result_rows = db.session.execute(
+                prepared, parameters=[query_embedding, limit + 1])
 
             similar_events = []
             visited_run_ids = {str(run_id)}  # Skip current run_id
@@ -664,7 +721,8 @@ class SCTService:
 
         except Exception as e:
             LOGGER.error(f"Error fetching similar events: {e}", exc_info=True)
-            raise SCTServiceException(f"Failed to fetch similar events: {str(e)}")
+            raise SCTServiceException(
+                f"Failed to fetch similar events: {str(e)}")
 
     @staticmethod
     def get_similar_runs_info(run_ids: list[str]):
@@ -682,7 +740,8 @@ class SCTService:
         all_issue_links = {}
 
         for batch_run_ids in chunk(run_ids):
-            batch_links = IssueLink.objects.filter(run_id__in=batch_run_ids).all()
+            batch_links = IssueLink.objects.filter(
+                run_id__in=batch_run_ids).all()
 
             for link in batch_links:
                 run_id_str = str(link.run_id)
@@ -713,7 +772,8 @@ class SCTService:
                     test_run = SCTTestRun.get(id=run_id)
                     test_runs[run_id] = test_run
                 except Exception as e:
-                    LOGGER.debug(f"Failed to fetch test run {run_id}: {str(e)}")
+                    LOGGER.debug(f"Failed to fetch test run {
+                                 run_id}: {str(e)}")
 
         # Step 4: Assign run and issue details to result for runs with issues
         for run_id in runs_with_issues:
@@ -723,7 +783,8 @@ class SCTService:
                     continue
 
                 links = all_issue_links.get(run_id, [])
-                issues = [issues_by_id[link.issue_id] for link in links if link.issue_id in issues_by_id]
+                issues = [issues_by_id[link.issue_id]
+                          for link in links if link.issue_id in issues_by_id]
 
                 try:
                     build_number = int(
@@ -756,12 +817,15 @@ class SCTService:
                 }
             except Exception as e:
                 LOGGER.error(f"Error fetching info for run {run_id}: {str(e)}")
-                result[run_id] = {"build_id": None, "start_time": None, "issues": []}
+                result[run_id] = {"build_id": None,
+                                  "start_time": None, "issues": []}
 
         # Step 5: If less than MAX_SIMILARS results, fetch MAX_SIMILARS more run details
         if len(result) < MAX_SIMILARS:
-            remaining_run_ids = [run_id for run_id in run_ids if run_id not in result]
-            additional_needed = min(MAX_SIMILARS - len(result), len(remaining_run_ids))
+            remaining_run_ids = [
+                run_id for run_id in run_ids if run_id not in result]
+            additional_needed = min(
+                MAX_SIMILARS - len(result), len(remaining_run_ids))
 
             if additional_needed > 0:
                 additional_run_ids = remaining_run_ids[:additional_needed]
@@ -772,7 +836,8 @@ class SCTService:
                         test_run = SCTTestRun.get(id=run_id)
                         additional_test_runs[run_id] = test_run
                     except Exception as e:
-                        LOGGER.debug(f"Failed to fetch additional test run {run_id}: {str(e)}")
+                        LOGGER.debug(f"Failed to fetch additional test run {
+                                     run_id}: {str(e)}")
 
                 for run_id in additional_run_ids:
                     try:
@@ -802,26 +867,32 @@ class SCTService:
                             "issues": [],
                         }
                     except Exception as e:
-                        LOGGER.error(f"Error fetching info for run {run_id}: {str(e)}")
-                        result[run_id] = {"build_id": None, "start_time": None, "issues": []}
+                        LOGGER.error(f"Error fetching info for run {
+                                     run_id}: {str(e)}")
+                        result[run_id] = {"build_id": None,
+                                          "start_time": None, "issues": []}
 
         return result
 
     @staticmethod
     def get_scylla_version_kernels_report(release_name: str):
-        all_release_runs = SCTTestRun.get_version_data_for_release(release_name=release_name)
+        all_release_runs = SCTTestRun.get_version_data_for_release(
+            release_name=release_name)
         kernels_by_version = {}
         kernel_metadata = {}
         for run in all_release_runs:
             packages = run["packages"]
             if not packages:
                 continue
-            scylla_pkgs = {p["name"]: p for p in packages if "scylla-server" in p["name"]}
+            scylla_pkgs = {
+                p["name"]: p for p in packages if "scylla-server" in p["name"]}
             scylla_pkg = scylla_pkgs["scylla-server-upgraded"] if scylla_pkgs.get(
                 "scylla-server-upgraded") else scylla_pkgs.get("scylla-server")
-            version = f"{scylla_pkg['version']}-{scylla_pkg['date']}.{scylla_pkg['revision_id']}" if scylla_pkg else "unknown"
+            version = f"{scylla_pkg['version']}-{scylla_pkg['date']
+                                                 }.{scylla_pkg['revision_id']}" if scylla_pkg else "unknown"
             kernel_packages = [p for p in packages if "kernel" in p["name"]]
-            kernel_package = kernel_packages[0] if len(kernel_packages) > 0 else None
+            kernel_package = kernel_packages[0] if len(
+                kernel_packages) > 0 else None
             if not kernel_package:
                 continue
             version_list = set(kernels_by_version.get(version, []))
@@ -847,7 +918,8 @@ class SCTService:
 
     @staticmethod
     def junit_submit(run_id: str, file_name: str, content: str) -> bool:
-        xml_content = str(base64.decodebytes(bytes(content, encoding="utf-8")), encoding="utf-8")
+        xml_content = str(base64.decodebytes(
+            bytes(content, encoding="utf-8")), encoding="utf-8")
         try:
             _ = ElementTree.fromstring(xml_content)
         except Exception:
@@ -873,7 +945,8 @@ class SCTService:
     def add_stress_command(run_id: str, cmd: str, ts: float, loader_name: str, log_name: str):
         try:
             run: SCTTestRun = SCTTestRun.get(id=run_id)
-            run.add_stress_command(cmd=cmd, ts=clamp_ts_to_milliseconds(ts), loader_name=loader_name, log_name=log_name)
+            run.add_stress_command(cmd=cmd, ts=clamp_ts_to_milliseconds(
+                ts), loader_name=loader_name, log_name=log_name)
             run.save()
         except SCTTestRun.DoesNotExist as exception:
             LOGGER.error("Run %s not found for SCTTestRun", run_id)

--- a/argus/backend/plugins/sct/testrun.py
+++ b/argus/backend/plugins/sct/testrun.py
@@ -23,6 +23,7 @@ from argus.backend.plugins.sct.udt import (
     PerformanceHDRHistogram
 )
 from argus.backend.util.common import chunk, get_build_number
+from argus.common.enums import ResourceState
 
 LOGGER = logging.getLogger(__name__)
 SCT_REGION_PROPERTY_MAP = {
@@ -127,6 +128,16 @@ class SCTNemesis(Model):
     stack_trace = columns.Text()
 
 
+class SCTResource(Model):
+    __table_name__ = "sct_resource"
+
+    run_id = columns.UUID(primary_key=True, partition_key=True)
+    name = columns.Text(primary_key=True)
+    state = columns.Text(default=lambda: ResourceState.RUNNING.value)
+    resource_type = columns.Text()
+    instance_info = columns.UserDefinedType(user_type=CloudInstanceDetails)
+
+
 class SCTTestRun(PluginModelBase):
     __table_name__ = "sct_test_run"
     _plugin_name = "scylla-cluster-tests"
@@ -195,7 +206,7 @@ class SCTTestRun(PluginModelBase):
     @classmethod
     def _stats_query(cls) -> str:
         return ("SELECT id, test_id, group_id, release_id, status, start_time, build_job_url, build_id, nemesis_stats, "
-                f"assignee, end_time, investigation_status, heartbeat, build_number, scylla_version, cloud_setup, allocated_resources FROM {cls.table_name()} WHERE build_id IN ? PER PARTITION LIMIT 15")
+                f"assignee, end_time, investigation_status, heartbeat, build_number, scylla_version, cloud_setup FROM {cls.table_name()} WHERE build_id IN ? PER PARTITION LIMIT 15")
 
     @classmethod
     def load_test_run(cls, run_id: UUID) -> 'SCTTestRun':
@@ -327,8 +338,8 @@ class SCTTestRun(PluginModelBase):
 
         return run
 
-    def get_resources(self) -> list[CloudResource]:
-        return self.allocated_resources
+    def get_resources(self) -> list[SCTResource]:
+        return list(SCTResource.filter(run_id=self.id).all())
 
     def get_nemeses(self) -> list[SCTNemesis]:
         return list(SCTNemesis.filter(run_id=self.id).all())
@@ -472,6 +483,8 @@ class SCTTestRun(PluginModelBase):
         response["junit_reports"] = list(
             SCTJunitReports.filter(test_id=run_id).all())
         response["nemesis_data"] = list(SCTNemesis.filter(run_id=run.id).all())
+        response["allocated_resources"] = list(
+            SCTResource.filter(run_id=run_id).all())
         return response
 
 

--- a/argus/backend/plugins/sct/testrun.py
+++ b/argus/backend/plugins/sct/testrun.py
@@ -21,6 +21,7 @@ from argus.backend.plugins.sct.udt import (
     PerformanceHDRHistogram
 )
 from argus.backend.util.common import chunk, get_build_number
+from argus.common.enums import ResourceState
 
 LOGGER = logging.getLogger(__name__)
 SCT_REGION_PROPERTY_MAP = {
@@ -56,7 +57,6 @@ class SCTTestRunSubmissionRequest():
     runner_private_ip: Optional[str] = field(default=None)
 
 
-
 class SCTEventSeverity(str, Enum):
     CRITICAL = "CRITICAL"
     ERROR = "ERROR"
@@ -65,14 +65,13 @@ class SCTEventSeverity(str, Enum):
     DEBUG = "DEBUG"
 
 
-
 class StressCommand(Model):
     run_id = columns.UUID(primary_key=True, partition_key=True)
-    ts = columns.DateTime(primary_key=True, clustering_order="DESC", default=lambda: datetime.now(tz=UTC))
+    ts = columns.DateTime(
+        primary_key=True, clustering_order="DESC", default=lambda: datetime.now(tz=UTC))
     cmd = columns.Text()
     log_name = columns.Text()
     node_name = columns.Text()
-
 
 
 class SCTEvent(Model):
@@ -88,7 +87,7 @@ class SCTEvent(Model):
 
     # DB Log columns
     node = columns.Text()
-    received_timestamp = columns.DateTime() # SCT DB message timestamp
+    received_timestamp = columns.DateTime()  # SCT DB message timestamp
 
     # Nemesis columns
     nemesis_name = columns.Text()
@@ -98,7 +97,6 @@ class SCTEvent(Model):
 
     # Misc
     known_issue = columns.Text()
-
 
     @classmethod
     def table_name(cls):
@@ -114,6 +112,16 @@ class SCTUnprocessedEvent(Model):
     ts = columns.DateTime(primary_key=True, clustering_order="DESC")
 
 
+class SCTResource(Model):
+    __table_name__ = "sct_resource"
+
+    run_id = columns.UUID(primary_key=True, partition_key=True)
+    name = columns.Text(primary_key=True)
+    state = columns.Text(default=lambda: ResourceState.RUNNING.value)
+    resource_type = columns.Text()
+    instance_info = columns.UserDefinedType(user_type=CloudInstanceDetails)
+
+
 class SCTTestRun(PluginModelBase):
     __table_name__ = "sct_test_run"
     _plugin_name = "scylla-cluster-tests"
@@ -126,7 +134,8 @@ class SCTTestRun(PluginModelBase):
     origin_url = columns.Text()
     started_by = columns.Text()
     config_files = columns.List(value_type=columns.Text())
-    packages = columns.List(value_type=columns.UserDefinedType(user_type=PackageVersion))
+    packages = columns.List(
+        value_type=columns.UserDefinedType(user_type=PackageVersion))
     scylla_version = columns.Text()
     version_source = columns.Text()
     yaml_test_duration = columns.Integer()
@@ -137,11 +146,14 @@ class SCTTestRun(PluginModelBase):
     cloud_setup = columns.UserDefinedType(user_type=CloudSetupDetails)
 
     # Test Runtime Resources
-    allocated_resources = columns.List(value_type=columns.UserDefinedType(user_type=CloudResource))
+    allocated_resources = columns.List(
+        value_type=columns.UserDefinedType(user_type=CloudResource))
 
     # Test Results
-    events = columns.List(value_type=columns.UserDefinedType(user_type=EventsBySeverity))
-    nemesis_data = columns.List(value_type=columns.UserDefinedType(user_type=NemesisRunInfo))
+    events = columns.List(
+        value_type=columns.UserDefinedType(user_type=EventsBySeverity))
+    nemesis_data = columns.List(
+        value_type=columns.UserDefinedType(user_type=NemesisRunInfo))
     screenshots = columns.List(value_type=columns.Text())
 
     # Subtest
@@ -176,7 +188,7 @@ class SCTTestRun(PluginModelBase):
     @classmethod
     def _stats_query(cls) -> str:
         return ("SELECT id, test_id, group_id, release_id, status, start_time, build_job_url, build_id, "
-                f"assignee, end_time, investigation_status, heartbeat, build_number, scylla_version, cloud_setup, allocated_resources, nemesis_data FROM {cls.table_name()} WHERE build_id IN ? PER PARTITION LIMIT 15")
+                f"assignee, end_time, investigation_status, heartbeat, build_number, scylla_version, cloud_setup, nemesis_data FROM {cls.table_name()} WHERE build_id IN ? PER PARTITION LIMIT 15")
 
     @classmethod
     def load_test_run(cls, run_id: UUID) -> 'SCTTestRun':
@@ -190,9 +202,12 @@ class SCTTestRun(PluginModelBase):
     @classmethod
     def get_distinct_product_versions(cls, release: ArgusRelease) -> list[str]:
         cluster = ScyllaCluster.get()
-        statement = cluster.prepare(f"SELECT scylla_version FROM {cls.table_name()} WHERE release_id = ?")
-        rows = cluster.session.execute(query=statement, parameters=(release.id,))
-        unique_versions = {r["scylla_version"] for r in rows if r["scylla_version"]}
+        statement = cluster.prepare(f"SELECT scylla_version FROM {
+                                    cls.table_name()} WHERE release_id = ?")
+        rows = cluster.session.execute(
+            query=statement, parameters=(release.id,))
+        unique_versions = {r["scylla_version"]
+                           for r in rows if r["scylla_version"]}
 
         return sorted(list(unique_versions), reverse=True)
 
@@ -200,7 +215,8 @@ class SCTTestRun(PluginModelBase):
     def get_version_data_for_release(cls, release_name: str):
         cluster = ScyllaCluster.get()
         release = ArgusRelease.get(name=release_name)
-        query = cluster.prepare(f"SELECT scylla_version, packages, status FROM {cls.table_name()} WHERE release_id = ?")
+        query = cluster.prepare(f"SELECT scylla_version, packages, status FROM {
+                                cls.table_name()} WHERE release_id = ?")
         rows = cluster.session.execute(query=query, parameters=(release.id,))
 
         return list(rows)
@@ -213,8 +229,10 @@ class SCTTestRun(PluginModelBase):
     @classmethod
     def get_distinct_cloud_images_for_release(cls, release: ArgusRelease):
         cluster = ScyllaCluster.get()
-        statement = cluster.prepare(f"SELECT cloud_setup FROM {cls.table_name()} WHERE release_id = ?")
-        rows = cluster.session.execute(query=statement, parameters=(release.id,))
+        statement = cluster.prepare(f"SELECT cloud_setup FROM {
+                                    cls.table_name()} WHERE release_id = ?")
+        rows = cluster.session.execute(
+            query=statement, parameters=(release.id,))
         unique_images = {cls.get_image(r) for r in rows if cls.get_image(r)}
 
         return sorted(list(unique_images), reverse=True)
@@ -222,7 +240,8 @@ class SCTTestRun(PluginModelBase):
     @classmethod
     def get_distinct_cloud_images_for_view(cls, tests: list[ArgusTest]):
         cluster = ScyllaCluster.get()
-        statement = cluster.prepare(f"SELECT cloud_setup FROM {cls.table_name()} WHERE build_id IN ?")
+        statement = cluster.prepare(f"SELECT cloud_setup FROM {
+                                    cls.table_name()} WHERE build_id IN ?")
         futures = []
         for batch in chunk(tests):
             futures.append(cluster.session.execute_async(query=statement,
@@ -241,7 +260,8 @@ class SCTTestRun(PluginModelBase):
         query = cluster.prepare(f"SELECT build_id, packages, scylla_version, test_name, perf_op_rate_average, perf_op_rate_total, "
                                 "perf_avg_latency_99th, perf_avg_latency_mean, perf_total_errors, id, start_time, build_job_url, build_number"
                                 f" FROM {cls.table_name()} WHERE build_id = ? AND start_time < ? AND test_name = ? ALLOW FILTERING")
-        rows = cluster.session.execute(query=query, parameters=(build_id, start_time, test_name))
+        rows = cluster.session.execute(
+            query=query, parameters=(build_id, start_time, test_name))
 
         return list(rows)
 
@@ -278,7 +298,8 @@ class SCTTestRun(PluginModelBase):
             backend = req.sct_config.get("cluster_backend")
             if duration_override := req.sct_config.get("stress_duration"):
                 run.stress_duration = float(duration_override)
-            region_key = SCT_REGION_PROPERTY_MAP.get(backend, SCT_REGION_PROPERTY_MAP["default"])
+            region_key = SCT_REGION_PROPERTY_MAP.get(
+                backend, SCT_REGION_PROPERTY_MAP["default"])
             raw_regions = req.sct_config.get(region_key) or "undefined_region"
             regions = raw_regions.split() if isinstance(raw_regions, str) else raw_regions
             primary_region = regions[0]
@@ -289,7 +310,8 @@ class SCTTestRun(PluginModelBase):
                     provider=backend,
                     region=primary_region,
                 )
-            run.cloud_setup = ResourceSetup.get_resource_setup(backend=backend, sct_config=req.sct_config)
+            run.cloud_setup = ResourceSetup.get_resource_setup(
+                backend=backend, sct_config=req.sct_config)
 
             run.config_files = req.sct_config.get("config_files")
             run.region_name = regions
@@ -298,8 +320,8 @@ class SCTTestRun(PluginModelBase):
 
         return run
 
-    def get_resources(self) -> list[CloudResource]:
-        return self.allocated_resources
+    def get_resources(self) -> list[SCTResource]:
+        return list(SCTResource.filter(run_id=self.id).all())
 
     def get_nemeses(self) -> list[NemesisRunInfo]:
         return self.nemesis_data
@@ -319,7 +341,6 @@ class SCTTestRun(PluginModelBase):
         s.save()
         return True
 
-
     def get_events_legacy(self) -> list[EventsBySeverity]:
         """
             Deprecated. To be replaced by new events system.
@@ -332,7 +353,8 @@ class SCTTestRun(PluginModelBase):
     @classmethod
     def get_events_limited(cls, run_id: UUID, before: datetime | None = None, after: datetime | None = None, severities: list[SCTEventSeverity] = None, per_partition_limit: int = 100) -> list[dict]:
         db = ScyllaCluster.get()
-        query = f"SELECT * FROM {SCTEvent.table_name()} WHERE run_id = ? AND severity IN ?"
+        query = f"SELECT * FROM {SCTEvent.table_name()
+                                 } WHERE run_id = ? AND severity IN ?"
         params = [run_id]
         if severities:
             severity_filter = [s.value for s in severities]
@@ -417,7 +439,8 @@ class SCTTestRun(PluginModelBase):
                          sut_package_name,
                          f"{sut_package_name}-target"
                          ]:
-            scylla_package = next((pkg for pkg in self.packages if pkg.name == sut_name), None)
+            scylla_package = next(
+                (pkg for pkg in self.packages if pkg.name == sut_name), None)
             if scylla_package:
                 break
 
@@ -425,7 +448,8 @@ class SCTTestRun(PluginModelBase):
             return (datetime.strptime(scylla_package.date, '%Y%m%d').replace(tzinfo=timezone.utc).timestamp()
                     + int(scylla_package.revision_id, 16) % 1000000 / 1000000)
         else:
-            raise ValueError(f"{sut_package_name} package not found in packages - cannot determine SUT timestamp")
+            raise ValueError(
+                f"{sut_package_name} package not found in packages - cannot determine SUT timestamp")
 
     @classmethod
     def get_run_response(cls, run_id: UUID) -> dict | None:
@@ -434,7 +458,10 @@ class SCTTestRun(PluginModelBase):
         except cls.DoesNotExist:
             return None
         response = dict(run.items())
-        response["junit_reports"] = list(SCTJunitReports.filter(test_id=run_id).all())
+        response["allocated_resources"] = list(
+            SCTResource.filter(run_id=run_id).all())
+        response["junit_reports"] = list(
+            SCTJunitReports.filter(test_id=run_id).all())
         return response
 
 

--- a/argus/backend/service/stats.py
+++ b/argus/backend/service/stats.py
@@ -493,7 +493,6 @@ class TestStats:
                 "id": run["id"],
                 "status": run["status"],
                 "setup": run.get("cloud_setup"),
-                "resources": run.get("allocated_resources"),
                 "build_number": run["build_number"],
                 "build_job_name": run["build_id"],
                 "start_time": run["start_time"],

--- a/argus/backend/service/stats.py
+++ b/argus/backend/service/stats.py
@@ -501,7 +501,6 @@ class TestStats:
                 "id": run["id"],
                 "status": run["status"],
                 "setup": run.get("cloud_setup"),
-                "resources": run.get("allocated_resources"),
                 "build_number": run["build_number"],
                 "build_job_name": run["build_id"],
                 "start_time": run["start_time"],

--- a/argus/backend/tests/sct_api/test_sct_api.py
+++ b/argus/backend/tests/sct_api/test_sct_api.py
@@ -4,7 +4,7 @@ import time
 from uuid import uuid4
 import pytest
 
-from argus.backend.plugins.sct.testrun import SCTNemesis, SCTTestRun
+from argus.backend.plugins.sct.testrun import SCTResource, SCTNemesis, SCTTestRun
 from argus.common.utils import clamp_ts_to_milliseconds
 
 API_PREFIX = "/api/v1/client/sct"
@@ -102,7 +102,7 @@ def test_set_runner(flask_client, sct_run_id):
     assert run.sct_runner_host is not None
     assert run.sct_runner_host.provider == "aws"
     assert run.sct_runner_host.public_ip == "1.2.3.4"
-    assert any(res.resource_type == "sct-runner" and res.name == "runner-1" for res in run.allocated_resources)
+    assert any(res.resource_type == "sct-runner" and res.name == "runner-1" for res in SCTResource.filter(run_id=sct_run_id).all())
 
 
 def _create_resource(flask_client, sct_run_id, resource_name="node-1"):
@@ -137,8 +137,7 @@ def test_resource_create(flask_client, sct_run_id):
     assert resp.json["status"] == "ok"
 
     # Verify resource persisted
-    run = SCTTestRun.get(id=sct_run_id)
-    res = next(r for r in run.allocated_resources if r.name == "node-1")
+    res = SCTResource.get(run_id=sct_run_id, name="node-1")
     assert res.resource_type == "db_node"
     assert res.instance_info.shards_amount == 8
     assert res.state == "running"
@@ -160,8 +159,7 @@ def test_resource_update_shards(flask_client, sct_run_id):
     assert resp.json["status"] == "ok"
 
     # Verify shards updated
-    run = SCTTestRun.get(id=sct_run_id)
-    res = next(r for r in run.allocated_resources if r.name == "node-2")
+    res = SCTResource.get(run_id=sct_run_id, name="node-2")
     assert res.instance_info.shards_amount == 16
 
 
@@ -178,8 +176,7 @@ def test_resource_update(flask_client, sct_run_id):
     assert resp.json["status"] == "ok"
 
     # Verify update applied
-    run = SCTTestRun.get(id=sct_run_id)
-    res = next(r for r in run.allocated_resources if r.name == "node-3")
+    res = SCTResource.get(run_id=sct_run_id, name="node-3")
     assert res.instance_info.shards_amount == 12
 
 
@@ -196,8 +193,7 @@ def test_resource_terminate(flask_client, sct_run_id):
     assert resp.json["status"] == "ok"
 
     # Verify termination reflected in model
-    run = SCTTestRun.get(id=sct_run_id)
-    res = next(r for r in run.allocated_resources if r.name == "node-4")
+    res = SCTResource.get(run_id=sct_run_id, name="node-4")
     assert res.state == "terminated"
     assert res.instance_info.termination_reason == "test-complete"
     assert res.instance_info.termination_time and res.instance_info.termination_time > 0

--- a/argus/backend/tests/sct_api/test_sct_api.py
+++ b/argus/backend/tests/sct_api/test_sct_api.py
@@ -4,7 +4,7 @@ import time
 from uuid import uuid4
 import pytest
 
-from argus.backend.plugins.sct.testrun import SCTTestRun
+from argus.backend.plugins.sct.testrun import SCTResource, SCTTestRun
 from argus.common.utils import clamp_ts_to_milliseconds
 
 API_PREFIX = "/api/v1/client/sct"
@@ -102,7 +102,7 @@ def test_set_runner(flask_client, sct_run_id):
     assert run.sct_runner_host is not None
     assert run.sct_runner_host.provider == "aws"
     assert run.sct_runner_host.public_ip == "1.2.3.4"
-    assert any(res.resource_type == "sct-runner" and res.name == "runner-1" for res in run.allocated_resources)
+    assert any(res.resource_type == "sct-runner" and res.name == "runner-1" for res in SCTResource.filter(run_id=sct_run_id).all())
 
 
 def _create_resource(flask_client, sct_run_id, resource_name="node-1"):
@@ -137,8 +137,7 @@ def test_resource_create(flask_client, sct_run_id):
     assert resp.json["status"] == "ok"
 
     # Verify resource persisted
-    run = SCTTestRun.get(id=sct_run_id)
-    res = next(r for r in run.allocated_resources if r.name == "node-1")
+    res = SCTResource.get(run_id=sct_run_id, name="node-1")
     assert res.resource_type == "db_node"
     assert res.instance_info.shards_amount == 8
     assert res.state == "running"
@@ -160,8 +159,7 @@ def test_resource_update_shards(flask_client, sct_run_id):
     assert resp.json["status"] == "ok"
 
     # Verify shards updated
-    run = SCTTestRun.get(id=sct_run_id)
-    res = next(r for r in run.allocated_resources if r.name == "node-2")
+    res = SCTResource.get(run_id=sct_run_id, name="node-2")
     assert res.instance_info.shards_amount == 16
 
 
@@ -178,8 +176,7 @@ def test_resource_update(flask_client, sct_run_id):
     assert resp.json["status"] == "ok"
 
     # Verify update applied
-    run = SCTTestRun.get(id=sct_run_id)
-    res = next(r for r in run.allocated_resources if r.name == "node-3")
+    res = SCTResource.get(run_id=sct_run_id, name="node-3")
     assert res.instance_info.shards_amount == 12
 
 
@@ -196,8 +193,7 @@ def test_resource_terminate(flask_client, sct_run_id):
     assert resp.json["status"] == "ok"
 
     # Verify termination reflected in model
-    run = SCTTestRun.get(id=sct_run_id)
-    res = next(r for r in run.allocated_resources if r.name == "node-4")
+    res = SCTResource.get(run_id=sct_run_id, name="node-4")
     assert res.state == "terminated"
     assert res.instance_info.termination_reason == "test-complete"
     assert res.instance_info.termination_time and res.instance_info.termination_time > 0

--- a/argus/client/sct/client.py
+++ b/argus/client/sct/client.py
@@ -17,6 +17,8 @@ class ArgusSCTClient(ArgusClient):
     class Routes(ArgusClient.Routes):
         SUBMIT_PACKAGES = "/sct/$id/packages/submit"
         SUBMIT_SCREENSHOTS = "/sct/$id/screenshots/submit"
+        GET_RESOURCES = "/sct/$id/resource/all"
+        GET_RESOURCE = "/sct/$id/resource/$name/get"
         CREATE_RESOURCE = "/sct/$id/resource/create"
         TERMINATE_RESOURCE = "/sct/$id/resource/$name/terminate"
         UPDATE_RESOURCE = "/sct/$id/resource/$name/update"
@@ -63,6 +65,28 @@ class ArgusSCTClient(ArgusClient):
         """
         response = super().set_status(run_type=self.test_type, run_id=self.run_id, new_status=new_status)
         self.check_response(response)
+
+    def get_resources(self) -> dict[str, Any]:
+        """
+            Get resources allocated for the run.
+        """
+        response = self.get(
+            endpoint=self.Routes.GET_RESOURCES,
+            location_params={"id": str(self.run_id)},
+        )
+        self.check_response(response)
+        return response.json()["response"]
+
+    def get_resource(self, name: str) -> dict[str, Any]:
+        """
+            Get a specific resource by name.
+        """
+        response = self.get(
+            endpoint=self.Routes.GET_RESOURCE,
+            location_params={"id": str(self.run_id),  "name": name},
+        )
+        self.check_response(response)
+        return response.json()["response"]
 
     def set_sct_runner(self, public_ip: str, private_ip: str, region: str, backend: str, name: str = None) -> None:
         """

--- a/argus/client/sct/client.py
+++ b/argus/client/sct/client.py
@@ -17,6 +17,8 @@ class ArgusSCTClient(ArgusClient):
     class Routes(ArgusClient.Routes):
         SUBMIT_PACKAGES = "/sct/$id/packages/submit"
         SUBMIT_SCREENSHOTS = "/sct/$id/screenshots/submit"
+        GET_RESOURCES = "/sct/$id/resource/all"
+        GET_RESOURCE = "/sct/$id/resource/$name/get"
         CREATE_RESOURCE = "/sct/$id/resource/create"
         TERMINATE_RESOURCE = "/sct/$id/resource/$name/terminate"
         UPDATE_RESOURCE = "/sct/$id/resource/$name/update"
@@ -65,6 +67,28 @@ class ArgusSCTClient(ArgusClient):
         response = super().set_status(run_type=self.test_type,
                                       run_id=self.run_id, new_status=new_status)
         self.check_response(response)
+
+    def get_resources(self) -> dict[str, Any]:
+        """
+            Get resources allocated for the run.
+        """
+        response = self.get(
+            endpoint=self.Routes.GET_RESOURCES,
+            location_params={"id": str(self.run_id)},
+        )
+        self.check_response(response)
+        return response.json()["response"]
+
+    def get_resource(self, name: str) -> dict[str, Any]:
+        """
+            Get a specific resource by name.
+        """
+        response = self.get(
+            endpoint=self.Routes.GET_RESOURCE,
+            location_params={"id": str(self.run_id),  "name": name},
+        )
+        self.check_response(response)
+        return response.json()["response"]
 
     def set_sct_runner(self, public_ip: str, private_ip: str, region: str, backend: str, name: str = None) -> None:
         """

--- a/scripts/migration/migration_2026-04-14.py
+++ b/scripts/migration/migration_2026-04-14.py
@@ -1,0 +1,55 @@
+import logging
+
+from cassandra.cqlengine.query import BatchQuery
+
+from argus.backend.db import ScyllaCluster
+from argus.backend.plugins.sct.testrun import SCTResource, SCTTestRun
+from argus.backend.util.logsetup import setup_application_logging
+
+
+setup_application_logging(log_level=logging.INFO)
+LOGGER = logging.getLogger(__name__)
+DB = ScyllaCluster.get()
+
+
+def migrate():
+    LOGGER.warning("Starting migration: copying allocated_resources to sct_resource table...")
+
+    total_runs = 0
+    total_resources = 0
+    skipped_runs = 0
+
+    for run in SCTTestRun.filter().limit(None).only(["id", "allocated_resources"]).all():
+        total_runs += 1
+        resources = run.allocated_resources
+        if not resources:
+            skipped_runs += 1
+            continue
+
+        with BatchQuery() as b:
+            for res in resources:
+                SCTResource.batch(b).create(
+                    run_id=run.id,
+                    name=res.name,
+                    state=res.state,
+                    resource_type=res.resource_type,
+                    instance_info=res.instance_info,
+                )
+                total_resources += 1
+
+        LOGGER.info(
+            "Migrated %d resources for run_id=%s",
+            len(resources),
+            run.id,
+        )
+
+    LOGGER.warning(
+        "Migration complete. runs_processed=%d skipped=%d resources_migrated=%d",
+        total_runs,
+        skipped_runs,
+        total_resources,
+    )
+
+
+if __name__ == "__main__":
+    migrate()


### PR DESCRIPTION
This commit moves out the allocated_resources resources field to a
separate table, following up the same rework happening for Events and Nemeses.

All interfaces are preserved while removing unnecessary access in stats.py

Fixes ARGUS-4
