### PR TITLE
feature(ssh-tunnel): add secure multi-host tunnel backend and admin APIs

### DIFF
--- a/argus/backend/controller/admin_api.py
+++ b/argus/backend/controller/admin_api.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict
 import logging
 from uuid import UUID
 from flask import (
@@ -7,6 +8,7 @@ from flask import (
 )
 from argus.backend.error_handlers import handle_api_exception
 from argus.backend.service.release_manager import ReleaseEditPayload, ReleaseManagerService
+from argus.backend.service.tunnel_service import ProxyTunnelConfigPayload, TunnelService
 from argus.backend.service.user import UserService, api_login_required, check_roles
 from argus.backend.models.web import User, UserRoles
 
@@ -352,4 +354,51 @@ def user_toggle_admin(user_id: str):
     return {
         "status": "ok",
         "response": result
+    }
+
+
+@bp.route("/proxy-tunnel/config", methods=["GET"])
+@check_roles(UserRoles.Admin)
+@api_login_required
+def get_proxy_tunnel_config():
+    config = TunnelService().get_proxy_tunnel_config()
+    return {
+        "status": "ok",
+        "response": asdict(config) if config else None,
+    }
+
+
+@bp.route("/proxy-tunnel/config", methods=["POST"])
+@check_roles(UserRoles.Admin)
+@api_login_required
+def save_proxy_tunnel_config():
+    payload: ProxyTunnelConfigPayload = get_payload(request)
+    config = TunnelService().save_proxy_tunnel_config(payload)
+    return {
+        "status": "ok",
+        "response": asdict(config),
+    }
+
+
+@bp.route("/ssh/keys", methods=["GET"])
+@check_roles(UserRoles.Admin)
+@api_login_required
+def list_ssh_keys():
+    keys = TunnelService().list_keys()
+    return {
+        "status": "ok",
+        "response": [asdict(row) for row in keys],
+    }
+
+
+@bp.route("/ssh/keys/<string:key_id>", methods=["DELETE"])
+@check_roles(UserRoles.Admin)
+@api_login_required
+def delete_ssh_key(key_id: str):
+    TunnelService().delete_key(UUID(key_id))
+    return {
+        "status": "ok",
+        "response": {
+            "deleted": True,
+        },
     }

--- a/argus/backend/controller/admin_api.py
+++ b/argus/backend/controller/admin_api.py
@@ -27,6 +27,10 @@ class ProxyTunnelActivePayload(TypedDict):
     is_active: bool
 
 
+class ProxyTunnelConfigCreatePayload(ProxyTunnelConfigPayload):
+    host_key_fingerprint: str
+
+
 def parse_active_only(value: str | None) -> bool | None:
     if value is None:
         return None
@@ -405,7 +409,7 @@ def list_proxy_tunnel_configs():
 @check_roles(UserRoles.Admin)
 @api_login_required
 def save_proxy_tunnel_config():
-    payload: ProxyTunnelConfigPayload = get_payload(request)
+    payload: ProxyTunnelConfigCreatePayload = get_payload(request)
     config = TunnelService().save_proxy_tunnel_config(payload)
     return {
         "status": "ok",

--- a/argus/backend/controller/admin_api.py
+++ b/argus/backend/controller/admin_api.py
@@ -1,5 +1,6 @@
 from dataclasses import asdict
 import logging
+from typing import TypedDict
 from uuid import UUID
 from flask import (
     Blueprint,
@@ -15,6 +16,24 @@ from argus.backend.models.web import User, UserRoles
 bp = Blueprint('admin_api', __name__, url_prefix='/api/v1')
 LOGGER = logging.getLogger(__name__)
 bp.register_error_handler(Exception, handle_api_exception)
+
+ACTIVE_ONLY_MAP = {
+    "true": True,
+    "false": False,
+}
+
+
+class ProxyTunnelActivePayload(TypedDict):
+    is_active: bool
+
+
+def parse_active_only(value: str | None) -> bool | None:
+    if value is None:
+        return None
+    lowered = value.strip().lower()
+    if lowered not in ACTIVE_ONLY_MAP:
+        raise Exception("active_only must be one of: true,false")
+    return ACTIVE_ONLY_MAP[lowered]
 
 
 def get_payload(client_request: Request):
@@ -361,10 +380,24 @@ def user_toggle_admin(user_id: str):
 @check_roles(UserRoles.Admin)
 @api_login_required
 def get_proxy_tunnel_config():
-    config = TunnelService().get_proxy_tunnel_config()
+    tunnel_id = request.args.get("tunnel_id")
+    config = TunnelService().get_proxy_tunnel_config(tunnel_id=tunnel_id)
     return {
         "status": "ok",
         "response": asdict(config) if config else None,
+    }
+
+
+@bp.route("/proxy-tunnel/configs", methods=["GET"])
+@check_roles(UserRoles.Admin)
+@api_login_required
+def list_proxy_tunnel_configs():
+    active_only = parse_active_only(request.args.get("active_only"))
+
+    configs = TunnelService().list_proxy_tunnel_configs(active_only=active_only)
+    return {
+        "status": "ok",
+        "response": [asdict(row) for row in configs],
     }
 
 
@@ -374,6 +407,18 @@ def get_proxy_tunnel_config():
 def save_proxy_tunnel_config():
     payload: ProxyTunnelConfigPayload = get_payload(request)
     config = TunnelService().save_proxy_tunnel_config(payload)
+    return {
+        "status": "ok",
+        "response": asdict(config),
+    }
+
+
+@bp.route("/proxy-tunnel/config/<string:tunnel_id>/active", methods=["POST"])
+@check_roles(UserRoles.Admin)
+@api_login_required
+def set_proxy_tunnel_config_active(tunnel_id: str):
+    payload: ProxyTunnelActivePayload = get_payload(request)
+    config = TunnelService().set_proxy_tunnel_config_active(UUID(tunnel_id), payload["is_active"])
     return {
         "status": "ok",
         "response": asdict(config),

--- a/argus/backend/controller/auth.py
+++ b/argus/backend/controller/auth.py
@@ -6,7 +6,14 @@ from flask import (
 from werkzeug.security import check_password_hash
 from argus.backend.error_handlers import handle_profile_exception
 from argus.backend.models.web import User, UserRoles
-from argus.backend.service.user import UserService, UserServiceException, check_roles, load_logged_in_user, login_required
+from argus.backend.service.user import (
+    UserService,
+    UserServiceException,
+    check_roles,
+    enforce_ssh_tunnel_server_scope,
+    load_logged_in_user,
+    login_required,
+)
 
 bp = Blueprint('auth', __name__, url_prefix='/auth')
 bp.register_error_handler(UserServiceException, handle_profile_exception)
@@ -111,3 +118,4 @@ def logout():
 
 
 bp.before_app_request(load_logged_in_user)
+bp.before_app_request(enforce_ssh_tunnel_server_scope)

--- a/argus/backend/controller/auth.py
+++ b/argus/backend/controller/auth.py
@@ -10,7 +10,6 @@ from argus.backend.service.user import (
     UserService,
     UserServiceException,
     check_roles,
-    enforce_ssh_tunnel_server_scope,
     load_logged_in_user,
     login_required,
 )
@@ -118,4 +117,3 @@ def logout():
 
 
 bp.before_app_request(load_logged_in_user)
-bp.before_app_request(enforce_ssh_tunnel_server_scope)

--- a/argus/backend/controller/client_api.py
+++ b/argus/backend/controller/client_api.py
@@ -7,9 +7,11 @@ from argus.backend.service.user import api_login_required
 from argus.backend.service.client_service import ClientService
 from argus.backend.util.common import get_payload
 from argus.backend.plugins.loader import AVAILABLE_PLUGINS
+from argus.backend.controller.ssh_api import bp as ssh_bp
 
 bp = Blueprint("client_api", __name__, url_prefix="/client")
 bp.register_error_handler(Exception, handle_api_exception)
+bp.register_blueprint(ssh_bp)
 for plugin in AVAILABLE_PLUGINS.values():
     if plugin.controller:
         bp.register_blueprint(plugin.controller)

--- a/argus/backend/controller/ssh_api.py
+++ b/argus/backend/controller/ssh_api.py
@@ -1,0 +1,89 @@
+import logging
+from uuid import UUID
+
+from flask import Blueprint, Response, g, request
+
+from argus.backend.error_handlers import handle_api_exception
+from argus.backend.service.tunnel_service import TunnelService
+from argus.backend.service.user import api_login_required
+
+bp = Blueprint("ssh_api", __name__, url_prefix="/ssh")
+bp.register_error_handler(Exception, handle_api_exception)
+
+LOGGER = logging.getLogger(__name__)
+
+
+@bp.route("/tunnel", methods=["POST"])
+@api_login_required
+def register_tunnel():
+    """
+    Register a client SSH public key and obtain proxy tunnel connection details.
+
+    Request JSON body
+    -----------------
+    public_key  : str  — OpenSSH-format ed25519 (or other) public key (required)
+    ttl_seconds : int  — optional key lifetime in seconds (default 86400 / 24 h)
+    tunnel_id   : str  — optional UUID of a specific ProxyTunnelConfig to use;
+                         defaults to the currently active config
+
+    Response
+    --------
+    {
+        "status": "ok",
+        "response": {
+            "key_id":               "<uuid>",
+            "tunnel_id":            "<uuid>",
+            "proxy_host":           "proxy.example.com",
+            "proxy_port":           22,
+            "proxy_user":           "argus-proxy",
+            "target_host":          "10.0.0.5",
+            "target_port":          8080,
+            "host_key_fingerprint": "SHA256:...",
+            "expires_at":           "2026-04-16T12:00:00Z"
+        }
+    }
+    """
+    payload = request.get_json() or {}
+    public_key = payload.get("public_key")
+    ttl_seconds = payload.get("ttl_seconds")
+    tunnel_id = payload.get("tunnel_id")
+
+    if tunnel_id:
+        try:
+            tunnel_id = UUID(str(tunnel_id))
+        except ValueError as exc:
+            return {"status": "error", "response": {"message": f"Invalid tunnel_id: {exc}"}}, 400
+
+    result = TunnelService().register_tunnel(
+        user=g.user,
+        public_key=public_key,
+        tunnel_id=tunnel_id,
+        ttl_seconds=ttl_seconds,
+    )
+    return {"status": "ok", "response": result}
+
+
+@bp.route("/keys", methods=["GET"])
+@api_login_required
+def get_authorized_keys():
+    """
+    Return all non-expired SSH public keys in OpenSSH ``authorized_keys``
+    format (plain text, one key per line).
+
+    This endpoint is called by the proxy host's ``AuthorizedKeysCommand``
+    (via ``argus-cli ssh-keys``) on every SSH connection attempt.
+
+    Query parameters
+    ----------------
+    tunnel_id : str — optional UUID; restrict to keys for a specific tunnel
+    """
+    tunnel_id_str = request.args.get("tunnel_id")
+    tunnel_id = None
+    if tunnel_id_str:
+        try:
+            tunnel_id = UUID(tunnel_id_str)
+        except ValueError as exc:
+            return {"status": "error", "response": {"message": f"Invalid tunnel_id: {exc}"}}, 400
+
+    keys_text = TunnelService().get_authorized_keys(tunnel_id=tunnel_id)
+    return Response(keys_text, mimetype="text/plain")

--- a/argus/backend/controller/ssh_api.py
+++ b/argus/backend/controller/ssh_api.py
@@ -1,11 +1,18 @@
 import logging
+from dataclasses import asdict
+from typing import TypedDict
 
 from flask import Blueprint, Response, g, request
 
-from argus.backend.error_handlers import APIException
 from argus.backend.error_handlers import handle_api_exception
+from argus.backend.models.web import UserRoles
 from argus.backend.service.tunnel_service import TunnelService
-from argus.backend.service.user import api_login_required
+from argus.backend.service.user import api_login_required, check_roles
+
+
+class RegisterTunnelPayload(TypedDict, total=False):
+    public_key: str
+    ttl_seconds: int
 
 bp = Blueprint("ssh_api", __name__, url_prefix="/ssh")
 bp.register_error_handler(Exception, handle_api_exception)
@@ -23,7 +30,7 @@ def register_tunnel():
     -----------------
     public_key  : str  — OpenSSH-format ed25519 (or other) public key (required)
     ttl_seconds : int  — optional key lifetime in seconds.
-                         Must be within [86400, 2592000] (24h..30d).
+                         Must be within [3600, 2592000] (1h..30d).
                          Default is 86400 (24h).
 
     Response
@@ -42,7 +49,7 @@ def register_tunnel():
         }
     }
     """
-    payload = request.get_json() or {}
+    payload: RegisterTunnelPayload = request.get_json() or {}
     public_key = payload.get("public_key")
     ttl_seconds = payload.get("ttl_seconds")
 
@@ -51,14 +58,14 @@ def register_tunnel():
         public_key=public_key,
         ttl_seconds=ttl_seconds,
     )
-    return {"status": "ok", "response": result}
+    return {"status": "ok", "response": asdict(result)}
 
 
 @bp.route("/tunnel", methods=["GET"])
 @api_login_required
 def get_tunnel_connection():
     result = TunnelService().get_tunnel_connection(proxy_host=request.args.get("proxy_host"))
-    return {"status": "ok", "response": result}
+    return {"status": "ok", "response": asdict(result)}
 
 
 @bp.route("/tunnel/keys", methods=["GET"])
@@ -72,11 +79,12 @@ def get_user_keys():
     """
     tunnel_id = request.args.get("tunnel_id")
     result = TunnelService().list_keys(tunnel_id=tunnel_id, user_id=g.user.id)
-    return {"status": "ok", "response": result}
+    return {"status": "ok", "response": [asdict(row) for row in result]}
 
 
 @bp.route("/keys", methods=["GET"])
 @api_login_required
+@check_roles(UserRoles.SSHTunnelServer)
 def get_authorized_keys():
     """
     Return all non-expired SSH public keys in OpenSSH ``authorized_keys``
@@ -85,8 +93,5 @@ def get_authorized_keys():
     This endpoint is called by the proxy host's ``AuthorizedKeysCommand``
     (via ``argus-cli ssh-keys``) on every SSH connection attempt.
     """
-    if not g.user or not g.user.is_service_user():
-        raise APIException("Only service users can fetch SSH authorized keys")
-
     keys_text = TunnelService().get_authorized_keys()
     return Response(keys_text, mimetype="text/plain")

--- a/argus/backend/controller/ssh_api.py
+++ b/argus/backend/controller/ssh_api.py
@@ -22,7 +22,9 @@ def register_tunnel():
     Request JSON body
     -----------------
     public_key  : str  — OpenSSH-format ed25519 (or other) public key (required)
-    ttl_seconds : int  — optional key lifetime in seconds (default 86400 / 24 h)
+    ttl_seconds : int  — optional key lifetime in seconds.
+                         Must be within [86400, 2592000] (24h..30d).
+                         Default is 86400 (24h).
 
     Response
     --------

--- a/argus/backend/controller/ssh_api.py
+++ b/argus/backend/controller/ssh_api.py
@@ -1,8 +1,8 @@
 import logging
-from uuid import UUID
 
 from flask import Blueprint, Response, g, request
 
+from argus.backend.error_handlers import APIException
 from argus.backend.error_handlers import handle_api_exception
 from argus.backend.service.tunnel_service import TunnelService
 from argus.backend.service.user import api_login_required
@@ -23,8 +23,6 @@ def register_tunnel():
     -----------------
     public_key  : str  — OpenSSH-format ed25519 (or other) public key (required)
     ttl_seconds : int  — optional key lifetime in seconds (default 86400 / 24 h)
-    tunnel_id   : str  — optional UUID of a specific ProxyTunnelConfig to use;
-                         defaults to the currently active config
 
     Response
     --------
@@ -32,7 +30,6 @@ def register_tunnel():
         "status": "ok",
         "response": {
             "key_id":               "<uuid>",
-            "tunnel_id":            "<uuid>",
             "proxy_host":           "proxy.example.com",
             "proxy_port":           22,
             "proxy_user":           "argus-proxy",
@@ -46,20 +43,19 @@ def register_tunnel():
     payload = request.get_json() or {}
     public_key = payload.get("public_key")
     ttl_seconds = payload.get("ttl_seconds")
-    tunnel_id = payload.get("tunnel_id")
-
-    if tunnel_id:
-        try:
-            tunnel_id = UUID(str(tunnel_id))
-        except ValueError as exc:
-            return {"status": "error", "response": {"message": f"Invalid tunnel_id: {exc}"}}, 400
 
     result = TunnelService().register_tunnel(
         user=g.user,
         public_key=public_key,
-        tunnel_id=tunnel_id,
         ttl_seconds=ttl_seconds,
     )
+    return {"status": "ok", "response": result}
+
+
+@bp.route("/tunnel", methods=["GET"])
+@api_login_required
+def get_tunnel_connection():
+    result = TunnelService().get_tunnel_connection()
     return {"status": "ok", "response": result}
 
 
@@ -72,18 +68,9 @@ def get_authorized_keys():
 
     This endpoint is called by the proxy host's ``AuthorizedKeysCommand``
     (via ``argus-cli ssh-keys``) on every SSH connection attempt.
-
-    Query parameters
-    ----------------
-    tunnel_id : str — optional UUID; restrict to keys for a specific tunnel
     """
-    tunnel_id_str = request.args.get("tunnel_id")
-    tunnel_id = None
-    if tunnel_id_str:
-        try:
-            tunnel_id = UUID(tunnel_id_str)
-        except ValueError as exc:
-            return {"status": "error", "response": {"message": f"Invalid tunnel_id: {exc}"}}, 400
+    if not g.user or not g.user.is_service_user():
+        raise APIException("Only service users can fetch SSH authorized keys")
 
-    keys_text = TunnelService().get_authorized_keys(tunnel_id=tunnel_id)
+    keys_text = TunnelService().get_authorized_keys(service_user_id=g.user.id)
     return Response(keys_text, mimetype="text/plain")

--- a/argus/backend/controller/ssh_api.py
+++ b/argus/backend/controller/ssh_api.py
@@ -7,7 +7,7 @@ from flask import Blueprint, Response, g, request
 from argus.backend.error_handlers import handle_api_exception
 from argus.backend.models.web import UserRoles
 from argus.backend.service.tunnel_service import TunnelService
-from argus.backend.service.user import api_login_required, check_roles
+from argus.backend.service.user import allow_ssh_tunnel_server_scope, api_login_required, check_roles
 
 
 class RegisterTunnelPayload(TypedDict, total=False):
@@ -83,6 +83,7 @@ def get_user_keys():
 
 
 @bp.route("/keys", methods=["GET"])
+@allow_ssh_tunnel_server_scope
 @api_login_required
 @check_roles(UserRoles.SSHTunnelServer)
 def get_authorized_keys():

--- a/argus/backend/controller/ssh_api.py
+++ b/argus/backend/controller/ssh_api.py
@@ -57,7 +57,21 @@ def register_tunnel():
 @bp.route("/tunnel", methods=["GET"])
 @api_login_required
 def get_tunnel_connection():
-    result = TunnelService().get_tunnel_connection()
+    result = TunnelService().get_tunnel_connection(proxy_host=request.args.get("proxy_host"))
+    return {"status": "ok", "response": result}
+
+
+@bp.route("/tunnel/keys", methods=["GET"])
+@api_login_required
+def get_user_keys():
+    """
+    Return SSH keys owned by the authenticated user.
+
+    Optional query params:
+    - tunnel_id: UUID of a specific tunnel to scope keys
+    """
+    tunnel_id = request.args.get("tunnel_id")
+    result = TunnelService().list_keys(tunnel_id=tunnel_id, user_id=g.user.id)
     return {"status": "ok", "response": result}
 
 
@@ -74,5 +88,5 @@ def get_authorized_keys():
     if not g.user or not g.user.is_service_user():
         raise APIException("Only service users can fetch SSH authorized keys")
 
-    keys_text = TunnelService().get_authorized_keys(service_user_id=g.user.id)
+    keys_text = TunnelService().get_authorized_keys()
     return Response(keys_text, mimetype="text/plain")

--- a/argus/backend/models/ssh_key.py
+++ b/argus/backend/models/ssh_key.py
@@ -1,0 +1,51 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from cassandra.cqlengine import columns
+from cassandra.cqlengine.models import Model
+
+
+def _utcnow_naive() -> datetime:
+    return datetime.now(tz=UTC).replace(tzinfo=None)
+
+
+class SSHTunnelKey(Model):
+    """
+    Stores a client-registered SSH public key for a specific (user, tunnel) pair.
+
+    Rows are inserted with a ScyllaDB TTL (default 24 h). The ``expires_at``
+    field is informational — it mirrors the TTL so the client knows when to
+    re-register. Actual expiry is handled automatically by ScyllaDB.
+    """
+
+    id = columns.UUID(primary_key=True, default=uuid4)
+    user_id = columns.UUID(required=True, index=True)
+    tunnel_id = columns.UUID(required=True, index=True)
+    public_key = columns.Text(required=True)
+    fingerprint = columns.Text(required=True, index=True)
+    created_at = columns.DateTime(required=True, default=_utcnow_naive)
+    expires_at = columns.DateTime(required=True)
+
+
+class ProxyTunnelConfig(Model):
+    """
+    Stores the configuration of an SSH proxy tunnel server.
+
+    Only one config should have ``is_active=True`` at any time. When
+    ``TunnelService.save_proxy_tunnel_config`` creates a new config it
+    deactivates the previously active one.
+
+    A dedicated Argus service user (``service_user_id``) is created per
+    proxy host so the proxy host can call the authorised-keys API with its
+    own isolated credentials.
+    """
+
+    id = columns.UUID(primary_key=True, default=uuid4)
+    host = columns.Text(required=True)
+    port = columns.Integer(required=True)
+    proxy_user = columns.Text(required=True)
+    target_host = columns.Text(required=True)
+    target_port = columns.Integer(required=True)
+    host_key_fingerprint = columns.Text(required=True)
+    service_user_id = columns.UUID()
+    is_active = columns.Boolean(default=lambda: False, index=True)

--- a/argus/backend/models/ssh_key.py
+++ b/argus/backend/models/ssh_key.py
@@ -22,7 +22,7 @@ class SSHTunnelKey(Model):
     user_id = columns.UUID(required=True, index=True)
     tunnel_id = columns.UUID(required=True, index=True)
     public_key = columns.Text(required=True)
-    fingerprint = columns.Text(required=True, index=True)
+    fingerprint = columns.Text(required=True)
     created_at = columns.DateTime(required=True, default=_utcnow_naive)
     expires_at = columns.DateTime(required=True)
 
@@ -48,4 +48,4 @@ class ProxyTunnelConfig(Model):
     target_port = columns.Integer(required=True)
     host_key_fingerprint = columns.Text(required=True)
     service_user_id = columns.UUID()
-    is_active = columns.Boolean(default=lambda: False, index=True)
+    is_active = columns.Boolean(default=False)

--- a/argus/backend/models/ssh_key.py
+++ b/argus/backend/models/ssh_key.py
@@ -31,9 +31,8 @@ class ProxyTunnelConfig(Model):
     """
     Stores the configuration of an SSH proxy tunnel server.
 
-    Only one config should have ``is_active=True`` at any time. When
-    ``TunnelService.save_proxy_tunnel_config`` creates a new config it
-    deactivates the previously active one.
+    Multiple configs can be active at the same time. Active configs are used
+    for tunnel connection selection via round-robin.
 
     A dedicated Argus service user (``service_user_id``) is created per
     proxy host so the proxy host can call the authorised-keys API with its
@@ -48,4 +47,4 @@ class ProxyTunnelConfig(Model):
     target_port = columns.Integer(required=True)
     host_key_fingerprint = columns.Text(required=True)
     service_user_id = columns.UUID()
-    is_active = columns.Boolean(default=False)
+    is_active = columns.Boolean(default=True)

--- a/argus/backend/models/web.py
+++ b/argus/backend/models/web.py
@@ -17,6 +17,7 @@ from argus.backend.models.runtime_store import RuntimeStore
 from argus.backend.models.view_widgets import WidgetHighlights, WidgetComment
 from argus.backend.models.argus_ai import ErrorEventEmbeddings, CriticalEventEmbeddings, SCTErrorEventEmbedding, \
     SCTCriticalEventEmbedding
+from argus.backend.models.ssh_key import SSHTunnelKey, ProxyTunnelConfig
 
 
 def uuid_now():
@@ -431,6 +432,8 @@ USED_MODELS: list[Model] = [
     PytestResultTableOld,
     RunConfiguration,
     RunConfigParam,
+    SSHTunnelKey,
+    ProxyTunnelConfig,
 ]
 
 USED_TYPES: list[UserType] = [

--- a/argus/backend/models/web.py
+++ b/argus/backend/models/web.py
@@ -32,6 +32,7 @@ class UserRoles(str, Enum):
     User = "ROLE_USER"
     Manager = "ROLE_MANAGER"
     Admin = "ROLE_ADMIN"
+    SSHTunnelServer = "ROLE_SSH_TUNNEL_SERVER"
 
 
 class User(Model):

--- a/argus/backend/service/tunnel_service.py
+++ b/argus/backend/service/tunnel_service.py
@@ -3,6 +3,7 @@ import binascii
 import hashlib
 import logging
 import secrets
+import subprocess
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import TypedDict
@@ -77,13 +78,13 @@ class ProxyTunnelConfigDTO:
     api_token: str | None = None
 
 
-class ProxyTunnelConfigPayload(TypedDict):
+class ProxyTunnelConfigPayload(TypedDict, total=False):
     host: str
     port: int
     proxy_user: str
     target_host: str
     target_port: int
-    host_key_fingerprint: str
+    is_active: bool
 
 
 def _derive_fingerprint(public_key_str: str) -> str:
@@ -295,20 +296,28 @@ class TunnelService:
 
     def get_proxy_tunnel_config(self, tunnel_id: UUID | str | None = None) -> ProxyTunnelConfigDTO | None:
         """
-        Return the active proxy tunnel config as a dict, or a specific config
-        if ``tunnel_id`` is provided.  Returns ``None`` if none exists.
+        Return one active proxy tunnel config.
+
+        - If ``tunnel_id`` is provided: return that config only when it exists
+          and is active.
+        - If ``tunnel_id`` is not provided: pick one active config using
+          round-robin selection.
+
+        Returns ``None`` if no matching active config exists.
         """
         if tunnel_id is not None:
             if not isinstance(tunnel_id, UUID):
                 tunnel_id = UUID(str(tunnel_id))
             try:
                 config = ProxyTunnelConfig.get(id=tunnel_id)
+                if not config.is_active:
+                    return None
                 return self._to_proxy_tunnel_config_dto(config)
             except ProxyTunnelConfig.DoesNotExist:
                 return None
 
         try:
-            config = self._get_active_config()
+            config = self._get_active_config_round_robin()
             return self._to_proxy_tunnel_config_dto(config)
         except TunnelServiceException:
             return None
@@ -320,19 +329,26 @@ class TunnelService:
         1. Creates a dedicated Argus service user (e.g. ``proxy-tunnel-<host>``)
            with a fresh API token — this user is what the proxy host will
            authenticate as when calling ``GET /client/ssh/keys``.
-        2. Saves the new config with ``is_active=True`` and the service user's
-           id stored in ``service_user_id``.
+        2. Saves the new config with explicit ``is_active`` (default True) and the
+           service user's id stored in ``service_user_id``.
 
         Required payload keys: ``host``, ``port``, ``proxy_user``,
-        ``target_host``, ``target_port``, ``host_key_fingerprint``.
+        ``target_host``, ``target_port``.
+
+        The host key fingerprint is resolved automatically by connecting to the
+        proxy host with ``ssh-keyscan``.
 
         Returns the saved config as a dict (including ``service_user_id`` and
         the generated ``api_token`` so the caller can provision the proxy host).
         """
-        required = ("host", "port", "proxy_user", "target_host", "target_port", "host_key_fingerprint")
+        required = ("host", "port", "proxy_user", "target_host", "target_port")
         missing = [k for k in required if not payload.get(k)]
         if missing:
             raise TunnelServiceException(f"Missing required fields: {', '.join(missing)}")
+
+        is_active = payload.get("is_active", True)
+        port = int(payload["port"])
+        host_key_fingerprint = self._fetch_host_key_fingerprint(payload["host"], port)
 
         # Create a dedicated service user for this proxy host.
         service_user, api_token = self._create_proxy_service_user(payload["host"])
@@ -340,16 +356,37 @@ class TunnelService:
         config = ProxyTunnelConfig.create(
             id=uuid4(),
             host=payload["host"],
-            port=int(payload["port"]),
+            port=port,
             proxy_user=payload["proxy_user"],
             target_host=payload["target_host"],
             target_port=int(payload["target_port"]),
-            host_key_fingerprint=payload["host_key_fingerprint"],
+            host_key_fingerprint=host_key_fingerprint,
             service_user_id=service_user.id,
-            is_active=True,
+            is_active=is_active,
         )
 
         return self._to_proxy_tunnel_config_dto(config, api_token=api_token)
+
+    def list_proxy_tunnel_configs(self, active_only: bool | None = None) -> list[ProxyTunnelConfigDTO]:
+        """Return proxy tunnel configs, optionally filtered by active state."""
+        rows = list(ProxyTunnelConfig.objects.all())
+        if active_only is not None:
+            rows = [row for row in rows if bool(row.is_active) == active_only]
+        rows = sorted(rows, key=lambda row: (row.host or "", str(row.id)))
+        return [self._to_proxy_tunnel_config_dto(row) for row in rows]
+
+    def set_proxy_tunnel_config_active(self, tunnel_id: UUID | str, is_active: bool) -> ProxyTunnelConfigDTO:
+        """Enable or disable a specific proxy tunnel config."""
+        if not isinstance(tunnel_id, UUID):
+            tunnel_id = UUID(str(tunnel_id))
+        try:
+            config = ProxyTunnelConfig.get(id=tunnel_id)
+        except ProxyTunnelConfig.DoesNotExist as exc:
+            raise TunnelServiceException(f"Proxy tunnel config {tunnel_id} not found") from exc
+
+        config.update(is_active=is_active)
+        refreshed = ProxyTunnelConfig.get(id=tunnel_id)
+        return self._to_proxy_tunnel_config_dto(refreshed)
 
     # ------------------------------------------------------------------
     # Private helpers
@@ -358,6 +395,54 @@ class TunnelService:
     @staticmethod
     def _get_active_configs() -> list[ProxyTunnelConfig]:
         return [cfg for cfg in ProxyTunnelConfig.objects.all() if cfg.is_active]
+
+    @staticmethod
+    def _fetch_host_key_fingerprint(host: str, port: int) -> str:
+        """Resolve host key fingerprint for a proxy host using ssh-keyscan."""
+        try:
+            result = subprocess.run(
+                ["ssh-keyscan", "-p", str(port), "-t", "ed25519,ecdsa,rsa", host],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=10,
+            )
+        except FileNotFoundError as exc:
+            raise TunnelServiceException("ssh-keyscan is required on the Argus backend host") from exc
+        except subprocess.TimeoutExpired as exc:
+            raise TunnelServiceException(f"Timed out fetching host key from {host}:{port}") from exc
+
+        keys_by_type: dict[str, str] = {}
+        for line in result.stdout.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            parts = stripped.split()
+            if len(parts) < 3:
+                continue
+            key_type = parts[1]
+            key_data = parts[2]
+            if key_type.startswith("ssh-") or key_type.startswith("ecdsa-"):
+                keys_by_type.setdefault(key_type, f"{key_type} {key_data}")
+
+        preferred_types = (
+            "ssh-ed25519",
+            "ecdsa-sha2-nistp256",
+            "ecdsa-sha2-nistp384",
+            "ecdsa-sha2-nistp521",
+            "ssh-rsa",
+        )
+        for key_type in preferred_types:
+            if key_type in keys_by_type:
+                return _derive_fingerprint(keys_by_type[key_type])
+
+        if keys_by_type:
+            return _derive_fingerprint(next(iter(keys_by_type.values())))
+
+        stderr = (result.stderr or "").strip()
+        if stderr:
+            raise TunnelServiceException(f"Failed to fetch host key for {host}:{port}: {stderr}")
+        raise TunnelServiceException(f"Failed to fetch host key for {host}:{port}")
 
     def _get_active_config(self, proxy_host: str | None = None) -> ProxyTunnelConfig:
         configs = self._get_active_configs()

--- a/argus/backend/service/tunnel_service.py
+++ b/argus/backend/service/tunnel_service.py
@@ -6,10 +6,10 @@ import secrets
 from datetime import datetime, timedelta, timezone
 from uuid import UUID, uuid4
 
-from argus.backend.error_handlers import APIException
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.primitives.serialization import load_ssh_public_key
 
+from argus.backend.models.runtime_store import RuntimeStore
 from argus.backend.models.ssh_key import ProxyTunnelConfig, SSHTunnelKey
 from argus.backend.models.web import User, UserRoles
 from argus.backend.service.user import UserService
@@ -20,6 +20,7 @@ DEFAULT_TTL_SECONDS = 86400  # 24 hours
 MIN_TTL_SECONDS = 86400  # 24 hours
 MAX_TTL_SECONDS = 2592000  # 30 days
 DEFAULT_KEYS_LIST_LIMIT = 5000
+PROXY_RR_INDEX_KEY = "ssh_tunnel_proxy_rr_index"
 
 
 class TunnelServiceException(Exception):
@@ -58,14 +59,14 @@ class TunnelService:
 
     Key registration flow (called from ``POST /client/ssh/tunnel``):
     1. Validate and fingerprint the supplied public key.
-    2. Fetch the active ``ProxyTunnelConfig`` — raise if none exists.
+    2. Select one active ``ProxyTunnelConfig`` using round-robin.
     3. Insert ``SSHTunnelKey`` with a ScyllaDB TTL so ScyllaDB auto-expires it.
     4. Return the proxy connection parameters plus ``expires_at`` so the client
        knows when to re-register.
 
     Authorised-keys flow (called from ``GET /client/ssh/keys`` by the proxy
     host via ``AuthorizedKeysCommand``):
-    1. Fetch all non-expired ``SSHTunnelKey`` rows for the given tunnel.
+    1. Fetch all non-expired ``SSHTunnelKey`` rows.
     2. Return them as a newline-separated OpenSSH ``authorized_keys`` string.
     """
 
@@ -104,7 +105,7 @@ class TunnelService:
 
         fingerprint = _derive_fingerprint(public_key)
 
-        config = self._get_active_config()
+        config = self._get_active_config_round_robin()
 
         if ttl_seconds is None:
             ttl = DEFAULT_TTL_SECONDS
@@ -145,11 +146,17 @@ class TunnelService:
             "expires_at": expires_at,
         }
 
-    def get_tunnel_connection(self) -> dict:
+    def get_tunnel_connection(self, proxy_host: str | None = None) -> dict:
         """
         Return active proxy tunnel connection details for tunnel clients.
+
+        If ``proxy_host`` is provided, return that active host.
+        Otherwise, select one deterministically.
         """
-        config = self._get_active_config()
+        if proxy_host:
+            config = self._get_active_config(proxy_host=proxy_host)
+        else:
+            config = self._get_active_config_round_robin()
         return {
             "proxy_host": config.host,
             "proxy_port": config.port,
@@ -163,7 +170,7 @@ class TunnelService:
     # Authorised keys (used by the proxy host AuthorizedKeysCommand)
     # ------------------------------------------------------------------
 
-    def get_authorized_keys(self, service_user_id: UUID | str) -> str:
+    def get_authorized_keys(self) -> str:
         """
         Return all non-expired public keys in OpenSSH ``authorized_keys``
         format (one key per line).
@@ -172,14 +179,7 @@ class TunnelService:
         this is called, so a plain table scan is sufficient.
 
         """
-        if not isinstance(service_user_id, UUID):
-            service_user_id = UUID(str(service_user_id))
-
-        config = self._get_active_config()
-        if config.service_user_id != service_user_id:
-            raise APIException("Not authorized to fetch SSH keys for the active tunnel")
-
-        rows = SSHTunnelKey.objects.filter(tunnel_id=config.id).all()
+        rows = SSHTunnelKey.objects.all()
 
         keys = [row.public_key for row in rows if row.public_key]
         return "\n".join(keys)
@@ -188,7 +188,7 @@ class TunnelService:
     # Key management (admin / informational)
     # ------------------------------------------------------------------
 
-    def list_keys(self, tunnel_id: UUID | str | None = None) -> list[dict]:
+    def list_keys(self, tunnel_id: UUID | str | None = None, user_id: UUID | str | None = None) -> list[dict]:
         """
         Return a list of dicts describing all non-expired keys.
 
@@ -196,13 +196,22 @@ class TunnelService:
         ----------
         tunnel_id:
             When supplied, restrict to keys for that tunnel.
+        user_id:
+            When supplied, restrict to keys for that user.
         """
+        query = SSHTunnelKey.objects
+
+        if user_id is not None:
+            if not isinstance(user_id, UUID):
+                user_id = UUID(str(user_id))
+            query = query.filter(user_id=user_id)
+
+        rows = query.limit(DEFAULT_KEYS_LIST_LIMIT).all()
+
         if tunnel_id is not None:
             if not isinstance(tunnel_id, UUID):
                 tunnel_id = UUID(str(tunnel_id))
-            rows = SSHTunnelKey.objects.filter(tunnel_id=tunnel_id).limit(DEFAULT_KEYS_LIST_LIMIT).all()
-        else:
-            rows = SSHTunnelKey.objects.limit(DEFAULT_KEYS_LIST_LIMIT).all()
+            rows = [row for row in rows if row.tunnel_id == tunnel_id]
 
         return [row._as_dict() for row in rows]
 
@@ -248,11 +257,10 @@ class TunnelService:
         """
         Create a new ``ProxyTunnelConfig`` entry.
 
-        1. Deactivates any existing active config.
-        2. Creates a dedicated Argus service user (e.g. ``proxy-tunnel-<host>``)
+        1. Creates a dedicated Argus service user (e.g. ``proxy-tunnel-<host>``)
            with a fresh API token — this user is what the proxy host will
            authenticate as when calling ``GET /client/ssh/keys``.
-        3. Saves the new config with ``is_active=True`` and the service user's
+        2. Saves the new config with ``is_active=True`` and the service user's
            id stored in ``service_user_id``.
 
         Required payload keys: ``host``, ``port``, ``proxy_user``,
@@ -265,11 +273,6 @@ class TunnelService:
         missing = [k for k in required if not payload.get(k)]
         if missing:
             raise TunnelServiceException(f"Missing required fields: {', '.join(missing)}")
-
-        # Deactivate any currently active config.
-        for existing in ProxyTunnelConfig.objects.all():
-            if existing.is_active:
-                existing.update(is_active=False)
 
         # Create a dedicated service user for this proxy host.
         service_user, api_token = self._create_proxy_service_user(payload["host"])
@@ -294,14 +297,52 @@ class TunnelService:
     # Private helpers
     # ------------------------------------------------------------------
 
-    def _get_active_config(self) -> ProxyTunnelConfig:
-        configs = [cfg for cfg in ProxyTunnelConfig.objects.all() if cfg.is_active]
+    @staticmethod
+    def _get_active_configs() -> list[ProxyTunnelConfig]:
+        return [cfg for cfg in ProxyTunnelConfig.objects.all() if cfg.is_active]
+
+    def _get_active_config(self, proxy_host: str | None = None) -> ProxyTunnelConfig:
+        configs = self._get_active_configs()
         if not configs:
             raise TunnelServiceException(
                 "No active proxy tunnel configuration found. "
                 "An admin must configure a proxy host before tunnel registration is possible."
             )
-        return configs[0]
+
+        if proxy_host:
+            matching_configs = [cfg for cfg in configs if cfg.host == proxy_host]
+            if not matching_configs:
+                raise TunnelServiceException(f"No active proxy tunnel configuration found for host: {proxy_host}")
+            return sorted(matching_configs, key=lambda cfg: str(cfg.id))[0]
+
+        return sorted(configs, key=lambda cfg: (cfg.host or "", str(cfg.id)))[0]
+
+    def _get_active_config_round_robin(self) -> ProxyTunnelConfig:
+        configs = sorted(self._get_active_configs(), key=lambda cfg: (cfg.host or "", str(cfg.id)))
+        if not configs:
+            raise TunnelServiceException(
+                "No active proxy tunnel configuration found. "
+                "An admin must configure a proxy host before tunnel registration is possible."
+            )
+
+        current_index = 0
+        store = None
+        try:
+            store = RuntimeStore.get(key=PROXY_RR_INDEX_KEY)
+            if isinstance(store.value, int):
+                current_index = store.value
+        except RuntimeStore.DoesNotExist:
+            pass
+
+        selected = configs[current_index % len(configs)]
+        next_index = (current_index + 1) % len(configs)
+
+        if store is None:
+            store = RuntimeStore(key=PROXY_RR_INDEX_KEY)
+        store.value = next_index
+        store.save()
+
+        return selected
 
     @staticmethod
     def _create_proxy_service_user(host: str) -> tuple[User, str]:

--- a/argus/backend/service/tunnel_service.py
+++ b/argus/backend/service/tunnel_service.py
@@ -1,0 +1,341 @@
+import base64
+import hashlib
+import logging
+from datetime import datetime, timedelta, timezone
+from uuid import UUID, uuid4
+
+from cryptography.exceptions import UnsupportedAlgorithm
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat, load_ssh_public_key
+
+from argus.backend.models.ssh_key import ProxyTunnelConfig, SSHTunnelKey
+from argus.backend.models.web import User, UserRoles
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_TTL_SECONDS = 86400  # 24 hours
+
+
+class TunnelServiceException(Exception):
+    pass
+
+
+def _derive_fingerprint(public_key_str: str) -> str:
+    """
+    Derive an OpenSSH SHA-256 fingerprint from an OpenSSH-formatted public key
+    string (e.g. ``ssh-ed25519 AAAA... comment``).
+
+    Returns a string of the form ``SHA256:<base64>``, matching the output of
+    ``ssh-keygen -lf``.
+
+    Raises ``TunnelServiceException`` if the key cannot be parsed.
+    """
+    try:
+        key_bytes = public_key_str.strip().encode("utf-8")
+        public_key = load_ssh_public_key(key_bytes)
+        raw = public_key.public_bytes(Encoding.Raw, PublicFormat.Raw)
+        digest = hashlib.sha256(raw).digest()
+        b64 = base64.b64encode(digest).rstrip(b"=").decode("ascii")
+        return f"SHA256:{b64}"
+    except (ValueError, UnsupportedAlgorithm, TypeError) as exc:
+        raise TunnelServiceException(f"Invalid SSH public key: {exc}") from exc
+
+
+class TunnelService:
+    """
+    Business logic for SSH tunnel key registration and proxy tunnel config
+    management.
+
+    Key registration flow (called from ``POST /client/ssh/tunnel``):
+    1. Validate and fingerprint the supplied public key.
+    2. Fetch the active ``ProxyTunnelConfig`` — raise if none exists.
+    3. Insert ``SSHTunnelKey`` with a ScyllaDB TTL so ScyllaDB auto-expires it.
+    4. Return the proxy connection parameters plus ``expires_at`` so the client
+       knows when to re-register.
+
+    Authorised-keys flow (called from ``GET /client/ssh/keys`` by the proxy
+    host via ``AuthorizedKeysCommand``):
+    1. Fetch all non-expired ``SSHTunnelKey`` rows for the given tunnel.
+    2. Return them as a newline-separated OpenSSH ``authorized_keys`` string.
+    """
+
+    # ------------------------------------------------------------------
+    # Public key registration
+    # ------------------------------------------------------------------
+
+    def register_tunnel(
+        self,
+        user: User,
+        public_key: str,
+        tunnel_id: UUID | str | None = None,
+        ttl_seconds: int | None = None,
+    ) -> dict:
+        """
+        Register ``public_key`` for ``user`` against the active (or specified)
+        proxy tunnel config.
+
+        Parameters
+        ----------
+        user:
+            The authenticated Argus user.
+        public_key:
+            OpenSSH-encoded ed25519 (or other) public key string.
+        tunnel_id:
+            Optional. If supplied, register the key against that specific
+            ``ProxyTunnelConfig`` id.  Otherwise the currently active config is
+            used.
+        ttl_seconds:
+            How long (in seconds) the key should remain valid.  Defaults to
+            ``DEFAULT_TTL_SECONDS`` (86 400 / 24 h).
+
+        Returns
+        -------
+        dict with keys: ``proxy_host``, ``proxy_port``, ``proxy_user``,
+        ``target_host``, ``target_port``, ``host_key_fingerprint``,
+        ``expires_at`` (UTC ISO-8601 string), ``tunnel_id``, ``key_id``.
+        """
+        if not public_key or not public_key.strip():
+            raise TunnelServiceException("public_key is required")
+
+        fingerprint = _derive_fingerprint(public_key)
+
+        if tunnel_id is not None:
+            if not isinstance(tunnel_id, UUID):
+                tunnel_id = UUID(str(tunnel_id))
+            try:
+                config = ProxyTunnelConfig.get(id=tunnel_id)
+            except ProxyTunnelConfig.DoesNotExist as exc:
+                raise TunnelServiceException(f"Proxy tunnel config {tunnel_id} not found") from exc
+        else:
+            config = self._get_active_config()
+
+        ttl = int(ttl_seconds) if ttl_seconds else DEFAULT_TTL_SECONDS
+        now_utc = datetime.now(tz=timezone.utc).replace(tzinfo=None)
+        expires_at = now_utc + timedelta(seconds=ttl)
+
+        key = SSHTunnelKey.objects.ttl(ttl).create(
+            id=uuid4(),
+            user_id=user.id,
+            tunnel_id=config.id,
+            public_key=public_key.strip(),
+            fingerprint=fingerprint,
+            created_at=now_utc,
+            expires_at=expires_at,
+        )
+
+        return {
+            "key_id": str(key.id),
+            "tunnel_id": str(config.id),
+            "proxy_host": config.host,
+            "proxy_port": config.port,
+            "proxy_user": config.proxy_user,
+            "target_host": config.target_host,
+            "target_port": config.target_port,
+            "host_key_fingerprint": config.host_key_fingerprint,
+            "expires_at": expires_at.isoformat() + "Z",
+        }
+
+    # ------------------------------------------------------------------
+    # Authorised keys (used by the proxy host AuthorizedKeysCommand)
+    # ------------------------------------------------------------------
+
+    def get_authorized_keys(self, tunnel_id: UUID | str | None = None) -> str:
+        """
+        Return all non-expired public keys in OpenSSH ``authorized_keys``
+        format (one key per line).
+
+        ScyllaDB TTL guarantees that expired rows are already gone by the time
+        this is called, so a plain table scan is sufficient.
+
+        Parameters
+        ----------
+        tunnel_id:
+            When supplied, only keys for that tunnel are returned.  When
+            omitted, all keys across all tunnels are returned.
+        """
+        if tunnel_id is not None:
+            if not isinstance(tunnel_id, UUID):
+                tunnel_id = UUID(str(tunnel_id))
+            rows = SSHTunnelKey.objects.filter(tunnel_id=tunnel_id).all()
+        else:
+            rows = SSHTunnelKey.objects.all()
+
+        keys = [row.public_key for row in rows if row.public_key]
+        return "\n".join(keys)
+
+    # ------------------------------------------------------------------
+    # Key management (admin / informational)
+    # ------------------------------------------------------------------
+
+    def list_keys(self, tunnel_id: UUID | str | None = None) -> list[dict]:
+        """
+        Return a list of dicts describing all non-expired keys.
+
+        Parameters
+        ----------
+        tunnel_id:
+            When supplied, restrict to keys for that tunnel.
+        """
+        if tunnel_id is not None:
+            if not isinstance(tunnel_id, UUID):
+                tunnel_id = UUID(str(tunnel_id))
+            rows = SSHTunnelKey.objects.filter(tunnel_id=tunnel_id).all()
+        else:
+            rows = SSHTunnelKey.objects.all()
+
+        return [
+            {
+                "id": str(row.id),
+                "user_id": str(row.user_id),
+                "tunnel_id": str(row.tunnel_id),
+                "fingerprint": row.fingerprint,
+                "created_at": row.created_at.isoformat() + "Z" if row.created_at else None,
+                "expires_at": row.expires_at.isoformat() + "Z" if row.expires_at else None,
+            }
+            for row in rows
+        ]
+
+    def delete_key(self, key_id: UUID | str) -> None:
+        """
+        Delete a single ``SSHTunnelKey`` row.  Takes immediate effect — the
+        next ``AuthorizedKeysCommand`` call on the proxy host will not include
+        this key.
+        """
+        if not isinstance(key_id, UUID):
+            key_id = UUID(str(key_id))
+        try:
+            key = SSHTunnelKey.get(id=key_id)
+            key.delete()
+        except SSHTunnelKey.DoesNotExist as exc:
+            raise TunnelServiceException(f"SSH key {key_id} not found") from exc
+
+    # ------------------------------------------------------------------
+    # Proxy tunnel config management
+    # ------------------------------------------------------------------
+
+    def get_proxy_tunnel_config(self, tunnel_id: UUID | str | None = None) -> dict | None:
+        """
+        Return the active proxy tunnel config as a dict, or a specific config
+        if ``tunnel_id`` is provided.  Returns ``None`` if none exists.
+        """
+        if tunnel_id is not None:
+            if not isinstance(tunnel_id, UUID):
+                tunnel_id = UUID(str(tunnel_id))
+            try:
+                config = ProxyTunnelConfig.get(id=tunnel_id)
+                return self._config_to_dict(config)
+            except ProxyTunnelConfig.DoesNotExist:
+                return None
+
+        try:
+            config = self._get_active_config()
+            return self._config_to_dict(config)
+        except TunnelServiceException:
+            return None
+
+    def save_proxy_tunnel_config(self, payload: dict) -> dict:
+        """
+        Create a new ``ProxyTunnelConfig`` entry.
+
+        1. Deactivates any existing active config.
+        2. Creates a dedicated Argus service user (e.g. ``proxy-tunnel-<host>``)
+           with a fresh API token — this user is what the proxy host will
+           authenticate as when calling ``GET /client/ssh/keys``.
+        3. Saves the new config with ``is_active=True`` and the service user's
+           id stored in ``service_user_id``.
+
+        Required payload keys: ``host``, ``port``, ``proxy_user``,
+        ``target_host``, ``target_port``, ``host_key_fingerprint``.
+
+        Returns the saved config as a dict (including ``service_user_id`` and
+        the generated ``api_token`` so the caller can provision the proxy host).
+        """
+        required = ("host", "port", "proxy_user", "target_host", "target_port", "host_key_fingerprint")
+        missing = [k for k in required if not payload.get(k)]
+        if missing:
+            raise TunnelServiceException(f"Missing required fields: {', '.join(missing)}")
+
+        # Deactivate any currently active config.
+        for existing in ProxyTunnelConfig.objects.filter(is_active=True).all():
+            existing.update(is_active=False)
+
+        # Create a dedicated service user for this proxy host.
+        service_user, api_token = self._create_proxy_service_user(payload["host"])
+
+        config = ProxyTunnelConfig.create(
+            id=uuid4(),
+            host=payload["host"],
+            port=int(payload["port"]),
+            proxy_user=payload["proxy_user"],
+            target_host=payload["target_host"],
+            target_port=int(payload["target_port"]),
+            host_key_fingerprint=payload["host_key_fingerprint"],
+            service_user_id=service_user.id,
+            is_active=True,
+        )
+
+        result = self._config_to_dict(config)
+        result["api_token"] = api_token
+        return result
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _get_active_config(self) -> ProxyTunnelConfig:
+        configs = list(ProxyTunnelConfig.objects.filter(is_active=True).all())
+        if not configs:
+            raise TunnelServiceException(
+                "No active proxy tunnel configuration found. "
+                "An admin must configure a proxy host before tunnel registration is possible."
+            )
+        return configs[0]
+
+    @staticmethod
+    def _config_to_dict(config: ProxyTunnelConfig) -> dict:
+        return {
+            "id": str(config.id),
+            "host": config.host,
+            "port": config.port,
+            "proxy_user": config.proxy_user,
+            "target_host": config.target_host,
+            "target_port": config.target_port,
+            "host_key_fingerprint": config.host_key_fingerprint,
+            "service_user_id": str(config.service_user_id) if config.service_user_id else None,
+            "is_active": config.is_active,
+        }
+
+    @staticmethod
+    def _create_proxy_service_user(host: str) -> tuple[User, str]:
+        """
+        Create (or re-use) a service ``User`` for the given proxy host and
+        return ``(user, api_token)``.
+
+        The username follows the pattern ``proxy-tunnel-<host>`` to make it
+        easy to identify in the user list.
+        """
+        import secrets
+        from argus.backend.service.user import UserService
+
+        username = f"proxy-tunnel-{host}"
+
+        # Re-use existing service user if it already exists.
+        existing = User.exists_by_name(username)
+        if existing:
+            svc = UserService()
+            token = svc.get_or_generate_token(existing)
+            return existing, token
+
+        api_token = secrets.token_hex(32)
+        now = datetime.now(tz=timezone.utc).replace(tzinfo=None)
+        user = User.create(
+            id=uuid4(),
+            username=username,
+            full_name=f"Proxy Tunnel Service User ({host})",
+            password="",
+            email=f"{username}@argus.internal",
+            registration_date=now,
+            roles=[UserRoles.User.value],
+            api_token=api_token,
+            service_user=True,
+        )
+        return user, api_token

--- a/argus/backend/service/tunnel_service.py
+++ b/argus/backend/service/tunnel_service.py
@@ -1,18 +1,23 @@
 import base64
+import binascii
 import hashlib
 import logging
+import secrets
 from datetime import datetime, timedelta, timezone
 from uuid import UUID, uuid4
 
+from argus.backend.error_handlers import APIException
 from cryptography.exceptions import UnsupportedAlgorithm
-from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat, load_ssh_public_key
+from cryptography.hazmat.primitives.serialization import load_ssh_public_key
 
 from argus.backend.models.ssh_key import ProxyTunnelConfig, SSHTunnelKey
 from argus.backend.models.web import User, UserRoles
+from argus.backend.service.user import UserService
 
 LOGGER = logging.getLogger(__name__)
 
 DEFAULT_TTL_SECONDS = 86400  # 24 hours
+DEFAULT_KEYS_LIST_LIMIT = 5000
 
 
 class TunnelServiceException(Exception):
@@ -30,13 +35,17 @@ def _derive_fingerprint(public_key_str: str) -> str:
     Raises ``TunnelServiceException`` if the key cannot be parsed.
     """
     try:
-        key_bytes = public_key_str.strip().encode("utf-8")
-        public_key = load_ssh_public_key(key_bytes)
-        raw = public_key.public_bytes(Encoding.Raw, PublicFormat.Raw)
-        digest = hashlib.sha256(raw).digest()
+        stripped_key = public_key_str.strip()
+        parts = stripped_key.split()
+        if len(parts) < 2:
+            raise ValueError("Malformed OpenSSH public key")
+
+        load_ssh_public_key(stripped_key.encode("utf-8"))
+        key_blob = base64.b64decode(parts[1].encode("ascii"), validate=True)
+        digest = hashlib.sha256(key_blob).digest()
         b64 = base64.b64encode(digest).rstrip(b"=").decode("ascii")
         return f"SHA256:{b64}"
-    except (ValueError, UnsupportedAlgorithm, TypeError) as exc:
+    except (ValueError, UnsupportedAlgorithm, TypeError, binascii.Error) as exc:
         raise TunnelServiceException(f"Invalid SSH public key: {exc}") from exc
 
 
@@ -66,7 +75,6 @@ class TunnelService:
         self,
         user: User,
         public_key: str,
-        tunnel_id: UUID | str | None = None,
         ttl_seconds: int | None = None,
     ) -> dict:
         """
@@ -79,10 +87,6 @@ class TunnelService:
             The authenticated Argus user.
         public_key:
             OpenSSH-encoded ed25519 (or other) public key string.
-        tunnel_id:
-            Optional. If supplied, register the key against that specific
-            ``ProxyTunnelConfig`` id.  Otherwise the currently active config is
-            used.
         ttl_seconds:
             How long (in seconds) the key should remain valid.  Defaults to
             ``DEFAULT_TTL_SECONDS`` (86 400 / 24 h).
@@ -91,24 +95,25 @@ class TunnelService:
         -------
         dict with keys: ``proxy_host``, ``proxy_port``, ``proxy_user``,
         ``target_host``, ``target_port``, ``host_key_fingerprint``,
-        ``expires_at`` (UTC ISO-8601 string), ``tunnel_id``, ``key_id``.
+        ``expires_at`` (UTC datetime), ``tunnel_id``, ``key_id``.
         """
         if not public_key or not public_key.strip():
             raise TunnelServiceException("public_key is required")
 
         fingerprint = _derive_fingerprint(public_key)
 
-        if tunnel_id is not None:
-            if not isinstance(tunnel_id, UUID):
-                tunnel_id = UUID(str(tunnel_id))
-            try:
-                config = ProxyTunnelConfig.get(id=tunnel_id)
-            except ProxyTunnelConfig.DoesNotExist as exc:
-                raise TunnelServiceException(f"Proxy tunnel config {tunnel_id} not found") from exc
-        else:
-            config = self._get_active_config()
+        config = self._get_active_config()
 
-        ttl = int(ttl_seconds) if ttl_seconds else DEFAULT_TTL_SECONDS
+        if ttl_seconds is None:
+            ttl = DEFAULT_TTL_SECONDS
+        else:
+            try:
+                ttl = int(ttl_seconds)
+            except (TypeError, ValueError) as exc:
+                raise TunnelServiceException("ttl_seconds must be a positive integer") from exc
+            if ttl <= 0:
+                raise TunnelServiceException("ttl_seconds must be a positive integer")
+
         now_utc = datetime.now(tz=timezone.utc).replace(tzinfo=None)
         expires_at = now_utc + timedelta(seconds=ttl)
 
@@ -131,14 +136,28 @@ class TunnelService:
             "target_host": config.target_host,
             "target_port": config.target_port,
             "host_key_fingerprint": config.host_key_fingerprint,
-            "expires_at": expires_at.isoformat() + "Z",
+            "expires_at": expires_at,
+        }
+
+    def get_tunnel_connection(self) -> dict:
+        """
+        Return active proxy tunnel connection details for tunnel clients.
+        """
+        config = self._get_active_config()
+        return {
+            "proxy_host": config.host,
+            "proxy_port": config.port,
+            "proxy_user": config.proxy_user,
+            "target_host": config.target_host,
+            "target_port": config.target_port,
+            "host_key_fingerprint": config.host_key_fingerprint,
         }
 
     # ------------------------------------------------------------------
     # Authorised keys (used by the proxy host AuthorizedKeysCommand)
     # ------------------------------------------------------------------
 
-    def get_authorized_keys(self, tunnel_id: UUID | str | None = None) -> str:
+    def get_authorized_keys(self, service_user_id: UUID | str) -> str:
         """
         Return all non-expired public keys in OpenSSH ``authorized_keys``
         format (one key per line).
@@ -146,18 +165,15 @@ class TunnelService:
         ScyllaDB TTL guarantees that expired rows are already gone by the time
         this is called, so a plain table scan is sufficient.
 
-        Parameters
-        ----------
-        tunnel_id:
-            When supplied, only keys for that tunnel are returned.  When
-            omitted, all keys across all tunnels are returned.
         """
-        if tunnel_id is not None:
-            if not isinstance(tunnel_id, UUID):
-                tunnel_id = UUID(str(tunnel_id))
-            rows = SSHTunnelKey.objects.filter(tunnel_id=tunnel_id).all()
-        else:
-            rows = SSHTunnelKey.objects.all()
+        if not isinstance(service_user_id, UUID):
+            service_user_id = UUID(str(service_user_id))
+
+        config = self._get_active_config()
+        if config.service_user_id != service_user_id:
+            raise APIException("Not authorized to fetch SSH keys for the active tunnel")
+
+        rows = SSHTunnelKey.objects.filter(tunnel_id=config.id).all()
 
         keys = [row.public_key for row in rows if row.public_key]
         return "\n".join(keys)
@@ -178,21 +194,11 @@ class TunnelService:
         if tunnel_id is not None:
             if not isinstance(tunnel_id, UUID):
                 tunnel_id = UUID(str(tunnel_id))
-            rows = SSHTunnelKey.objects.filter(tunnel_id=tunnel_id).all()
+            rows = SSHTunnelKey.objects.filter(tunnel_id=tunnel_id).limit(DEFAULT_KEYS_LIST_LIMIT).all()
         else:
-            rows = SSHTunnelKey.objects.all()
+            rows = SSHTunnelKey.objects.limit(DEFAULT_KEYS_LIST_LIMIT).all()
 
-        return [
-            {
-                "id": str(row.id),
-                "user_id": str(row.user_id),
-                "tunnel_id": str(row.tunnel_id),
-                "fingerprint": row.fingerprint,
-                "created_at": row.created_at.isoformat() + "Z" if row.created_at else None,
-                "expires_at": row.expires_at.isoformat() + "Z" if row.expires_at else None,
-            }
-            for row in rows
-        ]
+        return [row._as_dict() for row in rows]
 
     def delete_key(self, key_id: UUID | str) -> None:
         """
@@ -222,13 +228,13 @@ class TunnelService:
                 tunnel_id = UUID(str(tunnel_id))
             try:
                 config = ProxyTunnelConfig.get(id=tunnel_id)
-                return self._config_to_dict(config)
+                return config._as_dict()
             except ProxyTunnelConfig.DoesNotExist:
                 return None
 
         try:
             config = self._get_active_config()
-            return self._config_to_dict(config)
+            return config._as_dict()
         except TunnelServiceException:
             return None
 
@@ -255,8 +261,9 @@ class TunnelService:
             raise TunnelServiceException(f"Missing required fields: {', '.join(missing)}")
 
         # Deactivate any currently active config.
-        for existing in ProxyTunnelConfig.objects.filter(is_active=True).all():
-            existing.update(is_active=False)
+        for existing in ProxyTunnelConfig.objects.all():
+            if existing.is_active:
+                existing.update(is_active=False)
 
         # Create a dedicated service user for this proxy host.
         service_user, api_token = self._create_proxy_service_user(payload["host"])
@@ -273,7 +280,7 @@ class TunnelService:
             is_active=True,
         )
 
-        result = self._config_to_dict(config)
+        result = config._as_dict()
         result["api_token"] = api_token
         return result
 
@@ -282,27 +289,13 @@ class TunnelService:
     # ------------------------------------------------------------------
 
     def _get_active_config(self) -> ProxyTunnelConfig:
-        configs = list(ProxyTunnelConfig.objects.filter(is_active=True).all())
+        configs = [cfg for cfg in ProxyTunnelConfig.objects.all() if cfg.is_active]
         if not configs:
             raise TunnelServiceException(
                 "No active proxy tunnel configuration found. "
                 "An admin must configure a proxy host before tunnel registration is possible."
             )
         return configs[0]
-
-    @staticmethod
-    def _config_to_dict(config: ProxyTunnelConfig) -> dict:
-        return {
-            "id": str(config.id),
-            "host": config.host,
-            "port": config.port,
-            "proxy_user": config.proxy_user,
-            "target_host": config.target_host,
-            "target_port": config.target_port,
-            "host_key_fingerprint": config.host_key_fingerprint,
-            "service_user_id": str(config.service_user_id) if config.service_user_id else None,
-            "is_active": config.is_active,
-        }
 
     @staticmethod
     def _create_proxy_service_user(host: str) -> tuple[User, str]:
@@ -313,9 +306,6 @@ class TunnelService:
         The username follows the pattern ``proxy-tunnel-<host>`` to make it
         easy to identify in the user list.
         """
-        import secrets
-        from argus.backend.service.user import UserService
-
         username = f"proxy-tunnel-{host}"
 
         # Re-use existing service user if it already exists.

--- a/argus/backend/service/tunnel_service.py
+++ b/argus/backend/service/tunnel_service.py
@@ -3,7 +3,9 @@ import binascii
 import hashlib
 import logging
 import secrets
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from typing import TypedDict
 from uuid import UUID, uuid4
 
 from cryptography.exceptions import UnsupportedAlgorithm
@@ -17,7 +19,7 @@ from argus.backend.service.user import UserService
 LOGGER = logging.getLogger(__name__)
 
 DEFAULT_TTL_SECONDS = 86400  # 24 hours
-MIN_TTL_SECONDS = 86400  # 24 hours
+MIN_TTL_SECONDS = 3600  # 1 hour
 MAX_TTL_SECONDS = 2592000  # 30 days
 DEFAULT_KEYS_LIST_LIMIT = 5000
 PROXY_RR_INDEX_KEY = "ssh_tunnel_proxy_rr_index"
@@ -25,6 +27,63 @@ PROXY_RR_INDEX_KEY = "ssh_tunnel_proxy_rr_index"
 
 class TunnelServiceException(Exception):
     pass
+
+
+@dataclass(frozen=True, slots=True)
+class TunnelRegistrationResponseDTO:
+    key_id: UUID
+    tunnel_id: UUID
+    proxy_host: str
+    proxy_port: int
+    proxy_user: str
+    target_host: str
+    target_port: int
+    host_key_fingerprint: str
+    expires_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class TunnelConnectionResponseDTO:
+    proxy_host: str
+    proxy_port: int
+    proxy_user: str
+    target_host: str
+    target_port: int
+    host_key_fingerprint: str
+
+
+@dataclass(frozen=True, slots=True)
+class SSHTunnelKeyDTO:
+    id: UUID
+    user_id: UUID
+    tunnel_id: UUID
+    public_key: str
+    fingerprint: str
+    created_at: datetime
+    expires_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class ProxyTunnelConfigDTO:
+    id: UUID
+    host: str
+    port: int
+    proxy_user: str
+    target_host: str
+    target_port: int
+    host_key_fingerprint: str
+    service_user_id: UUID | None
+    is_active: bool
+    api_token: str | None = None
+
+
+class ProxyTunnelConfigPayload(TypedDict):
+    host: str
+    port: int
+    proxy_user: str
+    target_host: str
+    target_port: int
+    host_key_fingerprint: str
 
 
 def _derive_fingerprint(public_key_str: str) -> str:
@@ -79,7 +138,7 @@ class TunnelService:
         user: User,
         public_key: str,
         ttl_seconds: int | None = None,
-    ) -> dict:
+    ) -> TunnelRegistrationResponseDTO:
         """
         Register ``public_key`` for ``user`` against the active (or specified)
         proxy tunnel config.
@@ -96,9 +155,10 @@ class TunnelService:
 
         Returns
         -------
-        dict with keys: ``proxy_host``, ``proxy_port``, ``proxy_user``,
-        ``target_host``, ``target_port``, ``host_key_fingerprint``,
-        ``expires_at`` (UTC datetime), ``tunnel_id``, ``key_id``.
+        TunnelRegistrationResponseDTO with keys: ``proxy_host``,
+        ``proxy_port``, ``proxy_user``, ``target_host``, ``target_port``,
+        ``host_key_fingerprint``, ``expires_at`` (UTC datetime),
+        ``tunnel_id``, ``key_id``.
         """
         if not public_key or not public_key.strip():
             raise TunnelServiceException("public_key is required")
@@ -134,19 +194,19 @@ class TunnelService:
             expires_at=expires_at,
         )
 
