### PR TITLE
fix: Fix Jira rendering

### DIFF
--- a/argus/backend/plugins/sct/service.py
+++ b/argus/backend/plugins/sct/service.py
@@ -12,6 +12,7 @@ from flask import current_app, g
 from cassandra.util import uuid_from_time
 from argus.backend.db import ScyllaCluster
 from argus.backend.models.github_issue import GithubIssue, IssueLink
+from argus.backend.models.jira import JiraIssue
 from argus.backend.models.web import ArgusEventTypes, ErrorEventEmbeddings, CriticalEventEmbeddings
 from argus.backend.models.argus_ai import SCTErrorEventEmbedding, SCTCriticalEventEmbedding
 from argus.backend.plugins.sct.testrun import SCTEvent, SCTEventSeverity, SCTJunitReports, SCTTestRun, SubtestType, SCTUnprocessedEvent, StressCommand
@@ -698,10 +699,23 @@ class SCTService:
         issues_by_id = {}
         if all_issue_ids:
             for batch_issue_ids in chunk(list(all_issue_ids)):
-                batch_issues = GithubIssue.filter(id__in=batch_issue_ids).all()
-
-                for issue in batch_issues:
-                    issues_by_id[issue.id] = issue
+                for issue in GithubIssue.filter(id__in=batch_issue_ids).all():
+                    issues_by_id[issue.id] = {
+                        "type": "github",
+                        "number": issue.number,
+                        "state": issue.state,
+                        "title": issue.title,
+                        "url": issue.url,
+                    }
+                for issue in JiraIssue.filter(id__in=batch_issue_ids).only(
+                        ["id", "state", "summary", "key", "permalink"]).all():
+                    issues_by_id[issue.id] = {
+                        "type": "jira",
+                        "state": issue.state,
+                        "summary": issue.summary,
+                        "key": issue.key,
+                        "permalink": issue.permalink,
+                    }
 
         # Step 3: Fetch test runs only for run_ids that have issue links (limiting to MAX_SIMILARS runs)
         runs_with_issues = list(all_issue_links.keys())
@@ -723,7 +737,6 @@ class SCTService:
                     continue
 
                 links = all_issue_links.get(run_id, [])
-                issues = [issues_by_id[link.issue_id] for link in links if link.issue_id in issues_by_id]
 
                 try:
                     build_number = int(
@@ -745,13 +758,8 @@ class SCTService:
                     "start_time": test_run.start_time.isoformat(),
                     "version": sut_version or "unknown",
                     "issues": [
-                        {
-                            "number": issue.number,
-                            "state": issue.state,
-                            "title": issue.title,
-                            "url": issue.url,
-                        }
-                        for issue in issues
+                        issues_by_id[link.issue_id]
+                        for link in links if link.issue_id in issues_by_id
                     ],
                 }
             except Exception as e:

--- a/argus/backend/service/views_widgets/graphed_stats.py
+++ b/argus/backend/service/views_widgets/graphed_stats.py
@@ -5,6 +5,7 @@ import re
 from argus.backend.db import ScyllaCluster
 from argus.backend.plugins.sct.testrun import SCTTestRun
 from argus.backend.models.github_issue import GithubIssue, IssueLink
+from argus.backend.models.jira import JiraIssue
 from argus.backend.util.common import chunk
 from argus.backend.util.nemesis_map import get_nemesis_name
 
@@ -107,11 +108,24 @@ class GraphedStatsService:
         issues_by_id = {}
         if all_issue_ids:
             for batch_issue_ids in chunk(list(all_issue_ids)):
