### PR TITLE
fix(frontend): use numeric-aware version sorting across all views 

### DIFF
--- a/frontend/Common/versionSort.test.ts
+++ b/frontend/Common/versionSort.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { compareVersions } from "./versionSort";
+
+describe("compareVersions", () => {
+    describe("basic numeric ordering", () => {
+        it("sorts simple versions numerically, not lexicographically", () => {
+            expect(compareVersions("5.10", "5.9")).toBeGreaterThan(0);
+            expect(compareVersions("5.2", "5.10")).toBeLessThan(0);
+        });
+
+        it("sorts three-segment versions", () => {
+            expect(compareVersions("5.2.1", "5.2.0")).toBeGreaterThan(0);
+            expect(compareVersions("5.2.1", "5.2.1")).toBe(0);
+            expect(compareVersions("5.2.1", "5.3.0")).toBeLessThan(0);
+        });
+
+        it("sorts calendar-style versions", () => {
+            expect(compareVersions("2025.1.3", "2024.2.9")).toBeGreaterThan(0);
+        });
+    });
+
+    describe("pre-release ordering", () => {
+        it("rc sorts before official release", () => {
+            expect(compareVersions("5.2.1.rc1", "5.2.1")).toBeLessThan(0);
+        });
+
+        it("dev sorts before rc (lexicographic)", () => {
+            expect(compareVersions("5.2.1.dev", "5.2.1.rc1")).toBeLessThan(0);
+        });
+
+        it("dev sorts before official release", () => {
+            expect(compareVersions("5.2.1.dev", "5.2.1")).toBeLessThan(0);
+        });
+
+        it("handles tilde-separated pre-release (6.0.0~rc1)", () => {
+            expect(compareVersions("6.0.0~rc1", "6.0.0")).toBeLessThan(0);
+            expect(compareVersions("6.0.0~rc1", "6.0.0~rc2")).toBeLessThan(0);
+        });
+    });
+
+    describe("build metadata stripping", () => {
+        it("ignores build metadata after first dash", () => {
+            expect(compareVersions("5.2.1-0.20240815.abc", "5.2.1")).toBe(0);
+        });
+
+        it("compares versions identically when only metadata differs", () => {
+            expect(compareVersions("5.2.1-build1", "5.2.1-build2")).toBe(0);
+        });
+    });
+
+    describe("different segment lengths", () => {
+        it("shorter numeric version is less than longer", () => {
+            expect(compareVersions("5.2", "5.2.1")).toBeLessThan(0);
+        });
+
+        it("equal versions return 0", () => {
+            expect(compareVersions("5.2.1", "5.2.1")).toBe(0);
+        });
+    });
+
+    describe("null/undefined/empty guards", () => {
+        it("both null returns 0", () => {
+            expect(compareVersions(null, null)).toBe(0);
+        });
+
+        it("both undefined returns 0", () => {
+            expect(compareVersions(undefined, undefined)).toBe(0);
+        });
+
+        it("null sorts after any real version", () => {
+            expect(compareVersions(null, "5.2.1")).toBeGreaterThan(0);
+            expect(compareVersions("5.2.1", null)).toBeLessThan(0);
+        });
+
+        it("undefined sorts after any real version", () => {
+            expect(compareVersions(undefined, "5.2.1")).toBeGreaterThan(0);
+            expect(compareVersions("5.2.1", undefined)).toBeLessThan(0);
+        });
+
+        it("empty string sorts after any real version", () => {
+            expect(compareVersions("", "5.2.1")).toBeGreaterThan(0);
+            expect(compareVersions("5.2.1", "")).toBeLessThan(0);
+        });
+    });
+
+    describe("full array sorting", () => {
+        it("sorts a mixed array in correct ascending order", () => {
+            const input = ["5.10.0", "5.9.0", "5.2.1.rc1", "5.2.1", "5.2.1.dev", "2024.1.3", "6.0.0~rc1", "6.0.0"];
+            const sorted = [...input].sort(compareVersions);
+            expect(sorted).toEqual([
+                "5.2.1.dev",
+                "5.2.1.rc1",
+                "5.2.1",
+                "5.9.0",
+                "5.10.0",
+                "6.0.0~rc1",
+                "6.0.0",
+                "2024.1.3",
+            ]);
+        });
+
+        it("pushes nullish values to the end", () => {
+            const input: (string | null | undefined)[] = ["5.2.1", null, "5.1.0", undefined, ""];
+            const sorted = [...input].sort(compareVersions);
+            expect(sorted.slice(0, 2)).toEqual(["5.1.0", "5.2.1"]);
+            // null, undefined, "" are all "empty" and sort after real versions (order among them is unstable)
+            expect(sorted.slice(2)).toHaveLength(3);
+            expect(sorted.slice(2)).toEqual(expect.arrayContaining([null, undefined, ""]));
+        });
+    });
+});