-        return {
-            "key_id": str(key.id),
-            "tunnel_id": str(config.id),
-            "proxy_host": config.host,
-            "proxy_port": config.port,
-            "proxy_user": config.proxy_user,
-            "target_host": config.target_host,
-            "target_port": config.target_port,
-            "host_key_fingerprint": config.host_key_fingerprint,
-            "expires_at": expires_at,
-        }
+        return TunnelRegistrationResponseDTO(
+            key_id=key.id,
+            tunnel_id=config.id,
+            proxy_host=config.host,
+            proxy_port=config.port,
+            proxy_user=config.proxy_user,
+            target_host=config.target_host,
+            target_port=config.target_port,
+            host_key_fingerprint=config.host_key_fingerprint,
+            expires_at=expires_at,
+        )
 
-    def get_tunnel_connection(self, proxy_host: str | None = None) -> dict:
+    def get_tunnel_connection(self, proxy_host: str | None = None) -> TunnelConnectionResponseDTO:
         """
         Return active proxy tunnel connection details for tunnel clients.
 
@@ -157,14 +217,14 @@ class TunnelService:
             config = self._get_active_config(proxy_host=proxy_host)
         else:
             config = self._get_active_config_round_robin()
-        return {
-            "proxy_host": config.host,
-            "proxy_port": config.port,
-            "proxy_user": config.proxy_user,
-            "target_host": config.target_host,
-            "target_port": config.target_port,
-            "host_key_fingerprint": config.host_key_fingerprint,
-        }
+        return TunnelConnectionResponseDTO(
+            proxy_host=config.host,
+            proxy_port=config.port,
+            proxy_user=config.proxy_user,
+            target_host=config.target_host,
+            target_port=config.target_port,
+            host_key_fingerprint=config.host_key_fingerprint,
+        )
 
     # ------------------------------------------------------------------
     # Authorised keys (used by the proxy host AuthorizedKeysCommand)
@@ -188,7 +248,7 @@ class TunnelService:
     # Key management (admin / informational)
     # ------------------------------------------------------------------
 
-    def list_keys(self, tunnel_id: UUID | str | None = None, user_id: UUID | str | None = None) -> list[dict]:
+    def list_keys(self, tunnel_id: UUID | str | None = None, user_id: UUID | str | None = None) -> list[SSHTunnelKeyDTO]:
         """
         Return a list of dicts describing all non-expired keys.
 