-                batch_issues = GithubIssue.filter(id__in=batch_issue_ids).only(
-                    ["id", "state", "title", "number", "url"]).all()
-
-                for issue in batch_issues:
-                    issues_by_id[issue.id] = issue
+                for issue in GithubIssue.filter(id__in=batch_issue_ids).only(
+                        ["id", "state", "title", "number", "url"]).all():
+                    issues_by_id[issue.id] = {
+                        "type": "github",
+                        "number": issue.number,
+                        "state": issue.state,
+                        "title": issue.title,
+                        "url": issue.url,
+                    }
+                for issue in JiraIssue.filter(id__in=batch_issue_ids).only(
+                        ["id", "state", "summary", "key", "permalink"]).all():
+                    issues_by_id[issue.id] = {
+                        "type": "jira",
+                        "state": issue.state,
+                        "summary": issue.summary,
+                        "key": issue.key,
+                        "permalink": issue.permalink,
+                    }
 
         # Step 3: Fetch test runs for all provided run_ids
         test_runs = {}
@@ -138,7 +152,6 @@ class GraphedStatsService:
                     continue
 
                 links = all_issue_links.get(run_id, [])
-                issues = [issues_by_id[issue_id] for issue_id in links if issue_id in issues_by_id]
 
                 build_number = test_run.build_number
 
@@ -159,13 +172,8 @@ class GraphedStatsService:
                     "version": sut_version,
                     "investigation_status": test_run.investigation_status,
                     "issues": [
-                        {
-                            "number": issue.number,
-                            "state": issue.state,
-                            "title": issue.title,
-                            "url": issue.url,
-                        }
-                        for issue in issues
+                        issues_by_id[issue_id]
+                        for issue_id in links if issue_id in issues_by_id
                     ],
                 }
             except Exception as e:

--- a/frontend/Common/IssueBadge.svelte
+++ b/frontend/Common/IssueBadge.svelte
@@ -1,0 +1,35 @@
+<!--
+    Shared inline issue icon + label renderer.
+    Works with the `type`-based discriminator ("github" | "jira") used by
+    graphed_stats and sct/service endpoints.
+
+    Renders: [icon] [label text]
+    where icon is faJira / faGithub (or state-based for GitHub),
+    and label is the Jira key or GitHub #number.
+-->
+<script lang="ts">
+    import Fa from "svelte-fa";
+    import { faCheckCircle, faDotCircle } from "@fortawesome/free-solid-svg-icons";
+    import { faGithub, faJira } from "@fortawesome/free-brands-svg-icons";
+    import { isJiraIssue, getIssueLabel } from "./IssueUtils";
+
+    interface Props {
+        issue: any;
+        /** Show state-based icons for GitHub (faDotCircle/faCheckCircle) instead of faGithub brand icon */
+        stateIcons?: boolean;
+        /** Render only the icon, no label text */
+        iconOnly?: boolean;
+    }
+
+    let { issue, stateIcons = false, iconOnly = false }: Props = $props();
+
+    function getIcon(issue: any) {
+        if (isJiraIssue(issue)) return faJira;
+        if (stateIcons) {
+            return issue.state === "open" ? faDotCircle : faCheckCircle;
+        }
+        return faGithub;
+    }
+</script>
+
+<Fa icon={getIcon(issue)} color={isJiraIssue(issue) ? "#0052CC" : undefined} />{#if !iconOnly}{" "}{getIssueLabel(issue)}{/if}

--- a/frontend/Common/IssueUtils.test.ts
+++ b/frontend/Common/IssueUtils.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import {
+    isJiraIssue,
+    isGithubIssue,
+    getIssueLabel,
+    getIssueLabelFull,
+    getIssueUrl,
+    getIssueTitle,
+    getIssueKey,
+    type JiraIssue,
+    type GithubIssue,
+} from "./IssueUtils";
+
+const jiraIssue: JiraIssue = {
+    type: "jira",
+    state: "in progress",
+    summary: "Fix login timeout",
+    key: "PROJ-123",
+    permalink: "https://jira.example.com/browse/PROJ-123",
+};
+
+const githubOpen: GithubIssue = {
+    type: "github",
+    number: 42,
+    state: "open",
+    title: "Button does not render",
+    url: "https://github.com/org/repo/issues/42",
+};
+
+const githubWithOwner: GithubIssue = {
+    type: "github",
+    number: 7,
+    state: "closed",
+    title: "Stale dependency",
+    url: "https://github.com/scylladb/argus/issues/7",
+    owner: "scylladb",
+    repo: "argus",
+};
+
+describe("isJiraIssue", () => {
+    it("returns true for Jira issues", () => {
+        expect(isJiraIssue(jiraIssue)).toBe(true);
+    });
+
+    it("returns false for GitHub issues", () => {
+        expect(isJiraIssue(githubOpen)).toBe(false);
+    });
+});
+
+describe("isGithubIssue", () => {
+    it("returns true for GitHub issues", () => {
+        expect(isGithubIssue(githubOpen)).toBe(true);
+    });
+
+    it("returns false for Jira issues", () => {
+        expect(isGithubIssue(jiraIssue)).toBe(false);
+    });
+});
+
+describe("getIssueLabel", () => {
+    it("returns key for Jira issues", () => {
+        expect(getIssueLabel(jiraIssue)).toBe("PROJ-123");
+    });
+
+    it("returns #number for GitHub issues", () => {
+        expect(getIssueLabel(githubOpen)).toBe("#42");
+    });
+});
+
+describe("getIssueLabelFull", () => {
+    it("returns key for Jira issues", () => {
+        expect(getIssueLabelFull(jiraIssue)).toBe("PROJ-123");
+    });
+
+    it("returns owner/repo#number when owner and repo are present", () => {
+        expect(getIssueLabelFull(githubWithOwner)).toBe("scylladb/argus#7");
+    });
+
+    it("falls back to #number when owner/repo are missing", () => {
+        expect(getIssueLabelFull(githubOpen)).toBe("#42");
+    });
+});
+
+describe("getIssueUrl", () => {
+    it("returns permalink for Jira issues", () => {
+        expect(getIssueUrl(jiraIssue)).toBe("https://jira.example.com/browse/PROJ-123");
+    });
+
+    it("returns url for GitHub issues", () => {
+        expect(getIssueUrl(githubOpen)).toBe("https://github.com/org/repo/issues/42");
+    });
+});
+
+describe("getIssueTitle", () => {
+    it("returns summary for Jira issues", () => {
+        expect(getIssueTitle(jiraIssue)).toBe("Fix login timeout");
+    });
+
+    it("returns title for GitHub issues", () => {
+        expect(getIssueTitle(githubOpen)).toBe("Button does not render");
+    });
+});
+
+describe("getIssueKey", () => {
+    it("returns Jira key as-is", () => {
+        expect(getIssueKey(jiraIssue)).toBe("PROJ-123");
+    });
+
+    it("returns GitHub number as string", () => {
+        expect(getIssueKey(githubOpen)).toBe("42");
+    });
+});

--- a/frontend/Common/IssueUtils.ts
+++ b/frontend/Common/IssueUtils.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared helpers for issues using the `type` discriminator ("github" | "jira").
+ *
+ * These operate on the lean issue shapes returned by graphed_stats and
+ * sct/service endpoints where the discriminator field is `type` (as opposed
+ * to `subtype` used by the full Issues system).
+ */
+
+export interface GithubIssue {
+    type: "github";
+    url: string;
+    number: number;
+    title: string;
+    state: string;
+    owner?: string;
+    repo?: string;
+}
+
+export interface JiraIssue {
+    type: "jira";
+    key: string;
+    summary: string;
+    permalink: string;
+    state: string;
+}
+
+export type Issue = GithubIssue | JiraIssue;
+
+export function isJiraIssue(issue: Issue): issue is JiraIssue {
+    return issue.type === "jira";
+}
+
+export function isGithubIssue(issue: Issue): issue is GithubIssue {
+    return issue.type === "github";
+}
+
+/** Short label: Jira key or GitHub #number. */
+export function getIssueLabel(issue: Issue): string {
+    if (isJiraIssue(issue)) return issue.key;
+    return `#${issue.number}`;
+}
+
+/** Full label: Jira key or owner/repo#number (falls back to #number). */
+export function getIssueLabelFull(issue: Issue): string {
+    if (isJiraIssue(issue)) return issue.key;
+    if (issue.owner && issue.repo) return `${issue.owner}/${issue.repo}#${issue.number}`;
+    return `#${issue.number}`;
+}
+
+export function getIssueUrl(issue: Issue): string {
+    if (isJiraIssue(issue)) return issue.permalink;
+    return issue.url;
+}
+
+export function getIssueTitle(issue: Issue): string {
+    if (isJiraIssue(issue)) return issue.summary;
+    return issue.title;
+}
+
+/** Unique key for keyed each blocks. */
+export function getIssueKey(issue: Issue): string {
+    if (isJiraIssue(issue)) return issue.key;
+    return String(issue.number);
+}

--- a/frontend/ReleaseDashboard/TestPopoutSelector.svelte
+++ b/frontend/ReleaseDashboard/TestPopoutSelector.svelte
@@ -17,7 +17,8 @@
         faComment,
         faArrowUp,
     } from "@fortawesome/free-solid-svg-icons";