--- a/frontend/Common/versionSort.ts
+++ b/frontend/Common/versionSort.ts
@@ -1,0 +1,84 @@
+/**
+ * Numeric-aware version string comparator.
+ *
+ * Handles versions like "5.2.1", "2024.1.3", "6.0.0~rc1", "5.2.1.dev",
+ * and build-metadata suffixes like "-0.20240815.abc1234".
+ *
+ * Sorting rules:
+ *  - Segments are split on "." and compared numerically when possible.
+ *  - Build metadata (everything after the first "-") is ignored.
+ *  - Pre-release tags (rc, dev) sort BEFORE the corresponding official
+ *    release, i.e. 5.2.1.rc1 < 5.2.1.
+ */
+
+const NUMERIC_RE = /^\d+$/;
+
+function isNumeric(s: string): boolean {
+    return NUMERIC_RE.test(s);
+}
+
+function parseVersion(raw: string): string[] {
+    // Normalize "~" separator to "."
+    let v = raw.replace(/~/g, ".");
+    // Strip build metadata after first "-"
+    const dashIdx = v.indexOf("-");
+    if (dashIdx !== -1) {
+        v = v.substring(0, dashIdx);
+    }
+    return v.split(".");
+}
+
+/**
+ * Compare two version strings.
+ * Returns negative if a < b, positive if a > b, 0 if equal.
+ *
+ * Pre-release versions (containing non-numeric segments like "rc1", "dev")
+ * sort before their corresponding official release:
+ *   5.2.1.dev < 5.2.1.rc1 < 5.2.1
+ */
+export function compareVersions(a: string | null | undefined, b: string | null | undefined): number {
+    // Treat null/undefined/empty as "no version" — push to the end.
+    const aEmpty = !a;
+    const bEmpty = !b;
+    if (aEmpty && bEmpty) return 0;
+    if (aEmpty) return 1;
+    if (bEmpty) return -1;
+
+    const segsA = parseVersion(a);
+    const segsB = parseVersion(b);
+    const len = Math.max(segsA.length, segsB.length);
+
+    for (let i = 0; i < len; i++) {
+        const sa = segsA[i];
+        const sb = segsB[i];
+
+        if (sa === undefined && sb === undefined) return 0;
+
+        if (sa === undefined) {
+            // A is shorter. If B's extra segment is non-numeric (pre-release),
+            // then A (the clean release) is larger.
+            return isNumeric(sb!) ? -1 : 1;
+        }
+        if (sb === undefined) {
+            // B is shorter — mirror of above.
+            return isNumeric(sa) ? 1 : -1;
+        }
+
+        const aNum = isNumeric(sa);
+        const bNum = isNumeric(sb);
+
+        if (aNum && bNum) {
+            const diff = parseInt(sa, 10) - parseInt(sb, 10);
+            if (diff !== 0) return diff;
+        } else if (aNum !== bNum) {
+            // One numeric, one not: numeric segment is "greater" (official > pre-release tag)
+            return aNum ? 1 : -1;
+        } else {
+            // Both non-numeric: lexicographic
+            const cmp = sa.localeCompare(sb);
+            if (cmp !== 0) return cmp;
+        }
+    }
+
+    return 0;
+}

--- a/frontend/ReleaseDashboard/TestDashboard.svelte
+++ b/frontend/ReleaseDashboard/TestDashboard.svelte
@@ -66,6 +66,7 @@
     import Select from "svelte-select";
     import { Collapse } from "bootstrap";
     import { titleCase } from "../Common/TextUtils";