@@ -213,7 +273,7 @@ class TunnelService:
                 tunnel_id = UUID(str(tunnel_id))
             rows = [row for row in rows if row.tunnel_id == tunnel_id]
 
-        return [row._as_dict() for row in rows]
+        return [self._to_ssh_tunnel_key_dto(row) for row in rows]
 
     def delete_key(self, key_id: UUID | str) -> None:
         """
@@ -226,14 +286,14 @@ class TunnelService:
         try:
             key = SSHTunnelKey.get(id=key_id)
             key.delete()
-        except SSHTunnelKey.DoesNotExist as exc:
-            raise TunnelServiceException(f"SSH key {key_id} not found") from exc
+        except SSHTunnelKey.DoesNotExist:
+            LOGGER.info("SSH key %s was already deleted or TTL-expired", key_id)
 
     # ------------------------------------------------------------------
     # Proxy tunnel config management
     # ------------------------------------------------------------------
 
-    def get_proxy_tunnel_config(self, tunnel_id: UUID | str | None = None) -> dict | None:
+    def get_proxy_tunnel_config(self, tunnel_id: UUID | str | None = None) -> ProxyTunnelConfigDTO | None:
         """
         Return the active proxy tunnel config as a dict, or a specific config
         if ``tunnel_id`` is provided.  Returns ``None`` if none exists.
@@ -243,17 +303,17 @@ class TunnelService:
                 tunnel_id = UUID(str(tunnel_id))
             try:
                 config = ProxyTunnelConfig.get(id=tunnel_id)
-                return config._as_dict()
+                return self._to_proxy_tunnel_config_dto(config)
             except ProxyTunnelConfig.DoesNotExist:
                 return None
 
         try:
             config = self._get_active_config()
-            return config._as_dict()
+            return self._to_proxy_tunnel_config_dto(config)
         except TunnelServiceException:
             return None
 
-    def save_proxy_tunnel_config(self, payload: dict) -> dict:
+    def save_proxy_tunnel_config(self, payload: ProxyTunnelConfigPayload) -> ProxyTunnelConfigDTO:
         """
         Create a new ``ProxyTunnelConfig`` entry.
 
@@ -289,9 +349,7 @@ class TunnelService:
             is_active=True,
         )
 
-        result = config._as_dict()
-        result["api_token"] = api_token
-        return result
+        return self._to_proxy_tunnel_config_dto(config, api_token=api_token)
 
     # ------------------------------------------------------------------
     # Private helpers
@@ -358,6 +416,15 @@ class TunnelService:
         # Re-use existing service user if it already exists.
         existing = User.exists_by_name(username)
         if existing:
+            should_save = False
+            if existing.roles != [UserRoles.SSHTunnelServer.value]:
+                existing.roles = [UserRoles.SSHTunnelServer.value]
+                should_save = True
+            if not existing.service_user:
+                existing.service_user = True
+                should_save = True
+            if should_save:
+                existing.save()
             svc = UserService()
             token = svc.get_or_generate_token(existing)
             return existing, token
@@ -371,8 +438,35 @@ class TunnelService:
             password="",
             email=f"{username}@argus.internal",
             registration_date=now,
-            roles=[UserRoles.User.value],
+            roles=[UserRoles.SSHTunnelServer.value],
             api_token=api_token,
             service_user=True,
         )
         return user, api_token
+
+    @staticmethod
+    def _to_ssh_tunnel_key_dto(row: SSHTunnelKey) -> SSHTunnelKeyDTO:
+        return SSHTunnelKeyDTO(
+            id=row.id,
+            user_id=row.user_id,
+            tunnel_id=row.tunnel_id,
+            public_key=row.public_key,
+            fingerprint=row.fingerprint,
+            created_at=row.created_at,
+            expires_at=row.expires_at,
+        )
+
+    @staticmethod
+    def _to_proxy_tunnel_config_dto(config: ProxyTunnelConfig, api_token: str | None = None) -> ProxyTunnelConfigDTO:
+        return ProxyTunnelConfigDTO(
+            id=config.id,
+            host=config.host,
+            port=config.port,
+            proxy_user=config.proxy_user,
+            target_host=config.target_host,
+            target_port=config.target_port,
+            host_key_fingerprint=config.host_key_fingerprint,
+            service_user_id=config.service_user_id,
+            is_active=bool(config.is_active),
+            api_token=api_token,
+        )

--- a/argus/backend/service/tunnel_service.py
+++ b/argus/backend/service/tunnel_service.py
@@ -17,6 +17,8 @@ from argus.backend.service.user import UserService
 LOGGER = logging.getLogger(__name__)
 
 DEFAULT_TTL_SECONDS = 86400  # 24 hours
+MIN_TTL_SECONDS = 86400  # 24 hours
+MAX_TTL_SECONDS = 2592000  # 30 days
 DEFAULT_KEYS_LIST_LIMIT = 5000
 
 
@@ -110,9 +112,13 @@ class TunnelService:
             try:
                 ttl = int(ttl_seconds)
             except (TypeError, ValueError) as exc:
-                raise TunnelServiceException("ttl_seconds must be a positive integer") from exc
-            if ttl <= 0:
-                raise TunnelServiceException("ttl_seconds must be a positive integer")
+                raise TunnelServiceException(
+                    f"ttl_seconds must be between {MIN_TTL_SECONDS} and {MAX_TTL_SECONDS} seconds"
+                ) from exc
+            if ttl < MIN_TTL_SECONDS or ttl > MAX_TTL_SECONDS:
+                raise TunnelServiceException(
+                    f"ttl_seconds must be between {MIN_TTL_SECONDS} and {MAX_TTL_SECONDS} seconds"
+                )
 
         now_utc = datetime.now(tz=timezone.utc).replace(tzinfo=None)
         expires_at = now_utc + timedelta(seconds=ttl)

--- a/argus/backend/service/tunnel_service.py
+++ b/argus/backend/service/tunnel_service.py
@@ -31,26 +31,26 @@ class TunnelServiceException(Exception):
 
 
 @dataclass(frozen=True, slots=True)
-class TunnelRegistrationResponseDTO:
+class TunnelCommonFieldsDTO:
+    proxy_user: str
+    target_host: str
+    target_port: int
+    host_key_fingerprint: str
+
+
+@dataclass(frozen=True, slots=True)
+class TunnelRegistrationResponseDTO(TunnelCommonFieldsDTO):
     key_id: UUID
     tunnel_id: UUID
     proxy_host: str
     proxy_port: int
-    proxy_user: str
-    target_host: str
-    target_port: int
-    host_key_fingerprint: str
     expires_at: datetime
 
 
 @dataclass(frozen=True, slots=True)
-class TunnelConnectionResponseDTO:
+class TunnelConnectionResponseDTO(TunnelCommonFieldsDTO):
     proxy_host: str
     proxy_port: int
-    proxy_user: str
-    target_host: str
-    target_port: int
-    host_key_fingerprint: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -65,14 +65,10 @@ class SSHTunnelKeyDTO:
 
 
 @dataclass(frozen=True, slots=True)
-class ProxyTunnelConfigDTO:
+class ProxyTunnelConfigDTO(TunnelCommonFieldsDTO):
     id: UUID
     host: str
     port: int
-    proxy_user: str
-    target_host: str
-    target_port: int
-    host_key_fingerprint: str
     service_user_id: UUID | None
     is_active: bool
     api_token: str | None = None
@@ -285,11 +281,7 @@ class TunnelService:
         return [self._to_ssh_tunnel_key_dto(row) for row in rows]
 
     def delete_key(self, key_id: UUID | str) -> None:
-        """
-        Delete a single ``SSHTunnelKey`` row.  Takes immediate effect — the
-        next ``AuthorizedKeysCommand`` call on the proxy host will not include
-        this key.
-        """
+        """Delete a single ``SSHTunnelKey`` row."""
         if not isinstance(key_id, UUID):
             key_id = UUID(str(key_id))
         try:
@@ -516,7 +508,7 @@ class TunnelService:
         # Re-use existing tunnel service user if it already exists.
         existing = User.exists_by_name(username)
         if existing:
-            if not existing.service_user or UserRoles.SSHTunnelServer.value not in (existing.roles or []):
+            if not existing.is_service_user() or not UserService.check_roles(UserRoles.SSHTunnelServer, existing):
                 raise TunnelServiceException(
                     f"User '{username}' already exists and is not a dedicated SSH tunnel service user"
                 )

--- a/argus/backend/service/tunnel_service.py
+++ b/argus/backend/service/tunnel_service.py
@@ -55,7 +55,7 @@ class TunnelConnectionResponseDTO:
 
 @dataclass(frozen=True, slots=True)
 class SSHTunnelKeyDTO:
-    id: UUID
+    key_id: UUID
     user_id: UUID
     tunnel_id: UUID
     public_key: str
@@ -84,6 +84,7 @@ class ProxyTunnelConfigPayload(TypedDict, total=False):
     proxy_user: str
     target_host: str
     target_port: int
+    host_key_fingerprint: str
     is_active: bool
 
 
@@ -262,17 +263,24 @@ class TunnelService:
         """
         query = SSHTunnelKey.objects
 
+        if tunnel_id is not None:
+            if not isinstance(tunnel_id, UUID):
+                tunnel_id = UUID(str(tunnel_id))
+
         if user_id is not None:
             if not isinstance(user_id, UUID):
                 user_id = UUID(str(user_id))
             query = query.filter(user_id=user_id)
 
-        rows = query.limit(DEFAULT_KEYS_LIST_LIMIT).all()
+        if tunnel_id is not None and user_id is None:
+            query = query.filter(tunnel_id=tunnel_id)
 
-        if tunnel_id is not None:
-            if not isinstance(tunnel_id, UUID):
-                tunnel_id = UUID(str(tunnel_id))
+        rows = list(query.all())
+
+        if tunnel_id is not None and user_id is not None:
             rows = [row for row in rows if row.tunnel_id == tunnel_id]
+
+        rows = rows[:DEFAULT_KEYS_LIST_LIMIT]
 
         return [self._to_ssh_tunnel_key_dto(row) for row in rows]
 
@@ -300,8 +308,8 @@ class TunnelService:
 
         - If ``tunnel_id`` is provided: return that config only when it exists
           and is active.
-        - If ``tunnel_id`` is not provided: pick one active config using
-          round-robin selection.
+        - If ``tunnel_id`` is not provided: return one active config using
+          deterministic selection (non-mutating).
 
         Returns ``None`` if no matching active config exists.
         """
@@ -317,7 +325,7 @@ class TunnelService:
                 return None
 
         try:
-            config = self._get_active_config_round_robin()
+            config = self._get_active_config()
             return self._to_proxy_tunnel_config_dto(config)
         except TunnelServiceException:
             return None
@@ -333,22 +341,29 @@ class TunnelService:
            service user's id stored in ``service_user_id``.
 
         Required payload keys: ``host``, ``port``, ``proxy_user``,
-        ``target_host``, ``target_port``.
+        ``target_host``, ``target_port``, ``host_key_fingerprint``.
 
-        The host key fingerprint is resolved automatically by connecting to the
-        proxy host with ``ssh-keyscan``.
+        The host key fingerprint is verified by resolving the host key with
+        ``ssh-keyscan`` and comparing it against the provided
+        ``host_key_fingerprint`` value.
 
         Returns the saved config as a dict (including ``service_user_id`` and
         the generated ``api_token`` so the caller can provision the proxy host).
         """
-        required = ("host", "port", "proxy_user", "target_host", "target_port")
+        required = ("host", "port", "proxy_user", "target_host", "target_port", "host_key_fingerprint")
         missing = [k for k in required if not payload.get(k)]
         if missing:
             raise TunnelServiceException(f"Missing required fields: {', '.join(missing)}")
 
         is_active = payload.get("is_active", True)
         port = int(payload["port"])
-        host_key_fingerprint = self._fetch_host_key_fingerprint(payload["host"], port)
+        discovered_fingerprint = self._fetch_host_key_fingerprint(payload["host"], port)
+        provided_fingerprint = payload["host_key_fingerprint"].strip()
+        if discovered_fingerprint != provided_fingerprint:
+            raise TunnelServiceException(
+                "Host key fingerprint mismatch for "
+                f"{payload['host']}:{port}. Expected {provided_fingerprint}, got {discovered_fingerprint}"
+            )
 
         # Create a dedicated service user for this proxy host.
         service_user, api_token = self._create_proxy_service_user(payload["host"])
@@ -360,7 +375,7 @@ class TunnelService:
             proxy_user=payload["proxy_user"],
             target_host=payload["target_host"],
             target_port=int(payload["target_port"]),
-            host_key_fingerprint=host_key_fingerprint,
+            host_key_fingerprint=provided_fingerprint,
             service_user_id=service_user.id,
             is_active=is_active,
         )
