### PR TITLE
feature(issues): add product version filtering to issues endpoint and dashboard

### DIFF
--- a/argus/backend/controller/testrun_api.py
+++ b/argus/backend/controller/testrun_api.py
@@ -240,12 +240,16 @@ def issues_get():
     key_value = UUID(key_value)
     aggregate_by_issue = request.args.get("aggregateByIssue")
     aggregate_by_issue = bool(int(aggregate_by_issue)) if aggregate_by_issue else False
+    product_version = request.args.get("productVersion") or None
+    include_no_version = bool(int(request.args.get("includeNoVersion", 0)))
 
     service = IssueService()
     issues = service.get(
         filter_key=filter_key,
         filter_id=key_value,
-        aggregate_by_issue=aggregate_by_issue
+        aggregate_by_issue=aggregate_by_issue,
+        product_version=product_version,
+        include_no_version=include_no_version,
     )
 
     return {

--- a/argus/backend/plugins/core.py
+++ b/argus/backend/plugins/core.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Iterable
 from datetime import datetime, UTC
 from math import ceil
 from uuid import UUID
@@ -7,6 +8,7 @@ from time import time
 from cassandra.cqlengine import columns
 from cassandra.cqlengine.models import Model
 from cassandra.cqlengine.usertype import UserType
+from cassandra.concurrent import execute_concurrent_with_args
 from flask import Blueprint
 from argus.backend.db import ScyllaCluster
 from argus.backend.models.plan import ArgusReleasePlan
@@ -192,6 +194,19 @@ class PluginModelBase(Model):
         rows = cluster.session.execute(query=query, parameters=(run_id,))
 
         return list(rows)
+
+    @classmethod
+    def get_versions_by_run_ids(cls, run_ids: Iterable[UUID]) -> dict[UUID, str | None]:
+        """Parallel per-run_id lookups of scylla_version from the plugin table."""
+        cluster = ScyllaCluster.get()
+        query = cluster.prepare(f"SELECT scylla_version FROM {cls.table_name()} WHERE id = ?")
+        params = [(rid,) for rid in run_ids]
+        results = execute_concurrent_with_args(cluster.session, query, params, concurrency=50)
+        return {
+            p[0]: rows.one().get("scylla_version")
+            for p, (success, rows) in zip(params, results)
+            if success and rows
+        }
 
     @classmethod
     def get_run_response(cls, run_id: UUID) -> dict | None:

--- a/argus/backend/service/github_service.py
+++ b/argus/backend/service/github_service.py
@@ -197,6 +197,10 @@ class GithubService:
             links = list(self._get_github_issues_for_view(filter_id))
         else:
             links = list(IssueLink.filter(**{filter_key: filter_id}).allow_filtering().all())
+        return self.resolve_issues(links, aggregate_by_issue)
+
+    def resolve_issues(self, links: list[IssueLink], aggregate_by_issue: bool = False) -> list[dict]:
+        """Resolve GithubIssue records from pre-filtered links and build response dicts."""
         issues = reduce(lambda acc, link: acc[link.issue_id].append(link) or acc, links, defaultdict(list))
         resolved_issues = []
         for batch in chunk(issues.keys()):

--- a/argus/backend/service/issue_service.py
+++ b/argus/backend/service/issue_service.py
@@ -1,6 +1,7 @@
 from uuid import UUID
-from argus.backend.models.github_issue import GithubIssue
+from argus.backend.models.github_issue import GithubIssue, IssueLink
 from argus.backend.service.github_service import GithubService
+from argus.backend.service.issue_utils import build_version_map, filter_links_by_version
 from argus.backend.service.jira_service import JiraService
 
 
@@ -13,9 +14,33 @@ class IssueService:
     def _get_service(self, url):
         return self.gh if "github.com" in url else self.jira
 
-    def get(self, filter_key: str, filter_id: UUID | str, aggregate_by_issue: bool = False):
-        issues = self.gh.get_issues(filter_key=filter_key, filter_id=filter_id, aggregate_by_issue=aggregate_by_issue)
-        jira_issues = self.jira.get_issues(filter_key=filter_key, filter_id=filter_id, aggregate_by_issue=aggregate_by_issue)
+    def _get_links(self, filter_key: str, filter_id: UUID | str) -> list[IssueLink]:
+        if filter_key not in ["release_id", "group_id", "test_id", "run_id", "user_id", "view_id", "event_id"]:
+            raise Exception(
+                "filter_key can only be one of: \"release_id\", \"group_id\", \"test_id\", \"run_id\", \"user_id\", \"view_id\", \"event_id\""
+            )
+        if filter_key == "view_id":
+            gh_links = list(self.gh._get_github_issues_for_view(filter_id))
+            jira_links = list(self.jira._get_jira_issues_for_view(filter_id))
+            return gh_links + jira_links
+        return list(IssueLink.filter(**{filter_key: filter_id}).allow_filtering().all())
+
+    def get(
+        self,
+        filter_key: str,
+        filter_id: UUID | str,
+        aggregate_by_issue: bool = False,
+        product_version: str | None = None,
+        include_no_version: bool = False,
+    ):
+        links = self._get_links(filter_key, filter_id)
+
+        if product_version:
+            version_map = build_version_map(links)
+            links = filter_links_by_version(links, product_version, include_no_version, version_map)
+
+        issues = self.gh.resolve_issues(links=links, aggregate_by_issue=aggregate_by_issue)
+        jira_issues = self.jira.resolve_issues(links=links, aggregate_by_issue=aggregate_by_issue)
         issues.extend(jira_issues)
 
         return issues

--- a/argus/backend/service/issue_utils.py
+++ b/argus/backend/service/issue_utils.py
@@ -1,0 +1,69 @@
+import logging
+from collections import defaultdict
+from uuid import UUID
+
+from argus.backend.models.github_issue import IssueLink
+from argus.backend.models.web import ArgusTest
+from argus.backend.plugins.loader import AVAILABLE_PLUGINS
+from argus.backend.util.common import check_version, chunk
+
+LOGGER = logging.getLogger(__name__)
+
+
+def build_version_map(links: list[IssueLink]) -> dict[UUID, str | None]:
+    """Resolve scylla_version for run_ids by looking up only the correct plugin table.
+
+    1. Batch-fetch ArgusTest records to learn each test's plugin_name.
+    2. Group run_ids by plugin_name via link.test_id.
+    3. Query only the primary model for each plugin.
+    """
+    # test_id → plugin_name
+    unique_test_ids = {link.test_id for link in links}
+    test_plugin_map: dict[UUID, str] = {}
+    for batch in chunk(unique_test_ids):
+        for test in ArgusTest.filter(id__in=batch).only(["id", "plugin_name"]).all():
+            test_plugin_map[test.id] = test.plugin_name
+
+    # run_id → plugin model, grouped (deduplicated)
+    runs_by_plugin: dict[str, set[UUID]] = defaultdict(set)
+    for link in links:
+        plugin_name = test_plugin_map.get(link.test_id)
+        if plugin_name:
+            runs_by_plugin[plugin_name].add(link.run_id)
+
+    # Query each plugin's primary model only for its own run_ids
+    version_map: dict[UUID, str | None] = {}
+    for plugin_name, run_ids in runs_by_plugin.items():
+        plugin = AVAILABLE_PLUGINS.get(plugin_name)
+        if not plugin:
+            continue
+        resolved = plugin.model.get_versions_by_run_ids(run_ids)
+        version_map.update(resolved)
+    return version_map
+
+
+def filter_links_by_version(
+    links: list[IssueLink],
+    product_version: str,
+    include_no_version: bool = False,
+    version_map: dict[UUID, str | None] | None = None,
+) -> list[IssueLink]:
+    """Filter IssueLink records to only those whose associated run matches the given version.
+
+    If version_map is not provided, it is built by resolving test_id → plugin_name
+    and querying only the correct plugin table for each run.
+    """
+    if version_map is None:
+        version_map = build_version_map(links)
+
+    def matches(link: IssueLink) -> bool:
+        run_version = version_map.get(link.run_id)
+        if product_version == "!noVersion":
+            return not run_version
+        if check_version(product_version, run_version):
+            return True
+        if include_no_version and not run_version:
+            return True
+        return False
+
+    return [link for link in links if matches(link)]

--- a/argus/backend/service/jira_service.py
+++ b/argus/backend/service/jira_service.py
@@ -179,6 +179,10 @@ class JiraService:
             links = list(self._get_jira_issues_for_view(filter_id))
         else:
             links = list(IssueLink.filter(**{filter_key: filter_id}).allow_filtering().all())
+        return self.resolve_issues(links, aggregate_by_issue)
+
+    def resolve_issues(self, links: list[IssueLink], aggregate_by_issue: bool = False) -> list[dict]:
+        """Resolve JiraIssue records from pre-filtered links and build response dicts."""
         issues = reduce(lambda acc, link: acc[link.issue_id].append(link) or acc, links, defaultdict(list))
         resolved_issues = []
         for batch in chunk(issues.keys()):

--- a/argus/backend/service/stats.py
+++ b/argus/backend/service/stats.py
@@ -12,7 +12,7 @@ from argus.backend.models.github_issue import GithubIssue, IssueLink
 from argus.backend.models.jira import JiraIssue
 from argus.backend.models.plan import ArgusReleasePlan
 from argus.backend.plugins.loader import all_plugin_models
-from argus.backend.util.common import chunk, get_build_number
+from argus.backend.util.common import chunk, get_build_number, check_version
 from argus.common.enums import TestStatus, TestInvestigationStatus
 from argus.backend.models.web import ArgusRelease, ArgusGroup, ArgusScheduleTest, ArgusTest, \
     ArgusTestRunComment, ArgusUserView
@@ -153,14 +153,6 @@ def _get_image(row: dict):
     if cs := row.get("cloud_setup"):
         return cs.db_node.image_id
 
-
-def check_version(filter_string: str, version: str) -> bool:
-    if not version:
-        return False
-    if version.startswith(filter_string):
-        return True
-
-    return False
 
 def _fetch_multiple_release_queries(entity: Model, releases: list[str]):
     result_set = []

--- a/argus/backend/tests/issues/test_issue_version_filter.py
+++ b/argus/backend/tests/issues/test_issue_version_filter.py
@@ -1,0 +1,232 @@
+from dataclasses import asdict
+import itertools
+import logging
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import pytest
+
+from argus.backend.models.github_issue import GithubIssue
+from argus.backend.models.jira import JiraIssue
+from argus.backend.plugins.sct.testrun import SCTTestRun
+from argus.backend.service.client_service import ClientService
+from argus.backend.service.issue_service import IssueService
+from argus.backend.service.testrun import TestRunService
+from argus.backend.tests.conftest import get_fake_test_run
+
+if TYPE_CHECKING:
+    from argus.backend.models.web import ArgusRelease, ArgusTest
+
+LOGGER = logging.getLogger(__name__)
+
+# Unique issue numbers across parametrized cases (session-scoped DB).
+issue_counter = itertools.count(1000)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def submit_run_with_version(
+    client_service: ClientService,
+    testrun_service: TestRunService,
+    fake_test: "ArgusTest",
+    scylla_version: str | None = None,
+) -> SCTTestRun:
+    """Submit a test run and optionally set its scylla_version."""
+    run_type, run_request = get_fake_test_run(fake_test)
+    client_service.submit_run(run_type, asdict(run_request))
+    run: SCTTestRun = testrun_service.get_run(run_type, run_request.run_id)
+    if scylla_version is not None:
+        run.scylla_version = scylla_version
+        run.save()
+    return run
+
+
+def create_github_issue(
+    owner: str = "scylladb", repo: str = "argus", number: int | None = None, title: str = "Test Issue",
+) -> GithubIssue:
+    """Create and persist a GithubIssue."""
+    if number is None:
+        number = next(issue_counter)
+    return GithubIssue.create(
+        user_id=uuid4(),
+        type="issues",
+        owner=owner,
+        repo=repo,
+        number=number,
+        state="open",
+        title=title,
+        url=f"https://github.com/{owner}/{repo}/issues/{number}",
+    )
+
+
+def create_jira_issue(
+    key: str | None = None, summary: str = "Test Jira Issue", project: str = "SCYLLA",
+) -> JiraIssue:
+    """Create and persist a JiraIssue."""
+    if key is None:
+        key = f"SCYLLA-{next(issue_counter)}"
+    return JiraIssue.create(
+        user_id=uuid4(),
+        key=key,
+        state="todo",
+        summary=summary,
+        project=project,
+        permalink=f"https://scylladb.atlassian.net/browse/{key}",
+    )
+
+
+DYNAMIC_FIELDS = {"links", "added_on"}
+
+
+def strip_dynamic(record: dict) -> dict:
+    """Remove dynamic fields (links, added_on) that can't be compared statically."""
+    return {k: v for k, v in record.items() if k not in DYNAMIC_FIELDS}
+
+
+def expected_github_issue(issue: GithubIssue) -> dict:
+    """Static shape of a service-level GitHub issue result (without links/added_on)."""
+    return {
+        "id": issue.id,
+        "user_id": issue.user_id,
+        "type": "issues",
+        "owner": "scylladb",
+        "repo": "argus",
+        "number": issue.number,
+        "state": "open",
+        "title": issue.title,
+        "labels": [],
+        "assignees": [],
+        "url": issue.url,
+        "subtype": "github",
+    }
+
+
+def expected_jira_issue(issue: JiraIssue) -> dict:
+    """Static shape of a service-level Jira issue result (without links/added_on)."""
+    return {
+        "id": issue.id,
+        "user_id": issue.user_id,
+        "summary": issue.summary,
+        "key": issue.key,
+        "state": "todo",
+        "project": "SCYLLA",
+        "permalink": issue.permalink,
+        "labels": [],
+        "assignees": [],
+        "subtype": "jira",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def linked_github_issue(client_service, testrun_service, fake_test, issue_service):
+    """Factory fixture: call with (scylla_version, title) to get (run, issue) with a linked GitHub issue."""
+
+    def factory(scylla_version: str | None, title: str) -> tuple[SCTTestRun, GithubIssue]:
+        run = submit_run_with_version(client_service, testrun_service, fake_test, scylla_version=scylla_version)
+        issue = create_github_issue(title=title)
+        issue_service.submit(issue_url=issue.url, test_id=run.test_id, run_id=run.id)
+        return run, issue
+
+    return factory
+
+
+@pytest.fixture
+def linked_jira_issue(client_service, testrun_service, fake_test, issue_service):
+    """Factory fixture: call with (scylla_version, summary) to get (run, issue) with a linked Jira issue."""
+
+    def factory(scylla_version: str | None, summary: str) -> tuple[SCTTestRun, JiraIssue]:
+        run = submit_run_with_version(client_service, testrun_service, fake_test, scylla_version=scylla_version)
+        issue = create_jira_issue(summary=summary)
+        issue_service.submit(issue_url=issue.permalink, test_id=run.test_id, run_id=run.id)
+        return run, issue
+
+    return factory
+
+
+# ---------------------------------------------------------------------------
+# Service-level tests: IssueService.get() with product_version
+# ---------------------------------------------------------------------------
+
+EXPECTED_BUILDERS = {
+    "github": expected_github_issue,
+    "jira": expected_jira_issue,
+}
+
+
+@pytest.mark.parametrize("issue_type", ["github", "jira"])
+@pytest.mark.parametrize(
+    "scylla_version, product_version, include_no_version, expects_match",
+    [
+        pytest.param("2025.1.12", "2025.1.12", False, True, id="exact_match"),
+        pytest.param("2025.1.12", "2025.1", False, True, id="prefix_match"),
+        pytest.param("2024.2.5", "2025.1", False, False, id="non_matching"),
+        pytest.param("2024.2.5", None, False, True, id="no_filter"),
+        pytest.param(None, "!noVersion", False, True, id="no_version_special"),
+        pytest.param("2025.1.12", "!noVersion", False, False, id="no_version_excludes_versioned"),
+        pytest.param(None, "2025.1", True, True, id="include_no_version_true"),
+        pytest.param(None, "2025.1", False, False, id="include_no_version_false"),
+    ],
+)
+def test_get_issues_version_filter(
+    request: pytest.FixtureRequest,
+    issue_service: IssueService,
+    issue_type: str,
+    scylla_version: str | None,
+    product_version: str | None,
+    include_no_version: bool,
+    expects_match: bool,
+):
+    """Issues are filtered (or not) based on run version, product_version param, and include_no_version flag."""
+    fixture_name = f"linked_{issue_type}_issue"
+    factory = request.getfixturevalue(fixture_name)
+    run, issue = factory(scylla_version, f"{issue_type}: {scylla_version}")
+
+    results = issue_service.get(
+        filter_key="run_id",
+        filter_id=run.id,
+        aggregate_by_issue=True,
+        product_version=product_version,
+        include_no_version=include_no_version,
+    )
+
+    comparable = [strip_dynamic(r) for r in results]
+    link_run_ids = [link.run_id for r in results for link in r["links"]]
+    expected = [EXPECTED_BUILDERS[issue_type](issue)] if expects_match else []
+    expected_link_run_ids = [run.id] if expects_match else []
+
+    assert comparable == expected
+    assert link_run_ids == expected_link_run_ids
+
+
+# ---------------------------------------------------------------------------
+# Service-level test: release_id filter key (multi-run, stays standalone)
+# ---------------------------------------------------------------------------
+
+
+def test_get_issues_version_filter_with_release_filter_key(
+    issue_service: IssueService,
+    linked_github_issue,
+    release: "ArgusRelease",
+):
+    """Version filtering should work with filter_key='release_id' (the primary dashboard use case)."""
+    linked_github_issue("2025.2.1", "Release filter match")
+    linked_github_issue("2024.1.0", "Release filter no match")
+
+    results = issue_service.get(
+        filter_key="release_id",
+        filter_id=release.id,
+        aggregate_by_issue=True,
+        product_version="2025.2",
+    )
+
+    returned_titles = {r["title"] for r in results}
+    assert "Release filter match" in returned_titles
+    assert "Release filter no match" not in returned_titles

--- a/argus/backend/util/common.py
+++ b/argus/backend/util/common.py
@@ -70,3 +70,12 @@ def get_build_number(build_job_url: str) -> int | None:
         except ValueError:
             LOGGER.error("Error parsing build number from %s: got %s as build_number", build_job_url, build_number)
     return None
+
+
+def check_version(filter_string: str, version: str) -> bool:
+    if not version:
+        return False
+    if version.startswith(filter_string):
+        return True
+
+    return False

--- a/frontend/Github/Issues.svelte
+++ b/frontend/Github/Issues.svelte
@@ -140,7 +140,6 @@
 </script>
 
 <script lang="ts">
-    import { onMount } from "svelte";
     import { PLUGIN_NAMES } from "../Common/PluginNames";
     import { newIssueDestinations } from "../Common/IssueDestinations";
     import GithubIssue from "./GithubIssue.svelte";
@@ -152,6 +151,7 @@
     import queryString from 'query-string';
     import JiraIssue from "../Jira/JiraIssue.svelte";
     import { sha1 } from "js-sha1";
+    import { untrack } from "svelte";
     interface Props {
         id?: string;
         runId: any;
@@ -160,6 +160,8 @@
         filter_key?: string;
         submitDisabled?: boolean;
         aggregateByIssue?: boolean;
+        productVersion?: string;
+        includeNoVersion?: boolean;
     }
 
     let {
@@ -169,22 +171,29 @@
         pluginName,
         filter_key = "run_id",
         submitDisabled = false,
-        aggregateByIssue = false
+        aggregateByIssue = false,
+        productVersion = undefined,
+        includeNoVersion = false,
     }: Props = $props();
     let newIssueUrl = $state("");
     let issues: Issue[] = $state([]);
     let fetching = $state(false);
     let showAllLabels = $state(false);
     export const fetchIssues = async function () {
-        issues = [];
         fetching = true;
         try {
-
-            let params = queryString.stringify({
+            let queryParams: Record<string, any> = {
                 filterKey: filter_key,
                 id: id,
                 aggregateByIssue: new Number(aggregateByIssue),
-            }).toString();
+            };
+            if (productVersion) {
+                queryParams.productVersion = productVersion;
+                if (includeNoVersion) {
+                    queryParams.includeNoVersion = 1;
+                }
+            }
+            let params = queryString.stringify(queryParams).toString();
             let apiResponse = await fetch("/api/v1/issues/get?" + params);
             let apiJson = await apiResponse.json();
             if (apiJson.status === "ok") {
@@ -332,8 +341,11 @@
 
     let sortedIssues = $derived(paginateIssues(issues, sortCriteria, reverseSort, filterString));
 
-    onMount(() => {
-        fetchIssues();
+    $effect(() => {
+        // Read both props together as a single dependency so the effect fires
+        // exactly once even when both change in the same Svelte flush.
+        void [productVersion, includeNoVersion];
+        untrack(() => fetchIssues());
     });
 </script>
 
@@ -395,7 +407,6 @@
     <div class="container-fluid mb-2">
         {#if issues.length > 0}
             <h6 class="d-flex">
-                <div>Issues</div>
                 <div class="ms-auto">
                     <IssuesCopyModal sortedIssues={sortedIssues} currentPage={currentPage} selectedLabels={selectedLabels}>
                         <Fa icon={faCopy}/>
@@ -480,11 +491,13 @@
             </div>
         {:else}
             <div class="row">
-                <div class="col text-center text-muted">
+                <div class="col text-center text-muted p-3">
                     {#if fetching}
                         <span class="spinner-border spinner-border-sm"></span> Fetching...
+                    {:else if productVersion}
+                        No issues linked for version {productVersion === "!noVersion" ? "runs without a version" : productVersion}.
                     {:else}
-                        No Issues.
+                        No issues found.
                     {/if}
                 </div>
             </div>

--- a/frontend/Github/Issues.svelte
+++ b/frontend/Github/Issues.svelte
@@ -140,7 +140,6 @@
 </script>
 
 <script lang="ts">
-    import { onMount } from "svelte";
     import { PLUGIN_NAMES } from "../Common/PluginNames";
     import { newIssueDestinations } from "../Common/IssueDestinations";
     import GithubIssue from "./GithubIssue.svelte";
@@ -160,6 +159,8 @@
         filter_key?: string;
         submitDisabled?: boolean;
         aggregateByIssue?: boolean;
+        productVersion?: string;
+        includeNoVersion?: boolean;
     }
 
     let {
@@ -169,7 +170,9 @@
         pluginName,
         filter_key = "run_id",
         submitDisabled = false,
-        aggregateByIssue = false
+        aggregateByIssue = false,
+        productVersion = undefined,
+        includeNoVersion = false,
     }: Props = $props();
     let newIssueUrl = $state("");
     let issues: Issue[] = $state([]);
@@ -179,12 +182,18 @@
         issues = [];
         fetching = true;
         try {
-
-            let params = queryString.stringify({
+            let queryParams: Record<string, any> = {
                 filterKey: filter_key,
                 id: id,
                 aggregateByIssue: new Number(aggregateByIssue),
-            }).toString();
+            };
+            if (productVersion) {
+                queryParams.productVersion = productVersion;
+                if (includeNoVersion) {
+                    queryParams.includeNoVersion = 1;
+                }
+            }
+            let params = queryString.stringify(queryParams).toString();
             let apiResponse = await fetch("/api/v1/issues/get?" + params);
             let apiJson = await apiResponse.json();
             if (apiJson.status === "ok") {
@@ -332,7 +341,10 @@
 
     let sortedIssues = $derived(paginateIssues(issues, sortCriteria, reverseSort, filterString));
 
-    onMount(() => {
+    $effect(() => {
+        // Track reactive props — re-fetch when either changes (and on mount).
+        void productVersion;
+        void includeNoVersion;
         fetchIssues();
     });
 </script>
@@ -395,7 +407,6 @@
     <div class="container-fluid mb-2">
         {#if issues.length > 0}
             <h6 class="d-flex">
-                <div>Issues</div>
                 <div class="ms-auto">
                     <IssuesCopyModal sortedIssues={sortedIssues} currentPage={currentPage} selectedLabels={selectedLabels}>
                         <Fa icon={faCopy}/>
@@ -480,11 +491,13 @@
             </div>
         {:else}
             <div class="row">
-                <div class="col text-center text-muted">
+                <div class="col text-center text-muted p-3">
                     {#if fetching}
                         <span class="spinner-border spinner-border-sm"></span> Fetching...
+                    {:else if productVersion}
+                        No issues linked for version {productVersion === "!noVersion" ? "runs without a version" : productVersion}.
                     {:else}
-                        No Issues.
+                        No issues found.
                     {/if}
                 </div>
             </div>

--- a/frontend/Github/Issues.test.ts
+++ b/frontend/Github/Issues.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+// AlertStore and child-component stores must be mocked before the component
+// is imported so Svelte's module evaluation picks up the stubs.
+vi.mock("../Stores/AlertStore", () => ({ sendMessage: vi.fn() }));
+vi.mock("../Stores/UserlistSubscriber.js", () => ({
+    userList: {
+        subscribe: (fn: (v: unknown) => void) => {
+            fn({});
+            return () => {};
+        },
+    },
+}));
+
+import Issues from "./Issues.svelte";
+
+// ---------------------------------------------------------------------------
+// Module-level fixtures
+// ---------------------------------------------------------------------------
+
+// A minimal successful API response with no issues — enough to reach the
+// empty-state branch without rendering child GithubIssue / JiraIssue components.
+const EMPTY_OK_RESPONSE = { json: () => Promise.resolve({ status: "ok", response: [] }) };
+
+const BASE_PROPS = {
+    runId: "run-1",
+    testId: "test-1",
+    pluginName: "scylla-cluster-tests",
+    id: "run-1",
+    submitDisabled: true, // hides the issue-submission form; keeps render minimal
+} as const;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderIssues(extraProps: Record<string, unknown> = {}) {
+    return render(Issues, { props: { ...BASE_PROPS, ...extraProps } });
+}
+
+// Pull the URL string that fetch was called with out of the spy.
+function capturedUrl(fetchSpy: ReturnType<typeof vi.fn>, callIndex = 0): string {
+    return fetchSpy.mock.calls[callIndex][0] as string;
+}
+
+// Wait until the component has settled after a fetch: the empty-state text is
+// visible, meaning fetching=false and issues=[] have been written back to $state.
+// After this point, any spurious $effect re-run would have already fired.
+async function waitForFetchToSettle(emptyStateText = "No issues found.") {
+    await waitFor(() => expect(screen.getByText(emptyStateText)).toBeTruthy());
+    // Flush any remaining microtasks / Svelte scheduler ticks.
+    await tick();
+    await tick();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Issues.svelte — productVersion filtering", () => {
+    let fetchSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        fetchSpy = vi.fn().mockResolvedValue(EMPTY_OK_RESPONSE);
+        vi.stubGlobal("fetch", fetchSpy);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        cleanup();
+    });
+
+    // --- no spurious re-fetch after mount -----------------------------------
+
+    // NOTE: This test attempts to catch the $effect re-run bug where calling
+    // fetchIssues() without untrack() causes the effect to re-run after
+    // issues/fetching $state is written back. In jsdom the Svelte scheduler
+    // coalesces microtasks fast enough that the spurious call may not be
+    // observable within waitFor's timeout, so this test is a best-effort
+    // guard rather than a guaranteed regression detector for that specific bug.
+    it("fetches exactly once on mount and does not re-fetch after state settles", async () => {
+        renderIssues({ productVersion: "6.2.0" });
+        await waitForFetchToSettle("No issues linked for version 6.2.0.");
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    // --- query-string construction ------------------------------------------
+
+    it("omits productVersion and includeNoVersion from the request when productVersion is not set", async () => {
+        renderIssues();
+        await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+
+        const url = capturedUrl(fetchSpy);
+        expect(url).not.toContain("productVersion");
+        expect(url).not.toContain("includeNoVersion");
+    });
+
+    it("includes productVersion in the request when the prop is provided", async () => {
+        renderIssues({ productVersion: "6.2.0" });
+        await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+
+        expect(capturedUrl(fetchSpy)).toContain("productVersion=6.2.0");
+    });
+
+    it.each([
+        {
+            productVersion: "6.2.0",
+            includeNoVersion: false,
+            shouldInclude: false,
+            label: "omits includeNoVersion when false",
+        },
+        {
+            productVersion: "6.2.0",
+            includeNoVersion: true,
+            shouldInclude: true,
+            label: "includes includeNoVersion=1 when true",
+        },
+    ])("$label", async ({ productVersion, includeNoVersion, shouldInclude }) => {
+        renderIssues({ productVersion, includeNoVersion });
+        await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+
+        const url = capturedUrl(fetchSpy);
+        if (shouldInclude) {
+            expect(url).toContain("includeNoVersion=1");
+        } else {
+            expect(url).not.toContain("includeNoVersion");
+        }
+    });
+
+    it("omits includeNoVersion even when true if productVersion is not set", async () => {
+        renderIssues({ includeNoVersion: true });
+        await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+
+        expect(capturedUrl(fetchSpy)).not.toContain("includeNoVersion");
+    });
+
+    // --- reactive re-fetch --------------------------------------------------
+
+    it("re-fetches when productVersion prop changes", async () => {
+        const { rerender } = renderIssues({ productVersion: "6.1.0" });
+        await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+
+        await rerender({ props: { ...BASE_PROPS, productVersion: "6.2.0" } });
+        await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
+
+        expect(capturedUrl(fetchSpy, 1)).toContain("productVersion=6.2.0");
+    });
+
+    it("re-fetches when includeNoVersion prop changes", async () => {
+        const { rerender } = renderIssues({ productVersion: "6.2.0", includeNoVersion: false });
+        await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+
+        await rerender({ props: { ...BASE_PROPS, productVersion: "6.2.0", includeNoVersion: true } });
+        await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
+
+        expect(capturedUrl(fetchSpy, 1)).toContain("includeNoVersion=1");
+    });
+
+    // --- empty-state messages -----------------------------------------------
+    it.each([
+        {
+            productVersion: "6.2.0",
+            expected: "No issues linked for version 6.2.0.",
+            label: "named version",
+        },
+        {
+            productVersion: "!noVersion",
+            expected: "No issues linked for version runs without a version.",
+            label: "!noVersion sentinel",
+        },
+    ])("shows version-specific empty-state for $label", async ({ productVersion, expected }) => {
+        renderIssues({ productVersion });
+        await waitFor(() => expect(screen.getByText(expected)).toBeTruthy());
+    });
+
+    it("shows generic empty-state when productVersion is not set", async () => {
+        renderIssues();
+        await waitFor(() => expect(screen.getByText("No issues found.")).toBeTruthy());
+    });
+});

--- a/frontend/ReleaseDashboard/ReleaseDashboard.svelte
+++ b/frontend/ReleaseDashboard/ReleaseDashboard.svelte
@@ -11,6 +11,7 @@
     let clickedTests = $state({});
     let issuesClicked = $state(false);
     let productVersion = $state(queryString.parse(document.location.search)?.productVersion);
+    let includeNoVersion = $state(false);
     let stats = $state();
 
     const handleTestClick = function (detail) {
@@ -29,6 +30,7 @@
 
     const handleVersionChange = function (e) {
         productVersion = e.detail.version;
+        includeNoVersion = e.detail.includeNoVersion;
     };
 
     const handleDeleteRequest = function(e) {
@@ -75,7 +77,7 @@
                             data-bs-target="#collapseIssues"
                             onclick={() => issuesClicked = true}
                         >
-                            All Issues
+                            Issues
                         </button>
                     </h2>
                     <div
@@ -89,6 +91,8 @@
                                 filter_key="release_id"
                                 submitDisabled={true}
                                 aggregateByIssue={true}
+                                {productVersion}
+                                {includeNoVersion}
                             />
                             {/if}
                         </div>

--- a/frontend/ReleaseDashboard/TestDashboard.svelte
+++ b/frontend/ReleaseDashboard/TestDashboard.svelte
@@ -375,8 +375,7 @@
         return [...enterpriseVersions, ...ossVersions, ...unrecognizedVersions];
     };
 
-    const fetchImages = async function() {
-        let response = await fetch(PANEL_MODES[dashboardObjectType].imagesRoute(dashboardObject));
+    const fetchImages = async function() {        let response = await fetch(PANEL_MODES[dashboardObjectType].imagesRoute(dashboardObject));
         if (response.status != 200) {
             return Promise.reject("API Error");
         }
@@ -387,6 +386,9 @@
 
         return json.response.map(v => ({ label: v, value : v}));
     };
+
+    let versionsPromise: Promise<string[]> = fetchVersions();
+    let imagesPromise: Promise<{label: string, value: string}[]> = fetchImages();
 
     const shouldFilterVersion = function (version) {
         if (!stats) return false;
@@ -423,7 +425,7 @@
         params.productVersion = versionString;
         history.pushState(undefined, "", `?${queryString.stringify(params, { arrayFormat: "bracket" })}`);
         fetchStats();
-        dispatch("versionChange", { version: productVersion });
+        dispatch("versionChange", { version: productVersion, includeNoVersion: versionsIncludeNoVersion });
     };
 
     const handleTestClick = function (testStats, groupStats) {
@@ -520,7 +522,7 @@
         {/if}
     </div>
     {#if !settings.targetVersion}
-        {#await fetchVersions()}
+        {#await versionsPromise}
             <div>Loading versions...</div>
         {:then versions}
             <div class="d-inline-flex flex-wrap mb-2 rounded bg-white p-2" style="flex-basis: 10%; row-gap: 0.75em">
@@ -642,7 +644,7 @@
                             <div class="mb-2 d-inline-flex w-50 align-items-start flex-column rounded bg-white">
                             <div class="p-2">Filter by ImageId</div>
                             <div class="p-2 w-100">
-                                {#await fetchImages()}
+                                {#await imagesPromise}
                                     <div class="spinner-grow spinner-grow-sm"></div> Loading Images...
                                 {:then images}
                                 <Select

--- a/frontend/ReleaseDashboard/TestDashboard.svelte
+++ b/frontend/ReleaseDashboard/TestDashboard.svelte
@@ -422,7 +422,7 @@
         params.productVersion = versionString;
         history.pushState(undefined, "", `?${queryString.stringify(params, { arrayFormat: "bracket" })}`);
         fetchStats();
-        dispatch("versionChange", { version: productVersion });
+        dispatch("versionChange", { version: productVersion, includeNoVersion: versionsIncludeNoVersion });
     };
 
     const handleTestClick = function (testStats, groupStats) {

--- a/frontend/Views/Widgets/ViewGithubIssues.svelte
+++ b/frontend/Views/Widgets/ViewGithubIssues.svelte
@@ -23,7 +23,7 @@
                 data-bs-target="#collapseIssues"
                 onclick={() => issuesClicked = true}
             >
-                All Issues
+                Issues
             </button>
         </h2>
         <div
@@ -37,7 +37,9 @@
                         filter_key="view_id"
                         submitDisabled={settings.submitDisabled}
                         aggregateByIssue={settings.aggregateByIssue}
+                        {productVersion}
                     />
+                    <!-- includeNoVersion intentionally omitted — Views dashboard has no toggle for it -->
                 {/if}
             </div>
         </div>


### PR DESCRIPTION
## Why
I would like to get answer to the question: “What issue were found during investigation of version 2025.1.12” easily, it will help me go over the issues in a reasonable manner, without having to click on each run and gather issues from there.

## Summary
- Add `productVersion` and `includeNoVersion` query params to the `/api/v1/issues/get` endpoint, enabling filtering of issues by the Scylla version of their linked test runs
- Backend centralizes link fetching in `IssueService`, builds a version map by resolving `test_id → plugin_name → plugin model`, then batch-fetches `scylla_version` using `execute_concurrent_with_args` with bounded concurrency
- Frontend passes `productVersion` and `includeNoVersion` through from the Release Dashboard and Views Dashboard to the `<Issues>` component, which re-fetches automatically when either value changes

## Changes

### Backend
- **`argus/backend/plugins/core.py`** — Added `get_versions_by_run_ids()` classmethod to `PluginModelBase` using `execute_concurrent_with_args(concurrency=50)`
- **`argus/backend/service/issue_utils.py`** — New module with `build_version_map()` (resolves run versions via correct plugin table) and `filter_links_by_version()` helper
- **`argus/backend/service/issue_service.py`** — Refactored `IssueService.get()` to fetch all links once via `_get_links()`, build version map once, filter once, then delegate to `resolve_issues()` on gh/jira services
- **`argus/backend/service/github_service.py`** — Reverted `get_issues()` to original signature, added `resolve_issues()` method that takes pre-filtered links
- **`argus/backend/service/jira_service.py`** — Same pattern as github_service
- **`argus/backend/controller/testrun_api.py`** — Updated `/issues/get` endpoint to accept `productVersion` and `includeNoVersion` query params
- **`argus/backend/util/common.py`** — Moved `check_version()` from `stats.py` to avoid circular imports
- **`argus/backend/service/stats.py`** — Now imports `check_version` from `util.common`

### Frontend
- **`frontend/Github/Issues.svelte`** — Added `productVersion`/`includeNoVersion` props, single `$effect` for reactive re-fetch, version-aware empty state message, removed unused `onMount` import and duplicate inner heading
- **`frontend/ReleaseDashboard/ReleaseDashboard.svelte`** — Passes version props to `<Issues>`, captures `includeNoVersion` from `versionChange` event
- **`frontend/ReleaseDashboard/TestDashboard.svelte`** — Includes `includeNoVersion` in `versionChange` event dispatch
- **`frontend/Views/Widgets/ViewGithubIssues.svelte`** — Passes `productVersion` to `<Issues>`

### Tests
- **`argus/backend/tests/issues/test_issue_version_filter.py`** — 17 parametrized service-level tests covering exact match, prefix match, non-matching version, no filter, `!noVersion` special value, `includeNoVersion` toggle, release-level filtering, for both GitHub and Jira issue types

Fix https://scylladb.atlassian.net/browse/ARGUS-128