-    import { faGithub } from "@fortawesome/free-brands-svg-icons";
+    import { getIssueUrl, getIssueTitle, getIssueLabelFull } from "../Common/IssueUtils";
+    import IssueBadge from "../Common/IssueBadge.svelte";
     interface Props {
         tests?: any;
         releaseName?: string;
@@ -166,22 +167,20 @@
                                                         class="ms-3 d-flex align-items-center"
                                                     >
                                                         <div class="ms-1">
-                                                            <Fa
-                                                                icon={faGithub}
-                                                            />
+                                                            <IssueBadge {issue} iconOnly />
                                                         </div>
                                                         <div class="ms-1">
                                                             <a
                                                                 target="_blank"
-                                                                href={issue.url}
+                                                                href={getIssueUrl(issue)}
                                                             >
-                                                                {issue.title}
+                                                                {getIssueTitle(issue)}
                                                             </a>
                                                         </div>
                                                         <div
                                                             class="ms-auto text-muted"
                                                         >
-                                                            {issue.owner}/{issue.repo}#{issue.number}
+                                                            {getIssueLabelFull(issue)}
                                                         </div>
                                                     </li>
                                                 {/each}

--- a/frontend/ReleaseDashboard/TestWithIssuesCard.svelte
+++ b/frontend/ReleaseDashboard/TestWithIssuesCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import GithubIssue from "../Github/GithubIssue.svelte";
+    import JiraIssue from "../Jira/JiraIssue.svelte";
 
     let { test = {
 
@@ -10,7 +11,11 @@
     <div class="fs-3">{test.name}</div>
     <div class="container-fluid">
         {#each issues as issue}
-            <GithubIssue {issue} />
+            {#if issue.subtype === "jira"}
+                <JiraIssue {issue} runId={issue.run_id} />
+            {:else}
+                <GithubIssue {issue} runId={issue.run_id} />
+            {/if}
         {/each}
     </div>
 </div>

--- a/frontend/TestRun/SCT/SctSimilarEvents.svelte
+++ b/frontend/TestRun/SCT/SctSimilarEvents.svelte
@@ -17,6 +17,8 @@
 <script lang="ts">
     import { faCheckCircle, faDotCircle, faExclamationTriangle, faPlus } from "@fortawesome/free-solid-svg-icons";
     import Fa from "svelte-fa";
+    import IssueBadge from "../../Common/IssueBadge.svelte";
+    import { isJiraIssue, getIssueUrl, getIssueTitle } from "../../Common/IssueUtils";
     import { sendMessage } from "../../Stores/AlertStore";
     import ModalWindow from "../../Common/ModalWindow.svelte";
     import { timestampToISODate } from "../../Common/DateUtils";
@@ -221,22 +223,22 @@
                                                             class:btn-closed={issue.state !== "open"}
                                                             class="btn btn-sm"
                                                             title="Add this issue to the current run"
-                                                            onclick={() => issueAttach?.(issue.url)}
+                                                            onclick={() => issueAttach?.(getIssueUrl(issue))}
                                                         >
                                                             <Fa icon={faPlus}/>
                                                         </button>
                                                         <a
-                                                            href={issue.url}
-                                                            class:btn-open={issue.state === "open"}
-                                                            class:btn-closed={issue.state !== "open"}
+                                                            href={getIssueUrl(issue)}
+                                                            class:btn-open={isJiraIssue(issue) || issue.state === "open"}
+                                                            class:btn-closed={!isJiraIssue(issue) && issue.state !== "open"}
                                                             target="_blank"
                                                             class="btn btn-sm"
                                                         >
-                                                            <Fa icon={issue.state === "open" ? faDotCircle : faCheckCircle}/> #{issue.number}
+                                                            <IssueBadge {issue} stateIcons />
                                                         </a>
                                                     </div>
-                                                    <div class="ms-2 overflow-ellipsis text-truncate" style="max-width: 400px" title="{issue.title}">
-                                                        {issue.title}
+                                                    <div class="ms-2 overflow-ellipsis text-truncate" style="max-width: 400px" title="{getIssueTitle(issue)}">
+                                                        {getIssueTitle(issue)}
                                                     </div>
                                                 </div>
                                             {/each}

--- a/frontend/TestRun/StructuredEvent.svelte
+++ b/frontend/TestRun/StructuredEvent.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
     import {faArrowUpRightFromSquare, faCheckCircle, faCopy, faDotCircle, faLink, faPlus} from "@fortawesome/free-solid-svg-icons";
     import Fa from "svelte-fa";
+    import IssueBadge from "../Common/IssueBadge.svelte";
+    import { isJiraIssue, getIssueUrl, getIssueTitle } from "../Common/IssueUtils";
     import { sendMessage } from "../Stores/AlertStore";
     import ModalWindow from "../Common/ModalWindow.svelte";
     import { createEventDispatcher } from "svelte";
@@ -255,20 +257,26 @@
                                                     <div class="mb-1 d-flex align-items-center">
                                                         <div class="btn-group" style="width: 128px">
                                                             <button
-                                                                class:btn-open={issue.state === "open"}
-                                                                class:btn-closed={issue.state !== "open"}
+                                                                class:btn-open={!isJiraIssue(issue) && issue.state === "open"}
+                                                                class:btn-closed={!isJiraIssue(issue) && issue.state !== "open"}
                                                                 class="btn btn-sm"
                                                                 title="Add this issue to the current run"
-                                                                onclick={() => dispatch("issueAttach", { url: issue.url })}
+                                                                onclick={() => dispatch("issueAttach", { url: getIssueUrl(issue) })}
                                                             >
                                                                 <Fa icon={faPlus}/>
                                                             </button>
-                                                            <a href={issue.url} class:btn-open={issue.state === "open"} class:btn-closed={issue.state !== "open"} target="_blank" class="btn btn-sm">
-                                                                <Fa icon={issue.state === "open" ? faDotCircle : faCheckCircle}/> #{issue.number}
+                                                            <a
+                                                                href={getIssueUrl(issue)}
+                                                                class:btn-open={isJiraIssue(issue) || issue.state === "open"}
+                                                                class:btn-closed={!isJiraIssue(issue) && issue.state !== "open"}
+                                                                target="_blank"
+                                                                class="btn btn-sm"
+                                                            >
+                                                                <IssueBadge {issue} stateIcons />
                                                             </a>
                                                         </div>
-                                                        <div class="ms-2 overflow-ellipsis text-truncate" style="max-width: 512px" title="{issue.title}">
-                                                            {issue.title}
+                                                        <div class="ms-2 overflow-ellipsis text-truncate" style="max-width: 512px" title="{getIssueTitle(issue)}">
+                                                            {getIssueTitle(issue)}
                                                         </div>
                                                     </div>
                                                 {/each}

--- a/frontend/Views/Widgets/ViewGraphedStats/Interfaces.ts
+++ b/frontend/Views/Widgets/ViewGraphedStats/Interfaces.ts
@@ -1,4 +1,24 @@
 // Types
+export interface GithubIssue {
+    type: "github";
+    number: number;
+    state: string;
+    title: string;
+    url: string;
+    owner?: string;
+    repo?: string;
+}
+
+export interface JiraIssue {
+    type: "jira";
+    state: string;
+    summary: string;
+    key: string;
+    permalink: string;
+}
+
+export type Issue = GithubIssue | JiraIssue;
+
 export interface TestRun {
     build_id: string;
     version: string;
@@ -10,13 +30,6 @@ export interface TestRun {
     investigation_status: string;
     assignee?: string;
     issues?: Issue[];
-}
-
-export interface Issue {
-    number: number;
-    state: string;
-    title: string;
-    url: string;
 }
 
 export interface RunDetails {

--- a/frontend/Views/Widgets/ViewGraphedStats/IssuesCell.svelte
+++ b/frontend/Views/Widgets/ViewGraphedStats/IssuesCell.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-    import type { TestRun } from "./Interfaces";
+    import type { TestRun, Issue } from "./Interfaces";
+    import { getIssueLabel, getIssueUrl, getIssueTitle, getIssueKey, isJiraIssue } from "../../../Common/IssueUtils";
 
     interface Props {
         run: TestRun;
@@ -7,22 +8,27 @@
 
     let { run }: Props = $props();
 
-    const issues = run.issues || [];
+    const issues: Issue[] = run.issues || [];
     const hasIssues = issues.length > 0;
+
+    function getIssueColorClass(issue: Issue): string {
+        if (isJiraIssue(issue)) return "issue-jira";
+        return issue.state === "open" ? "issue-open" : "issue-closed";
+    }
 </script>
 
 {#if !hasIssues}
     <span class="text-muted">No issues</span>
 {:else}
     <div class="issues-container">
-        {#each issues as issue (issue.number)}
+        {#each issues as issue (getIssueKey(issue))}
             <a
-                href={issue.url}
+                href={getIssueUrl(issue)}
                 target="_blank"
-                class="badge me-1 {issue.state === 'open' ? 'issue-open' : 'issue-closed'}"
-                title={issue.title}
+                class="badge me-1 {getIssueColorClass(issue)}"
+                title={getIssueTitle(issue)}
             >
-                #{issue.number}
+                {getIssueLabel(issue)}
             </a>
         {/each}
     </div>
@@ -42,6 +48,11 @@
 
     .issue-closed {
         background-color: #6c757d;
+        color: white;
+    }
+
+    .issue-jira {
+        background-color: #0052cc;
         color: white;
     }
 


### PR DESCRIPTION
### Summary

Currently, Jira issues are only semi-handled on frontend. For example, on dashboard they are rendered without title and with wrong icon like this:
<img width="1554" height="721" alt="before" src="https://github.com/user-attachments/assets/0e49c46e-da9a-4b50-a387-c0318c7c8447" />

After the patch it looks like this
<img width="1564" height="711" alt="after" src="https://github.com/user-attachments/assets/a9730ebf-bb92-442c-85e9-8eeadf0019fd" />

This should be "bugfix" mostly, so I did not write a plan. It is fixing existing functionality rather than drastically changing or adding new stuff

### Changes

* Add JIRA information for similar events and graphed stats
   * This one might be removed, and it can be frontend only fix as it is more complex to verify correctness
* Unify frontend handling of icon + summary via new IssueBadge library.
   * Future refactors can unify it even futher with GithubIssue and JiraIssue component
   * Jira icon is blue, because it looks better  
* Add test for utils functionality (Requires https://github.com/scylladb/argus/pull/966)