@@ -498,18 +513,13 @@ class TunnelService:
         """
         username = f"proxy-tunnel-{host}"
 
-        # Re-use existing service user if it already exists.
+        # Re-use existing tunnel service user if it already exists.
         existing = User.exists_by_name(username)
         if existing:
-            should_save = False
-            if existing.roles != [UserRoles.SSHTunnelServer.value]:
-                existing.roles = [UserRoles.SSHTunnelServer.value]
-                should_save = True
-            if not existing.service_user:
-                existing.service_user = True
-                should_save = True
-            if should_save:
-                existing.save()
+            if not existing.service_user or UserRoles.SSHTunnelServer.value not in (existing.roles or []):
+                raise TunnelServiceException(
+                    f"User '{username}' already exists and is not a dedicated SSH tunnel service user"
+                )
             svc = UserService()
             token = svc.get_or_generate_token(existing)
             return existing, token
@@ -532,7 +542,7 @@ class TunnelService:
     @staticmethod
     def _to_ssh_tunnel_key_dto(row: SSHTunnelKey) -> SSHTunnelKeyDTO:
         return SSHTunnelKeyDTO(
-            id=row.id,
+            key_id=row.id,
             user_id=row.user_id,
             tunnel_id=row.tunnel_id,
             public_key=row.public_key,

--- a/argus/backend/service/user.py
+++ b/argus/backend/service/user.py
@@ -23,11 +23,7 @@ from argus.backend.util.common import FlaskView, gen_pass
 
 LOGGER = logging.getLogger(__name__)
 
-SSH_TUNNEL_SERVER_ALLOWED_PATH = "/api/v1/client/ssh/keys"
-SSH_TUNNEL_SERVER_ALLOWED_METHODS = {"GET", "HEAD", "OPTIONS"}
-SSH_TUNNEL_SERVER_SCOPE_ERROR = (
-    "ROLE_SSH_TUNNEL_SERVER can only call GET /api/v1/client/ssh/keys"
-)
+SSH_TUNNEL_SERVER_ALLOWED_ENDPOINTS_KEY = "ssh_tunnel_server_allowed_endpoints"
 
 class UserServiceException(Exception):
     pass
@@ -417,6 +413,16 @@ def login_required(view: FlaskView):
                 "message": "Authorization required"
             }, 403
 
+        if is_scoped_ssh_tunnel_server_blocked(g.user):
+            if getattr(view, "api_view", False):
+                return {
+                    "status": "error",
+                    "message": "Authorization required",
+                }, 403
+
+            flash(message='Not authorized to access this area', category='error')
+            return redirect(url_for('main.home'))
+
         return view(*args, **kwargs)
 
     return wrapped_view
@@ -439,6 +445,11 @@ def check_roles(needed_roles: list[str] | str = None):
 
         return wrapped_view
     return inner
+
+
+def allow_ssh_tunnel_server_scope(view: FlaskView):
+    setattr(view, "allow_ssh_tunnel_server_scope", True)
+    return view
 
 
 def load_logged_in_user():
@@ -472,27 +483,25 @@ def is_ssh_tunnel_server_user(user: User | None) -> bool:
 
 
 def is_ssh_tunnel_server_request_allowed() -> bool:
-    return request.path == SSH_TUNNEL_SERVER_ALLOWED_PATH and request.method in SSH_TUNNEL_SERVER_ALLOWED_METHODS
+    endpoint = request.endpoint
+    if not endpoint:
+        return False
+
+    allowed_endpoint_methods = current_app.extensions.get(SSH_TUNNEL_SERVER_ALLOWED_ENDPOINTS_KEY)
+    if allowed_endpoint_methods is None:
+        allowed_endpoint_methods = set()
+        for rule in current_app.url_map.iter_rules():
+            view = current_app.view_functions.get(rule.endpoint)
+            if getattr(view, "allow_ssh_tunnel_server_scope", False):
+                for method in rule.methods:
+                    allowed_endpoint_methods.add((rule.endpoint, method))
+        current_app.extensions[SSH_TUNNEL_SERVER_ALLOWED_ENDPOINTS_KEY] = allowed_endpoint_methods
+
+    return (endpoint, request.method) in allowed_endpoint_methods
 
 
 def is_scoped_ssh_tunnel_server_blocked(user: User | None) -> bool:
     return is_ssh_tunnel_server_user(user) and not is_ssh_tunnel_server_request_allowed()
-
-
-def enforce_ssh_tunnel_server_scope():
-    if not is_scoped_ssh_tunnel_server_blocked(g.user):
-        return None
-
-    if request.path.startswith("/api/"):
-        return {
-            "status": "error",
-            "response": {
-                "message": SSH_TUNNEL_SERVER_SCOPE_ERROR,
-            },
-        }, 403
-
-    flash(message='Not authorized to access this area', category='error')
-    return redirect(url_for('main.home'))
 
 
 def _get_cf_access_payload(token: str) -> dict | None:

--- a/argus/backend/service/user.py
+++ b/argus/backend/service/user.py
@@ -487,17 +487,20 @@ def is_ssh_tunnel_server_request_allowed() -> bool:
     if not endpoint:
         return False
 
-    allowed_endpoint_methods = current_app.extensions.get(SSH_TUNNEL_SERVER_ALLOWED_ENDPOINTS_KEY)
-    if allowed_endpoint_methods is None:
-        allowed_endpoint_methods = set()
-        for rule in current_app.url_map.iter_rules():
-            view = current_app.view_functions.get(rule.endpoint)
-            if getattr(view, "allow_ssh_tunnel_server_scope", False):
-                for method in rule.methods:
-                    allowed_endpoint_methods.add((rule.endpoint, method))
-        current_app.extensions[SSH_TUNNEL_SERVER_ALLOWED_ENDPOINTS_KEY] = allowed_endpoint_methods
+    allowed_endpoint_methods = current_app.extensions.get(SSH_TUNNEL_SERVER_ALLOWED_ENDPOINTS_KEY, set())
 
     return (endpoint, request.method) in allowed_endpoint_methods
+
+
+def cache_ssh_tunnel_server_allowed_endpoints(app):
+    allowed_endpoint_methods = set()
+    for rule in app.url_map.iter_rules():
+        view = app.view_functions.get(rule.endpoint)
+        if getattr(view, "allow_ssh_tunnel_server_scope", False):
+            for method in rule.methods:
+                allowed_endpoint_methods.add((rule.endpoint, method))
+
+    app.extensions[SSH_TUNNEL_SERVER_ALLOWED_ENDPOINTS_KEY] = allowed_endpoint_methods
 
 
 def is_scoped_ssh_tunnel_server_blocked(user: User | None) -> bool:

--- a/argus/backend/service/user.py
+++ b/argus/backend/service/user.py
@@ -23,6 +23,12 @@ from argus.backend.util.common import FlaskView, gen_pass
 
 LOGGER = logging.getLogger(__name__)
 
+SSH_TUNNEL_SERVER_ALLOWED_PATH = "/api/v1/client/ssh/keys"
+SSH_TUNNEL_SERVER_ALLOWED_METHODS = {"GET", "HEAD", "OPTIONS"}
+SSH_TUNNEL_SERVER_SCOPE_ERROR = (
+    "ROLE_SSH_TUNNEL_SERVER can only call GET /api/v1/client/ssh/keys"
+)
+
 class UserServiceException(Exception):
     pass
 
@@ -457,6 +463,36 @@ def load_logged_in_user():
         except User.DoesNotExist:
             session.clear()
     g.user = None
+
+
+def is_ssh_tunnel_server_user(user: User | None) -> bool:
+    if not user:
+        return False
+    return UserService.check_roles(UserRoles.SSHTunnelServer, user)
+
+
+def is_ssh_tunnel_server_request_allowed() -> bool:
+    return request.path == SSH_TUNNEL_SERVER_ALLOWED_PATH and request.method in SSH_TUNNEL_SERVER_ALLOWED_METHODS
+
+
+def is_scoped_ssh_tunnel_server_blocked(user: User | None) -> bool:
+    return is_ssh_tunnel_server_user(user) and not is_ssh_tunnel_server_request_allowed()
+
+
+def enforce_ssh_tunnel_server_scope():
+    if not is_scoped_ssh_tunnel_server_blocked(g.user):
+        return None
+
+    if request.path.startswith("/api/"):
+        return {
+            "status": "error",
+            "response": {
+                "message": SSH_TUNNEL_SERVER_SCOPE_ERROR,
+            },
+        }, 403
+
+    flash(message='Not authorized to access this area', category='error')
+    return redirect(url_for('main.home'))
 
 
 def _get_cf_access_payload(token: str) -> dict | None:

--- a/argus/backend/tests/tunnel/test_admin_proxy_tunnel_api.py
+++ b/argus/backend/tests/tunnel/test_admin_proxy_tunnel_api.py
@@ -7,6 +7,7 @@ from flask import g
 from flask.testing import FlaskClient
 
 from argus.backend.models.ssh_key import ProxyTunnelConfig, SSHTunnelKey
+from argus.backend.models.web import User
 from argus.backend.service.tunnel_service import TunnelService
 
 API_PREFIX = "/admin/api/v1"
@@ -63,7 +64,9 @@ def test_admin_can_save_and_get_proxy_tunnel_config(flask_client: FlaskClient, a
         "proxy_user": "argus-proxy",
         "target_host": "10.0.0.99",
         "target_port": 8080,
+        "host_key_fingerprint": None,
     }
+    payload["host_key_fingerprint"] = f"SHA256:{payload['host']}"
 
     try:
         save_resp = _json_post(flask_client, f"{API_PREFIX}/proxy-tunnel/config", payload)
@@ -97,6 +100,58 @@ def test_admin_can_save_and_get_proxy_tunnel_config(flask_client: FlaskClient, a
         if created_config_id:
             try:
                 ProxyTunnelConfig.get(id=created_config_id).delete()
+            except Exception:
+                pass
+        _restore_active_configs(previous_active_ids)
+
+
+@pytest.mark.docker_required
+def test_admin_get_proxy_tunnel_config_without_id_is_non_mutating(flask_client: FlaskClient, argus_db):
+    first_cfg = None
+    second_cfg = None
+    previous_active_ids = _deactivate_all_configs()
+    try:
+        first_payload = {
+            "host": f"proxy-admin-first-{uuid4().hex[:8]}.example.com",
+            "port": 22,
+            "proxy_user": "argus-proxy",
+            "target_host": "10.0.0.31",
+            "target_port": 8080,
+            "host_key_fingerprint": None,
+        }
+        first_payload["host_key_fingerprint"] = f"SHA256:{first_payload['host']}"
+        second_payload = {
+            "host": f"proxy-admin-second-{uuid4().hex[:8]}.example.com",
+            "port": 22,
+            "proxy_user": "argus-proxy",
+            "target_host": "10.0.0.32",
+            "target_port": 8080,
+            "host_key_fingerprint": None,
+        }
+        second_payload["host_key_fingerprint"] = f"SHA256:{second_payload['host']}"
+
+        first_resp = _json_post(flask_client, f"{API_PREFIX}/proxy-tunnel/config", first_payload)
+        second_resp = _json_post(flask_client, f"{API_PREFIX}/proxy-tunnel/config", second_payload)
+        assert first_resp.status_code == 200
+        assert second_resp.status_code == 200
+        first_cfg = first_resp.json["response"]["id"]
+        second_cfg = second_resp.json["response"]["id"]
+
+        read1 = flask_client.get(f"{API_PREFIX}/proxy-tunnel/config")
+        read2 = flask_client.get(f"{API_PREFIX}/proxy-tunnel/config")
+        assert read1.status_code == 200
+        assert read2.status_code == 200
+        assert read1.json["response"]["id"] == read2.json["response"]["id"]
+        assert read1.json["response"]["id"] in {first_cfg, second_cfg}
+    finally:
+        if first_cfg:
+            try:
+                ProxyTunnelConfig.get(id=first_cfg).delete()
+            except Exception:
+                pass
+        if second_cfg:
+            try:
+                ProxyTunnelConfig.get(id=second_cfg).delete()
             except Exception:
                 pass
         _restore_active_configs(previous_active_ids)
@@ -148,7 +203,7 @@ def test_admin_can_list_and_delete_ssh_key(flask_client: FlaskClient, argus_db):
     assert list_resp.status_code == 200
     assert list_resp.json["status"] == "ok"
     rows = list_resp.json["response"]
-    assert any(row["id"] == str(key_id) for row in rows)
+    assert any(row["key_id"] == str(key_id) for row in rows)
 
     delete_resp = flask_client.delete(f"{API_PREFIX}/ssh/keys/{key_id}")
     assert delete_resp.status_code == 200
@@ -167,15 +222,19 @@ def test_admin_can_list_and_toggle_proxy_tunnel_configs(flask_client: FlaskClien
         "proxy_user": "argus-proxy",
         "target_host": "10.0.0.90",
         "target_port": 8080,
+        "host_key_fingerprint": None,
     }
+    payload_active["host_key_fingerprint"] = f"SHA256:{payload_active['host']}"
     payload_inactive = {
         "host": f"proxy-list-inactive-{uuid4().hex[:8]}.example.com",
         "port": 22,
         "proxy_user": "argus-proxy",
         "target_host": "10.0.0.91",
         "target_port": 8080,
+        "host_key_fingerprint": None,
         "is_active": False,
     }
+    payload_inactive["host_key_fingerprint"] = f"SHA256:{payload_inactive['host']}"
 
     active_id = None
     inactive_id = None
@@ -225,6 +284,43 @@ def test_admin_can_list_and_toggle_proxy_tunnel_configs(flask_client: FlaskClien
 
 
 @pytest.mark.docker_required
+def test_admin_save_proxy_tunnel_config_rejects_username_collision(flask_client: FlaskClient, argus_db):
+    host = f"proxy-collision-{uuid4().hex[:8]}.example.com"
+    payload = {
+        "host": host,
+        "port": 22,
+        "proxy_user": "argus-proxy",
+        "target_host": "10.0.0.33",
+        "target_port": 8080,
+        "host_key_fingerprint": f"SHA256:{host}",
+    }
+
+    username = f"proxy-tunnel-{host}"
+    now_utc = datetime.now(tz=UTC).replace(tzinfo=None)
+    collision_user = User.create(
+        id=uuid4(),
+        username=username,
+        full_name="Conflicting User",
+        password="",
+        email=f"{username}@example.com",
+        registration_date=now_utc,
+        roles=["ROLE_USER"],
+        api_token="",
+        service_user=False,
+    )
+    try:
+        resp = _json_post(flask_client, f"{API_PREFIX}/proxy-tunnel/config", payload)
+        assert resp.status_code == 200
+        assert resp.json["status"] == "error"
+        assert "already exists and is not a dedicated SSH tunnel service user" in resp.json["response"]["message"]
+    finally:
+        try:
+            collision_user.delete()
+        except Exception:
+            pass
+
+
+@pytest.mark.docker_required
 @pytest.mark.parametrize(
     "method,path,payload",
     [
@@ -239,6 +335,7 @@ def test_admin_can_list_and_toggle_proxy_tunnel_configs(flask_client: FlaskClien
                 "proxy_user": "argus-proxy",
                 "target_host": "10.0.0.88",
                 "target_port": 8080,
+                "host_key_fingerprint": "SHA256:proxy-non-admin.example.com",
             },
         ),
         ("POST", f"{API_PREFIX}/proxy-tunnel/config/{uuid4()}/active", {"is_active": False}),

--- a/argus/backend/tests/tunnel/test_admin_proxy_tunnel_api.py
+++ b/argus/backend/tests/tunnel/test_admin_proxy_tunnel_api.py
@@ -1,0 +1,163 @@
+import json
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from flask import g
+from flask.testing import FlaskClient
+
+from argus.backend.models.ssh_key import ProxyTunnelConfig, SSHTunnelKey
+
+API_PREFIX = "/admin/api/v1"
+
+
+def _json_post(client: FlaskClient, url: str, payload: dict) -> object:
+    return client.post(url, data=json.dumps(payload), content_type="application/json")
+
+
+def _active_config_ids() -> list:
+    return [cfg.id for cfg in ProxyTunnelConfig.objects.all() if cfg.is_active]
+
+
+def _deactivate_all_configs() -> list:
+    cfg_ids = _active_config_ids()
+    for cfg_id in cfg_ids:
+        ProxyTunnelConfig.get(id=cfg_id).update(is_active=False)
+    return cfg_ids
+
+
+def _restore_active_configs(cfg_ids: list):
+    for cfg_id in cfg_ids:
+        try:
+            ProxyTunnelConfig.get(id=cfg_id).update(is_active=True)
+        except Exception:
+            pass
+
+
+@pytest.fixture
+def normal_user_identity():
+    previous_roles = list(getattr(g.user, "roles", []))
+    g.user.roles = ["ROLE_USER"]
+    yield
+    g.user.roles = previous_roles
+
+
+@pytest.mark.docker_required
+def test_admin_can_save_and_get_proxy_tunnel_config(flask_client: FlaskClient, argus_db):
+    previous_active_ids = _deactivate_all_configs()
+    created_config_id = None
+
+    payload = {
+        "host": f"proxy-admin-{uuid4().hex[:8]}.example.com",
+        "port": 22,
+        "proxy_user": "argus-proxy",
+        "target_host": "10.0.0.99",
+        "target_port": 8080,
+        "host_key_fingerprint": "SHA256:admin-config",
+    }
+
+    try:
+        save_resp = _json_post(flask_client, f"{API_PREFIX}/proxy-tunnel/config", payload)
+        assert save_resp.status_code == 200
+        assert save_resp.json["status"] == "ok"
+        saved = save_resp.json["response"]
+
+        assert saved["host"] == payload["host"]
+        assert saved["port"] == payload["port"]
+        assert saved["proxy_user"] == payload["proxy_user"]
+        assert saved["target_host"] == payload["target_host"]
+        assert saved["target_port"] == payload["target_port"]
+        assert saved["host_key_fingerprint"] == payload["host_key_fingerprint"]
+        assert saved["service_user_id"] is not None
+        assert saved["api_token"] is not None
+        created_config_id = saved["id"]
+
+        get_resp = flask_client.get(f"{API_PREFIX}/proxy-tunnel/config")
+        assert get_resp.status_code == 200
+        assert get_resp.json["status"] == "ok"
+        config = get_resp.json["response"]
+        assert config is not None
+        assert config["id"] == created_config_id
+        assert config["host"] == payload["host"]
+    finally:
+        if created_config_id:
+            try:
+                ProxyTunnelConfig.get(id=created_config_id).delete()
+            except Exception:
+                pass
+        _restore_active_configs(previous_active_ids)
+
+
+@pytest.mark.docker_required
+def test_admin_can_list_and_delete_ssh_key(flask_client: FlaskClient, argus_db):
+    key_id = uuid4()
+    tunnel_id = uuid4()
+    now_utc = datetime.now(tz=UTC).replace(tzinfo=None)
+    pub_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFj+zV+Y9lW7eGLtQ+uY1M4NeC+YABN9nDl2sjp4rU0m"
+
+    SSHTunnelKey.objects.ttl(86400).create(
+        id=key_id,
+        user_id=g.user.id,
+        tunnel_id=tunnel_id,
+        public_key=pub_key,
+        fingerprint="SHA256:admin-key",
+        created_at=now_utc,
+        expires_at=now_utc,
+    )
+
+    list_resp = flask_client.get(f"{API_PREFIX}/ssh/keys")
+    assert list_resp.status_code == 200
+    assert list_resp.json["status"] == "ok"
+    rows = list_resp.json["response"]
+    assert any(row["id"] == str(key_id) for row in rows)
+
+    delete_resp = flask_client.delete(f"{API_PREFIX}/ssh/keys/{key_id}")
+    assert delete_resp.status_code == 200
+    assert delete_resp.json["status"] == "ok"
+    assert delete_resp.json["response"]["deleted"] is True
+
+    with pytest.raises(SSHTunnelKey.DoesNotExist):
+        SSHTunnelKey.get(id=key_id)
+
+
+@pytest.mark.docker_required
+@pytest.mark.parametrize(
+    "method,path,payload",
+    [
+        ("GET", f"{API_PREFIX}/proxy-tunnel/config", None),
+        (
+            "POST",
+            f"{API_PREFIX}/proxy-tunnel/config",
+            {
+                "host": "proxy-non-admin.example.com",
+                "port": 22,
+                "proxy_user": "argus-proxy",
+                "target_host": "10.0.0.88",
+                "target_port": 8080,
+                "host_key_fingerprint": "SHA256:non-admin",
+            },
+        ),
+        ("GET", f"{API_PREFIX}/ssh/keys", None),
+        ("DELETE", f"{API_PREFIX}/ssh/keys/{uuid4()}", None),
+    ],
+)
+def test_admin_proxy_tunnel_endpoints_require_admin_role(
+    flask_client: FlaskClient,
+    argus_db,
+    normal_user_identity,
+    method: str,
+    path: str,
+    payload: dict | None,
+):
+    previous_secret = flask_client.application.secret_key
+    flask_client.application.secret_key = "test-secret"
+    try:
+        if payload is None:
+            resp = flask_client.open(path, method=method)
+        else:
+            resp = flask_client.open(path, method=method, json=payload)
+    finally:
+        flask_client.application.secret_key = previous_secret
+
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/")

--- a/argus/backend/tests/tunnel/test_admin_proxy_tunnel_api.py
+++ b/argus/backend/tests/tunnel/test_admin_proxy_tunnel_api.py
@@ -7,6 +7,7 @@ from flask import g
 from flask.testing import FlaskClient
 
 from argus.backend.models.ssh_key import ProxyTunnelConfig, SSHTunnelKey
+from argus.backend.service.tunnel_service import TunnelService
 
 API_PREFIX = "/admin/api/v1"
 
@@ -42,6 +43,15 @@ def normal_user_identity():
     g.user.roles = previous_roles
 
 
+@pytest.fixture(autouse=True)
+def mock_host_fingerprint(monkeypatch):
+    monkeypatch.setattr(
+        TunnelService,
+        "_fetch_host_key_fingerprint",
+        staticmethod(lambda host, _port: f"SHA256:{host}"),
+    )
+
+
 @pytest.mark.docker_required
 def test_admin_can_save_and_get_proxy_tunnel_config(flask_client: FlaskClient, argus_db):
     previous_active_ids = _deactivate_all_configs()
@@ -53,7 +63,6 @@ def test_admin_can_save_and_get_proxy_tunnel_config(flask_client: FlaskClient, a
         "proxy_user": "argus-proxy",
         "target_host": "10.0.0.99",
         "target_port": 8080,
-        "host_key_fingerprint": "SHA256:admin-config",
     }
 
     try:
@@ -67,7 +76,7 @@ def test_admin_can_save_and_get_proxy_tunnel_config(flask_client: FlaskClient, a
         assert saved["proxy_user"] == payload["proxy_user"]
         assert saved["target_host"] == payload["target_host"]
         assert saved["target_port"] == payload["target_port"]
-        assert saved["host_key_fingerprint"] == payload["host_key_fingerprint"]
+        assert saved["host_key_fingerprint"] == f"SHA256:{payload['host']}"
         assert saved["service_user_id"] is not None
         assert saved["api_token"] is not None
         created_config_id = saved["id"]
@@ -79,6 +88,11 @@ def test_admin_can_save_and_get_proxy_tunnel_config(flask_client: FlaskClient, a
         assert config is not None
         assert config["id"] == created_config_id
         assert config["host"] == payload["host"]
+
+        by_id_resp = flask_client.get(f"{API_PREFIX}/proxy-tunnel/config?tunnel_id={created_config_id}")
+        assert by_id_resp.status_code == 200
+        assert by_id_resp.json["status"] == "ok"
+        assert by_id_resp.json["response"]["id"] == created_config_id
     finally:
         if created_config_id:
             try:
@@ -86,6 +100,31 @@ def test_admin_can_save_and_get_proxy_tunnel_config(flask_client: FlaskClient, a
             except Exception:
                 pass
         _restore_active_configs(previous_active_ids)
+
+
+@pytest.mark.docker_required
+def test_admin_get_proxy_tunnel_config_ignores_inactive_tunnel_id(flask_client: FlaskClient, argus_db):
+    cfg = ProxyTunnelConfig.create(
+        id=uuid4(),
+        host=f"proxy-inactive-id-{uuid4().hex[:8]}.example.com",
+        port=22,
+        proxy_user="argus-proxy",
+        target_host="10.0.0.77",
+        target_port=8080,
+        host_key_fingerprint="SHA256:inactive-id",
+        service_user_id=g.user.id,
+        is_active=False,
+    )
+    try:
+        resp = flask_client.get(f"{API_PREFIX}/proxy-tunnel/config?tunnel_id={cfg.id}")
+        assert resp.status_code == 200
+        assert resp.json["status"] == "ok"
+        assert resp.json["response"] is None
+    finally:
+        try:
+            cfg.delete()
+        except Exception:
+            pass
 
 
 @pytest.mark.docker_required
@@ -121,10 +160,76 @@ def test_admin_can_list_and_delete_ssh_key(flask_client: FlaskClient, argus_db):
 
 
 @pytest.mark.docker_required
+def test_admin_can_list_and_toggle_proxy_tunnel_configs(flask_client: FlaskClient, argus_db):
+    payload_active = {
+        "host": f"proxy-list-active-{uuid4().hex[:8]}.example.com",
+        "port": 22,
+        "proxy_user": "argus-proxy",
+        "target_host": "10.0.0.90",
+        "target_port": 8080,
+    }
+    payload_inactive = {
+        "host": f"proxy-list-inactive-{uuid4().hex[:8]}.example.com",
+        "port": 22,
+        "proxy_user": "argus-proxy",
+        "target_host": "10.0.0.91",
+        "target_port": 8080,
+        "is_active": False,
+    }
+
+    active_id = None
+    inactive_id = None
+    try:
+        active_resp = _json_post(flask_client, f"{API_PREFIX}/proxy-tunnel/config", payload_active)
+        inactive_resp = _json_post(flask_client, f"{API_PREFIX}/proxy-tunnel/config", payload_inactive)
+        assert active_resp.status_code == 200
+        assert inactive_resp.status_code == 200
+        active_id = active_resp.json["response"]["id"]
+        inactive_id = inactive_resp.json["response"]["id"]
+
+        list_all = flask_client.get(f"{API_PREFIX}/proxy-tunnel/configs")
+        assert list_all.status_code == 200
+        all_ids = {row["id"] for row in list_all.json["response"]}
+        assert active_id in all_ids
+        assert inactive_id in all_ids
+
+        list_active = flask_client.get(f"{API_PREFIX}/proxy-tunnel/configs?active_only=true")
+        assert list_active.status_code == 200
+        active_ids = {row["id"] for row in list_active.json["response"]}
+        assert active_id in active_ids
+        assert inactive_id not in active_ids
+
+        toggle_resp = _json_post(
+            flask_client,
+            f"{API_PREFIX}/proxy-tunnel/config/{inactive_id}/active",
+            {"is_active": True},
+        )
+        assert toggle_resp.status_code == 200
+        assert toggle_resp.json["response"]["is_active"] is True
+
+        list_active_after = flask_client.get(f"{API_PREFIX}/proxy-tunnel/configs?active_only=true")
+        assert list_active_after.status_code == 200
+        active_ids_after = {row["id"] for row in list_active_after.json["response"]}
+        assert inactive_id in active_ids_after
+    finally:
+        if active_id:
+            try:
+                ProxyTunnelConfig.get(id=active_id).delete()
+            except Exception:
+                pass
+        if inactive_id:
+            try:
+                ProxyTunnelConfig.get(id=inactive_id).delete()
+            except Exception:
+                pass
+
+
+@pytest.mark.docker_required
 @pytest.mark.parametrize(
     "method,path,payload",
     [
         ("GET", f"{API_PREFIX}/proxy-tunnel/config", None),
+        ("GET", f"{API_PREFIX}/proxy-tunnel/configs", None),
         (
             "POST",
             f"{API_PREFIX}/proxy-tunnel/config",
@@ -134,9 +239,9 @@ def test_admin_can_list_and_delete_ssh_key(flask_client: FlaskClient, argus_db):
                 "proxy_user": "argus-proxy",
                 "target_host": "10.0.0.88",
                 "target_port": 8080,
-                "host_key_fingerprint": "SHA256:non-admin",
             },
         ),
+        ("POST", f"{API_PREFIX}/proxy-tunnel/config/{uuid4()}/active", {"is_active": False}),
         ("GET", f"{API_PREFIX}/ssh/keys", None),
         ("DELETE", f"{API_PREFIX}/ssh/keys/{uuid4()}", None),
     ],

--- a/argus/backend/tests/tunnel/test_ssh_api.py
+++ b/argus/backend/tests/tunnel/test_ssh_api.py
@@ -406,10 +406,10 @@ def test_get_authorized_keys_unauthenticated(argus_db, active_config):
 @pytest.mark.docker_required
 def test_ssh_tunnel_server_role_cannot_call_other_api(flask_client: FlaskClient, argus_db, ssh_tunnel_server_identity):
     """ROLE_SSH_TUNNEL_SERVER should be hard-scoped to GET /client/ssh/keys only."""
-    resp = flask_client.get("/api/v1/version")
+    resp = flask_client.get("/api/v1/releases")
     assert resp.status_code == 403
     assert resp.json["status"] == "error"
-    assert "ROLE_SSH_TUNNEL_SERVER can only call GET /api/v1/client/ssh/keys" in resp.json["response"]["message"]
+    assert resp.json["message"] == "Authorization required"
 
 
 # ---------------------------------------------------------------------------

--- a/argus/backend/tests/tunnel/test_ssh_api.py
+++ b/argus/backend/tests/tunnel/test_ssh_api.py
@@ -18,6 +18,7 @@ from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from flask import g
 from flask.testing import FlaskClient
 
+from argus.backend.models.runtime_store import RuntimeStore
 from argus.backend.models.ssh_key import ProxyTunnelConfig, SSHTunnelKey
 
 API_PREFIX = "/api/v1/client/ssh"
@@ -69,6 +70,8 @@ def active_config(argus_db) -> ProxyTunnelConfig:
         cfg = ProxyTunnelConfig.get(id=cfg_id)
         cfg.update(is_active=False)
 
+    _clear_proxy_rr_state()
+
     config = _make_active_config(service_user_id=g.user.id)
     yield config
     try:
@@ -115,6 +118,13 @@ def _restore_active_configs(cfg_ids: list):
             pass
 
 
+def _clear_proxy_rr_state() -> None:
+    try:
+        RuntimeStore.get(key="ssh_tunnel_proxy_rr_index").delete()
+    except RuntimeStore.DoesNotExist:
+        pass
+
+
 # ---------------------------------------------------------------------------
 # GET /api/v1/client/ssh/tunnel
 # ---------------------------------------------------------------------------
@@ -133,6 +143,42 @@ def test_get_tunnel_connection_success(flask_client: FlaskClient, argus_db, acti
     assert data["target_host"] == active_config.target_host
     assert data["target_port"] == active_config.target_port
     assert data["host_key_fingerprint"] == active_config.host_key_fingerprint
+
+
+@pytest.mark.docker_required
+def test_get_tunnel_connection_select_specific_host(flask_client: FlaskClient, argus_db, active_config):
+    second = _make_active_config(is_active=True)
+    try:
+        resp = flask_client.get(f"{API_PREFIX}/tunnel?proxy_host={second.host}")
+        assert resp.status_code == 200
+        body = resp.json
+        assert body["status"] == "ok"
+        assert body["response"]["proxy_host"] == second.host
+    finally:
+        try:
+            second.delete()
+        except Exception:
+            pass
+
+
+@pytest.mark.docker_required
+def test_get_tunnel_connection_round_robin(flask_client: FlaskClient, argus_db, active_config):
+    second = _make_active_config(is_active=True)
+    try:
+        _clear_proxy_rr_state()
+        resp1 = flask_client.get(f"{API_PREFIX}/tunnel")
+        resp2 = flask_client.get(f"{API_PREFIX}/tunnel")
+        assert resp1.status_code == 200
+        assert resp2.status_code == 200
+        host1 = resp1.json["response"]["proxy_host"]
+        host2 = resp2.json["response"]["proxy_host"]
+        assert host1 != host2
+        assert {host1, host2} == {active_config.host, second.host}
+    finally:
+        try:
+            second.delete()
+        except Exception:
+            pass
 
 
 @pytest.mark.docker_required
@@ -275,8 +321,43 @@ def test_get_authorized_keys_forbidden_for_normal_user(flask_client: FlaskClient
 
 
 @pytest.mark.docker_required
+def test_get_authorized_keys_with_multiple_active_configs(flask_client: FlaskClient, argus_db, active_config, service_user_identity):
+    """API should still return keys when multiple active tunnel configs are present."""
+    from datetime import UTC, datetime
+
+    second = _make_active_config(is_active=True)
+    try:
+        key_one = _make_public_key()
+        key_two = _make_public_key()
+        _json_post(flask_client, f"{API_PREFIX}/tunnel", {"public_key": key_one})
+        now_utc = datetime.now(tz=UTC).replace(tzinfo=None)
+        SSHTunnelKey.objects.ttl(86400).create(
+            id=uuid4(),
+            user_id=g.user.id,
+            tunnel_id=second.id,
+            public_key=key_two,
+            fingerprint="SHA256:test-second",
+            created_at=now_utc,
+            expires_at=now_utc,
+        )
+
+        now_resp = flask_client.get(f"{API_PREFIX}/keys")
+        assert now_resp.status_code == 200
+        keys_text = now_resp.data.decode("utf-8")
+        assert key_one.strip() in keys_text
+        assert key_two.strip() in keys_text
+    finally:
+        try:
+            second.delete()
+        except Exception:
+            pass
+
+
+@pytest.mark.docker_required
 def test_get_authorized_keys_empty_when_no_keys(flask_client: FlaskClient, argus_db, active_config, service_user_identity):
-    """GET /ssh/keys for a tunnel with no registered keys should return empty text."""
+    """GET /ssh/keys for an empty database should return empty text."""
+    for row in SSHTunnelKey.objects.all():
+        row.delete()
     resp = flask_client.get(f"{API_PREFIX}/keys")
     assert resp.status_code == 200
     assert resp.data.decode("utf-8").strip() == ""
@@ -296,3 +377,70 @@ def test_get_authorized_keys_unauthenticated(argus_db, active_config):
         g.user = previous_user
 
     assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/client/ssh/tunnel/keys
+# ---------------------------------------------------------------------------
+
+@pytest.mark.docker_required
+def test_get_user_keys_returns_only_current_user(flask_client: FlaskClient, argus_db, active_config):
+    from datetime import UTC, datetime
+
+    own_key = _make_public_key()
+    _json_post(flask_client, f"{API_PREFIX}/tunnel", {"public_key": own_key})
+
+    foreign_key = _make_public_key()
+    now_utc = datetime.now(tz=UTC).replace(tzinfo=None)
+    SSHTunnelKey.objects.ttl(86400).create(
+        id=uuid4(),
+        user_id=uuid4(),
+        tunnel_id=active_config.id,
+        public_key=foreign_key,
+        fingerprint="SHA256:foreign",
+        created_at=now_utc,
+        expires_at=now_utc,
+    )
+
+    resp = flask_client.get(f"{API_PREFIX}/tunnel/keys")
+    assert resp.status_code == 200
+    assert resp.json["status"] == "ok"
+
+    rows = resp.json["response"]
+    public_keys = {row["public_key"] for row in rows}
+    assert own_key.strip() in public_keys
+    assert foreign_key.strip() not in public_keys
+
+
+@pytest.mark.docker_required
+def test_get_user_keys_can_filter_by_tunnel(flask_client: FlaskClient, argus_db, active_config):
+    from datetime import UTC, datetime
+
+    own_key = _make_public_key()
+    _json_post(flask_client, f"{API_PREFIX}/tunnel", {"public_key": own_key})
+
+    second = _make_active_config(is_active=True)
+    try:
+        other_tunnel_key = _make_public_key()
+        now_utc = datetime.now(tz=UTC).replace(tzinfo=None)
+        SSHTunnelKey.objects.ttl(86400).create(
+            id=uuid4(),
+            user_id=g.user.id,
+            tunnel_id=second.id,
+            public_key=other_tunnel_key,
+            fingerprint="SHA256:second-tunnel",
+            created_at=now_utc,
+            expires_at=now_utc,
+        )
+
+        resp = flask_client.get(f"{API_PREFIX}/tunnel/keys?tunnel_id={active_config.id}")
+        assert resp.status_code == 200
+        rows = resp.json["response"]
+        keys = {row["public_key"] for row in rows}
+        assert own_key.strip() in keys
+        assert other_tunnel_key.strip() not in keys
+    finally:
+        try:
+            second.delete()
+        except Exception:
+            pass

--- a/argus/backend/tests/tunnel/test_ssh_api.py
+++ b/argus/backend/tests/tunnel/test_ssh_api.py
@@ -181,7 +181,7 @@ def test_register_tunnel_with_ttl_seconds(flask_client: FlaskClient, argus_db, a
     """ttl_seconds should be honoured and reflected in expires_at."""
     from datetime import datetime, timezone
 
-    ttl = 7200  # 2 hours
+    ttl = 172800  # 2 days
     payload = {"public_key": _make_public_key(), "ttl_seconds": ttl}
     before = datetime.now(tz=timezone.utc)
     resp = _json_post(flask_client, f"{API_PREFIX}/tunnel", payload)
@@ -196,13 +196,14 @@ def test_register_tunnel_with_ttl_seconds(flask_client: FlaskClient, argus_db, a
 
 @pytest.mark.docker_required
 def test_register_tunnel_invalid_ttl(flask_client: FlaskClient, argus_db, active_config):
-    """Invalid ttl_seconds should return an error response."""
-    payload = {"public_key": _make_public_key(), "ttl_seconds": 0}
-    resp = _json_post(flask_client, f"{API_PREFIX}/tunnel", payload)
+    """TTL outside [24h, 30d] should return an error response."""
+    for ttl in (0, 86399, 2592001):
+        payload = {"public_key": _make_public_key(), "ttl_seconds": ttl}
+        resp = _json_post(flask_client, f"{API_PREFIX}/tunnel", payload)
 
-    assert resp.status_code == 200
-    assert resp.json["status"] == "error"
-    assert "ttl_seconds must be a positive integer" in resp.json["response"]["message"]
+        assert resp.status_code == 200
+        assert resp.json["status"] == "error"
+        assert "ttl_seconds must be between 86400 and 2592000 seconds" in resp.json["response"]["message"]
 
 
 @pytest.mark.docker_required

--- a/argus/backend/tests/tunnel/test_ssh_api.py
+++ b/argus/backend/tests/tunnel/test_ssh_api.py
@@ -88,19 +88,19 @@ def active_config(argus_db) -> ProxyTunnelConfig:
 
 
 @pytest.fixture
-def service_user_identity():
-    previous = getattr(g.user, "service_user", False)
-    g.user.service_user = True
+def ssh_tunnel_server_identity():
+    previous_roles = list(getattr(g.user, "roles", []))
+    g.user.roles = ["ROLE_SSH_TUNNEL_SERVER"]
     yield
-    g.user.service_user = previous
+    g.user.roles = previous_roles
 
 
 @pytest.fixture
 def normal_user_identity():
-    previous = getattr(g.user, "service_user", False)
-    g.user.service_user = False
+    previous_roles = list(getattr(g.user, "roles", []))
+    g.user.roles = ["ROLE_USER"]
     yield
-    g.user.service_user = previous
+    g.user.roles = previous_roles
 
 
 def _deactivate_all_configs() -> list:
@@ -242,14 +242,14 @@ def test_register_tunnel_with_ttl_seconds(flask_client: FlaskClient, argus_db, a
 
 @pytest.mark.docker_required
 def test_register_tunnel_invalid_ttl(flask_client: FlaskClient, argus_db, active_config):
-    """TTL outside [24h, 30d] should return an error response."""
-    for ttl in (0, 86399, 2592001):
+    """TTL outside [1h, 30d] should return an error response."""
+    for ttl in (0, 3599, 2592001):
         payload = {"public_key": _make_public_key(), "ttl_seconds": ttl}
         resp = _json_post(flask_client, f"{API_PREFIX}/tunnel", payload)
 
         assert resp.status_code == 200
         assert resp.json["status"] == "error"
-        assert "ttl_seconds must be between 86400 and 2592000 seconds" in resp.json["response"]["message"]
+        assert "ttl_seconds must be between 3600 and 2592000 seconds" in resp.json["response"]["message"]
 
 
 @pytest.mark.docker_required
@@ -297,11 +297,22 @@ def test_register_tunnel_unauthenticated(argus_db, active_config):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.docker_required
-def test_get_authorized_keys_success(flask_client: FlaskClient, argus_db, active_config, service_user_identity):
+def test_get_authorized_keys_success(flask_client: FlaskClient, argus_db, active_config, ssh_tunnel_server_identity):
     """GET /ssh/keys should return 200 with plain-text content."""
-    # Register a key first so there is something to return
+    # Insert a key directly so scoped role does not call other endpoints.
+    from datetime import UTC, datetime
+
     pub_key = _make_public_key()
-    _json_post(flask_client, f"{API_PREFIX}/tunnel", {"public_key": pub_key})
+    now_utc = datetime.now(tz=UTC).replace(tzinfo=None)
+    SSHTunnelKey.objects.ttl(86400).create(
+        id=uuid4(),
+        user_id=g.user.id,
+        tunnel_id=active_config.id,
+        public_key=pub_key,
+        fingerprint="SHA256:test-one",
+        created_at=now_utc,
+        expires_at=now_utc,
+    )
 
     resp = flask_client.get(f"{API_PREFIX}/keys")
 
@@ -313,15 +324,20 @@ def test_get_authorized_keys_success(flask_client: FlaskClient, argus_db, active
 
 @pytest.mark.docker_required
 def test_get_authorized_keys_forbidden_for_normal_user(flask_client: FlaskClient, argus_db, active_config, normal_user_identity):
-    """GET /ssh/keys should fail for non-service users."""
-    resp = flask_client.get(f"{API_PREFIX}/keys")
-    assert resp.status_code == 200
-    assert resp.json["status"] == "error"
-    assert "Only service users can fetch SSH authorized keys" in resp.json["response"]["message"]
+    """GET /ssh/keys should fail for users without SSH tunnel server role."""
+    previous_secret = flask_client.application.secret_key
+    flask_client.application.secret_key = "test-secret"
+    try:
+        resp = flask_client.get(f"{API_PREFIX}/keys")
+    finally:
+        flask_client.application.secret_key = previous_secret
+
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/")
 
 
 @pytest.mark.docker_required
-def test_get_authorized_keys_with_multiple_active_configs(flask_client: FlaskClient, argus_db, active_config, service_user_identity):
+def test_get_authorized_keys_with_multiple_active_configs(flask_client: FlaskClient, argus_db, active_config, ssh_tunnel_server_identity):
     """API should still return keys when multiple active tunnel configs are present."""
     from datetime import UTC, datetime
 
@@ -329,8 +345,16 @@ def test_get_authorized_keys_with_multiple_active_configs(flask_client: FlaskCli
     try:
         key_one = _make_public_key()
         key_two = _make_public_key()
-        _json_post(flask_client, f"{API_PREFIX}/tunnel", {"public_key": key_one})
         now_utc = datetime.now(tz=UTC).replace(tzinfo=None)
+        SSHTunnelKey.objects.ttl(86400).create(
+            id=uuid4(),
+            user_id=g.user.id,
+            tunnel_id=active_config.id,
+            public_key=key_one,
+            fingerprint="SHA256:test-first",
+            created_at=now_utc,
+            expires_at=now_utc,
+        )
         SSHTunnelKey.objects.ttl(86400).create(
             id=uuid4(),
             user_id=g.user.id,
@@ -354,7 +378,7 @@ def test_get_authorized_keys_with_multiple_active_configs(flask_client: FlaskCli
 
 
 @pytest.mark.docker_required
-def test_get_authorized_keys_empty_when_no_keys(flask_client: FlaskClient, argus_db, active_config, service_user_identity):
+def test_get_authorized_keys_empty_when_no_keys(flask_client: FlaskClient, argus_db, active_config, ssh_tunnel_server_identity):
     """GET /ssh/keys for an empty database should return empty text."""
     for row in SSHTunnelKey.objects.all():
         row.delete()
@@ -377,6 +401,15 @@ def test_get_authorized_keys_unauthenticated(argus_db, active_config):
         g.user = previous_user
 
     assert resp.status_code == 403
+
+
+@pytest.mark.docker_required
+def test_ssh_tunnel_server_role_cannot_call_other_api(flask_client: FlaskClient, argus_db, ssh_tunnel_server_identity):
+    """ROLE_SSH_TUNNEL_SERVER should be hard-scoped to GET /client/ssh/keys only."""
+    resp = flask_client.get("/api/v1/version")
+    assert resp.status_code == 403
+    assert resp.json["status"] == "error"
+    assert "ROLE_SSH_TUNNEL_SERVER can only call GET /api/v1/client/ssh/keys" in resp.json["response"]["message"]
 
 
 # ---------------------------------------------------------------------------

--- a/argus/backend/tests/tunnel/test_ssh_api.py
+++ b/argus/backend/tests/tunnel/test_ssh_api.py
@@ -1,0 +1,269 @@
+"""
+Flask integration tests for the SSH tunnel API (Step 4a routes).
+
+Routes under test:
+    POST  /api/v1/client/ssh/tunnel
+    GET   /api/v1/client/ssh/keys
+
+Run with:
+    uv run pytest argus/backend/tests/tunnel/test_ssh_api.py -m docker_required -v
+"""
+import json
+from uuid import uuid4
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+from flask.testing import FlaskClient
+
+from argus.backend.models.ssh_key import ProxyTunnelConfig, SSHTunnelKey
+
+API_PREFIX = "/api/v1/client/ssh"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_public_key() -> str:
+    """Generate a fresh ed25519 public key in OpenSSH format."""
+    priv = Ed25519PrivateKey.generate()
+    pub = priv.public_key()
+    return pub.public_bytes(Encoding.OpenSSH, PublicFormat.OpenSSH).decode("utf-8")
+
+
+def _make_active_config(**overrides) -> ProxyTunnelConfig:
+    """Create and persist a ProxyTunnelConfig with is_active=True."""
+    defaults = dict(
+        id=uuid4(),
+        host=f"proxy-{uuid4().hex[:6]}.example.com",
+        port=22,
+        proxy_user="argus-proxy",
+        target_host="10.0.0.1",
+        target_port=8080,
+        host_key_fingerprint="SHA256:testfp",
+        is_active=True,
+    )
+    defaults.update(overrides)
+    return ProxyTunnelConfig.create(**defaults)
+
+
+def _json_post(client: FlaskClient, url: str, payload: dict) -> object:
+    return client.post(url, data=json.dumps(payload), content_type="application/json")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def active_config(argus_db) -> ProxyTunnelConfig:
+    # Deactivate any stale configs to keep the test environment predictable.
+    for cfg in ProxyTunnelConfig.objects.filter(is_active=True).all():
+        cfg.update(is_active=False)
+    config = _make_active_config()
+    yield config
+    try:
+        config.delete()
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/client/ssh/tunnel
+# ---------------------------------------------------------------------------
+
+@pytest.mark.docker_required
+def test_register_tunnel_success(flask_client: FlaskClient, argus_db, active_config):
+    """A valid POST /ssh/tunnel should return 200 with proxy connection details."""
+    payload = {"public_key": _make_public_key()}
+    resp = _json_post(flask_client, f"{API_PREFIX}/tunnel", payload)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json
+    assert body["status"] == "ok"
+    data = body["response"]
+    assert data["proxy_host"] == active_config.host
+    assert data["proxy_port"] == active_config.port
+    assert data["proxy_user"] == active_config.proxy_user
+    assert data["target_host"] == active_config.target_host
+    assert data["target_port"] == active_config.target_port
+    assert data["host_key_fingerprint"] == active_config.host_key_fingerprint
+    assert data["expires_at"].endswith("Z")
+    assert "key_id" in data
+    assert "tunnel_id" in data
+
+    # Verify the key was actually persisted in the DB
+    key = SSHTunnelKey.get(id=data["key_id"])
+    assert key.fingerprint.startswith("SHA256:")
+
+
+@pytest.mark.docker_required
+def test_register_tunnel_with_ttl_seconds(flask_client: FlaskClient, argus_db, active_config):
+    """ttl_seconds should be honoured and reflected in expires_at."""
+    from datetime import datetime, timezone
+
+    ttl = 7200  # 2 hours
+    payload = {"public_key": _make_public_key(), "ttl_seconds": ttl}
+    before = datetime.now(tz=timezone.utc)
+    resp = _json_post(flask_client, f"{API_PREFIX}/tunnel", payload)
+    after = datetime.now(tz=timezone.utc)
+
+    assert resp.status_code == 200
+    expires_at = datetime.fromisoformat(
+        resp.json["response"]["expires_at"].rstrip("Z")
+    ).replace(tzinfo=timezone.utc)
+    assert (before.timestamp() + ttl - 5) <= expires_at.timestamp() <= (after.timestamp() + ttl + 5)
+
+
+@pytest.mark.docker_required
+def test_register_tunnel_with_explicit_tunnel_id(flask_client: FlaskClient, argus_db):
+    """tunnel_id in the payload should register the key against that specific config."""
+    config = _make_active_config(is_active=False)
+    try:
+        payload = {"public_key": _make_public_key(), "tunnel_id": str(config.id)}
+        resp = _json_post(flask_client, f"{API_PREFIX}/tunnel", payload)
+
+        assert resp.status_code == 200
+        assert resp.json["response"]["tunnel_id"] == str(config.id)
+    finally:
+        try:
+            config.delete()
+        except Exception:
+            pass
+
+
+@pytest.mark.docker_required
+def test_register_tunnel_missing_public_key(flask_client: FlaskClient, argus_db, active_config):
+    """A request without public_key should return an error response."""
+    resp = _json_post(flask_client, f"{API_PREFIX}/tunnel", {})
+
+    assert resp.status_code == 200  # Flask error handler returns 200 with status=error
+    assert resp.json["status"] == "error"
+
+
+@pytest.mark.docker_required
+def test_register_tunnel_invalid_public_key(flask_client: FlaskClient, argus_db, active_config):
+    """An unparseable public key should return an error response."""
+    payload = {"public_key": "clearly-not-a-key"}
+    resp = _json_post(flask_client, f"{API_PREFIX}/tunnel", payload)
+
+    assert resp.status_code == 200
+    assert resp.json["status"] == "error"
+    assert "Invalid SSH public key" in resp.json["response"]["message"]
+
+
+@pytest.mark.docker_required
+def test_register_tunnel_invalid_tunnel_id(flask_client: FlaskClient, argus_db, active_config):
+    """A malformed tunnel_id UUID should return 400."""
+    payload = {"public_key": _make_public_key(), "tunnel_id": "not-a-uuid"}
+    resp = _json_post(flask_client, f"{API_PREFIX}/tunnel", payload)
+
+    assert resp.status_code == 400
+
+
+@pytest.mark.docker_required
+def test_register_tunnel_unauthenticated(argus_db, active_config):
+    """Requests without a valid auth token should be rejected with 403."""
+    from flask import g
+    from argus_backend import argus_app
+
+    previous_user = g.user
+    try:
+        g.user = None
+        with argus_app.test_client() as unauthenticated_client:
+            # Don't set any Authorization header — g.user will be None
+            resp = unauthenticated_client.post(
+                f"{API_PREFIX}/tunnel",
+                data=json.dumps({"public_key": _make_public_key()}),
+                content_type="application/json",
+            )
+    finally:
+        g.user = previous_user
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/client/ssh/keys
+# ---------------------------------------------------------------------------
+
+@pytest.mark.docker_required
+def test_get_authorized_keys_success(flask_client: FlaskClient, argus_db, active_config):
+    """GET /ssh/keys should return 200 with plain-text content."""
+    # Register a key first so there is something to return
+    pub_key = _make_public_key()
+    _json_post(flask_client, f"{API_PREFIX}/tunnel", {"public_key": pub_key})
+
+    resp = flask_client.get(f"{API_PREFIX}/keys")
+
+    assert resp.status_code == 200
+    assert resp.content_type.startswith("text/plain")
+    keys_text = resp.data.decode("utf-8")
+    assert pub_key.strip() in keys_text
+
+
+@pytest.mark.docker_required
+def test_get_authorized_keys_filtered_by_tunnel(flask_client: FlaskClient, argus_db):
+    """GET /ssh/keys?tunnel_id=<id> should only return keys for that tunnel."""
+    config_a = _make_active_config(is_active=False)
+    config_b = _make_active_config(is_active=False)
+    try:
+        pub_key_a = _make_public_key()
+        pub_key_b = _make_public_key()
+
+        _json_post(flask_client, f"{API_PREFIX}/tunnel", {
+            "public_key": pub_key_a, "tunnel_id": str(config_a.id)
+        })
+        _json_post(flask_client, f"{API_PREFIX}/tunnel", {
+            "public_key": pub_key_b, "tunnel_id": str(config_b.id)
+        })
+
+        resp = flask_client.get(f"{API_PREFIX}/keys?tunnel_id={config_a.id}")
+        assert resp.status_code == 200
+        keys_text = resp.data.decode("utf-8")
+        assert pub_key_a.strip() in keys_text
+        assert pub_key_b.strip() not in keys_text
+    finally:
+        for cfg in (config_a, config_b):
+            try:
+                cfg.delete()
+            except Exception:
+                pass
+
+
+@pytest.mark.docker_required
+def test_get_authorized_keys_invalid_tunnel_id(flask_client: FlaskClient, argus_db):
+    """GET /ssh/keys with a malformed tunnel_id should return 400."""
+    resp = flask_client.get(f"{API_PREFIX}/keys?tunnel_id=not-a-uuid")
+    assert resp.status_code == 400
+
+
+@pytest.mark.docker_required
+def test_get_authorized_keys_unauthenticated(argus_db, active_config):
+    """GET /ssh/keys without auth should return 403."""
+    from flask import g
+    from argus_backend import argus_app
+
+    previous_user = g.user
+    try:
+        g.user = None
+        with argus_app.test_client() as unauthenticated_client:
+            resp = unauthenticated_client.get(f"{API_PREFIX}/keys")
+    finally:
+        g.user = previous_user
+    assert resp.status_code == 403
+
+
+@pytest.mark.docker_required
+def test_get_authorized_keys_empty_when_no_keys(flask_client: FlaskClient, argus_db):
+    """GET /ssh/keys for a tunnel with no registered keys should return empty text."""
+    config = _make_active_config(is_active=False)
+    try:
+        resp = flask_client.get(f"{API_PREFIX}/keys?tunnel_id={config.id}")
+        assert resp.status_code == 200
+        assert resp.data.decode("utf-8").strip() == ""
+    finally:
+        try:
+            config.delete()
+        except Exception:
+            pass

--- a/argus/backend/tests/tunnel/test_ssh_api.py
+++ b/argus/backend/tests/tunnel/test_ssh_api.py
@@ -2,6 +2,7 @@
 Flask integration tests for the SSH tunnel API (Step 4a routes).
 
 Routes under test:
+    GET   /api/v1/client/ssh/tunnel
     POST  /api/v1/client/ssh/tunnel
     GET   /api/v1/client/ssh/keys
 
@@ -14,6 +15,7 @@ from uuid import uuid4
 import pytest
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+from flask import g
 from flask.testing import FlaskClient
 
 from argus.backend.models.ssh_key import ProxyTunnelConfig, SSHTunnelKey
@@ -52,21 +54,97 @@ def _json_post(client: FlaskClient, url: str, payload: dict) -> object:
     return client.post(url, data=json.dumps(payload), content_type="application/json")
 
 
+def _active_config_ids() -> list:
+    return [cfg.id for cfg in ProxyTunnelConfig.objects.all() if cfg.is_active]
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
 @pytest.fixture
 def active_config(argus_db) -> ProxyTunnelConfig:
-    # Deactivate any stale configs to keep the test environment predictable.
-    for cfg in ProxyTunnelConfig.objects.filter(is_active=True).all():
+    previous_active_ids = _active_config_ids()
+    for cfg_id in previous_active_ids:
+        cfg = ProxyTunnelConfig.get(id=cfg_id)
         cfg.update(is_active=False)
-    config = _make_active_config()
+
+    config = _make_active_config(service_user_id=g.user.id)
     yield config
     try:
         config.delete()
     except Exception:
         pass
+
+    for cfg_id in previous_active_ids:
+        try:
+            cfg = ProxyTunnelConfig.get(id=cfg_id)
+            cfg.update(is_active=True)
+        except Exception:
+            pass
+
+
+@pytest.fixture
+def service_user_identity():
+    previous = getattr(g.user, "service_user", False)
+    g.user.service_user = True
+    yield
+    g.user.service_user = previous
+
+
+@pytest.fixture
+def normal_user_identity():
+    previous = getattr(g.user, "service_user", False)
+    g.user.service_user = False
+    yield
+    g.user.service_user = previous
+
+
+def _deactivate_all_configs() -> list:
+    cfg_ids = _active_config_ids()
+    for cfg_id in cfg_ids:
+        ProxyTunnelConfig.get(id=cfg_id).update(is_active=False)
+    return cfg_ids
+
+
+def _restore_active_configs(cfg_ids: list):
+    for cfg_id in cfg_ids:
+        try:
+            ProxyTunnelConfig.get(id=cfg_id).update(is_active=True)
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/client/ssh/tunnel
+# ---------------------------------------------------------------------------
+
+@pytest.mark.docker_required
+def test_get_tunnel_connection_success(flask_client: FlaskClient, argus_db, active_config):
+    resp = flask_client.get(f"{API_PREFIX}/tunnel")
+
+    assert resp.status_code == 200
+    body = resp.json
+    assert body["status"] == "ok"
+    data = body["response"]
+    assert data["proxy_host"] == active_config.host
+    assert data["proxy_port"] == active_config.port
+    assert data["proxy_user"] == active_config.proxy_user
+    assert data["target_host"] == active_config.target_host
+    assert data["target_port"] == active_config.target_port
+    assert data["host_key_fingerprint"] == active_config.host_key_fingerprint
+
+
+@pytest.mark.docker_required
+def test_get_tunnel_connection_no_active_config_returns_error(flask_client: FlaskClient, argus_db):
+    previous_active_ids = _deactivate_all_configs()
+    try:
+        resp = flask_client.get(f"{API_PREFIX}/tunnel")
+        assert resp.status_code == 200
+        assert resp.json["status"] == "error"
+        assert "No active proxy tunnel configuration" in resp.json["response"]["message"]
+    finally:
+        _restore_active_configs(previous_active_ids)
 
 
 # ---------------------------------------------------------------------------
@@ -117,20 +195,14 @@ def test_register_tunnel_with_ttl_seconds(flask_client: FlaskClient, argus_db, a
 
 
 @pytest.mark.docker_required
-def test_register_tunnel_with_explicit_tunnel_id(flask_client: FlaskClient, argus_db):
-    """tunnel_id in the payload should register the key against that specific config."""
-    config = _make_active_config(is_active=False)
-    try:
-        payload = {"public_key": _make_public_key(), "tunnel_id": str(config.id)}
-        resp = _json_post(flask_client, f"{API_PREFIX}/tunnel", payload)
+def test_register_tunnel_invalid_ttl(flask_client: FlaskClient, argus_db, active_config):
+    """Invalid ttl_seconds should return an error response."""
+    payload = {"public_key": _make_public_key(), "ttl_seconds": 0}
+    resp = _json_post(flask_client, f"{API_PREFIX}/tunnel", payload)
 
-        assert resp.status_code == 200
-        assert resp.json["response"]["tunnel_id"] == str(config.id)
-    finally:
-        try:
-            config.delete()
-        except Exception:
-            pass
+    assert resp.status_code == 200
+    assert resp.json["status"] == "error"
+    assert "ttl_seconds must be a positive integer" in resp.json["response"]["message"]
 
 
 @pytest.mark.docker_required
@@ -154,25 +226,14 @@ def test_register_tunnel_invalid_public_key(flask_client: FlaskClient, argus_db,
 
 
 @pytest.mark.docker_required
-def test_register_tunnel_invalid_tunnel_id(flask_client: FlaskClient, argus_db, active_config):
-    """A malformed tunnel_id UUID should return 400."""
-    payload = {"public_key": _make_public_key(), "tunnel_id": "not-a-uuid"}
-    resp = _json_post(flask_client, f"{API_PREFIX}/tunnel", payload)
-
-    assert resp.status_code == 400
-
-
-@pytest.mark.docker_required
 def test_register_tunnel_unauthenticated(argus_db, active_config):
     """Requests without a valid auth token should be rejected with 403."""
-    from flask import g
     from argus_backend import argus_app
 
     previous_user = g.user
     try:
         g.user = None
         with argus_app.test_client() as unauthenticated_client:
-            # Don't set any Authorization header — g.user will be None
             resp = unauthenticated_client.post(
                 f"{API_PREFIX}/tunnel",
                 data=json.dumps({"public_key": _make_public_key()}),
@@ -180,6 +241,7 @@ def test_register_tunnel_unauthenticated(argus_db, active_config):
             )
     finally:
         g.user = previous_user
+
     assert resp.status_code == 403
 
 
@@ -188,7 +250,7 @@ def test_register_tunnel_unauthenticated(argus_db, active_config):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.docker_required
-def test_get_authorized_keys_success(flask_client: FlaskClient, argus_db, active_config):
+def test_get_authorized_keys_success(flask_client: FlaskClient, argus_db, active_config, service_user_identity):
     """GET /ssh/keys should return 200 with plain-text content."""
     # Register a key first so there is something to return
     pub_key = _make_public_key()
@@ -203,45 +265,25 @@ def test_get_authorized_keys_success(flask_client: FlaskClient, argus_db, active
 
 
 @pytest.mark.docker_required
-def test_get_authorized_keys_filtered_by_tunnel(flask_client: FlaskClient, argus_db):
-    """GET /ssh/keys?tunnel_id=<id> should only return keys for that tunnel."""
-    config_a = _make_active_config(is_active=False)
-    config_b = _make_active_config(is_active=False)
-    try:
-        pub_key_a = _make_public_key()
-        pub_key_b = _make_public_key()
-
-        _json_post(flask_client, f"{API_PREFIX}/tunnel", {
-            "public_key": pub_key_a, "tunnel_id": str(config_a.id)
-        })
-        _json_post(flask_client, f"{API_PREFIX}/tunnel", {
-            "public_key": pub_key_b, "tunnel_id": str(config_b.id)
-        })
-
-        resp = flask_client.get(f"{API_PREFIX}/keys?tunnel_id={config_a.id}")
-        assert resp.status_code == 200
-        keys_text = resp.data.decode("utf-8")
-        assert pub_key_a.strip() in keys_text
-        assert pub_key_b.strip() not in keys_text
-    finally:
-        for cfg in (config_a, config_b):
-            try:
-                cfg.delete()
-            except Exception:
-                pass
+def test_get_authorized_keys_forbidden_for_normal_user(flask_client: FlaskClient, argus_db, active_config, normal_user_identity):
+    """GET /ssh/keys should fail for non-service users."""
+    resp = flask_client.get(f"{API_PREFIX}/keys")
+    assert resp.status_code == 200
+    assert resp.json["status"] == "error"
+    assert "Only service users can fetch SSH authorized keys" in resp.json["response"]["message"]
 
 
 @pytest.mark.docker_required
-def test_get_authorized_keys_invalid_tunnel_id(flask_client: FlaskClient, argus_db):
-    """GET /ssh/keys with a malformed tunnel_id should return 400."""
-    resp = flask_client.get(f"{API_PREFIX}/keys?tunnel_id=not-a-uuid")
-    assert resp.status_code == 400
+def test_get_authorized_keys_empty_when_no_keys(flask_client: FlaskClient, argus_db, active_config, service_user_identity):
+    """GET /ssh/keys for a tunnel with no registered keys should return empty text."""
+    resp = flask_client.get(f"{API_PREFIX}/keys")
+    assert resp.status_code == 200
+    assert resp.data.decode("utf-8").strip() == ""
 
 
 @pytest.mark.docker_required
 def test_get_authorized_keys_unauthenticated(argus_db, active_config):
     """GET /ssh/keys without auth should return 403."""
-    from flask import g
     from argus_backend import argus_app
 
     previous_user = g.user
@@ -251,19 +293,5 @@ def test_get_authorized_keys_unauthenticated(argus_db, active_config):
             resp = unauthenticated_client.get(f"{API_PREFIX}/keys")
     finally:
         g.user = previous_user
+
     assert resp.status_code == 403
-
-
-@pytest.mark.docker_required
-def test_get_authorized_keys_empty_when_no_keys(flask_client: FlaskClient, argus_db):
-    """GET /ssh/keys for a tunnel with no registered keys should return empty text."""
-    config = _make_active_config(is_active=False)
-    try:
-        resp = flask_client.get(f"{API_PREFIX}/keys?tunnel_id={config.id}")
-        assert resp.status_code == 200
-        assert resp.data.decode("utf-8").strip() == ""
-    finally:
-        try:
-            config.delete()
-        except Exception:
-            pass

--- a/argus/backend/tests/tunnel/test_tunnel_service.py
+++ b/argus/backend/tests/tunnel/test_tunnel_service.py
@@ -14,6 +14,7 @@ from uuid import uuid4
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
+from argus.backend.models.runtime_store import RuntimeStore
 from argus.backend.models.ssh_key import ProxyTunnelConfig, SSHTunnelKey
 from argus.backend.models.web import User, UserRoles
 from argus.backend.service.tunnel_service import TunnelService, TunnelServiceException, _derive_fingerprint
@@ -82,6 +83,13 @@ def _restore_configs(config_ids: list) -> None:
             pass
 
 
+def _clear_proxy_rr_state() -> None:
+    try:
+        RuntimeStore.get(key="ssh_tunnel_proxy_rr_index").delete()
+    except RuntimeStore.DoesNotExist:
+        pass
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -100,6 +108,7 @@ def tunnel_user(argus_db) -> User:
 def active_config(argus_db) -> ProxyTunnelConfig:
     previous_active_ids = _active_config_ids()
     _deactivate_configs(previous_active_ids)
+    _clear_proxy_rr_state()
 
     config = _make_active_config()
     yield config
@@ -224,7 +233,7 @@ def test_get_authorized_keys_format(argus_db, tunnel_user, active_config):
     svc = TunnelService()
     svc.register_tunnel(user=tunnel_user, public_key=pub_key)
 
-    keys_text = svc.get_authorized_keys(service_user_id=active_config.service_user_id)
+    keys_text = svc.get_authorized_keys()
     lines = [ln for ln in keys_text.splitlines() if ln.strip()]
     assert any(pub_key.strip() in ln for ln in lines), "Registered key not found in authorized_keys output"
     for line in lines:
@@ -233,13 +242,41 @@ def test_get_authorized_keys_format(argus_db, tunnel_user, active_config):
 
 
 @pytest.mark.docker_required
-def test_get_authorized_keys_rejects_non_matching_service_user(argus_db, tunnel_user, active_config):
-    """get_authorized_keys should reject callers that are not the active tunnel service user."""
-    svc = TunnelService()
-    svc.register_tunnel(user=tunnel_user, public_key=_make_public_key())
+def test_get_authorized_keys_includes_keys_from_multiple_tunnels(argus_db, tunnel_user, active_config):
+    """authorized_keys should contain all keys across active tunnel hosts."""
+    second = _make_active_config(is_active=True)
+    try:
+        key_a = _make_public_key()
+        key_b = _make_public_key()
 
-    with pytest.raises(Exception, match="Not authorized"):
-        svc.get_authorized_keys(service_user_id=uuid4())
+        now_utc = datetime.now(tz=UTC).replace(tzinfo=None)
+        SSHTunnelKey.objects.ttl(86400).create(
+            id=uuid4(),
+            user_id=tunnel_user.id,
+            tunnel_id=active_config.id,
+            public_key=key_a,
+            fingerprint="SHA256:test-a",
+            created_at=now_utc,
+            expires_at=now_utc,
+        )
+        SSHTunnelKey.objects.ttl(86400).create(
+            id=uuid4(),
+            user_id=tunnel_user.id,
+            tunnel_id=second.id,
+            public_key=key_b,
+            fingerprint="SHA256:test-b",
+            created_at=now_utc,
+            expires_at=now_utc,
+        )
+
+        keys_text = TunnelService().get_authorized_keys()
+        assert key_a.strip() in keys_text
+        assert key_b.strip() in keys_text
+    finally:
+        try:
+            second.delete()
+        except Exception:
+            pass
 
 
 @pytest.mark.docker_required
@@ -313,7 +350,7 @@ def test_save_proxy_tunnel_config_creates_service_user(argus_db):
 
 @pytest.mark.docker_required
 def test_save_proxy_tunnel_config_deactivates_old(argus_db):
-    """Creating a new config should deactivate the previously active one."""
+    """Creating a new config should leave prior active configs active."""
     previous_active_ids = _active_config_ids()
     _deactivate_configs(previous_active_ids)
 
@@ -342,7 +379,7 @@ def test_save_proxy_tunnel_config_deactivates_old(argus_db):
         assert second["is_active"] is True
 
         refreshed_first = ProxyTunnelConfig.get(id=first["id"])
-        assert refreshed_first.is_active is False
+        assert refreshed_first.is_active is True
     finally:
         _restore_configs(previous_active_ids)
 
@@ -402,3 +439,64 @@ def test_get_tunnel_connection_returns_active_fields(argus_db, active_config):
     assert result["target_host"] == active_config.target_host
     assert result["target_port"] == active_config.target_port
     assert result["host_key_fingerprint"] == active_config.host_key_fingerprint
+
+
+@pytest.mark.docker_required
+def test_register_tunnel_uses_round_robin_when_multiple_active(argus_db, tunnel_user, active_config):
+    """register_tunnel should rotate selected host when multiple active configs exist."""
+    second = _make_active_config(is_active=True)
+    try:
+        _clear_proxy_rr_state()
+        svc = TunnelService()
+        first = svc.register_tunnel(user=tunnel_user, public_key=_make_public_key())
+        second_pick = svc.register_tunnel(user=tunnel_user, public_key=_make_public_key())
+
+        assert first["proxy_host"] != second_pick["proxy_host"]
+        assert {first["proxy_host"], second_pick["proxy_host"]} == {active_config.host, second.host}
+    finally:
+        try:
+            second.delete()
+        except Exception:
+            pass
+
+
+@pytest.mark.docker_required
+def test_get_tunnel_connection_selects_specific_host(argus_db, active_config):
+    """get_tunnel_connection should return requested active host when proxy_host is provided."""
+    second = _make_active_config(is_active=True)
+    try:
+        result = TunnelService().get_tunnel_connection(proxy_host=second.host)
+        assert result["proxy_host"] == second.host
+        assert result["proxy_port"] == second.port
+        assert result["proxy_user"] == second.proxy_user
+    finally:
+        try:
+            second.delete()
+        except Exception:
+            pass
+
+
+@pytest.mark.docker_required
+def test_get_tunnel_connection_unknown_host_raises(argus_db, active_config):
+    """Selecting an inactive/unknown host should raise."""
+    with pytest.raises(TunnelServiceException, match="No active proxy tunnel configuration found for host"):
+        TunnelService().get_tunnel_connection(proxy_host="missing-host.example.com")
+
+
+@pytest.mark.docker_required
+def test_get_tunnel_connection_round_robin(argus_db, active_config):
+    """get_tunnel_connection without proxy_host should rotate across active hosts."""
+    second = _make_active_config(is_active=True)
+    try:
+        _clear_proxy_rr_state()
+        svc = TunnelService()
+        first = svc.get_tunnel_connection()
+        second_pick = svc.get_tunnel_connection()
+
+        assert first["proxy_host"] != second_pick["proxy_host"]
+        assert {first["proxy_host"], second_pick["proxy_host"]} == {active_config.host, second.host}
+    finally:
+        try:
+            second.delete()
+        except Exception:
+            pass

--- a/argus/backend/tests/tunnel/test_tunnel_service.py
+++ b/argus/backend/tests/tunnel/test_tunnel_service.py
@@ -132,18 +132,18 @@ def test_register_tunnel_stores_key(argus_db, tunnel_user, active_config):
 
     result = svc.register_tunnel(user=tunnel_user, public_key=pub_key)
 
-    assert result["proxy_host"] == active_config.host
-    assert result["proxy_port"] == active_config.port
-    assert result["proxy_user"] == active_config.proxy_user
-    assert result["target_host"] == active_config.target_host
-    assert result["target_port"] == active_config.target_port
-    assert result["host_key_fingerprint"] == active_config.host_key_fingerprint
-    assert isinstance(result["expires_at"], datetime)
-    assert "key_id" in result
-    assert "tunnel_id" in result
+    assert result.proxy_host == active_config.host
+    assert result.proxy_port == active_config.port
+    assert result.proxy_user == active_config.proxy_user
+    assert result.target_host == active_config.target_host
+    assert result.target_port == active_config.target_port
+    assert result.host_key_fingerprint == active_config.host_key_fingerprint
+    assert isinstance(result.expires_at, datetime)
+    assert result.key_id is not None
+    assert result.tunnel_id is not None
 
     # Verify the DB row exists
-    key = SSHTunnelKey.get(id=result["key_id"])
+    key = SSHTunnelKey.get(id=result.key_id)
     assert str(key.user_id) == str(tunnel_user.id)
     assert str(key.tunnel_id) == str(active_config.id)
     assert key.public_key == pub_key.strip()
@@ -162,18 +162,18 @@ def test_register_tunnel_custom_ttl(argus_db, tunnel_user, active_config):
     result = svc.register_tunnel(user=tunnel_user, public_key=pub_key, ttl_seconds=ttl)
     after = datetime.now(tz=timezone.utc)
 
-    expires_at = result["expires_at"].replace(tzinfo=timezone.utc)
+    expires_at = result.expires_at.replace(tzinfo=timezone.utc)
     # expires_at should be approximately now + 1 hour (allow ±5 s for test timing)
     assert (before.timestamp() + ttl - 5) <= expires_at.timestamp() <= (after.timestamp() + ttl + 5)
 
 
 @pytest.mark.docker_required
 def test_register_tunnel_invalid_ttl_raises(argus_db, tunnel_user, active_config):
-    """TTL outside [24h, 30d] or non-integer ttl_seconds should raise TunnelServiceException."""
+    """TTL outside [1h, 30d] or non-integer ttl_seconds should raise TunnelServiceException."""
     svc = TunnelService()
 
-    for ttl in (0, -1, 86399, 2592001, "abc", "0"):
-        with pytest.raises(TunnelServiceException, match="ttl_seconds must be between 86400 and 2592000 seconds"):
+    for ttl in (0, -1, 3599, 2592001, "abc", "0"):
+        with pytest.raises(TunnelServiceException, match="ttl_seconds must be between 3600 and 2592000 seconds"):
             svc.register_tunnel(user=tunnel_user, public_key=_make_public_key(), ttl_seconds=ttl)
 
 
@@ -188,7 +188,7 @@ def test_register_tunnel_ttl_upper_bound_allowed(argus_db, tunnel_user, active_c
     result = svc.register_tunnel(user=tunnel_user, public_key=_make_public_key(), ttl_seconds=ttl)
     after = datetime.now(tz=timezone.utc)
 
-    expires_at = result["expires_at"].replace(tzinfo=timezone.utc)
+    expires_at = result.expires_at.replace(tzinfo=timezone.utc)
     assert (before.timestamp() + ttl - 5) <= expires_at.timestamp() <= (after.timestamp() + ttl + 5)
 
 
@@ -298,7 +298,7 @@ def test_delete_key_removes_row(argus_db, tunnel_user, active_config):
     pub_key = _make_public_key()
     svc = TunnelService()
     result = svc.register_tunnel(user=tunnel_user, public_key=pub_key)
-    key_id = result["key_id"]
+    key_id = result.key_id
 
     svc.delete_key(key_id)
 
@@ -307,11 +307,10 @@ def test_delete_key_removes_row(argus_db, tunnel_user, active_config):
 
 
 @pytest.mark.docker_required
-def test_delete_key_nonexistent_raises(argus_db):
-    """delete_key for an unknown id should raise TunnelServiceException."""
+def test_delete_key_nonexistent_is_noop(argus_db):
+    """delete_key for an unknown id should not raise (already TTL-expired is valid)."""
     svc = TunnelService()
-    with pytest.raises(TunnelServiceException, match="not found"):
-        svc.delete_key(uuid4())
+    svc.delete_key(uuid4())
 
 
 # ---------------------------------------------------------------------------
@@ -337,13 +336,14 @@ def test_save_proxy_tunnel_config_creates_service_user(argus_db):
         svc = TunnelService()
         result = svc.save_proxy_tunnel_config(payload)
 
-        assert result["is_active"] is True
-        assert result["service_user_id"] is not None
-        assert "api_token" in result
+        assert result.is_active is True
+        assert result.service_user_id is not None
+        assert result.api_token is not None
 
-        service_user = User.get(id=result["service_user_id"])
+        service_user = User.get(id=result.service_user_id)
         assert service_user.service_user is True
         assert f"proxy-tunnel-{host}" in service_user.username
+        assert service_user.roles == [UserRoles.SSHTunnelServer.value]
     finally:
         _restore_configs(previous_active_ids)
 
@@ -365,7 +365,7 @@ def test_save_proxy_tunnel_config_deactivates_old(argus_db):
         )
         svc = TunnelService()
         first = svc.save_proxy_tunnel_config(first_payload)
-        assert first["is_active"] is True
+        assert first.is_active is True
 
         second_payload = dict(
             host=f"proxy-second-{uuid4().hex[:6]}.example.com",
@@ -376,9 +376,9 @@ def test_save_proxy_tunnel_config_deactivates_old(argus_db):
             host_key_fingerprint="SHA256:second",
         )
         second = svc.save_proxy_tunnel_config(second_payload)
-        assert second["is_active"] is True
+        assert second.is_active is True
 
-        refreshed_first = ProxyTunnelConfig.get(id=first["id"])
+        refreshed_first = ProxyTunnelConfig.get(id=first.id)
         assert refreshed_first.is_active is True
     finally:
         _restore_configs(previous_active_ids)
@@ -407,8 +407,8 @@ def test_get_proxy_tunnel_config_returns_active(argus_db):
         svc = TunnelService()
         result = svc.get_proxy_tunnel_config()
         assert result is not None
-        assert str(result["id"]) == str(config.id)
-        assert result["is_active"] is True
+        assert str(result.id) == str(config.id)
+        assert result.is_active is True
     finally:
         try:
             config.delete()
@@ -433,12 +433,12 @@ def test_get_proxy_tunnel_config_none_when_no_active(argus_db):
 def test_get_tunnel_connection_returns_active_fields(argus_db, active_config):
     """get_tunnel_connection should return active config fields used by SSH clients."""
     result = TunnelService().get_tunnel_connection()
-    assert result["proxy_host"] == active_config.host
-    assert result["proxy_port"] == active_config.port
-    assert result["proxy_user"] == active_config.proxy_user
-    assert result["target_host"] == active_config.target_host
-    assert result["target_port"] == active_config.target_port
-    assert result["host_key_fingerprint"] == active_config.host_key_fingerprint
+    assert result.proxy_host == active_config.host
+    assert result.proxy_port == active_config.port
+    assert result.proxy_user == active_config.proxy_user
+    assert result.target_host == active_config.target_host
+    assert result.target_port == active_config.target_port
+    assert result.host_key_fingerprint == active_config.host_key_fingerprint
 
 
 @pytest.mark.docker_required
@@ -451,8 +451,8 @@ def test_register_tunnel_uses_round_robin_when_multiple_active(argus_db, tunnel_
         first = svc.register_tunnel(user=tunnel_user, public_key=_make_public_key())
         second_pick = svc.register_tunnel(user=tunnel_user, public_key=_make_public_key())
 
-        assert first["proxy_host"] != second_pick["proxy_host"]
-        assert {first["proxy_host"], second_pick["proxy_host"]} == {active_config.host, second.host}
+        assert first.proxy_host != second_pick.proxy_host
+        assert {first.proxy_host, second_pick.proxy_host} == {active_config.host, second.host}
     finally:
         try:
             second.delete()
@@ -466,9 +466,9 @@ def test_get_tunnel_connection_selects_specific_host(argus_db, active_config):
     second = _make_active_config(is_active=True)
     try:
         result = TunnelService().get_tunnel_connection(proxy_host=second.host)
-        assert result["proxy_host"] == second.host
-        assert result["proxy_port"] == second.port
-        assert result["proxy_user"] == second.proxy_user
+        assert result.proxy_host == second.host
+        assert result.proxy_port == second.port
+        assert result.proxy_user == second.proxy_user
     finally:
         try:
             second.delete()
@@ -493,8 +493,8 @@ def test_get_tunnel_connection_round_robin(argus_db, active_config):
         first = svc.get_tunnel_connection()
         second_pick = svc.get_tunnel_connection()
 
-        assert first["proxy_host"] != second_pick["proxy_host"]
-        assert {first["proxy_host"], second_pick["proxy_host"]} == {active_config.host, second.host}
+        assert first.proxy_host != second_pick.proxy_host
+        assert {first.proxy_host, second_pick.proxy_host} == {active_config.host, second.host}
     finally:
         try:
             second.delete()

--- a/argus/backend/tests/tunnel/test_tunnel_service.py
+++ b/argus/backend/tests/tunnel/test_tunnel_service.py
@@ -1,0 +1,372 @@
+"""
+Tests for TunnelService — require a running ScyllaDB container.
+
+Run with:
+    uv run pytest argus/backend/tests/tunnel/test_tunnel_service.py -m docker_required -v
+"""
+import pytest
+from datetime import UTC, datetime
+from secrets import token_hex
+from uuid import uuid4
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from argus.backend.models.ssh_key import ProxyTunnelConfig, SSHTunnelKey
+from argus.backend.models.web import User, UserRoles
+from argus.backend.service.tunnel_service import TunnelService, TunnelServiceException
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_public_key() -> str:
+    """Generate a fresh ed25519 public key in OpenSSH format."""
+    priv = Ed25519PrivateKey.generate()
+    pub = priv.public_key()
+    return pub.public_bytes(Encoding.OpenSSH, PublicFormat.OpenSSH).decode("utf-8")
+
+
+def _make_user() -> User:
+    """Create and persist a transient Argus user for testing."""
+    return User.create(
+        id=uuid4(),
+        username=f"tunnel_test_{uuid4().hex[:8]}",
+        full_name="Tunnel Test User",
+        password="",
+        email=f"tunnel_test_{uuid4().hex[:8]}@test.internal",
+        registration_date=datetime.now(tz=UTC),
+        roles=[UserRoles.User.value],
+        api_token=token_hex(32),
+        service_user=False,
+    )
+
+
+def _make_active_config(**overrides) -> ProxyTunnelConfig:
+    """Create and persist a ProxyTunnelConfig with is_active=True."""
+    defaults = dict(
+        id=uuid4(),
+        host=f"proxy-{uuid4().hex[:6]}.example.com",
+        port=22,
+        proxy_user="argus-proxy",
+        target_host="10.0.0.1",
+        target_port=8080,
+        host_key_fingerprint="SHA256:testfingerprint",
+        is_active=True,
+    )
+    defaults.update(overrides)
+    return ProxyTunnelConfig.create(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tunnel_user(argus_db) -> User:
+    user = _make_user()
+    yield user
+    try:
+        user.delete()
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def active_config(argus_db) -> ProxyTunnelConfig:
+    config = _make_active_config()
+    yield config
+    try:
+        config.delete()
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# TunnelService.register_tunnel
+# ---------------------------------------------------------------------------
+
+@pytest.mark.docker_required
+def test_register_tunnel_stores_key(argus_db, tunnel_user, active_config):
+    """register_tunnel should persist an SSHTunnelKey row in the DB."""
+    pub_key = _make_public_key()
+    svc = TunnelService()
+
+    result = svc.register_tunnel(user=tunnel_user, public_key=pub_key)
+
+    assert result["proxy_host"] == active_config.host
+    assert result["proxy_port"] == active_config.port
+    assert result["proxy_user"] == active_config.proxy_user
+    assert result["target_host"] == active_config.target_host
+    assert result["target_port"] == active_config.target_port
+    assert result["host_key_fingerprint"] == active_config.host_key_fingerprint
+    assert result["expires_at"].endswith("Z")
+    assert "key_id" in result
+    assert "tunnel_id" in result
+
+    # Verify the DB row exists
+    key = SSHTunnelKey.get(id=result["key_id"])
+    assert str(key.user_id) == str(tunnel_user.id)
+    assert str(key.tunnel_id) == str(active_config.id)
+    assert key.public_key == pub_key.strip()
+    assert key.fingerprint.startswith("SHA256:")
+
+
+@pytest.mark.docker_required
+def test_register_tunnel_custom_ttl(argus_db, tunnel_user, active_config):
+    """A custom ttl_seconds should be reflected in the expires_at timestamp."""
+    from datetime import datetime, timezone
+    pub_key = _make_public_key()
+    svc = TunnelService()
+    ttl = 3600  # 1 hour
+
+    before = datetime.now(tz=timezone.utc)
+    result = svc.register_tunnel(user=tunnel_user, public_key=pub_key, ttl_seconds=ttl)
+    after = datetime.now(tz=timezone.utc)
+
+    expires_at = datetime.fromisoformat(result["expires_at"].rstrip("Z")).replace(tzinfo=timezone.utc)
+    # expires_at should be approximately now + 1 hour (allow ±5 s for test timing)
+    assert (before.timestamp() + ttl - 5) <= expires_at.timestamp() <= (after.timestamp() + ttl + 5)
+
+
+@pytest.mark.docker_required
+def test_register_tunnel_no_active_config_raises(argus_db, tunnel_user):
+    """register_tunnel should raise TunnelServiceException when no active config exists."""
+    # Deactivate all configs
+    for cfg in ProxyTunnelConfig.objects.filter(is_active=True).all():
+        cfg.update(is_active=False)
+
+    svc = TunnelService()
+    with pytest.raises(TunnelServiceException, match="No active proxy tunnel"):
+        svc.register_tunnel(user=tunnel_user, public_key=_make_public_key())
+
+
+@pytest.mark.docker_required
+def test_register_tunnel_invalid_public_key(argus_db, tunnel_user, active_config):
+    """Submitting garbage as a public key should raise TunnelServiceException."""
+    svc = TunnelService()
+    with pytest.raises(TunnelServiceException, match="Invalid SSH public key"):
+        svc.register_tunnel(user=tunnel_user, public_key="this-is-not-a-valid-key")
+
+
+@pytest.mark.docker_required
+def test_register_tunnel_missing_public_key(argus_db, tunnel_user, active_config):
+    """Missing public_key should raise TunnelServiceException."""
+    svc = TunnelService()
+    with pytest.raises(TunnelServiceException, match="public_key is required"):
+        svc.register_tunnel(user=tunnel_user, public_key="")
+
+
+@pytest.mark.docker_required
+def test_register_tunnel_by_tunnel_id(argus_db, tunnel_user):
+    """register_tunnel should accept an explicit tunnel_id."""
+    config = _make_active_config(is_active=False)  # not the active one
+    try:
+        pub_key = _make_public_key()
+        svc = TunnelService()
+        result = svc.register_tunnel(user=tunnel_user, public_key=pub_key, tunnel_id=config.id)
+        assert result["tunnel_id"] == str(config.id)
+    finally:
+        try:
+            config.delete()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# TunnelService.get_authorized_keys
+# ---------------------------------------------------------------------------
+
+@pytest.mark.docker_required
+def test_get_authorized_keys_format(argus_db, tunnel_user, active_config):
+    """Each line of get_authorized_keys output should be a valid OpenSSH key."""
+    pub_key = _make_public_key()
+    svc = TunnelService()
+    svc.register_tunnel(user=tunnel_user, public_key=pub_key)
+
+    keys_text = svc.get_authorized_keys(tunnel_id=active_config.id)
+    lines = [ln for ln in keys_text.splitlines() if ln.strip()]
+    assert any(pub_key.strip() in ln for ln in lines), "Registered key not found in authorized_keys output"
+    for line in lines:
+        # Each line must start with a key type
+        assert line.startswith(("ssh-", "ecdsa-", "sk-")), f"Unexpected line format: {line!r}"
+
+
+@pytest.mark.docker_required
+def test_get_authorized_keys_scoped_by_tunnel(argus_db, tunnel_user):
+    """get_authorized_keys with a specific tunnel_id should not return keys from other tunnels."""
+    config_a = _make_active_config(is_active=False)
+    config_b = _make_active_config(is_active=False)
+    try:
+        pub_key_a = _make_public_key()
+        pub_key_b = _make_public_key()
+        svc = TunnelService()
+        svc.register_tunnel(user=tunnel_user, public_key=pub_key_a, tunnel_id=config_a.id)
+        svc.register_tunnel(user=tunnel_user, public_key=pub_key_b, tunnel_id=config_b.id)
+
+        keys_for_a = svc.get_authorized_keys(tunnel_id=config_a.id)
+        assert pub_key_a.strip() in keys_for_a
+        assert pub_key_b.strip() not in keys_for_a
+
+        keys_for_b = svc.get_authorized_keys(tunnel_id=config_b.id)
+        assert pub_key_b.strip() in keys_for_b
+        assert pub_key_a.strip() not in keys_for_b
+    finally:
+        for cfg in (config_a, config_b):
+            try:
+                cfg.delete()
+            except Exception:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# TunnelService.delete_key
+# ---------------------------------------------------------------------------
+
+@pytest.mark.docker_required
+def test_delete_key_removes_row(argus_db, tunnel_user, active_config):
+    """delete_key should remove the SSHTunnelKey row from the DB."""
+    pub_key = _make_public_key()
+    svc = TunnelService()
+    result = svc.register_tunnel(user=tunnel_user, public_key=pub_key)
+    key_id = result["key_id"]
+
+    svc.delete_key(key_id)
+
+    with pytest.raises(SSHTunnelKey.DoesNotExist):
+        SSHTunnelKey.get(id=key_id)
+
+
+@pytest.mark.docker_required
+def test_delete_key_nonexistent_raises(argus_db):
+    """delete_key for an unknown id should raise TunnelServiceException."""
+    svc = TunnelService()
+    with pytest.raises(TunnelServiceException, match="not found"):
+        svc.delete_key(uuid4())
+
+
+# ---------------------------------------------------------------------------
+# TunnelService.save_proxy_tunnel_config
+# ---------------------------------------------------------------------------
+
+@pytest.mark.docker_required
+def test_save_proxy_tunnel_config_creates_service_user(argus_db):
+    """save_proxy_tunnel_config should create a dedicated service user."""
+    # Deactivate all configs first so we start clean
+    for cfg in ProxyTunnelConfig.objects.filter(is_active=True).all():
+        cfg.update(is_active=False)
+
+    host = f"proxy-svcuser-{uuid4().hex[:6]}.example.com"
+    payload = dict(
+        host=host,
+        port=22,
+        proxy_user="argus-proxy",
+        target_host="10.0.1.1",
+        target_port=8080,
+        host_key_fingerprint="SHA256:svcusertest",
+    )
+    svc = TunnelService()
+    result = svc.save_proxy_tunnel_config(payload)
+
+    assert result["is_active"] is True
+    assert result["service_user_id"] is not None
+    assert "api_token" in result  # token returned so admin can provision
+
+    # Service user exists in DB
+    service_user = User.get(id=result["service_user_id"])
+    assert service_user.service_user is True
+    assert f"proxy-tunnel-{host}" in service_user.username
+
+
+@pytest.mark.docker_required
+def test_save_proxy_tunnel_config_deactivates_old(argus_db):
+    """Creating a new config should deactivate the previously active one."""
+    # Deactivate any stale configs
+    for cfg in ProxyTunnelConfig.objects.filter(is_active=True).all():
+        cfg.update(is_active=False)
+
+    first_payload = dict(
+        host=f"proxy-first-{uuid4().hex[:6]}.example.com",
+        port=22,
+        proxy_user="argus-proxy",
+        target_host="10.0.2.1",
+        target_port=8080,
+        host_key_fingerprint="SHA256:first",
+    )
+    svc = TunnelService()
+    first = svc.save_proxy_tunnel_config(first_payload)
+    assert first["is_active"] is True
+
+    second_payload = dict(
+        host=f"proxy-second-{uuid4().hex[:6]}.example.com",
+        port=22,
+        proxy_user="argus-proxy",
+        target_host="10.0.2.2",
+        target_port=8080,
+        host_key_fingerprint="SHA256:second",
+    )
+    second = svc.save_proxy_tunnel_config(second_payload)
+    assert second["is_active"] is True
+
+    # The first config should now be inactive in the DB
+    refreshed_first = ProxyTunnelConfig.get(id=first["id"])
+    assert refreshed_first.is_active is False
+
+
+@pytest.mark.docker_required
+def test_save_proxy_tunnel_config_missing_fields(argus_db):
+    """save_proxy_tunnel_config should raise when required fields are absent."""
+    svc = TunnelService()
+    with pytest.raises(TunnelServiceException, match="Missing required fields"):
+        svc.save_proxy_tunnel_config({"host": "proxy.example.com"})
+
+
+# ---------------------------------------------------------------------------
+# TunnelService.get_proxy_tunnel_config
+# ---------------------------------------------------------------------------
+
+@pytest.mark.docker_required
+def test_get_proxy_tunnel_config_returns_active(argus_db):
+    """get_proxy_tunnel_config should return the currently active config."""
+    for cfg in ProxyTunnelConfig.objects.filter(is_active=True).all():
+        cfg.update(is_active=False)
+
+    config = _make_active_config()
+    try:
+        svc = TunnelService()
+        result = svc.get_proxy_tunnel_config()
+        assert result is not None
+        assert result["id"] == str(config.id)
+        assert result["is_active"] is True
+    finally:
+        try:
+            config.delete()
+        except Exception:
+            pass
+
+
+@pytest.mark.docker_required
+def test_get_proxy_tunnel_config_by_id(argus_db):
+    """get_proxy_tunnel_config with a tunnel_id should return that specific config."""
+    config = _make_active_config(is_active=False)
+    try:
+        svc = TunnelService()
+        result = svc.get_proxy_tunnel_config(tunnel_id=config.id)
+        assert result is not None
+        assert result["id"] == str(config.id)
+    finally:
+        try:
+            config.delete()
+        except Exception:
+            pass
+
+
+@pytest.mark.docker_required
+def test_get_proxy_tunnel_config_none_when_no_active(argus_db):
+    """get_proxy_tunnel_config should return None when no active config exists."""
+    for cfg in ProxyTunnelConfig.objects.filter(is_active=True).all():
+        cfg.update(is_active=False)
+
+    svc = TunnelService()
+    assert svc.get_proxy_tunnel_config() is None

--- a/argus/backend/tests/tunnel/test_tunnel_service.py
+++ b/argus/backend/tests/tunnel/test_tunnel_service.py
@@ -4,6 +4,8 @@ Tests for TunnelService — require a running ScyllaDB container.
 Run with:
     uv run pytest argus/backend/tests/tunnel/test_tunnel_service.py -m docker_required -v
 """