+    import { compareVersions } from "../Common/versionSort";
     interface Props {
         dashboardObject: any;
         dashboardObjectType?: string;
@@ -362,13 +363,13 @@
             .filter(([_, isEnterprise]) => isEnterprise)
             .map(([version]) => version)
             .filter((version, idx, src) => src.indexOf(version) === idx)
-            .sort()
+            .sort(compareVersions)
             .reverse();
         const ossVersions = uniqueShortVersions
             .filter(([_, isEnterprise]) => !isEnterprise)
             .map(([version]) => version)
             .filter((version, idx, src) => src.indexOf(version) === idx)
-            .sort()
+            .sort(compareVersions)
             .reverse();
 
         return [...enterpriseVersions, ...ossVersions, ...unrecognizedVersions];

--- a/frontend/Views/Widgets/ViewGraphedStats/Filters.svelte
+++ b/frontend/Views/Widgets/ViewGraphedStats/Filters.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { derived } from "svelte/store";
     import type { DataResponse } from "./Interfaces";
+    import { compareVersions } from "../../../Common/versionSort";
 
     interface Props {
         allData: DataResponse;
@@ -12,10 +13,10 @@
 
     const versions = derived(
         { subscribe: (fn) => () => {} }, // Dummy store for derived since allData is a prop
-        () => [...new Set(allData.test_runs.map((run) => run.version))].sort()
+        () => [...new Set(allData.test_runs.map((run) => run.version))].sort(compareVersions)
     );
     const releases = derived(versions, ($versions) =>
-        [...new Set($versions.map((v) => v.split(".").slice(0, 2).join(".")))].sort()
+        [...new Set($versions.map((v) => v.split(".").slice(0, 2).join(".")))].sort(compareVersions)
     );
 </script>
 

--- a/frontend/Views/Widgets/ViewGraphedStats/NemesisTable.svelte
+++ b/frontend/Views/Widgets/ViewGraphedStats/NemesisTable.svelte
@@ -3,6 +3,7 @@
     import StackTracePreview from "./StackTracePreview.svelte";
     import StatusBadge from "./StatusBadge.svelte";
     import type { NemesisData } from "./Interfaces";
+    import { compareVersions } from "../../../Common/versionSort";
 
     interface Props {
         nemesisName: string | null;
@@ -42,7 +43,7 @@
         {
             key: "version",
             label: "Version",
-            sort: (a: NemesisData, b: NemesisData) => a.version.localeCompare(b.version),
+            sort: (a: NemesisData, b: NemesisData) => compareVersions(a.version, b.version),
             width: "130px",
         },
         { key: "stack_trace", label: "Stack Trace", component: StackTracePreview },

--- a/frontend/Views/Widgets/ViewGraphedStats/TestRunTable.svelte
+++ b/frontend/Views/Widgets/ViewGraphedStats/TestRunTable.svelte
@@ -2,6 +2,7 @@
     import { run as run_1 } from 'svelte/legacy';
 
     import PaginatedTable from "./PaginatedTable.svelte";
+    import { compareVersions } from "../../../Common/versionSort";
     import AssigneeCell from "./AssigneeCell.svelte";
     import StatusCell from "./StatusCell.svelte";
     import IssuesCell from "./IssuesCell.svelte";
@@ -102,7 +103,7 @@
         {
             key: "version",
             label: "Version",
-            sort: (a: TestRun, b: TestRun) => a.version.localeCompare(b.version),
+            sort: (a: TestRun, b: TestRun) => compareVersions(a.version, b.version),
             width: "130px",
         },
         {

--- a/frontend/Views/Widgets/ViewNemesisStats.svelte
+++ b/frontend/Views/Widgets/ViewNemesisStats.svelte
@@ -2,6 +2,7 @@
     import { run as run_1 } from 'svelte/legacy';
 
     import { onMount } from "svelte";
+    import { compareVersions } from "../../Common/versionSort";
     import Chart from "chart.js/auto";
 
     let { viewId, dashboardObject } = $props();
@@ -63,8 +64,8 @@
     }
 
     function extractVersionsAndReleases(data) {
-        versions = [...new Set(data.map((nemesis) => nemesis.version))].sort();
-        releases = [...new Set(versions.map((version) => version.split(".").slice(0, 2).join(".")))].sort();
+        versions = [...new Set(data.map((nemesis) => nemesis.version))].sort(compareVersions);
+        releases = [...new Set(versions.map((version) => version.split(".").slice(0, 2).join(".")))].sort(compareVersions);
     }
 
     function filterData(data) {
@@ -276,7 +277,7 @@
             } else if (sortField === "duration") {
                 comparison = a.duration - b.duration;
             } else if (sortField === "version") {
-                comparison = a.version.localeCompare(b.version);
+                comparison = compareVersions(a.version, b.version);
             } else if (sortField === "start_time") {
                 // Use numeric comparison for timestamps
                 comparison = a.start_time - b.start_time;


### PR DESCRIPTION
### Summary

Fix the version sorting on frontend, so it is numeric based.
```
 Sorting rules:
 *  - Segments are split on "." and compared numerically when possible.
 *  - Build metadata (everything after the first "-") is ignored.
 *  - Pre-release tags (rc, dev) sort BEFORE the corresponding official
 *    release, i.e. 5.2.1.rc1 < 5.2.1.
```
Before:
<img width="2188" height="171" alt="before" src="https://github.com/user-attachments/assets/cb66d143-e3da-4d70-a982-a0346ef13638" />
After
<img width="2172" height="153" alt="after" src="https://github.com/user-attachments/assets/518dcca7-8631-427f-8f24-d9dd747827ae" />

Notably: 6.2.0 is ahead of 6.10.0, 6.0.0~rc2 is ahead of 6.0.0 etc