+import base64
+import hashlib
 import pytest
 from datetime import UTC, datetime
 from secrets import token_hex
@@ -14,7 +16,7 @@ from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
 from argus.backend.models.ssh_key import ProxyTunnelConfig, SSHTunnelKey
 from argus.backend.models.web import User, UserRoles
-from argus.backend.service.tunnel_service import TunnelService, TunnelServiceException
+from argus.backend.service.tunnel_service import TunnelService, TunnelServiceException, _derive_fingerprint
 
 
 # ---------------------------------------------------------------------------
@@ -53,10 +55,31 @@ def _make_active_config(**overrides) -> ProxyTunnelConfig:
         target_host="10.0.0.1",
         target_port=8080,
         host_key_fingerprint="SHA256:testfingerprint",
+        service_user_id=uuid4(),
         is_active=True,
     )
     defaults.update(overrides)
     return ProxyTunnelConfig.create(**defaults)
+
+
+def _active_config_ids() -> list:
+    return [cfg.id for cfg in ProxyTunnelConfig.objects.all() if cfg.is_active]
+
+
+def _deactivate_configs(config_ids: list) -> None:
+    for cfg_id in config_ids:
+        try:
+            ProxyTunnelConfig.get(id=cfg_id).update(is_active=False)
+        except Exception:
+            pass
+
+
+def _restore_configs(config_ids: list) -> None:
+    for cfg_id in config_ids:
+        try:
+            ProxyTunnelConfig.get(id=cfg_id).update(is_active=True)
+        except Exception:
+            pass
 
 
 # ---------------------------------------------------------------------------
@@ -75,12 +98,17 @@ def tunnel_user(argus_db) -> User:
 
 @pytest.fixture
 def active_config(argus_db) -> ProxyTunnelConfig:
+    previous_active_ids = _active_config_ids()
+    _deactivate_configs(previous_active_ids)
+
     config = _make_active_config()
     yield config
     try:
         config.delete()
     except Exception:
         pass
+
+    _restore_configs(previous_active_ids)
 
 
 # ---------------------------------------------------------------------------
@@ -101,7 +129,7 @@ def test_register_tunnel_stores_key(argus_db, tunnel_user, active_config):
     assert result["target_host"] == active_config.target_host
     assert result["target_port"] == active_config.target_port
     assert result["host_key_fingerprint"] == active_config.host_key_fingerprint
-    assert result["expires_at"].endswith("Z")
+    assert isinstance(result["expires_at"], datetime)
     assert "key_id" in result
     assert "tunnel_id" in result
 
@@ -125,21 +153,33 @@ def test_register_tunnel_custom_ttl(argus_db, tunnel_user, active_config):
     result = svc.register_tunnel(user=tunnel_user, public_key=pub_key, ttl_seconds=ttl)
     after = datetime.now(tz=timezone.utc)
 
-    expires_at = datetime.fromisoformat(result["expires_at"].rstrip("Z")).replace(tzinfo=timezone.utc)
+    expires_at = result["expires_at"].replace(tzinfo=timezone.utc)
     # expires_at should be approximately now + 1 hour (allow ±5 s for test timing)
     assert (before.timestamp() + ttl - 5) <= expires_at.timestamp() <= (after.timestamp() + ttl + 5)
 
 
 @pytest.mark.docker_required
+def test_register_tunnel_invalid_ttl_raises(argus_db, tunnel_user, active_config):
+    """Non-positive or non-integer ttl_seconds should raise TunnelServiceException."""
+    svc = TunnelService()
+
+    for ttl in (0, -1, "abc", "0"):
+        with pytest.raises(TunnelServiceException, match="ttl_seconds must be a positive integer"):
+            svc.register_tunnel(user=tunnel_user, public_key=_make_public_key(), ttl_seconds=ttl)
+
+
+@pytest.mark.docker_required
 def test_register_tunnel_no_active_config_raises(argus_db, tunnel_user):
     """register_tunnel should raise TunnelServiceException when no active config exists."""
-    # Deactivate all configs
-    for cfg in ProxyTunnelConfig.objects.filter(is_active=True).all():
-        cfg.update(is_active=False)
+    previous_active_ids = _active_config_ids()
+    _deactivate_configs(previous_active_ids)
 
-    svc = TunnelService()
-    with pytest.raises(TunnelServiceException, match="No active proxy tunnel"):
-        svc.register_tunnel(user=tunnel_user, public_key=_make_public_key())
+    try:
+        svc = TunnelService()
+        with pytest.raises(TunnelServiceException, match="No active proxy tunnel"):
+            svc.register_tunnel(user=tunnel_user, public_key=_make_public_key())
+    finally:
+        _restore_configs(previous_active_ids)
 
 
 @pytest.mark.docker_required
@@ -158,22 +198,6 @@ def test_register_tunnel_missing_public_key(argus_db, tunnel_user, active_config
         svc.register_tunnel(user=tunnel_user, public_key="")
 
 
-@pytest.mark.docker_required
-def test_register_tunnel_by_tunnel_id(argus_db, tunnel_user):
-    """register_tunnel should accept an explicit tunnel_id."""
-    config = _make_active_config(is_active=False)  # not the active one
-    try:
-        pub_key = _make_public_key()
-        svc = TunnelService()
-        result = svc.register_tunnel(user=tunnel_user, public_key=pub_key, tunnel_id=config.id)
-        assert result["tunnel_id"] == str(config.id)
-    finally:
-        try:
-            config.delete()
-        except Exception:
-            pass
-
-
 # ---------------------------------------------------------------------------
 # TunnelService.get_authorized_keys
 # ---------------------------------------------------------------------------
@@ -185,7 +209,7 @@ def test_get_authorized_keys_format(argus_db, tunnel_user, active_config):
     svc = TunnelService()
     svc.register_tunnel(user=tunnel_user, public_key=pub_key)
 
-    keys_text = svc.get_authorized_keys(tunnel_id=active_config.id)
+    keys_text = svc.get_authorized_keys(service_user_id=active_config.service_user_id)
     lines = [ln for ln in keys_text.splitlines() if ln.strip()]
     assert any(pub_key.strip() in ln for ln in lines), "Registered key not found in authorized_keys output"
     for line in lines:
@@ -194,30 +218,22 @@ def test_get_authorized_keys_format(argus_db, tunnel_user, active_config):
 
 
 @pytest.mark.docker_required
-def test_get_authorized_keys_scoped_by_tunnel(argus_db, tunnel_user):
-    """get_authorized_keys with a specific tunnel_id should not return keys from other tunnels."""
-    config_a = _make_active_config(is_active=False)
-    config_b = _make_active_config(is_active=False)
-    try:
-        pub_key_a = _make_public_key()
-        pub_key_b = _make_public_key()
-        svc = TunnelService()
-        svc.register_tunnel(user=tunnel_user, public_key=pub_key_a, tunnel_id=config_a.id)
-        svc.register_tunnel(user=tunnel_user, public_key=pub_key_b, tunnel_id=config_b.id)
+def test_get_authorized_keys_rejects_non_matching_service_user(argus_db, tunnel_user, active_config):
+    """get_authorized_keys should reject callers that are not the active tunnel service user."""
+    svc = TunnelService()
+    svc.register_tunnel(user=tunnel_user, public_key=_make_public_key())
 
-        keys_for_a = svc.get_authorized_keys(tunnel_id=config_a.id)
-        assert pub_key_a.strip() in keys_for_a
-        assert pub_key_b.strip() not in keys_for_a
+    with pytest.raises(Exception, match="Not authorized"):
+        svc.get_authorized_keys(service_user_id=uuid4())
 
-        keys_for_b = svc.get_authorized_keys(tunnel_id=config_b.id)
-        assert pub_key_b.strip() in keys_for_b
-        assert pub_key_a.strip() not in keys_for_b
-    finally:
-        for cfg in (config_a, config_b):
-            try:
-                cfg.delete()
-            except Exception:
-                pass
+
+@pytest.mark.docker_required
+def test_derive_fingerprint_matches_openssh_wire_blob(argus_db):
+    """Fingerprint derivation should match SHA256 of OpenSSH wire blob (ssh-keygen format)."""
+    public_key = _make_public_key()
+    key_blob = base64.b64decode(public_key.split()[1])
+    expected = f"SHA256:{base64.b64encode(hashlib.sha256(key_blob).digest()).rstrip(b'=').decode('ascii')}"
+    assert _derive_fingerprint(public_key) == expected
 
 
 # ---------------------------------------------------------------------------
@@ -253,65 +269,67 @@ def test_delete_key_nonexistent_raises(argus_db):
 @pytest.mark.docker_required
 def test_save_proxy_tunnel_config_creates_service_user(argus_db):
     """save_proxy_tunnel_config should create a dedicated service user."""
-    # Deactivate all configs first so we start clean
-    for cfg in ProxyTunnelConfig.objects.filter(is_active=True).all():
-        cfg.update(is_active=False)
+    previous_active_ids = _active_config_ids()
+    _deactivate_configs(previous_active_ids)
 
-    host = f"proxy-svcuser-{uuid4().hex[:6]}.example.com"
-    payload = dict(
-        host=host,
-        port=22,
-        proxy_user="argus-proxy",
-        target_host="10.0.1.1",
-        target_port=8080,
-        host_key_fingerprint="SHA256:svcusertest",
-    )
-    svc = TunnelService()
-    result = svc.save_proxy_tunnel_config(payload)
+    try:
+        host = f"proxy-svcuser-{uuid4().hex[:6]}.example.com"
+        payload = dict(
+            host=host,
+            port=22,
+            proxy_user="argus-proxy",
+            target_host="10.0.1.1",
+            target_port=8080,
+            host_key_fingerprint="SHA256:svcusertest",
+        )
+        svc = TunnelService()
+        result = svc.save_proxy_tunnel_config(payload)
 
-    assert result["is_active"] is True
-    assert result["service_user_id"] is not None
-    assert "api_token" in result  # token returned so admin can provision
+        assert result["is_active"] is True
+        assert result["service_user_id"] is not None
+        assert "api_token" in result
 
-    # Service user exists in DB
-    service_user = User.get(id=result["service_user_id"])
-    assert service_user.service_user is True
-    assert f"proxy-tunnel-{host}" in service_user.username
+        service_user = User.get(id=result["service_user_id"])
+        assert service_user.service_user is True
+        assert f"proxy-tunnel-{host}" in service_user.username
+    finally:
+        _restore_configs(previous_active_ids)
 
 
 @pytest.mark.docker_required
 def test_save_proxy_tunnel_config_deactivates_old(argus_db):
     """Creating a new config should deactivate the previously active one."""
-    # Deactivate any stale configs
-    for cfg in ProxyTunnelConfig.objects.filter(is_active=True).all():
-        cfg.update(is_active=False)
+    previous_active_ids = _active_config_ids()
+    _deactivate_configs(previous_active_ids)
 
-    first_payload = dict(
-        host=f"proxy-first-{uuid4().hex[:6]}.example.com",
-        port=22,
-        proxy_user="argus-proxy",
-        target_host="10.0.2.1",
-        target_port=8080,
-        host_key_fingerprint="SHA256:first",
-    )
-    svc = TunnelService()
-    first = svc.save_proxy_tunnel_config(first_payload)
-    assert first["is_active"] is True
+    try:
+        first_payload = dict(
+            host=f"proxy-first-{uuid4().hex[:6]}.example.com",
+            port=22,
+            proxy_user="argus-proxy",
+            target_host="10.0.2.1",
+            target_port=8080,
+            host_key_fingerprint="SHA256:first",
+        )
+        svc = TunnelService()
+        first = svc.save_proxy_tunnel_config(first_payload)
+        assert first["is_active"] is True
 
-    second_payload = dict(
-        host=f"proxy-second-{uuid4().hex[:6]}.example.com",
-        port=22,
-        proxy_user="argus-proxy",
-        target_host="10.0.2.2",
-        target_port=8080,
-        host_key_fingerprint="SHA256:second",
-    )
-    second = svc.save_proxy_tunnel_config(second_payload)
-    assert second["is_active"] is True
+        second_payload = dict(
+            host=f"proxy-second-{uuid4().hex[:6]}.example.com",
+            port=22,
+            proxy_user="argus-proxy",
+            target_host="10.0.2.2",
+            target_port=8080,
+            host_key_fingerprint="SHA256:second",
+        )
+        second = svc.save_proxy_tunnel_config(second_payload)
+        assert second["is_active"] is True
 
-    # The first config should now be inactive in the DB
-    refreshed_first = ProxyTunnelConfig.get(id=first["id"])
-    assert refreshed_first.is_active is False
+        refreshed_first = ProxyTunnelConfig.get(id=first["id"])
+        assert refreshed_first.is_active is False
+    finally:
+        _restore_configs(previous_active_ids)
 
 
 @pytest.mark.docker_required
@@ -329,44 +347,43 @@ def test_save_proxy_tunnel_config_missing_fields(argus_db):
 @pytest.mark.docker_required
 def test_get_proxy_tunnel_config_returns_active(argus_db):
     """get_proxy_tunnel_config should return the currently active config."""
-    for cfg in ProxyTunnelConfig.objects.filter(is_active=True).all():
-        cfg.update(is_active=False)
+    previous_active_ids = _active_config_ids()
+    _deactivate_configs(previous_active_ids)
 
     config = _make_active_config()
     try:
         svc = TunnelService()
         result = svc.get_proxy_tunnel_config()
         assert result is not None
-        assert result["id"] == str(config.id)
+        assert str(result["id"]) == str(config.id)
         assert result["is_active"] is True
     finally:
         try:
             config.delete()
         except Exception:
             pass
-
-
-@pytest.mark.docker_required
-def test_get_proxy_tunnel_config_by_id(argus_db):
-    """get_proxy_tunnel_config with a tunnel_id should return that specific config."""
-    config = _make_active_config(is_active=False)
-    try:
-        svc = TunnelService()
-        result = svc.get_proxy_tunnel_config(tunnel_id=config.id)
-        assert result is not None
-        assert result["id"] == str(config.id)
-    finally:
-        try:
-            config.delete()
-        except Exception:
-            pass
+        _restore_configs(previous_active_ids)
 
 
 @pytest.mark.docker_required
 def test_get_proxy_tunnel_config_none_when_no_active(argus_db):
     """get_proxy_tunnel_config should return None when no active config exists."""
-    for cfg in ProxyTunnelConfig.objects.filter(is_active=True).all():
-        cfg.update(is_active=False)
+    previous_active_ids = _active_config_ids()
+    _deactivate_configs(previous_active_ids)
+    try:
+        svc = TunnelService()
+        assert svc.get_proxy_tunnel_config() is None
+    finally:
+        _restore_configs(previous_active_ids)
 
-    svc = TunnelService()
-    assert svc.get_proxy_tunnel_config() is None
+
+@pytest.mark.docker_required
+def test_get_tunnel_connection_returns_active_fields(argus_db, active_config):
+    """get_tunnel_connection should return active config fields used by SSH clients."""
+    result = TunnelService().get_tunnel_connection()
+    assert result["proxy_host"] == active_config.host
+    assert result["proxy_port"] == active_config.port
+    assert result["proxy_user"] == active_config.proxy_user
+    assert result["target_host"] == active_config.target_host
+    assert result["target_port"] == active_config.target_port
+    assert result["host_key_fingerprint"] == active_config.host_key_fingerprint

--- a/argus/backend/tests/tunnel/test_tunnel_service.py
+++ b/argus/backend/tests/tunnel/test_tunnel_service.py
@@ -7,6 +7,7 @@ Run with:
 import base64
 import hashlib
 import pytest
+from pytest import MonkeyPatch
 from datetime import UTC, datetime
 from secrets import token_hex
 from uuid import uuid4
@@ -118,6 +119,18 @@ def active_config(argus_db) -> ProxyTunnelConfig:
         pass
 
     _restore_configs(previous_active_ids)
+
+
+@pytest.fixture
+def mock_host_fingerprint():
+    monkeypatch = MonkeyPatch()
+    monkeypatch.setattr(
+        TunnelService,
+        "_fetch_host_key_fingerprint",
+        staticmethod(lambda host, _port: f"SHA256:{host}"),
+    )
+    yield
+    monkeypatch.undo()
 
 
 # ---------------------------------------------------------------------------
@@ -318,7 +331,7 @@ def test_delete_key_nonexistent_is_noop(argus_db):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.docker_required
-def test_save_proxy_tunnel_config_creates_service_user(argus_db):
+def test_save_proxy_tunnel_config_creates_service_user(argus_db, mock_host_fingerprint):
     """save_proxy_tunnel_config should create a dedicated service user."""
     previous_active_ids = _active_config_ids()
     _deactivate_configs(previous_active_ids)
@@ -331,7 +344,6 @@ def test_save_proxy_tunnel_config_creates_service_user(argus_db):
             proxy_user="argus-proxy",
             target_host="10.0.1.1",
             target_port=8080,
-            host_key_fingerprint="SHA256:svcusertest",
         )
         svc = TunnelService()
         result = svc.save_proxy_tunnel_config(payload)
@@ -349,8 +361,8 @@ def test_save_proxy_tunnel_config_creates_service_user(argus_db):
 
 
 @pytest.mark.docker_required
-def test_save_proxy_tunnel_config_deactivates_old(argus_db):
-    """Creating a new config should leave prior active configs active."""
+def test_save_proxy_tunnel_config_deactivates_old(argus_db, mock_host_fingerprint):
+    """Creating a new config should not force-deactivate prior active configs."""
     previous_active_ids = _active_config_ids()
     _deactivate_configs(previous_active_ids)
 
@@ -361,7 +373,6 @@ def test_save_proxy_tunnel_config_deactivates_old(argus_db):
             proxy_user="argus-proxy",
             target_host="10.0.2.1",
             target_port=8080,
-            host_key_fingerprint="SHA256:first",
         )
         svc = TunnelService()
         first = svc.save_proxy_tunnel_config(first_payload)
@@ -373,7 +384,6 @@ def test_save_proxy_tunnel_config_deactivates_old(argus_db):
             proxy_user="argus-proxy",
             target_host="10.0.2.2",
             target_port=8080,
-            host_key_fingerprint="SHA256:second",
         )
         second = svc.save_proxy_tunnel_config(second_payload)
         assert second.is_active is True
@@ -385,11 +395,118 @@ def test_save_proxy_tunnel_config_deactivates_old(argus_db):
 
 
 @pytest.mark.docker_required
-def test_save_proxy_tunnel_config_missing_fields(argus_db):
+def test_save_proxy_tunnel_config_can_create_inactive(argus_db, mock_host_fingerprint):
+    """save_proxy_tunnel_config should accept is_active=False for disabled hosts."""
+    host = f"proxy-inactive-{uuid4().hex[:6]}.example.com"
+    payload = dict(
+        host=host,
+        port=22,
+        proxy_user="argus-proxy",
+        target_host="10.0.3.1",
+        target_port=8080,
+        is_active=False,
+    )
+
+    svc = TunnelService()
+    result = svc.save_proxy_tunnel_config(payload)
+    assert result.is_active is False
+
+
+@pytest.mark.docker_required
+def test_list_proxy_tunnel_configs_filters_active(argus_db):
+    """list_proxy_tunnel_configs should support active_only filtering."""
+    active_cfg = _make_active_config(is_active=True)
+    inactive_cfg = _make_active_config(is_active=False)
+    try:
+        svc = TunnelService()
+        active_rows = svc.list_proxy_tunnel_configs(active_only=True)
+        inactive_rows = svc.list_proxy_tunnel_configs(active_only=False)
+
+        active_ids = {str(row.id) for row in active_rows}
+        inactive_ids = {str(row.id) for row in inactive_rows}
+        assert str(active_cfg.id) in active_ids
+        assert str(inactive_cfg.id) in inactive_ids
+    finally:
+        try:
+            active_cfg.delete()
+        except Exception:
+            pass
+        try:
+            inactive_cfg.delete()
+        except Exception:
+            pass
+
+
+@pytest.mark.docker_required
+def test_set_proxy_tunnel_config_active_toggles_state(argus_db):
+    """set_proxy_tunnel_config_active should toggle single config state."""
+    cfg = _make_active_config(is_active=False)
+    try:
+        svc = TunnelService()
+        enabled = svc.set_proxy_tunnel_config_active(cfg.id, True)
+        assert enabled.is_active is True
+
+        disabled = svc.set_proxy_tunnel_config_active(cfg.id, False)
+        assert disabled.is_active is False
+    finally:
+        try:
+            cfg.delete()
+        except Exception:
+            pass
+
+
+@pytest.mark.docker_required
+def test_save_proxy_tunnel_config_missing_fields(argus_db, mock_host_fingerprint):
     """save_proxy_tunnel_config should raise when required fields are absent."""
     svc = TunnelService()
     with pytest.raises(TunnelServiceException, match="Missing required fields"):
         svc.save_proxy_tunnel_config({"host": "proxy.example.com"})
+
+
+@pytest.mark.docker_required
+def test_fetch_host_key_fingerprint_prefers_ed25519(argus_db):
+    svc = TunnelService()
+    ed25519_pub = _make_public_key()
+
+    class _Result:
+        def __init__(self):
+            self.stdout = (
+                "example.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7fY7Y1hQ7jLlY9gZmve6n9YjKTRv9QTHd8xh9Mo6mMma7mXFF7n6yFB6gki8k4d9eQWIRtwywR6fRa3fVYvULr3zP1mpIhA2bc6ctXb9x7Xj7J2Ff8V0s8m2q9f5P6m3trcTQj1qk0Eo2FtfYV3xJkYyWm3q2bN4YfQYyp7Y6dQz8fXw91n6mQmA6W6M3uVlbM8qqQvY8jN8cQpD6k9lQGmQ1ZlW9d6kqv6dQd7w9cH8q5rR9k1M6t8eN7gQW8qD9r1m2b4u6p8s0t2v4w6x8y0z2A4C6E8G0I2K4M6O8Q0S2U4W6Y8a0c2e4g6i8k0m2o4q6s8u0w2y4\n"
+                f"example.com {ed25519_pub}\n"
+            )
+            self.stderr = ""
+
+    import argus.backend.service.tunnel_service as tunnel_module
+
+    original_run = tunnel_module.subprocess.run
+    tunnel_module.subprocess.run = lambda *args, **kwargs: _Result()
+    try:
+        fingerprint = svc._fetch_host_key_fingerprint("example.com", 22)
+    finally:
+        tunnel_module.subprocess.run = original_run
+
+    expected = _derive_fingerprint(ed25519_pub)
+    assert fingerprint == expected
+
+
+@pytest.mark.docker_required
+def test_fetch_host_key_fingerprint_raises_when_empty(argus_db):
+    svc = TunnelService()
+
+    class _Result:
+        def __init__(self):
+            self.stdout = ""
+            self.stderr = "connection refused"
+
+    import argus.backend.service.tunnel_service as tunnel_module
+
+    original_run = tunnel_module.subprocess.run
+    tunnel_module.subprocess.run = lambda *args, **kwargs: _Result()
+    try:
+        with pytest.raises(TunnelServiceException, match="Failed to fetch host key"):
+            svc._fetch_host_key_fingerprint("bad.example.com", 22)
+    finally:
+        tunnel_module.subprocess.run = original_run
 
 
 # ---------------------------------------------------------------------------
@@ -427,6 +544,44 @@ def test_get_proxy_tunnel_config_none_when_no_active(argus_db):
         assert svc.get_proxy_tunnel_config() is None
     finally:
         _restore_configs(previous_active_ids)
+
+
+@pytest.mark.docker_required
+def test_get_proxy_tunnel_config_returns_none_for_inactive_tunnel_id(argus_db):
+    """get_proxy_tunnel_config(tunnel_id=...) should ignore inactive configs."""
+    cfg = _make_active_config(is_active=False)
+    try:
+        assert TunnelService().get_proxy_tunnel_config(tunnel_id=cfg.id) is None
+    finally:
+        try:
+            cfg.delete()
+        except Exception:
+            pass
+
+
+@pytest.mark.docker_required
+def test_get_proxy_tunnel_config_round_robin_without_tunnel_id(argus_db):
+    """get_proxy_tunnel_config() should rotate when multiple active configs exist."""
+    first = _make_active_config(is_active=True)
+    second = _make_active_config(is_active=True)
+    try:
+        _clear_proxy_rr_state()
+        svc = TunnelService()
+        pick1 = svc.get_proxy_tunnel_config()
+        pick2 = svc.get_proxy_tunnel_config()
+        assert pick1 is not None
+        assert pick2 is not None
+        assert pick1.host != pick2.host
+        assert {pick1.host, pick2.host} == {first.host, second.host}
+    finally:
+        try:
+            first.delete()
+        except Exception:
+            pass
+        try:
+            second.delete()
+        except Exception:
+            pass
 
 
 @pytest.mark.docker_required

--- a/argus/backend/tests/tunnel/test_tunnel_service.py
+++ b/argus/backend/tests/tunnel/test_tunnel_service.py
@@ -344,6 +344,7 @@ def test_save_proxy_tunnel_config_creates_service_user(argus_db, mock_host_finge
             proxy_user="argus-proxy",
             target_host="10.0.1.1",
             target_port=8080,
+            host_key_fingerprint=f"SHA256:{host}",
         )
         svc = TunnelService()
         result = svc.save_proxy_tunnel_config(payload)
@@ -356,6 +357,31 @@ def test_save_proxy_tunnel_config_creates_service_user(argus_db, mock_host_finge
         assert service_user.service_user is True
         assert f"proxy-tunnel-{host}" in service_user.username
         assert service_user.roles == [UserRoles.SSHTunnelServer.value]
+    finally:
+        _restore_configs(previous_active_ids)
+
+
+@pytest.mark.docker_required
+def test_save_proxy_tunnel_config_reuses_existing_tunnel_service_user(argus_db, mock_host_fingerprint):
+    """Saving config for the same host should re-use the existing tunnel service user."""
+    previous_active_ids = _active_config_ids()
+    _deactivate_configs(previous_active_ids)
+    host = f"proxy-reuse-{uuid4().hex[:6]}.example.com"
+    payload = dict(
+        host=host,
+        port=22,
+        proxy_user="argus-proxy",
+        target_host="10.0.1.1",
+        target_port=8080,
+        host_key_fingerprint=f"SHA256:{host}",
+    )
+
+    try:
+        svc = TunnelService()
+        first = svc.save_proxy_tunnel_config(payload)
+        second = svc.save_proxy_tunnel_config(payload)
+
+        assert first.service_user_id == second.service_user_id
     finally:
         _restore_configs(previous_active_ids)
 
@@ -375,6 +401,7 @@ def test_save_proxy_tunnel_config_deactivates_old(argus_db, mock_host_fingerprin
             target_port=8080,
         )
         svc = TunnelService()
+        first_payload["host_key_fingerprint"] = f"SHA256:{first_payload['host']}"
         first = svc.save_proxy_tunnel_config(first_payload)
         assert first.is_active is True
 
@@ -385,6 +412,7 @@ def test_save_proxy_tunnel_config_deactivates_old(argus_db, mock_host_fingerprin
             target_host="10.0.2.2",
             target_port=8080,
         )
+        second_payload["host_key_fingerprint"] = f"SHA256:{second_payload['host']}"
         second = svc.save_proxy_tunnel_config(second_payload)
         assert second.is_active is True
 
@@ -404,6 +432,7 @@ def test_save_proxy_tunnel_config_can_create_inactive(argus_db, mock_host_finger
         proxy_user="argus-proxy",
         target_host="10.0.3.1",
         target_port=8080,
+        host_key_fingerprint=f"SHA256:{host}",
         is_active=False,
     )
 
@@ -461,6 +490,49 @@ def test_save_proxy_tunnel_config_missing_fields(argus_db, mock_host_fingerprint
     svc = TunnelService()
     with pytest.raises(TunnelServiceException, match="Missing required fields"):
         svc.save_proxy_tunnel_config({"host": "proxy.example.com"})
+
+
+@pytest.mark.docker_required
+def test_save_proxy_tunnel_config_rejects_fingerprint_mismatch(argus_db, mock_host_fingerprint):
+    """Config save should fail when provided fingerprint does not match discovered host key."""
+    host = f"proxy-mismatch-{uuid4().hex[:6]}.example.com"
+    payload = dict(
+        host=host,
+        port=22,
+        proxy_user="argus-proxy",
+        target_host="10.0.7.1",
+        target_port=8080,
+        host_key_fingerprint="SHA256:incorrect",
+    )
+    with pytest.raises(TunnelServiceException, match="Host key fingerprint mismatch"):
+        TunnelService().save_proxy_tunnel_config(payload)
+
+
+@pytest.mark.docker_required
+def test_create_proxy_service_user_rejects_username_collision(argus_db):
+    host = f"proxy-collision-{uuid4().hex[:6]}.example.com"
+    username = f"proxy-tunnel-{host}"
+    now_utc = datetime.now(tz=UTC).replace(tzinfo=None)
+    collision_user = User.create(
+        id=uuid4(),
+        username=username,
+        full_name="Conflicting User",
+        password="",
+        email=f"{username}@example.com",
+        registration_date=now_utc,
+        roles=[UserRoles.User.value],
+        api_token="",
+        service_user=False,
+    )
+
+    try:
+        with pytest.raises(TunnelServiceException, match="already exists and is not a dedicated SSH tunnel service user"):
+            TunnelService()._create_proxy_service_user(host)
+    finally:
+        try:
+            collision_user.delete()
+        except Exception:
+            pass
 
 
 @pytest.mark.docker_required
@@ -561,7 +633,7 @@ def test_get_proxy_tunnel_config_returns_none_for_inactive_tunnel_id(argus_db):
 
 @pytest.mark.docker_required
 def test_get_proxy_tunnel_config_round_robin_without_tunnel_id(argus_db):
-    """get_proxy_tunnel_config() should rotate when multiple active configs exist."""
+    """get_proxy_tunnel_config() should be deterministic for admin reads."""
     first = _make_active_config(is_active=True)
     second = _make_active_config(is_active=True)
     try:
@@ -571,8 +643,7 @@ def test_get_proxy_tunnel_config_round_robin_without_tunnel_id(argus_db):
         pick2 = svc.get_proxy_tunnel_config()
         assert pick1 is not None
         assert pick2 is not None
-        assert pick1.host != pick2.host
-        assert {pick1.host, pick2.host} == {first.host, second.host}
+        assert pick1.host == pick2.host
     finally:
         try:
             first.delete()
@@ -582,6 +653,33 @@ def test_get_proxy_tunnel_config_round_robin_without_tunnel_id(argus_db):
             second.delete()
         except Exception:
             pass
+
+
+@pytest.mark.docker_required
+def test_get_proxy_tunnel_config_does_not_advance_round_robin_index(argus_db):
+    """Admin reads should not mutate RR index used by client tunnel selection."""
+    previous_active_ids = _active_config_ids()
+    _deactivate_configs(previous_active_ids)
+    first = _make_active_config(is_active=True)
+    second = _make_active_config(is_active=True)
+    try:
+        _clear_proxy_rr_state()
+        service = TunnelService()
+        _ = service.get_proxy_tunnel_config()
+        first_pick = service.get_tunnel_connection().proxy_host
+        second_pick = service.get_tunnel_connection().proxy_host
+        assert first_pick != second_pick
+        assert {first_pick, second_pick} == {first.host, second.host}
+    finally:
+        try:
+            first.delete()
+        except Exception:
+            pass
+        try:
+            second.delete()
+        except Exception:
+            pass
+        _restore_configs(previous_active_ids)
 
 
 @pytest.mark.docker_required

--- a/argus/backend/tests/tunnel/test_tunnel_service.py
+++ b/argus/backend/tests/tunnel/test_tunnel_service.py
@@ -147,7 +147,7 @@ def test_register_tunnel_custom_ttl(argus_db, tunnel_user, active_config):
     from datetime import datetime, timezone
     pub_key = _make_public_key()
     svc = TunnelService()
-    ttl = 3600  # 1 hour
+    ttl = 172800  # 2 days
 
     before = datetime.now(tz=timezone.utc)
     result = svc.register_tunnel(user=tunnel_user, public_key=pub_key, ttl_seconds=ttl)
@@ -160,12 +160,27 @@ def test_register_tunnel_custom_ttl(argus_db, tunnel_user, active_config):
 
 @pytest.mark.docker_required
 def test_register_tunnel_invalid_ttl_raises(argus_db, tunnel_user, active_config):
-    """Non-positive or non-integer ttl_seconds should raise TunnelServiceException."""
+    """TTL outside [24h, 30d] or non-integer ttl_seconds should raise TunnelServiceException."""
     svc = TunnelService()
 
-    for ttl in (0, -1, "abc", "0"):
-        with pytest.raises(TunnelServiceException, match="ttl_seconds must be a positive integer"):
+    for ttl in (0, -1, 86399, 2592001, "abc", "0"):
+        with pytest.raises(TunnelServiceException, match="ttl_seconds must be between 86400 and 2592000 seconds"):
             svc.register_tunnel(user=tunnel_user, public_key=_make_public_key(), ttl_seconds=ttl)
+
+
+@pytest.mark.docker_required
+def test_register_tunnel_ttl_upper_bound_allowed(argus_db, tunnel_user, active_config):
+    """A TTL of exactly 30 days should be accepted."""
+    from datetime import datetime, timezone
+
+    ttl = 2592000
+    svc = TunnelService()
+    before = datetime.now(tz=timezone.utc)
+    result = svc.register_tunnel(user=tunnel_user, public_key=_make_public_key(), ttl_seconds=ttl)
+    after = datetime.now(tz=timezone.utc)
+
+    expires_at = result["expires_at"].replace(tzinfo=timezone.utc)
+    assert (before.timestamp() + ttl - 5) <= expires_at.timestamp() <= (after.timestamp() + ttl + 5)
 
 
 @pytest.mark.docker_required

--- a/argus_backend.py
+++ b/argus_backend.py
@@ -14,6 +14,7 @@ from argus.backend.db import ScyllaCluster
 from argus.backend.controller import auth
 from argus.backend.util.config import Config
 from jwt import PyJWKClient
+from argus.backend.service.user import cache_ssh_tunnel_server_allowed_endpoints
 
 LOGGER = logging.getLogger(__name__)
 
@@ -75,6 +76,7 @@ def start_server(config=None) -> Flask:
     app.register_blueprint(api.bp)
     app.register_blueprint(admin.bp)
     app.register_blueprint(cli_bp)
+    cache_ssh_tunnel_server_allowed_endpoints(app)
     with app.app_context():
         try:
             register_metrics()

--- a/docs/plans/ssh-tunnel-design.md
+++ b/docs/plans/ssh-tunnel-design.md
@@ -236,13 +236,14 @@ Class `TunnelService`:
     2. Takes immediate effect — next `AuthorizedKeysCommand` call won't include it
 
 - `get_proxy_tunnel_config() -> ProxyTunnelConfig | None`:
-    1. Return active proxy tunnel config (for admin panel display)
+    1. Return one deterministic active proxy tunnel config (for admin panel display)
+    2. Must be non-mutating (does not advance round-robin state used by client tunnel selection)
 
 - `save_proxy_tunnel_config(payload: dict) -> ProxyTunnelConfig`:
     1. Create a proxy tunnel config row (active by default, or explicitly disabled via `is_active=false`)
     2. Create a dedicated Argus service user for this proxy host (e.g., `proxy-tunnel-<host>`), generate API token
-    3. Resolve `host_key_fingerprint` automatically by running `ssh-keyscan` against `host:port`
-    4. Save proxy tunnel config with `service_user_id` and resolved `host_key_fingerprint`
+    3. Verify `host_key_fingerprint` by running `ssh-keyscan` against `host:port` and comparing discovered fingerprint with the provided value
+    4. Save proxy tunnel config with `service_user_id` and verified `host_key_fingerprint`
     5. Run provisioning script on the proxy host (Step 4c), passing the service user's API token
     6. On success: keep requested active state. On failure: mark inactive, return error.
     7. Return saved config
@@ -301,7 +302,7 @@ Add to existing admin API blueprint (follows existing pattern: `@api_login_requi
 @check_roles(UserRoles.Admin)
 def get_proxy_tunnel_config():
     # tunnel_id is optional:
-    # - without tunnel_id: returns one active config (round-robin selection)
+    # - without tunnel_id: returns one deterministic active config (non-mutating)
     # - with tunnel_id: returns that config only if it is active
     config = TunnelService().get_proxy_tunnel_config(tunnel_id=request.args.get("tunnel_id"))
     return {"status": "ok", "response": config}
@@ -417,7 +418,7 @@ New admin panel section "SSH Tunnel" accessible from the admin sidebar. Follows 
 - Proxy User (text input, default "argus-proxy")
 - Target Host (text input — Argus private IP)
 - Target Port (number input, default 8080)
-- Host Key Fingerprint (read-only; auto-discovered by backend using `ssh-keyscan`)
+- Host Key Fingerprint (required input; backend verifies it with `ssh-keyscan` before saving)
 - Service User (read-only, auto-created — shows the dedicated Argus user + token created for this proxy host)
 - Active toggle (boolean; multiple hosts can be active at the same time)
 - Save button → triggers provisioning script on the proxy host. On success: config saved + active. On failure: error message shown, config not activated.

--- a/docs/plans/ssh-tunnel-design.md
+++ b/docs/plans/ssh-tunnel-design.md
@@ -160,8 +160,8 @@ aws ec2 describe-instances --filters "Name=tag:Name,Values=argus-*" \
 - [x] Step 2: Proxy tunnel config in DB - `argus/backend/models/ssh_key.py` (done in PR #967)
 - [x] Step 3: Backend service - `argus/backend/service/tunnel_service.py` (done in PR #967)
 - [x] Step 4a: Client API - `argus/backend/controller/ssh_api.py` (done in PR #967)
+- [x] Step 4b: Admin API - `argus/backend/controller/admin_api.py`
 - [x] Step 9 (partial): backend tunnel tests (`argus/backend/tests/tunnel/test_tunnel_service.py`, `argus/backend/tests/tunnel/test_ssh_api.py`) (done in PR #967)
-- [ ] Step 4b: Admin API
 - [ ] Step 4c: Proxy host provisioning template
 - [ ] Step 4d: Admin Panel UI
 - [ ] Step 5: Client module - `argus/client/tunnel.py`

--- a/docs/plans/ssh-tunnel-design.md
+++ b/docs/plans/ssh-tunnel-design.md
@@ -154,7 +154,24 @@ aws ec2 describe-instances --filters "Name=tag:Name,Values=argus-*" \
 
 ## Implementation Plan
 
+### Current Status
+
+- [x] Step 1: DB model - `argus/backend/models/ssh_key.py` (done in PR #967)
+- [x] Step 2: Proxy tunnel config in DB - `argus/backend/models/ssh_key.py` (done in PR #967)
+- [x] Step 3: Backend service - `argus/backend/service/tunnel_service.py` (done in PR #967)
+- [x] Step 4a: Client API - `argus/backend/controller/ssh_api.py` (done in PR #967)
+- [x] Step 9 (partial): backend tunnel tests (`argus/backend/tests/tunnel/test_tunnel_service.py`, `argus/backend/tests/tunnel/test_ssh_api.py`) (done in PR #967)
+- [ ] Step 4b: Admin API
+- [ ] Step 4c: Proxy host provisioning template
+- [ ] Step 4d: Admin Panel UI
+- [ ] Step 5: Client module - `argus/client/tunnel.py`
+- [ ] Step 6: Modify `argus/client/base.py`
+- [ ] Step 7: Python CLI integration
+- [ ] Step 7b: Go CLI `ssh-keys` command
+
 ### Step 1: DB model — `argus/backend/models/ssh_key.py`
+
+Status: Done in PR #967.
 
 ```python
 class SSHTunnelKey(Model):
@@ -170,6 +187,8 @@ class SSHTunnelKey(Model):
 Add to `USED_MODELS` list in `argus/backend/models/web.py`.
 
 ### Step 2: Proxy tunnel config in DB — `argus/backend/models/ssh_key.py`
+
+Status: Done in PR #967.
 
 ```python
 class ProxyTunnelConfig(Model):
@@ -191,6 +210,8 @@ Add to `USED_MODELS`. Managed via admin panel (Step 4d). Only one active proxy h
 `admin_user` and `admin_key_path` (SSH credentials for provisioning access to the proxy host) are stored in `argus_web.yaml`.
 
 ### Step 3: Backend service — `argus/backend/service/tunnel_service.py`
+
+Status: Done in PR #967.
 
 Class `TunnelService`:
 
@@ -231,6 +252,8 @@ Class `TunnelService`:
     4. On failure: mark config as inactive, return error to admin
 
 ### Step 4a: Client API — `argus/backend/controller/ssh_api.py`
+
+Status: Done in PR #967.
 
 Blueprint registered under `/client/`:
 
@@ -481,6 +504,8 @@ Behavior:
 **Proxy host deployment:** Binary at `/usr/local/bin/argus-cli`, owned by root, mode 0755. Config via env vars embedded in the `argus-authorized-keys` wrapper script.
 
 ### Step 9: Tests
+
+Status: Partially done in PR #967 (backend tunnel tests for service/API).
 
 **`argus/client/tests/test_tunnel.py`:**
 

--- a/docs/plans/ssh-tunnel-design.md
+++ b/docs/plans/ssh-tunnel-design.md
@@ -161,7 +161,7 @@ aws ec2 describe-instances --filters "Name=tag:Name,Values=argus-*" \
 - [x] Step 3: Backend service - `argus/backend/service/tunnel_service.py` (done in PR #967)
 - [x] Step 4a: Client API - `argus/backend/controller/ssh_api.py` (done in PR #967)
 - [x] Step 4b: Admin API - `argus/backend/controller/admin_api.py`
-- [x] Step 9 (partial): backend tunnel tests (`argus/backend/tests/tunnel/test_tunnel_service.py`, `argus/backend/tests/tunnel/test_ssh_api.py`) (done in PR #967)
+- [x] Step 9 (partial): backend tunnel tests (`argus/backend/tests/tunnel/test_tunnel_service.py`, `argus/backend/tests/tunnel/test_ssh_api.py`, `argus/backend/tests/tunnel/test_admin_proxy_tunnel_api.py`) (done in PR #967)
 - [ ] Step 4c: Proxy host provisioning template
 - [ ] Step 4d: Admin Panel UI
 - [ ] Step 5: Client module - `argus/client/tunnel.py`
@@ -203,9 +203,15 @@ class ProxyTunnelConfig(Model):
     is_active = columns.Boolean()
 ```
 
-Add to `USED_MODELS`. Managed via admin panel (Step 4d). Only one active proxy host at a time (`is_active=True`).
+Add to `USED_MODELS`. Managed via admin panel (Step 4d).
 
-**Service user per proxy host:** When admin saves a new proxy tunnel config, the backend automatically creates a dedicated Argus user (e.g., `proxy-tunnel-<host>`) with a fresh API token. This token is deployed to the proxy host during provisioning for argus-cli to call the authorized keys endpoint. Each proxy host gets its own isolated credentials — revoking a proxy host's access is as simple as deleting its service user.
+**Multi-host active mode:** Multiple proxy hosts may be active at the same time (`is_active=True`).
+
+- Tunnel registration and tunnel-info endpoints can pick among active hosts (round-robin).
+- Admin can disable a host by setting `is_active=False`.
+- Disabled hosts remain in DB for audit/re-enable workflows.
+
+**Service user per proxy host:** When admin saves a new proxy tunnel config, the backend automatically creates a dedicated Argus user (e.g., `proxy-tunnel-<host>`) with a fresh API token. This token is deployed to the proxy host during provisioning for argus-cli to call the authorized keys endpoint. Access is role-scoped (`ROLE_SSH_TUNNEL_SERVER`) and hard-limited to `GET /api/v1/client/ssh/keys`.
 
 `admin_user` and `admin_key_path` (SSH credentials for provisioning access to the proxy host) are stored in `argus_web.yaml`.
 
@@ -217,7 +223,7 @@ Class `TunnelService`:
 
 - `register_tunnel(user: User, public_key: str, ttl_seconds: int = None) -> dict`:
     1. Store `SSHTunnelKey` in DB (public key only) with ScyllaDB TTL (default 86400s / 24h, or client-provided `ttl_seconds`). Set `expires_at = now_utc + ttl` for informational purposes.
-    2. Get active `ProxyTunnelConfig`
+    2. Get one active `ProxyTunnelConfig` (round-robin across active hosts)
     3. Return `{proxy_host, proxy_port, proxy_user, target_host, target_port, host_key_fingerprint, expires_at}` (all datetimes UTC ISO-8601)
 
 - `get_authorized_keys() -> str`:
@@ -233,12 +239,19 @@ Class `TunnelService`:
     1. Return active proxy tunnel config (for admin panel display)
 
 - `save_proxy_tunnel_config(payload: dict) -> ProxyTunnelConfig`:
-    1. Deactivate any existing active config
+    1. Create a proxy tunnel config row (active by default, or explicitly disabled via `is_active=false`)
     2. Create a dedicated Argus service user for this proxy host (e.g., `proxy-tunnel-<host>`), generate API token
-    3. Save proxy tunnel config with `service_user_id`
-    4. Run provisioning script on the proxy host (Step 4c), passing the service user's API token
-    5. On success: mark config as active. On failure: mark inactive, return error.
-    6. Return saved config
+    3. Resolve `host_key_fingerprint` automatically by running `ssh-keyscan` against `host:port`
+    4. Save proxy tunnel config with `service_user_id` and resolved `host_key_fingerprint`
+    5. Run provisioning script on the proxy host (Step 4c), passing the service user's API token
+    6. On success: keep requested active state. On failure: mark inactive, return error.
+    7. Return saved config
+
+- `list_proxy_tunnel_configs(active_only: bool | None = None) -> list[ProxyTunnelConfig]`:
+    1. Return all configs, optionally filtered by active state
+
+- `set_proxy_tunnel_config_active(tunnel_id: UUID, is_active: bool) -> ProxyTunnelConfig`:
+    1. Enable or disable a specific proxy host config
 
 - `provision_proxy_tunnel(config: ProxyTunnelConfig, auth_token: str)`:
     1. SSH to proxy host as admin (admin credentials from `argus_web.yaml`)
@@ -287,8 +300,19 @@ Add to existing admin API blueprint (follows existing pattern: `@api_login_requi
 @api_login_required
 @check_roles(UserRoles.Admin)
 def get_proxy_tunnel_config():
-    config = TunnelService().get_proxy_tunnel_config()
+    # tunnel_id is optional:
+    # - without tunnel_id: returns one active config (round-robin selection)
+    # - with tunnel_id: returns that config only if it is active
+    config = TunnelService().get_proxy_tunnel_config(tunnel_id=request.args.get("tunnel_id"))
     return {"status": "ok", "response": config}
+
+@bp.route("/proxy-tunnel/configs", methods=["GET"])
+@api_login_required
+@check_roles(UserRoles.Admin)
+def list_proxy_tunnel_configs():
+    # active_only is optional: "true" or "false"
+    configs = TunnelService().list_proxy_tunnel_configs(active_only=request.args.get("active_only"))
+    return {"status": "ok", "response": configs}
 
 @bp.route("/proxy-tunnel/config", methods=["POST"])
 @api_login_required
@@ -296,6 +320,14 @@ def get_proxy_tunnel_config():
 def save_proxy_tunnel_config():
     payload = request.get_json()
     config = TunnelService().save_proxy_tunnel_config(payload)
+    return {"status": "ok", "response": config}
+
+@bp.route("/proxy-tunnel/config/<tunnel_id>/active", methods=["POST"])
+@api_login_required
+@check_roles(UserRoles.Admin)
+def set_proxy_tunnel_config_active(tunnel_id):
+    payload = request.get_json()
+    config = TunnelService().set_proxy_tunnel_config_active(UUID(tunnel_id), payload["is_active"])
     return {"status": "ok", "response": config}
 
 # Key management (list, delete, cleanup)
@@ -385,12 +417,12 @@ New admin panel section "SSH Tunnel" accessible from the admin sidebar. Follows 
 - Proxy User (text input, default "argus-proxy")
 - Target Host (text input — Argus private IP)
 - Target Port (number input, default 8080)
-- Host Key Fingerprint (text input — obtain via `ssh-keyscan proxy-host | ssh-keygen -lf -`)
+- Host Key Fingerprint (read-only; auto-discovered by backend using `ssh-keyscan`)
 - Service User (read-only, auto-created — shows the dedicated Argus user + token created for this proxy host)
-- Active toggle (boolean)
+- Active toggle (boolean; multiple hosts can be active at the same time)
 - Save button → triggers provisioning script on the proxy host. On success: config saved + active. On failure: error message shown, config not activated.
 - Re-provision button (re-run provisioning on existing proxy host, e.g., after argus-cli update)
-- Deactivate button
+- Deactivate button (sets `is_active=false` for that host)
 
 **SSH Keys table:**
 


### PR DESCRIPTION
Implements backend SSH tunnel support from `docs/plans/ssh-tunnel-design.md` with secure key registration, multi-host proxy routing, admin management APIs, and full backend test coverage.

## What is included

### DB models (Steps 1 + 2)
- `argus/backend/models/ssh_key.py`
  - `SSHTunnelKey`: stores client SSH public keys with TTL expiration.
  - `ProxyTunnelConfig`: stores proxy host tunnel config (`host`, `port`, `proxy_user`, `target_host`, `target_port`, `host_key_fingerprint`, `service_user_id`, `is_active`).
  - `is_active` default is now `true` for new configs.
- `argus/backend/models/web.py`
  - SSH models registered in `USED_MODELS`.
  - Added dedicated role: `ROLE_SSH_TUNNEL_SERVER`.

### Backend service (Step 3)
- `argus/backend/service/tunnel_service.py`
  - Type-safe DTO response models used for tunnel/key/config flows.
  - `register_tunnel(...)`: validates key and TTL, stores key with TTL, returns tunnel connection details.
  - `get_tunnel_connection(...)`: returns active proxy details with round-robin selection across active hosts.
  - `get_authorized_keys()`: returns all non-expired public keys for proxy authorized_keys use.
  - Admin helpers: `list_keys(...)`, `delete_key(...)`, `get_proxy_tunnel_config(...)`, `save_proxy_tunnel_config(...)`, `list_proxy_tunnel_configs(...)`, `set_proxy_tunnel_config_active(...)`.
- Review follow-ups implemented:
  - Minimum key TTL lowered to **1 hour** (`MIN_TTL_SECONDS=3600`, default remains 24h).
  - Replaced model `_as_dict()` style returns with explicit DTO mapping.
  - `delete_key(...)` is idempotent (missing/TTL-expired key does not raise).

### Host fingerprint onboarding improvement
- `save_proxy_tunnel_config(...)` no longer requires manual `host_key_fingerprint` input.
- Backend now resolves host key fingerprint automatically via `ssh-keyscan` (preferred key order: ed25519 -> ecdsa -> rsa), computes OpenSSH-style `SHA256:...`, and stores it.
- This removes manual fingerprint copy/paste from admin config creation.

### Client API routes (Step 4a)
- `argus/backend/controller/ssh_api.py` under `/api/v1/client/ssh`:
  - `POST /tunnel`
  - `GET /tunnel`
  - `GET /tunnel/keys`
  - `GET /keys` (authorized_keys plain-text endpoint)
- `argus/backend/controller/client_api.py`
  - SSH blueprint registration.

### Admin API routes (Step 4b)
- `argus/backend/controller/admin_api.py` under `/admin/api/v1` (Admin-only):
  - `GET /proxy-tunnel/config` (optional `tunnel_id`; returns only active config)
  - `GET /proxy-tunnel/configs` (optional `active_only=true|false`)
  - `POST /proxy-tunnel/config` (creates config; `is_active` optional)
  - `POST /proxy-tunnel/config/<tunnel_id>/active` (enable/disable host)
  - `GET /ssh/keys`
  - `DELETE /ssh/keys/<key_id>`
- All endpoints follow existing admin semantics:
  - `@check_roles(UserRoles.Admin)`
  - `@api_login_required`

### Security hardening
- `argus/backend/controller/ssh_api.py`
  - `GET /client/ssh/keys` is protected with `@check_roles(UserRoles.SSHTunnelServer)`.
- `argus/backend/service/user.py` + `argus/backend/controller/auth.py`
  - `ROLE_SSH_TUNNEL_SERVER` is hard-scoped to one allowed operation: `GET /api/v1/client/ssh/keys`.
- `argus/backend/service/tunnel_service.py`
  - Proxy service users are created/reused with only `ROLE_SSH_TUNNEL_SERVER`.

## Tests
Added/updated:
- `argus/backend/tests/tunnel/test_tunnel_service.py`
- `argus/backend/tests/tunnel/test_ssh_api.py`
- `argus/backend/tests/tunnel/test_admin_proxy_tunnel_api.py`

Validation run:
- `uv run pytest`
- Result: **256 passed**

## Design doc sync
Updated `docs/plans/ssh-tunnel-design.md` to match implementation:
- Multi-active host model + round-robin behavior
- Admin config list/toggle APIs
- Active-only semantics for specific config lookup
- Backend auto-discovery of host key fingerprint
- Step status updates including admin API tests

## Not included (follow-up PRs)
- Step 4c: proxy host provisioning template
- Step 4d: Admin panel UI
- Step 5/6: client tunnel module and `base.py` integration
- Step 7/7b: CLI tunnel integration (`argus-client` and Go `argus-cli ssh-keys`)