### PR TITLE
feature(skills): backport writing-plans and designing-skills from SCT

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,19 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
+
 Backend services live in `argus/backend` with Flask entry points defined in `argus_backend.py`; shared helpers sit in `argus/common`, while CLI tooling and client integrations are under `argus/client`. Frontend assets are in `frontend/`, compiled into `public/dist`, and HTML templates stay in `templates/`. Test suites are grouped in `argus/backend/tests`, `argus/client/tests`, and `pytest-argus-reporter/tests`.
 
 ## Build, Test, and Development Commands
+
 Install dependencies with `uv sync --all-extras` and `yarn install`. Rebuild the Svelte-based UI with `ROLLUP_ENV=development yarn rollup -c --watch`. Start the API locally via `FLASK_ENV=development FLASK_APP=argus_backend:start_server CQLENG_ALLOW_SCHEMA_MANAGEMENT=1 uv run flask run`. For linting, run `uv run ruff check`. Run server-side tests with `uv run pytest argus/backend/tests` and client utilities through `uv run pytest argus/client/tests`.
 
 ## Coding Style & Naming Conventions
+
 Python code targets 3.12, uses 4-space indentation, and a 120-character line width enforced by Ruff and Autopep8 (see `pyproject.toml`). Prefer descriptive snake_case for Python modules and functions; keep Svelte/JS components in PascalCase folders aligned with entry files (e.g., `frontend/AdminPanel/`). Organize Flask blueprints by feature under `argus/backend` and export public APIs through `__init__.py`.
 
 ## Svelte 5 Frontend Patterns
+
 - Favor the rune APIs (`$props`, `$state`, `$derived`, `run`) for component state and avoid legacy `$:` reactivity when a rune captures intent better.
 - Reach into the DOM through Svelte bindings or actions (`bind:this`, `use:…`) rather than global selectors; never call `Node.querySelector*` inside components—track nodes via bindings and stores instead.
 - Prefer component composition, snippets, and `@const/@render` blocks over imperative DOM updates; lean on `await tick()` when you must wait for the DOM after state changes.
@@ -18,10 +22,26 @@ Python code targets 3.12, uses 4-space indentation, and a 120-character line wid
 - Use TypeScript-friendly patterns (typed props, `import type …`) whenever you bind component instances or DOM nodes, and co-locate UI-specific helpers next to their components.
 
 ## Testing Guidelines
+
 Tests follow `test_*.py` naming and Pytest markers such as `@pytest.mark.docker_required` for Docker-heavy suites. Keep unit tests close to their modules (e.g., `results_service` tests). Execute full coverage with `uv run pytest --cov=argus backend/tests client/tests`. Add fixtures under `argus/backend/tests/conftest.py` when sharing setup.
 
 ## Commit & Pull Request Guidelines
+
 Adopt the Conventional Commits style observed in history (`fix(scope): message`, `feature(app): ...`). Compose commits around a single logical change and run lint/tests before pushing. Pull requests should describe intent, outline manual validation steps, and link tracking issues; include screenshots or API payload snippets when UI or API responses change.
 
 ## Configuration & Security Notes
+
 Never commit secrets: When testing against Cassandra, use the Docker compose setup in `dev-db/` and tear it down after use. Keep sample data archives outside the repository to avoid leaking production artifacts.
+
+## Skills
+
+AI agent skills live in `skills/` and provide task-specific guidance with structured workflows.
+
+| Skill            | Description                                                           | Path                               |
+| ---------------- | --------------------------------------------------------------------- | ---------------------------------- |
+| writing-plans    | Write implementation plans (full 7-section or lightweight mini-plans) | `skills/writing-plans/SKILL.md`    |
+| designing-skills | Meta-skill for creating and structuring new AI agent skills           | `skills/designing-skills/SKILL.md` |
+
+## Implementation Plans
+
+Plans are tracked in `docs/plans/`. See `docs/plans/INSTRUCTIONS.md` for the authoritative guide on plan structure, and `docs/plans/MASTER.md` for the registry of active plans.

--- a/docs/plans/INSTRUCTIONS.md
+++ b/docs/plans/INSTRUCTIONS.md
@@ -1,0 +1,125 @@
+# Implementation Plan Instructions
+
+This document is the **authoritative source** for how implementation plans are written and maintained in the Argus repository. If a skill or workflow conflicts with this file, follow this file.
+
+## Plan Types
+
+Argus supports two plan formats:
+
+| Aspect        | Full Plan                           | Mini-Plan                                  |
+| ------------- | ----------------------------------- | ------------------------------------------ |
+| Sections      | 7                                   | 4 (Problem, Approach, Files, Verification) |
+| Frontmatter   | Required                            | None                                       |
+| MASTER.md     | Required                            | None                                       |
+| progress.json | Required                            | None                                       |
+| Location      | `docs/plans/`                       | `docs/plans/mini-plans/`                   |
+| Filename      | `kebab-case-name.md`                | `YYYY-MM-DD-kebab-case-name.md`            |
+| Lifecycle     | Tracked until archived              | Disposable after PR merge or 30 days       |
+| Use when      | Multi-phase, 1K+ LOC, cross-cutting | Single PR, under ~1K LOC                   |
+
+## The 7-Section Structure (Full Plans)
+
+Every full implementation plan follows this structure:
+
+### 1. Problem Statement
+
+What problem are we solving, and why now? Include measurable pain points — "slow" is not a problem statement; "API response time exceeds 5s for release dashboard queries" is.
+
+### 2. Current State
+
+What exists today in the codebase. **Every file path, class, and method referenced must be verified against the actual repository.** Do not guess or hallucinate paths.
+
+### 3. Goals
+
+Numbered, measurable objectives. Each goal must have a verifiable condition — a number, threshold, or concrete outcome.
+
+### 4. Implementation Phases
+
+How to get from Current State to Goals. Each phase:
+
+- Is scoped to a **single Pull Request**
+- Targets **≤200 lines of changed code**
+- Has an **Importance** level: Critical / Important / Nice-to-have
+- Has a **Definition of Done** checklist with concrete, verifiable items
+
+Order phases by dependency — foundational changes before features that depend on them.
+
+### 5. Testing Requirements
+
+How each phase will be verified. Cover:
+
+- **Unit tests**: pytest tests in `argus/backend/tests/` or `argus/client/tests/`
+- **Integration tests**: tests requiring a running ScyllaDB instance
+- **Manual testing**: steps to verify UI or API behavior by hand
+
+### 6. Success Criteria
+
+How to know the entire plan is done. Reference Definition of Done items from phases — do not duplicate them. Add plan-level criteria only when phases individually succeeding doesn't guarantee overall success.
+
+### 7. Risk Mitigation
+
+What could go wrong. For each risk, specify:
+
+- **Likelihood**: Low / Medium / High
+- **Impact**: Low / Medium / High
+- **Mitigation**: Concrete steps to reduce or eliminate the risk
+
+## YAML Frontmatter
+
+Every full plan file must start with YAML frontmatter:
+
+```yaml
+---
+status: draft # draft | approved | in_progress | blocked | complete
+domain: backend # See domain taxonomy below
+created: 2025-01-15
+last_updated: 2025-01-15
+owner: github-username # or null
+---
+```
+
+### Domain Taxonomy
+
+| Domain           | Scope                                                                |
+| ---------------- | -------------------------------------------------------------------- |
+| `backend`        | Flask/FastAPI services, blueprints, server logic in `argus/backend/` |
+| `frontend`       | Svelte components, UI state, styles in `frontend/`                   |
+| `api`            | REST endpoints, request/response contracts, client-server interface  |
+| `database`       | ScyllaDB/Cassandra models, migrations, schema changes                |
+| `client`         | Python client library in `argus/client/`                             |
+| `testing`        | Test infrastructure, fixtures, reporters                             |
+| `ci-cd`          | GitHub Actions workflows, Docker builds, deployment                  |
+| `infrastructure` | Dev tooling, monitoring, operational concerns                        |
+
+## Plan File Conventions
+
+| Convention | Rule                                           |
+| ---------- | ---------------------------------------------- |
+| Location   | `docs/plans/` directory                        |
+| Filename   | kebab-case, descriptive (e.g., `api-tests.md`) |
+| Format     | Markdown with `# Plan Title` as first heading  |
+| Archiving  | Move completed plans to `docs/plans/archive/`  |
+
+## Tracking
+
+Every full plan must be:
+
+1. Registered in `docs/plans/MASTER.md` under the correct domain
+2. Added to `docs/plans/progress.json` with plan metadata
+
+Mini-plans are **not** registered in either tracking file.
+
+## Argus-Specific Considerations
+
+When writing plans for Argus, consider:
+
+| Area              | What to Include                                                             |
+| ----------------- | --------------------------------------------------------------------------- |
+| **Backend**       | Flask blueprints in `argus/backend/`, service layer patterns                |
+| **Frontend**      | Svelte 5 components using rune APIs, bundled via Rollup                     |
+| **Database**      | ScyllaDB/Cassandra models via CQLEngine (migrating to coodie)               |
+| **API**           | REST endpoints, JSON response contracts, httpx-based testing                |
+| **Client**        | Python client in `argus/client/`, CLI in `cli/`                             |
+| **CI/CD**         | GitHub Actions in `.github/workflows/`                                      |
+| **Testing**       | pytest in `argus/backend/tests/` and `argus/client/tests/`, Docker-based DB |
+| **Related Plans** | Check MASTER.md for existing plans in the same domain                       |

--- a/docs/plans/MASTER.md
+++ b/docs/plans/MASTER.md
@@ -1,0 +1,52 @@
+# Implementation Plans Registry
+
+Central tracking for all Argus implementation plans. Each plan is listed under its domain with current status.
+
+## Status Legend
+
+| Badge         | Meaning                        |
+| ------------- | ------------------------------ |
+| `draft`       | Plan written, not yet started  |
+| `approved`    | Reviewed and approved          |
+| `in_progress` | Active implementation          |
+| `blocked`     | Blocked by external dependency |
+| `complete`    | All phases done                |
+| `pending_pr`  | Plan in an unmerged PR         |
+
+---
+
+## Backend
+
+_No plans in this domain yet._
+
+## Frontend
+
+_No plans in this domain yet._
+
+## API
+
+| Plan                     | Status        | File                         | Owner |
+| ------------------------ | ------------- | ---------------------------- | ----- |
+| API Tests Implementation | `in_progress` | [api_tests.md](api_tests.md) | null  |
+
+## Database
+
+_No plans in this domain yet._
+
+## Client
+
+| Plan               | Status  | File                                         | Owner |
+| ------------------ | ------- | -------------------------------------------- | ----- |
+| SSH Tunnel Support | `draft` | [ssh-tunnel-design.md](ssh-tunnel-design.md) | null  |
+
+## Testing
+
+_No plans in this domain yet._
+
+## CI/CD
+
+_No plans in this domain yet._
+
+## Infrastructure
+
+_No plans in this domain yet._

--- a/docs/plans/api_tests.md
+++ b/docs/plans/api_tests.md
@@ -1,9 +1,17 @@
+---
+status: in_progress
+domain: api
+created: 2026-03-03
+last_updated: 2026-04-20
+owner: null
+---
+
 # API Tests Implementation Plan
 
 ## Background
 
 Argus is planning a major refactor: moving from Flask to FastAPI and replacing CQLEngine with the
-[coodie](https://github.com/scylladb/coodie) project.  To guarantee that no regressions are
+[coodie](https://github.com/scylladb/coodie) project. To guarantee that no regressions are
 introduced during the refactor, every public API endpoint must have an integration test that:
 
 1. Exercises the endpoint over HTTP (not through ORM or service-layer calls).
@@ -14,10 +22,10 @@ introduced during the refactor, every public API endpoint must have an integrati
 5. Requires **minimal or zero changes** after the Flask → FastAPI migration.
 
 The existing tests under `argus/backend/tests/sct_api/test_sct_api.py` already partially cover the
-SCT plugin endpoints and serve as the reference style.  The current weaknesses are:
+SCT plugin endpoints and serve as the reference style. The current weaknesses are:
 
-* Some tests still query `SCTTestRun.get(id=…)` to verify state, which couples them to CQLEngine.
-* There is no coverage of many endpoint groups (Client API, Testrun API, Release/Group/Test API,
+- Some tests still query `SCTTestRun.get(id=…)` to verify state, which couples them to CQLEngine.
+- There is no coverage of many endpoint groups (Client API, Testrun API, Release/Group/Test API,
   Admin API, etc.).
 
 ---
@@ -47,8 +55,8 @@ The `client` fixture in `conftest.py` is the **only** place that needs to change
 
 ### 2. Assert on JSON responses only
 
-Every assertion must be made against `response.json()` keys and values.  CQLEngine model queries
-(`Model.get(id=…)`) are **not allowed** in new tests.  If you need to verify that a write
+Every assertion must be made against `response.json()` keys and values. CQLEngine model queries
+(`Model.get(id=…)`) are **not allowed** in new tests. If you need to verify that a write
 was persisted, use the corresponding read/GET endpoint to fetch the object and assert on its fields.
 
 ```python
@@ -63,9 +71,9 @@ assert run.status == "created"
 
 ### 3. Test isolation via unique UUIDs
 
-Every test that creates a run, test, group, or release generates a fresh `uuid4()`.  Session-scoped
+Every test that creates a run, test, group, or release generates a fresh `uuid4()`. Session-scoped
 fixtures are allowed only for resources that are truly shared and read-only (e.g., a release and
-group hierarchy).  Mutable resources (individual test runs) must use function-scoped fixtures.
+group hierarchy). Mutable resources (individual test runs) must use function-scoped fixtures.
 
 ### 4. Authentication
 
@@ -127,7 +135,7 @@ def http_client(argus_app) -> httpx.Client:
 ```
 
 The existing `flask_client` fixture can remain for backward compatibility while old tests are being
-migrated.  New tests should use `http_client`.
+migrated. New tests should use `http_client`.
 
 ### Helper: `api_post` / `api_get`
 
@@ -148,18 +156,18 @@ def api_get(client: httpx.Client, path: str, **params) -> httpx.Response:
 
 ### `test_client_api.py` — `/api/v1/client/…`
 
-| Endpoint | Method | Test name |
-|----------|--------|-----------|
-| `/client/testrun/{run_type}/submit` | POST | `test_submit_run` |
-| `/client/testrun/{run_type}/{run_id}/get` | GET | `test_get_run` |
-| `/client/testrun/{run_type}/{run_id}/heartbeat` | POST | `test_heartbeat` |
-| `/client/testrun/{run_type}/{run_id}/get_status` | GET | `test_get_status` |
-| `/client/testrun/{run_type}/{run_id}/set_status` | POST | `test_set_status` |
-| `/client/testrun/{run_type}/{run_id}/update_product_version` | POST | `test_update_product_version` |
-| `/client/testrun/{run_type}/{run_id}/logs/submit` | POST | `test_submit_logs` |
-| `/client/{run_id}/config/submit` | POST | `test_submit_config` |
-| `/client/{run_id}/config/all` | GET | `test_get_all_configs` |
-| `/client/testrun/{run_type}/{run_id}/finalize` | POST | `test_finalize_run` |
+| Endpoint                                                     | Method | Test name                     |
+| ------------------------------------------------------------ | ------ | ----------------------------- |
+| `/client/testrun/{run_type}/submit`                          | POST   | `test_submit_run`             |
+| `/client/testrun/{run_type}/{run_id}/get`                    | GET    | `test_get_run`                |
+| `/client/testrun/{run_type}/{run_id}/heartbeat`              | POST   | `test_heartbeat`              |
+| `/client/testrun/{run_type}/{run_id}/get_status`             | GET    | `test_get_status`             |
+| `/client/testrun/{run_type}/{run_id}/set_status`             | POST   | `test_set_status`             |
+| `/client/testrun/{run_type}/{run_id}/update_product_version` | POST   | `test_update_product_version` |
+| `/client/testrun/{run_type}/{run_id}/logs/submit`            | POST   | `test_submit_logs`            |
+| `/client/{run_id}/config/submit`                             | POST   | `test_submit_config`          |
+| `/client/{run_id}/config/all`                                | GET    | `test_get_all_configs`        |
+| `/client/testrun/{run_type}/{run_id}/finalize`               | POST   | `test_finalize_run`           |
 
 Each test verifies `response.status_code == 200` and `response.json()["status"] == "ok"`.
 Tests that mutate state verify the mutation via a paired GET endpoint.
@@ -193,16 +201,16 @@ Existing tests cover:
 
 **New tests to add:**
 
-| Endpoint | Method | Test name |
-|----------|--------|-----------|
-| `/{run_id}/events/get` | GET | `test_get_events` |
-| `/{run_id}/events/{severity}/get` | GET | `test_get_events_by_severity` |
-| `/{run_id}/events/{severity}/count` | GET | `test_count_events_by_severity` |
-| `/{run_id}/event/submit` (new-style) | POST | `test_submit_single_event` |
-| `/{run_id}/performance/submit` | POST | `test_submit_performance_results` |
-| `/{run_id}/performance/history` | GET | `test_get_performance_history` |
-| `/{run_id}/stress_cmd/get` | GET | `test_get_stress_commands` |
-| `/similar_runs_info` | POST | `test_similar_runs_info` |
+| Endpoint                             | Method | Test name                         |
+| ------------------------------------ | ------ | --------------------------------- |
+| `/{run_id}/events/get`               | GET    | `test_get_events`                 |
+| `/{run_id}/events/{severity}/get`    | GET    | `test_get_events_by_severity`     |
+| `/{run_id}/events/{severity}/count`  | GET    | `test_count_events_by_severity`   |
+| `/{run_id}/event/submit` (new-style) | POST   | `test_submit_single_event`        |
+| `/{run_id}/performance/submit`       | POST   | `test_submit_performance_results` |
+| `/{run_id}/performance/history`      | GET    | `test_get_performance_history`    |
+| `/{run_id}/stress_cmd/get`           | GET    | `test_get_stress_commands`        |
+| `/similar_runs_info`                 | POST   | `test_similar_runs_info`          |
 
 For all new tests, verification must use the paired GET endpoint rather than direct DB queries.
 
@@ -223,22 +231,22 @@ def test_get_events(http_client, sct_run_id_with_events):
 
 ### `test_testrun_api.py` — `/api/v1/run/…` and `/api/v1/test/…`
 
-| Endpoint | Method | Test name |
-|----------|--------|-----------|
-| `/test/{test_id}/runs` | GET | `test_get_runs_for_test` |
-| `/run/{run_type}/{run_id}` | GET | `test_get_testrun` |
-| `/run/{run_id}/activity` | GET | `test_testrun_activity` |
-| `/run/{test_id}/{run_id}/fetch_results` | GET | `test_fetch_results` |
-| `/test/{test_id}/run/{run_id}/status/set` | POST | `test_set_testrun_status` |
-| `/test/{test_id}/run/{run_id}/investigation_status/set` | POST | `test_set_investigation_status` |
-| `/test/{test_id}/run/{run_id}/assignee/set` | POST | `test_set_assignee` |
-| `/run/{run_id}/comments` | GET | `test_get_comments` |
-| `/test/{test_id}/run/{run_id}/comments/submit` | POST | `test_submit_comment` |
-| `/comment/{comment_id}/get` | GET | `test_get_comment_by_id` |
-| `/test/{test_id}/run/{run_id}/comment/{comment_id}/update` | POST | `test_update_comment` |
-| `/test/{test_id}/run/{run_id}/comment/{comment_id}/delete` | POST | `test_delete_comment` |
+| Endpoint                                                   | Method | Test name                       |
+| ---------------------------------------------------------- | ------ | ------------------------------- |
+| `/test/{test_id}/runs`                                     | GET    | `test_get_runs_for_test`        |
+| `/run/{run_type}/{run_id}`                                 | GET    | `test_get_testrun`              |
+| `/run/{run_id}/activity`                                   | GET    | `test_testrun_activity`         |
+| `/run/{test_id}/{run_id}/fetch_results`                    | GET    | `test_fetch_results`            |
+| `/test/{test_id}/run/{run_id}/status/set`                  | POST   | `test_set_testrun_status`       |
+| `/test/{test_id}/run/{run_id}/investigation_status/set`    | POST   | `test_set_investigation_status` |
+| `/test/{test_id}/run/{run_id}/assignee/set`                | POST   | `test_set_assignee`             |
+| `/run/{run_id}/comments`                                   | GET    | `test_get_comments`             |
+| `/test/{test_id}/run/{run_id}/comments/submit`             | POST   | `test_submit_comment`           |
+| `/comment/{comment_id}/get`                                | GET    | `test_get_comment_by_id`        |
+| `/test/{test_id}/run/{run_id}/comment/{comment_id}/update` | POST   | `test_update_comment`           |
+| `/test/{test_id}/run/{run_id}/comment/{comment_id}/delete` | POST   | `test_delete_comment`           |
 
-These tests require a run to already exist.  They should reuse the `sct_run_id` fixture from
+These tests require a run to already exist. They should reuse the `sct_run_id` fixture from
 `conftest.py` and use the `fake_test` / `release` / `group` hierarchy fixtures.
 
 Example:
@@ -261,53 +269,53 @@ def test_set_testrun_status(http_client, fake_test, sct_run_id):
 
 ### `test_release_api.py` — `/api/v1/releases`, `/api/v1/groups`, `/api/v1/tests`, `/api/v1/release/…`
 
-| Endpoint | Method | Test name |
-|----------|--------|-----------|
-| `/releases` | GET | `test_list_releases` |
-| `/groups` | GET | `test_list_groups` |
-| `/tests` | GET | `test_list_tests` |
-| `/release/{release_id}/details` | GET | `test_release_details` |
-| `/group/{group_id}/details` | GET | `test_group_details` |
-| `/test/{test_id}/details` | GET | `test_test_details` |
-| `/release/stats/v2` | GET | `test_release_stats` |
-| `/test-info` | GET | `test_test_info` |
-| `/test-results` | GET | `test_test_results` |
-| `/users` | GET | `test_list_users` |
-| `/version` | GET | `test_version` |
+| Endpoint                        | Method | Test name              |
+| ------------------------------- | ------ | ---------------------- |
+| `/releases`                     | GET    | `test_list_releases`   |
+| `/groups`                       | GET    | `test_list_groups`     |
+| `/tests`                        | GET    | `test_list_tests`      |
+| `/release/{release_id}/details` | GET    | `test_release_details` |
+| `/group/{group_id}/details`     | GET    | `test_group_details`   |
+| `/test/{test_id}/details`       | GET    | `test_test_details`    |
+| `/release/stats/v2`             | GET    | `test_release_stats`   |
+| `/test-info`                    | GET    | `test_test_info`       |
+| `/test-results`                 | GET    | `test_test_results`    |
+| `/users`                        | GET    | `test_list_users`      |
+| `/version`                      | GET    | `test_version`         |
 
-These are read-only tests.  They use existing session-scoped `release`, `group`, `fake_test`
+These are read-only tests. They use existing session-scoped `release`, `group`, `fake_test`
 fixtures and assert that the response shape is correct.
 
 ### `test_admin_api.py` — `/api/v1/…` (admin operations)
 
-| Endpoint | Method | Test name |
-|----------|--------|-----------|
-| `/release/create` | POST | `test_admin_create_release` |
-| `/release/edit` | POST | `test_admin_edit_release` |
-| `/release/delete` | POST | `test_admin_delete_release` |
-| `/group/create` (admin) | POST | `test_admin_create_group` |
-| `/group/update` | POST | `test_admin_update_group` |
-| `/group/delete` | POST | `test_admin_delete_group` |
-| `/test/create` (admin) | POST | `test_admin_create_test` |
-| `/test/update` | POST | `test_admin_update_test` |
-| `/test/delete` | POST | `test_admin_delete_test` |
-| `/releases/get` | GET | `test_admin_get_releases` |
-| `/groups/get` | GET | `test_admin_get_groups` |
-| `/tests/get` | GET | `test_admin_get_tests` |
-| `/users` (admin) | GET | `test_admin_list_users` |
+| Endpoint                | Method | Test name                   |
+| ----------------------- | ------ | --------------------------- |
+| `/release/create`       | POST   | `test_admin_create_release` |
+| `/release/edit`         | POST   | `test_admin_edit_release`   |
+| `/release/delete`       | POST   | `test_admin_delete_release` |
+| `/group/create` (admin) | POST   | `test_admin_create_group`   |
+| `/group/update`         | POST   | `test_admin_update_group`   |
+| `/group/delete`         | POST   | `test_admin_delete_group`   |
+| `/test/create` (admin)  | POST   | `test_admin_create_test`    |
+| `/test/update`          | POST   | `test_admin_update_test`    |
+| `/test/delete`          | POST   | `test_admin_delete_test`    |
+| `/releases/get`         | GET    | `test_admin_get_releases`   |
+| `/groups/get`           | GET    | `test_admin_get_groups`     |
+| `/tests/get`            | GET    | `test_admin_get_tests`      |
+| `/users` (admin)        | GET    | `test_admin_list_users`     |
 
 Each create/update/delete test creates its own isolated entity (unique name / UUID).
 
 ### `test_driver_matrix_api.py` — `/api/v1/client/driver_matrix/…`
 
-| Endpoint | Method | Test name |
-|----------|--------|-----------|
-| `/driver_matrix/result/submit` | POST | `test_submit_driver_matrix_result` |
-| `/driver_matrix/result/fail` | POST | `test_fail_driver_matrix_result` |
-| `/driver_matrix/env/submit` | POST | `test_submit_driver_matrix_env` |
-| `/driver_matrix/test_report` | GET | `test_get_driver_matrix_test_report` |
+| Endpoint                       | Method | Test name                            |
+| ------------------------------ | ------ | ------------------------------------ |
+| `/driver_matrix/result/submit` | POST   | `test_submit_driver_matrix_result`   |
+| `/driver_matrix/result/fail`   | POST   | `test_fail_driver_matrix_result`     |
+| `/driver_matrix/env/submit`    | POST   | `test_submit_driver_matrix_env`      |
+| `/driver_matrix/test_report`   | GET    | `test_get_driver_matrix_test_report` |
 
-These tests require a Driver Matrix run to be submitted first.  A `driver_matrix_run_id` fixture
+These tests require a Driver Matrix run to be submitted first. A `driver_matrix_run_id` fixture
 should be created analogous to `sct_run_id`.
 
 ---
@@ -318,10 +326,10 @@ The following changes are needed on existing tests in `test_sct_api.py` to align
 rules (should be applied as part of this work):
 
 1. Replace `flask_client.post(…)` / `flask_client.get(…)` calls with `http_client.post(…)` /
-   `http_client.get(…)`.  `httpx` returns a `Response` whose `.json()` is a method call (not a
+   `http_client.get(…)`. `httpx` returns a `Response` whose `.json()` is a method call (not a
    property), and `.status_code` is an integer.
 
-2. Remove all `SCTTestRun.get(id=…)` queries.  Replace each one with a GET request to the
+2. Remove all `SCTTestRun.get(id=…)` queries. Replace each one with a GET request to the
    corresponding read endpoint and assert on the JSON response.
 
 3. The `sct_run_id` fixture should remain function-scoped (already is) so each test has its own

--- a/docs/plans/progress.json
+++ b/docs/plans/progress.json
@@ -1,0 +1,22 @@
+[
+    {
+        "id": "api-tests",
+        "title": "API Tests Implementation",
+        "file": "docs/plans/api_tests.md",
+        "domain": "api",
+        "status": "in_progress",
+        "created": "2026-03-03",
+        "phases_total": null,
+        "phases_done": 0
+    },
+    {
+        "id": "ssh-tunnel-design",
+        "title": "SSH Tunnel Support for Argus Client",
+        "file": "docs/plans/ssh-tunnel-design.md",
+        "domain": "client",
+        "status": "draft",
+        "created": "2026-04-08",
+        "phases_total": null,
+        "phases_done": 0
+    }
+]

--- a/docs/plans/ssh-tunnel-design.md
+++ b/docs/plans/ssh-tunnel-design.md
@@ -1,3 +1,11 @@
+---
+status: draft
+domain: client
+created: 2026-04-08
+last_updated: 2026-04-20
+owner: null
+---
+
 # SSH Tunnel Support for Argus Client
 
 ## Context

--- a/skills/designing-skills/SKILL.md
+++ b/skills/designing-skills/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: designing-skills
+description: >-
+    Guides the design and structuring of AI agent skills for the Argus
+    repository with multi-step phases, progressive disclosure, and
+    dual-platform compatibility (GitHub Copilot and Claude Code / OpenCode).
+    Use when creating new skills, reviewing existing skills,
+    restructuring AI guidance into modular skill directories,
+    editing SKILL.md files, or improving agent instructions.
+---
+
+# Designing Skills for Argus
+
+Build modular, task-specific AI agent skills that work across GitHub Copilot, Claude Code, and OpenCode.
+
+## Essential Principles
+
+### Capture Intent Before Writing
+
+**Interview first, write second.**
+
+Before drafting any skill files, gather concrete information about the task domain:
+
+- What specific user requests should trigger this skill? Collect 5-10 example prompts.
+- What does a good output look like? Get example inputs and expected outputs.
+- What are the failure modes? What would "bad" output look like?
+- Are there edge cases or ambiguous scenarios?
+
+This front-loads the hardest design decisions. A skill written without intent capture produces generic guidance that doesn't match real usage patterns.
+
+### Description Is the Trigger
+
+**The `description` field controls when Claude Code / OpenCode activates the skill.**
+
+Claude decides whether to load a skill based solely on its frontmatter `description`. The body of SKILL.md — including "When to Use" and "When NOT to Use" sections — is only read AFTER the skill is already active. Put trigger keywords, use cases, and exclusions in the description. A bad description means wrong activations or missed activations regardless of what the body says.
+
+GitHub Copilot discovers skills through explicit references in `AGENTS.md` — the description field still helps Copilot agents understand the skill's purpose.
+
+**Description constraints:**
+
+- Maximum 1024 characters
+- No angle brackets (`<`, `>`) — they break YAML parsing in some tools
+- Use third-person voice: "Guides..." not "I help with..."
+- List triggering conditions, not workflow steps
+
+### Test the Description
+
+**Write trigger eval queries and verify activation.**
+
+A description you haven't tested is a description that doesn't work. For every skill, write 5-10 test queries:
+
+- **Should-trigger queries**: User prompts where this skill MUST activate (e.g., "Create a new skill for code review")
+- **Should-NOT-trigger queries**: User prompts where this skill must stay silent (e.g., "Fix the unit test for config parsing")
+
+Read the description in isolation (without the skill body) and ask: would each query activate this skill correctly? If not, revise the description before writing the rest of the skill.
+
+### Explain the Why
+
+**Every instruction must explain WHY, not just WHAT.**
+
+LLMs follow instructions better when they understand the reasoning. "Use numbered phases" is weaker than "Use numbered phases because unnumbered prose produces unreliable execution order." The WHY gives the LLM judgment to handle cases the instruction didn't explicitly cover.
+
+### Numbered Phases
+
+**Phases must be numbered with entry and exit criteria.**
+
+Unnumbered prose instructions produce unreliable execution order. Every phase needs:
+
+- A number (Phase 1, Phase 2, ...)
+- Entry criteria (what must be true before starting)
+- Numbered actions (what to do)
+- Exit criteria (how to know it's done)
+
+### Progressive Disclosure
+
+**Progressive disclosure is structural, not optional.**
+
+SKILL.md stays under 500 lines. It contains only what the LLM needs for every invocation: principles, routing, quick references, and links. Detailed patterns go in `references/`. Step-by-step processes go in `workflows/`. One level deep — no reference chains.
+
+### Keep It Lean
+
+**Remove instructions that don't improve outcomes.**
+
+After testing a skill, review every instruction. If removing an instruction doesn't degrade the output quality, delete it. Bloated skills dilute LLM attention — every line competes for context. Prefer 10 precise instructions over 30 vague ones.
+
+## When to Use
+
+- Creating a new skill directory under `skills/`
+- Reviewing or refactoring an existing skill for quality
+- Deciding how to split content between SKILL.md, references/, and workflows/
+- Structuring a skill that covers a specific Argus task domain (testing, planning, coding, reviewing)
+- Adding platform discovery configuration for a new skill
+- Testing whether a skill's description triggers correctly
+
+## When NOT to Use
+
+- Writing the actual domain content of a skill (this teaches structure, not domain expertise)
+- Simple one-off documentation updates — edit the relevant file directly
+- Updating `AGENTS.md` without creating a skill
+- Debugging skill logic that's domain-specific (use the domain skill itself)
+
+## High-Level Workflow
+
+The full process is in [create-a-skill.md](workflows/create-a-skill.md). Summary:
+
+1. **Capture intent** — Interview for 5-10 example prompts, expected outputs, and failure modes
+2. **Draft description** — Write trigger-focused frontmatter description; test against eval queries
+3. **Write SKILL.md** — Essential principles, When to Use / When NOT to Use, quick references
+4. **Split content** — Move detailed patterns to `references/`, step-by-step processes to `workflows/`
+5. **Register** — Add entries to `AGENTS.md` skills table
+6. **Validate** — Verify all links resolve, run linting, test trigger accuracy
+
+## Skill Directory Structure
+
+Every skill follows this structure:
+
+```
+skills/
+└── <skill-name>/             # kebab-case directory name
+    ├── SKILL.md              # Main skill definition with YAML frontmatter
+    ├── references/           # Deep-dive reference documents
+    │   ├── <topic>.md        # Detailed guidance on a specific topic
+    │   └── ...
+    └── workflows/            # Step-by-step processes
+        ├── <process>.md      # Numbered phases with entry/exit criteria
+        └── ...
+```
+
+### SKILL.md Template
+
+```markdown
+---
+name: <skill-name>
+description: >-
+    <Third-person description with trigger keywords.
+    Use when <specific scenarios>. Applies to <specific domains>.>
+---
+
+# <Skill Title>
+
+<One-line purpose statement.>
+
+## Essential Principles
+
+<3-5 non-negotiable rules, each explaining WHY>
+
+## When to Use
+
+<4-6 specific scenarios>
+
+## When NOT to Use
+
+<3-5 scenarios naming alternatives>
+
+## <Domain-Specific Sections>
+
+<Quick references, routing tables, decision trees>
+
+## Reference Index
+
+<Links to all supporting files in references/ and workflows/>
+
+## Success Criteria
+
+<Checklist for output validation>
+```
+
+## Platform Discovery Configuration
+
+When adding a new skill, update the platform reference file:
+
+### AGENTS.md
+
+Add an entry to the "Skills" section in `AGENTS.md`:
+
+```markdown
+## Skills
+
+| Skill            | Description                                 | Path                               |
+| ---------------- | ------------------------------------------- | ---------------------------------- |
+| designing-skills | Meta-skill for creating new AI agent skills | `skills/designing-skills/SKILL.md` |
+| <new-skill>      | <description>                               | `skills/<new-skill>/SKILL.md`      |
+```
+
+## Anti-Pattern Quick Reference
+
+The most common mistakes. Full catalog in [anti-patterns.md](references/anti-patterns.md).
+
+| ID    | Anti-Pattern                            | One-Line Fix                                                               |
+| ----- | --------------------------------------- | -------------------------------------------------------------------------- |
+| AP-1  | Vague description / missing scope       | Add trigger keywords to description; add When to Use / When NOT to Use     |
+| AP-2  | Monolithic SKILL.md (>500 lines)        | Split into references/ and workflows/                                      |
+| AP-3  | Reference chains (A -> B -> C)          | All files one hop from SKILL.md                                            |
+| AP-4  | Unnumbered phases                       | Number every phase with entry/exit criteria                                |
+| AP-5  | Missing exit criteria                   | Define what "done" means for every phase                                   |
+| AP-6  | No verification step                    | Add validation at the end of every workflow                                |
+| AP-7  | Broken file references                  | Verify every path resolves before submitting                               |
+| AP-8  | Platform-specific content in skill body | Keep skill content platform-agnostic                                       |
+| AP-9  | Missing discovery configuration         | Update AGENTS.md                                                           |
+| AP-10 | No concrete examples                    | Show input -> output for key instructions                                  |
+| AP-11 | Description summarizes workflow         | Description = triggering conditions only, not workflow steps               |
+| AP-12 | Convention violations in examples       | Verify examples use pytest, proper imports, Argus patterns                 |
+| AP-13 | Reference dump instead of guidance      | Teach decision criteria, not raw documentation                             |
+| AP-14 | No trigger test queries                 | Write 5-10 should-trigger and should-NOT-trigger queries                   |
+| AP-15 | Description exceeds constraints         | Max 1024 chars, no angle brackets, third-person voice                      |
+| AP-16 | No intent capture                       | Interview the user for example prompts and expected outputs before writing |
+| AP-17 | Instructions without reasoning          | Every rule must explain WHY, not just WHAT                                 |
+
+## Reference Index
+
+| File                                                | Content                                                                     |
+| --------------------------------------------------- | --------------------------------------------------------------------------- |
+| [skill-structure.md](references/skill-structure.md) | Argus-specific skill structure with file organization and frontmatter rules |
+| [anti-patterns.md](references/anti-patterns.md)     | Common mistakes when creating skills with before/after fixes                |
+
+| Workflow                                             | Purpose                                               |
+| ---------------------------------------------------- | ----------------------------------------------------- |
+| [create-a-skill.md](workflows/create-a-skill.md)     | 6-phase process for creating a new skill from scratch |
+| [test-and-iterate.md](workflows/test-and-iterate.md) | Test trigger accuracy and iteratively improve a skill |
+
+## Success Criteria
+
+A well-designed Argus skill:
+
+- [ ] Has valid YAML frontmatter with `name` and `description` fields
+- [ ] Description is under 1024 characters with no angle brackets
+- [ ] Has When to Use (4+ scenarios) AND When NOT to Use (3+ scenarios) sections
+- [ ] Numbers all phases with entry and exit criteria
+- [ ] Every instruction explains WHY, not just WHAT
+- [ ] Keeps SKILL.md under 500 lines with details in references/workflows
+- [ ] Has no broken file references (all paths resolve)
+- [ ] Has no reference chains (all links one hop from SKILL.md)
+- [ ] Includes a verification step at the end of workflows
+- [ ] Has trigger eval queries (5+ should-trigger, 3+ should-NOT-trigger)
+- [ ] Description tested against trigger eval queries and activates correctly
+- [ ] Includes concrete examples for key instructions
+- [ ] Is registered in `AGENTS.md`
+- [ ] Contains no platform-specific instructions in the skill body
+- [ ] Follows Argus conventions from `AGENTS.md`

--- a/skills/designing-skills/references/anti-patterns.md
+++ b/skills/designing-skills/references/anti-patterns.md
@@ -1,0 +1,252 @@
+# Anti-Patterns Catalog
+
+Common mistakes when creating Argus skills. Each entry includes the symptom, why it's wrong, and a fix.
+
+---
+
+## Structure Anti-Patterns
+
+### AP-1: Vague Description and Missing Scope
+
+**Symptom:** Skill has a vague `description` and no "When to Use" / "When NOT to Use" sections.
+
+**Why it's wrong:** AI agents activate skills based on `description`. Vague descriptions cause wrong activations or missed activations. Once active, the scope sections prevent the LLM from attempting tasks outside the skill's competence.
+
+**Fix:** Write the description with triggering conditions ("Use when..."), third-person voice ("Guides X" not "I help with X"), and specific keywords. Add When to Use (4+ concrete scenarios) and When NOT to Use (3+ scenarios naming alternatives).
+
+---
+
+### AP-2: Monolithic SKILL.md
+
+**Symptom:** SKILL.md exceeds 500 lines with everything inlined.
+
+**Why it's wrong:** Oversized files dilute LLM attention. Critical instructions get buried in reference material.
+
+**Fix:** SKILL.md under 500 lines with core principles and routing. Detailed reference material in `references/`. Step-by-step processes in `workflows/`.
+
+---
+
+### AP-3: Reference Chains
+
+**Symptom:** SKILL.md links to file A, which links to file B, which links to file C.
+
+**Why it's wrong:** Each hop degrades context. By the time the LLM reaches file C, context from SKILL.md has degraded.
+
+**Fix:** All files one hop from SKILL.md. Reference files do not link to other reference files.
+
+---
+
+### AP-4: Unnumbered Phases
+
+**Symptom:** Workflow uses prose paragraphs instead of numbered phases.
+
+**Why it's wrong:** The LLM cannot reliably determine ordering from prose.
+
+**Fix:** Number every phase. Add entry criteria, numbered actions, and exit criteria to each phase:
+
+```markdown
+### Phase 1: Setup
+
+**Entry:** User has provided [input]
+**Actions:**
+
+1. Validate input
+2. Check prerequisites
+   **Exit:** [Specific artifact] exists and is valid
+```
+
+---
+
+### AP-5: Missing Exit Criteria
+
+**Symptom:** Phases say what to do but not how to know when it's done.
+
+**Why it's wrong:** Without exit criteria, the LLM may produce incomplete work and move on, or loop endlessly.
+
+**Fix:** Define what "done" means for every phase. Use concrete checks: "SKILL.md exists and has valid frontmatter" not "write the skill."
+
+---
+
+### AP-6: No Verification Step
+
+**Symptom:** The workflow ends with "output the results" and no validation.
+
+**Why it's wrong:** LLMs can produce plausible but incorrect output. A verification step catches errors before the user acts on bad results.
+
+**Fix:** Add a final phase: verify all referenced paths exist, no placeholder text remains, frontmatter is valid YAML.
+
+---
+
+### AP-7: Broken File References
+
+**Symptom:** SKILL.md references `workflows/advanced.md` but the file doesn't exist.
+
+**Why it's wrong:** The LLM either hallucinates the content or stops. Silent failures with unpredictable behavior.
+
+**Fix:** Before submitting, verify every path referenced in SKILL.md exists.
+
+---
+
+## Platform Anti-Patterns
+
+### AP-8: Platform-Specific Content in Skill Body
+
+**Symptom:** SKILL.md contains instructions like "If you're Claude Code, do X" or "Copilot should do Y."
+
+**Why it's wrong:** Skills should be platform-agnostic. Platform-specific discovery is handled by `AGENTS.md` and tool configuration, not by skill content.
+
+**Fix:** Write skill content that works identically for any AI agent. Platform-specific configuration goes in the discovery files.
+
+---
+
+### AP-9: Missing Discovery Configuration
+
+**Symptom:** New skill is created but not registered in `AGENTS.md`.
+
+**Why it's wrong:** AI agents won't find the skill without a reference in the discovery file.
+
+**Fix:** Always update `AGENTS.md` when adding a new skill — add a row to the Skills table.
+
+---
+
+## Content Anti-Patterns
+
+### AP-10: No Concrete Examples
+
+**Symptom:** Skill describes rules in abstract terms without showing input -> output.
+
+**Why it's wrong:** Abstract rules are ambiguous. Concrete examples anchor the LLM's understanding and reduce interpretation drift.
+
+**Fix:** Show the exact output format with a realistic Argus-specific example.
+
+**Before:**
+
+```markdown
+Write tests following pytest conventions.
+```
+
+**After:**
+
+````markdown
+Write tests following pytest conventions:
+
+```python
+import pytest
+from argus.backend.service.results_service import ResultsService
+
+@pytest.fixture
+def results_service(db_session):
+    return ResultsService(session=db_session)
+
+def test_get_results_returns_empty_list(results_service):
+    results = results_service.get_results(release_id="nonexistent")
+    assert results == []
+```
+````
+
+---
+
+### AP-11: Description Summarizes Workflow
+
+**Symptom:** The `description` field summarizes the skill's workflow steps instead of listing triggering conditions.
+
+**Why it's wrong:** When the description contains workflow steps, the LLM follows the description and shortcuts past the actual SKILL.md body.
+
+**Before:**
+
+```yaml
+description: >-
+    First reads the test file, then identifies patterns,
+    then rewrites using pytest fixtures and parametrize.
+```
+
+**After:**
+
+```yaml
+description: >-
+    Guides writing unit tests for the Argus backend using pytest
+    conventions. Use when creating new test files, adding test cases,
+    refactoring tests, or reviewing test coverage.
+```
+
+---
+
+### AP-12: Convention Violations in Examples
+
+**Symptom:** Skill examples use patterns that violate Argus conventions (wrong import style, unittest instead of pytest, wrong indentation).
+
+**Why it's wrong:** LLMs learn from examples. Bad examples in skills propagate convention violations across the codebase.
+
+**Fix:** Verify all code examples follow Argus conventions from `AGENTS.md`:
+
+- Python 3.12, 4-space indentation, 120-char line width
+- pytest style (not unittest.TestCase)
+- snake_case for Python, PascalCase for Svelte components
+- Imports at top of file
+
+---
+
+### AP-13: Reference Dump Instead of Guidance
+
+**Symptom:** Skill pastes a full specification or API reference instead of teaching when and how to apply it.
+
+**Why it's wrong:** The LLM already has general knowledge. What it needs is judgment: when to apply technique A vs B, what tradeoffs to consider.
+
+**Fix:** Teach decision criteria, not raw documentation. Show when to use X vs Y and why, with Argus-specific context.
+
+---
+
+### AP-14: No Trigger Test Queries
+
+**Symptom:** Skill is created and registered but never tested to verify the description triggers correctly.
+
+**Why it's wrong:** Descriptions that look reasonable can still cause false positives (activating for wrong requests) or false negatives (missing correct requests). Without testing, these bugs only surface when a user encounters unexpected behavior.
+
+**Fix:** Write 5-10 should-trigger queries and 3-5 should-NOT-trigger queries. Test the description against each query in isolation. See [test-and-iterate.md](../workflows/test-and-iterate.md) for the full process.
+
+---
+
+### AP-15: Description Exceeds Constraints
+
+**Symptom:** Description is over 1024 characters, contains angle brackets (`<`, `>`), or uses first-person voice.
+
+**Why it's wrong:**
+
+- Overly long descriptions waste context window space and force the LLM to process unnecessary text at session start.
+- Angle brackets break YAML parsing in some tool chains.
+- First-person voice ("I help with...") causes the LLM to role-play the description instead of using it as a matching criterion.
+
+**Fix:** Keep description under 1024 characters (aim for 200-400). Remove all angle brackets — use plain text or quoted examples instead. Use third-person voice: "Guides..." not "I help with..."
+
+---
+
+### AP-16: No Intent Capture
+
+**Symptom:** Skill was written without collecting example user prompts, expected outputs, or failure modes.
+
+**Why it's wrong:** Skills written without concrete intent produce generic guidance that doesn't match real usage patterns. The description misses keywords users actually use, the "When to Use" section is too abstract, and the skill body covers hypothetical scenarios instead of real ones.
+
+**Fix:** Before writing any skill files, gather: 5-10 example user prompts (should-trigger), 3-5 boundary prompts (should-NOT-trigger), 2-3 examples of expected good output, and known failure modes. This front-loads the hardest design decisions.
+
+---
+
+### AP-17: Instructions Without Reasoning
+
+**Symptom:** Skill rules say WHAT to do but not WHY.
+
+**Before:**
+
+```markdown
+Use numbered phases for all workflows.
+```
+
+**After:**
+
+```markdown
+Use numbered phases for all workflows — unnumbered prose produces unreliable
+execution order because the LLM cannot determine sequence from paragraph structure.
+```
+
+**Why it's wrong:** Instructions without reasoning are brittle. The LLM follows them literally for exact matches but can't generalize to novel situations. When the WHY is included, the LLM can apply the principle's intent even in cases the instruction didn't explicitly cover.
+
+**Fix:** For every instruction, add a clause or sentence explaining the reasoning. Use "because", "since", "this prevents", or em-dashes to connect the rule to its purpose.

--- a/skills/designing-skills/references/skill-structure.md
+++ b/skills/designing-skills/references/skill-structure.md
@@ -1,0 +1,198 @@
+# Argus Skill Structure Reference
+
+Detailed guide to the file organization, frontmatter format, and content rules for Argus skills.
+
+---
+
+## Directory Layout
+
+```
+skills/
+└── <skill-name>/                 # kebab-case, descriptive name
+    ├── SKILL.md                  # Main skill definition (REQUIRED)
+    ├── references/               # Deep-dive reference documents (OPTIONAL)
+    │   ├── <topic-a>.md
+    │   └── <topic-b>.md
+    └── workflows/                # Step-by-step processes (OPTIONAL)
+        ├── <process-a>.md
+        └── <process-b>.md
+```
+
+### Naming Conventions
+
+- **Skill directory**: kebab-case, max 64 characters (e.g., `writing-plans`, `code-review`)
+- **Files**: kebab-case `.md` files (e.g., `skill-structure.md`, `create-a-skill.md`)
+- **SKILL.md**: Always uppercase — this is the entry point for the skill
+
+### Required vs Optional
+
+| Component     | Required | Purpose                                     |
+| ------------- | -------- | ------------------------------------------- |
+| `SKILL.md`    | Yes      | Main skill definition with frontmatter      |
+| `references/` | No       | Detailed guidance that SKILL.md summarizes  |
+| `workflows/`  | No       | Step-by-step processes with numbered phases |
+
+Simple skills (pure guidance, no workflows) may have only SKILL.md. Complex skills should split content into references/ and workflows/.
+
+---
+
+## SKILL.md Frontmatter
+
+Every SKILL.md starts with YAML frontmatter between `---` markers:
+
+```yaml
+---
+name: skill-name
+description: >-
+    Third-person description with trigger keywords.
+    Use when <specific scenarios>. Applies to <specific domains>.
+---
+```
+
+### Frontmatter Fields
+
+| Field         | Required | Description                                                |
+| ------------- | -------- | ---------------------------------------------------------- |
+| `name`        | Yes      | kebab-case, matches directory name, max 64 characters      |
+| `description` | Yes      | Max 1024 characters, no angle brackets, third-person voice |
+
+### Validation Rules
+
+These constraints ensure skills work reliably across platforms:
+
+| Rule               | Constraint                           | Reason                                        |
+| ------------------ | ------------------------------------ | --------------------------------------------- |
+| Name format        | kebab-case only                      | Consistent directory naming across platforms  |
+| Name length        | Max 64 characters                    | Filesystem and tool compatibility             |
+| Description length | Max 1024 characters                  | Context window efficiency; forces conciseness |
+| No angle brackets  | `<` and `>` forbidden in description | Breaks YAML parsing in some tool chains       |
+| Valid YAML         | Frontmatter must parse as valid YAML | Platforms read frontmatter programmatically   |
+
+### Writing Effective Descriptions
+
+The `description` field is the most important part of the skill — it determines when the skill activates. Think of it as a search index: it must contain the right keywords for the LLM to match against user requests.
+
+**Rules:**
+
+1. Use third-person voice: "Guides the creation of..." not "I help with..."
+2. Include trigger keywords that match user requests — add synonyms users might use
+3. List specific scenarios: "Use when creating unit tests, refactoring test files, or adding pytest fixtures"
+4. Stay under 1024 characters (hard limit) — aim for 200-400 characters
+5. Do NOT include workflow steps — only triggering conditions
+6. Include exclusions where the boundary is ambiguous: "Use when X. Not for Y."
+
+**Good example:**
+
+```yaml
+description: >-
+    Guides writing unit tests for the Argus backend using pytest
+    conventions. Use when creating new test files, adding test cases,
+    refactoring tests, or reviewing test coverage for Argus components.
+    Not for integration tests or performance benchmarks.
+```
+
+**Bad example:**
+
+```yaml
+description: >-
+    First reads the file, then creates a test class, then adds
+    fixtures and assertions. Outputs a complete test file.
+```
+
+**Why this matters:** The LLM reads every skill's description at session start and decides which to activate. A description that summarizes the workflow (bad example) causes the LLM to follow the description as instructions and skip the actual SKILL.md body. A description that lists triggering conditions (good example) lets the LLM correctly match user intent.
+
+### Optimizing Descriptions Iteratively
+
+If a skill isn't triggering correctly:
+
+1. **Write trigger eval queries** — 5-10 prompts that should trigger, 3-5 that shouldn't
+2. **Test the description in isolation** — read only the description, check each query
+3. **Fix false negatives** — add missing keywords, synonyms, or scenario phrases
+4. **Fix false positives** — narrow scope with exclusions or more specific terms
+5. **Re-test** — repeat until all queries pass
+
+See [test-and-iterate.md](../workflows/test-and-iterate.md) for the full process.
+
+---
+
+## Line Count Limits
+
+Progressive disclosure keeps context windows focused:
+
+| File Type       | Max Lines | Rationale                           |
+| --------------- | --------- | ----------------------------------- |
+| SKILL.md        | 500       | Contains only always-needed content |
+| Reference files | 400       | Detailed but focused on one topic   |
+| Workflow files  | 300       | Step-by-step processes stay concise |
+
+If a file exceeds its limit, split it into multiple files. SKILL.md should summarize and link; details go in references/ and workflows/.
+
+---
+
+## Content Organization Rules
+
+### What Goes in SKILL.md
+
+- Essential principles (3-5 non-negotiable rules)
+- When to Use / When NOT to Use sections
+- Quick reference tables (summarize detailed content)
+- Reference index (links to all supporting files)
+- Success criteria checklist
+
+### What Goes in references/
+
+- Detailed pattern catalogs (e.g., anti-patterns with before/after examples)
+- Deep-dive technical guides (e.g., import conventions, error handling)
+- Templates and format specifications
+- Extended examples that would bloat SKILL.md
+
+### What Goes in workflows/
+
+- Multi-step processes with numbered phases
+- Each phase has entry criteria, numbered actions, and exit criteria
+- Review checklists
+- Creation guides (e.g., "create-a-skill.md", "write-a-plan.md")
+
+### The One-Hop Rule
+
+All files are one hop from SKILL.md:
+
+```
+SKILL.md -> references/topic.md      (one hop)
+SKILL.md -> workflows/process.md     (one hop)
+references/a.md -> references/b.md   (reference chain - NOT allowed)
+```
+
+Reference files do not link to other reference files. If two reference topics are related, SKILL.md should link to both independently.
+
+---
+
+## Platform Discovery
+
+Skills need to be registered for AI platforms to find them.
+
+### AGENTS.md
+
+Add the skill to the "Skills" table in the root `AGENTS.md`:
+
+```markdown
+| <skill-name> | <description> | `skills/<skill-name>/SKILL.md` |
+```
+
+AI agents read the nearest `AGENTS.md` in the directory tree. Since skills are referenced from the root `AGENTS.md`, agents will find them when working anywhere in the repository.
+
+---
+
+## Argus-Specific Conventions
+
+Skills that generate code examples or instructions must follow Argus conventions:
+
+| Convention    | Source      | Rule                                                      |
+| ------------- | ----------- | --------------------------------------------------------- |
+| Python style  | `AGENTS.md` | Python 3.12, 4-space indent, 120-char line width          |
+| Import style  | `AGENTS.md` | Imports at top of file, organized by group                |
+| Test style    | `AGENTS.md` | pytest, not unittest.TestCase                             |
+| Naming        | `AGENTS.md` | snake_case for Python, PascalCase for Svelte              |
+| Linting       | `AGENTS.md` | Run `uv run ruff check`                                   |
+| Commit format | `AGENTS.md` | Conventional Commits (`fix(scope):`, `feature(app):`)     |
+| Test location | `AGENTS.md` | Tests in `argus/backend/tests/` and `argus/client/tests/` |

--- a/skills/designing-skills/workflows/create-a-skill.md
+++ b/skills/designing-skills/workflows/create-a-skill.md
@@ -1,0 +1,182 @@
+# Creating a New Argus Skill
+
+A 6-phase process for creating a skill from scratch in the Argus repository.
+
+---
+
+## Phase 1: Capture Intent and Define Scope
+
+**Entry:** You have a task domain in mind (e.g., "unit testing", "code review", "writing plans").
+
+**Actions:**
+
+1. **Gather concrete intent.** Before writing anything, collect:
+    - 5-10 example user prompts that should trigger this skill
+    - 3-5 example prompts that are related but should NOT trigger
+    - 2-3 examples of expected output (what does "good" look like?)
+    - Known failure modes (what would "bad" output look like?)
+
+    This step prevents writing generic skills that don't match real usage. If you're creating the skill for yourself, write the examples from your own experience. If for a team, ask for examples.
+
+2. **Draft the `description` first.** This is the most important field. AI agents use it to decide activation. Use third-person voice, include trigger keywords and exclusions. Verify: under 1024 characters, no angle brackets.
+
+3. **Write the "When to Use" section.** List 4-6 specific scenarios where the skill applies. Draw from the example prompts gathered in step 1. Be concrete: "when writing a new test file in `argus/backend/tests/`" not "when doing testing."
+
+4. **Write the "When NOT to Use" section.** List 3-5 scenarios where a different approach is better. Draw from the should-NOT-trigger prompts. Name the alternative: "use the writing-plans skill for implementation planning" not "not for complex tasks."
+
+5. **Define 3-5 essential principles.** These are non-negotiable rules for every invocation. Ask: "What mistake would ruin the output if the LLM made it?" Each principle guards against a specific failure mode. Every principle must explain WHY — reasoning helps the LLM generalize to cases the rule didn't explicitly cover.
+
+6. **Verify Argus alignment.** Check that your scope aligns with Argus conventions in `AGENTS.md`.
+
+**Exit:** Example prompts collected, draft description, When to Use, When NOT to Use, and essential principles documented.
+
+---
+
+## Phase 2: Plan Content Structure
+
+**Entry:** Phase 1 complete. Scope defined.
+
+**Actions:**
+
+1. **List all content the skill needs.** What guidance, examples, references, and processes are required?
+
+2. **Apply the 500-line test.** Can everything fit in SKILL.md under 500 lines? If not, identify what moves to references/ and workflows/.
+
+3. **Identify reference topics.** Each reference file covers one focused topic (e.g., "anti-patterns.md", "plan-templates.md"). Keep each under 400 lines.
+
+4. **Identify workflow processes.** Each workflow file is a numbered-phase process (e.g., "create-a-plan.md", "create-a-skill.md"). Keep each under 300 lines.
+
+5. **Plan the directory structure:**
+
+    ```
+    skills/<skill-name>/
+    ├── SKILL.md
+    ├── references/
+    │   ├── <topic-a>.md
+    │   └── <topic-b>.md
+    └── workflows/
+        └── <process>.md
+    ```
+
+6. **Verify the one-hop rule.** All files must be reachable directly from SKILL.md. No reference-to-reference links.
+
+**Exit:** Complete file list with content assignments for each file.
+
+---
+
+## Phase 3: Write Content
+
+**Entry:** Phase 2 complete. File structure planned.
+
+**Actions:**
+
+1. **Write reference files first.** These are the foundation that SKILL.md summarizes and links to.
+
+2. **Write workflow files.** Each workflow follows numbered phases:
+
+    ```markdown
+    ### Phase N: <Name>
+
+    **Entry:** <What must be true>
+    **Actions:**
+
+    1. <Specific step>
+    2. <Specific step>
+       **Exit:** <How to know it's done>
+    ```
+
+3. **Write SKILL.md last.** It summarizes and routes to the reference and workflow files. Follow the SKILL.md template structure (see SKILL.md -> Reference Index -> skill-structure.md):
+    - Frontmatter (name, description)
+    - Essential Principles
+    - When to Use / When NOT to Use
+    - Domain-specific quick references
+    - Reference Index (links to all supporting files)
+    - Success Criteria checklist
+
+4. **Include concrete examples.** Every key instruction should have an Argus-specific input -> output example.
+
+5. **Check line counts:**
+    - SKILL.md: under 500 lines
+    - Reference files: under 400 lines each
+    - Workflow files: under 300 lines each
+
+**Exit:** All content files written, line counts within limits.
+
+---
+
+## Phase 4: Configure Discovery
+
+**Entry:** Phase 3 complete. All skill files written.
+
+**Actions:**
+
+1. **Update `AGENTS.md`**. Add a row to the Skills table:
+
+    ```markdown
+    | <skill-name> | <description> | `skills/<skill-name>/SKILL.md` |
+    ```
+
+2. **Verify no other files need updating.** Check if any existing documentation references the skill's domain — if so, add a cross-reference to the skill.
+
+**Exit:** Skill is discoverable by AI agents via AGENTS.md.
+
+---
+
+## Phase 5: Validate
+
+**Entry:** Phase 4 complete. Skill is created and registered.
+
+**Actions:**
+
+1. **Verify all file references.** Every path in SKILL.md must resolve to an existing file.
+
+2. **Check frontmatter.** Valid YAML with:
+    - `name`: kebab-case, matches directory, max 64 characters
+    - `description`: third-person, trigger keywords, max 1024 characters, no angle brackets
+
+3. **Read the description in isolation.** Would it activate for the right requests and stay silent for wrong ones?
+
+4. **Read SKILL.md as a fresh reader.** Is the structure clear? Could an LLM follow it without prior context?
+
+5. **Check every instruction has a WHY.** Scan for rules that only say WHAT to do. Add reasoning where missing.
+
+6. **Scan for anti-patterns.** Check against the anti-pattern catalog (see SKILL.md -> Reference Index -> anti-patterns.md):
+    - No monolithic SKILL.md (AP-2)
+    - No reference chains (AP-3)
+    - No unnumbered phases (AP-4)
+    - No missing exit criteria (AP-5)
+    - No broken file references (AP-7)
+    - No platform-specific content (AP-8)
+    - No missing discovery configuration (AP-9)
+    - No description summarizing workflow steps (AP-11)
+    - No convention violations in examples (AP-12)
+    - No missing trigger tests (AP-14)
+    - No description constraint violations (AP-15)
+    - No missing intent capture (AP-16)
+    - No instructions without reasoning (AP-17)
+
+7. **Run linting.** Execute `uv run ruff check` to verify no formatting issues in any Python examples.
+
+8. **Verify AGENTS.md registration.** The skill must appear in the Skills table.
+
+**Exit:** All structural checks pass.
+
+---
+
+## Phase 6: Test Triggers and Iterate
+
+**Entry:** Phase 5 complete. Skill passes structural validation.
+
+**Actions:**
+
+1. **Use eval queries from Phase 1.** Take the example prompts gathered during intent capture. If you didn't gather them, write them now (5-10 should-trigger, 3-5 should-NOT-trigger).
+
+2. **Test the description against each query.** Read only the description field. For each query, decide: would the LLM activate this skill? Score pass/fail.
+
+3. **Fix any failures.** For false negatives, add missing trigger keywords. For false positives, narrow scope with exclusions or more specific terms. See [test-and-iterate.md](test-and-iterate.md) for the full process.
+
+4. **Apply the lean test.** Re-read every instruction in the skill. Remove anything that doesn't improve output quality — bloated skills dilute LLM attention.
+
+5. **Final verification.** Re-run Phase 5 checks after any changes made during iteration.
+
+**Exit:** All trigger eval queries pass. Skill is lean and well-reasoned. Ready for use.

--- a/skills/designing-skills/workflows/test-and-iterate.md
+++ b/skills/designing-skills/workflows/test-and-iterate.md
@@ -1,0 +1,118 @@
+# Testing and Iterating on a Skill
+
+A 4-phase process for verifying that a skill triggers correctly and improving it based on results.
+
+---
+
+## Phase 1: Write Trigger Eval Queries
+
+**Entry:** Skill has a complete SKILL.md with frontmatter `description`.
+
+**Actions:**
+
+1. **Write 5-10 should-trigger queries.** These are user prompts where the skill MUST activate. Draw from the "When to Use" scenarios and real user requests gathered during intent capture.
+
+    Example for `designing-skills`:
+
+    ```
+    - "Create a new skill for code review"
+    - "Help me structure a skill directory"
+    - "Review this skill for anti-patterns"
+    - "I want to add a new skill to the Argus repo"
+    - "How should I split content between SKILL.md and references?"
+    ```
+
+2. **Write 3-5 should-NOT-trigger queries.** These are prompts for related but out-of-scope tasks. Draw from the "When NOT to Use" scenarios.
+
+    Example for `designing-skills`:
+
+    ```
+    - "Fix the unit test for the results service"
+    - "Update the README with new installation steps"
+    - "Add a new API endpoint for releases"
+    ```
+
+3. **Include edge cases.** Write 2-3 ambiguous queries that test the boundary of the skill's scope. Decide whether each should trigger or not.
+
+    Example:
+
+    ```
+    - "Update AGENTS.md with a new skill entry" -> should-trigger (part of skill creation)
+    - "Update AGENTS.md with new architecture docs" -> should-NOT-trigger (general docs)
+    ```
+
+**Exit:** A list of eval queries, each labeled as should-trigger or should-NOT-trigger.
+
+---
+
+## Phase 2: Test the Description
+
+**Entry:** Phase 1 complete. Eval queries written.
+
+**Actions:**
+
+1. **Read the description in isolation.** Copy only the `description` field value. For each eval query, ask: "Given ONLY this description, would an LLM activate this skill for this query?"
+
+2. **Score each query.** Mark as:
+    - **Pass** — correctly triggers (or correctly stays silent)
+    - **Fail** — wrong behavior (false positive or false negative)
+
+3. **Calculate accuracy.** Count passes / total queries. Target: 100% for should-trigger, 100% for should-NOT-trigger.
+
+4. **Record failures.** For each failure, note:
+    - The query
+    - Expected behavior (trigger / no trigger)
+    - Actual behavior
+    - Likely cause (missing keyword, overly broad term, etc.)
+
+**Exit:** Accuracy scores and a list of failures with likely causes.
+
+---
+
+## Phase 3: Improve the Description
+
+**Entry:** Phase 2 complete. Failures identified.
+
+**Actions:**
+
+1. **Fix false negatives** (should-trigger but didn't). Add missing trigger keywords or scenarios to the description. Common fixes:
+    - Add synonyms the user might use ("structure" + "organize" + "design")
+    - Add specific task verbs ("creating", "reviewing", "refactoring")
+    - Add domain nouns that appear in the failing queries
+
+2. **Fix false positives** (should-NOT-trigger but did). Narrow the description scope. Common fixes:
+    - Add exclusion phrases ("Use when X, not for Y")
+    - Replace broad terms with specific ones ("Argus skills" instead of "documentation")
+    - Add qualifying context ("for the skills/ directory" not "for any directory")
+
+3. **Generalize fixes.** When fixing one query, ask: "Does this fix apply to a category of queries?" Apply the fix broadly rather than patching individual cases.
+
+4. **Check constraints.** After edits, verify:
+    - Under 1024 characters
+    - No angle brackets (`<`, `>`)
+    - Third-person voice maintained
+    - No workflow steps leaked into description
+
+5. **Re-run Phase 2.** Test the updated description against all eval queries.
+
+**Exit:** All eval queries pass. Description is within constraints.
+
+---
+
+## Phase 4: Validate Skill Quality
+
+**Entry:** Phase 3 complete. Description triggers correctly.
+
+**Actions:**
+
+1. **Review every instruction for WHY.** Read each rule or instruction in SKILL.md. If it only says WHAT to do without explaining WHY, add the reasoning. Instructions with reasoning produce more reliable LLM behavior.
+
+2. **Apply the lean test.** For each instruction, ask: "If I removed this, would the skill output get worse?" Remove instructions that don't improve outcomes — they dilute attention.
+
+3. **Check for generalized guidance.** Each instruction should apply broadly, not just to one specific edge case. If an instruction only fixes one scenario, generalize it or remove it.
+
+4. **Verify concrete examples.** Key instructions should have input -> output examples. Abstract rules without examples cause interpretation drift.
+
+5. **Final read-through.** Read the entire skill (SKILL.md + references + workflows) as if encountering it for the first time. Flag anything confusing, redundant, or contradictory.
+
+**Exit:** Skill is lean, well-reasoned, and triggers correctly. Ready for use.

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: writing-plans
+description: >-
+    Use when asked to generate an implementation plan, draft a plan, save a plan,
+    or design a feature rollout for the Argus repository. Supports two formats:
+    full 7-section plans for multi-phase work (1K+ LOC, tracked in MASTER.md)
+    and lightweight mini-plans for single-PR changes (under 1K LOC, stored in
+    docs/plans/mini-plans/). Routes automatically based on PR plans label,
+    user input, or task size estimate.
+---
+
+# Writing Implementation Plans for Argus
+
+Create well-structured implementation plans that follow Argus's 7-section format and enable incremental, PR-scoped development.
+
+## Essential Principles
+
+### Authoritative Source
+
+**`docs/plans/INSTRUCTIONS.md` is the authoritative source for plan structure.**
+
+This skill supplements — not replaces — the official instructions. Always read `docs/plans/INSTRUCTIONS.md` before writing a plan. If there is a conflict between this skill and `INSTRUCTIONS.md`, follow `INSTRUCTIONS.md`.
+
+### Code-Verified Current State
+
+**The Current State section must reference real files, classes, and methods.**
+
+Use file-reading tools to inspect actual code before writing Current State. Do not guess or hallucinate file names. Every path mentioned must resolve to an existing file in the repository.
+
+### PR-Scoped Phases
+
+**Each implementation phase should be scoped to a single Pull Request.**
+
+Large phases that span multiple PRs are hard to review and test. Break work into atomic phases with clear Definition of Done criteria. Within a PR, split logically distinct changes into separate commits for easier review. Order phases by dependency — foundational refactoring before feature implementation.
+
+### Measurable Goals
+
+**Goals and success criteria must be measurable, not vague.**
+
+"Improve performance" is not a goal. "Reduce release dashboard query time from 5s to under 500ms" is a goal. Include numbers, thresholds, or verifiable conditions.
+
+### Investigation Over Assumption
+
+**Mark unclear requirements as "Needs Investigation" instead of assuming.**
+
+When information is missing or ambiguous, explicitly flag it. Incorrect assumptions in a plan propagate through the entire implementation and cause rework.
+
+### Every Plan Must Have Status Metadata
+
+**All plans require YAML frontmatter with status, domain, and dates.**
+
+Plans without metadata are invisible to the tracking system. Every plan file must start with frontmatter specifying `status`, `domain`, `created`, `last_updated`, and `owner` fields. This enables `MASTER.md` and `progress.json` to reflect accurate state. See [frontmatter-fields.md](references/frontmatter-fields.md) for valid values.
+
+## Plan Type Routing
+
+When the user asks to "save a plan", "draft a plan", or similar, determine the plan type **before writing anything**.
+
+### Decision Tree
+
+```
+1. User explicitly said big/small?       -> Use that
+2. Working on a PR with `plans` label?   -> FULL plan
+3. Working on a PR without `plans` label? -> MINI-plan
+4. No PR context?                        -> Ask user, or estimate: >=1K LOC -> FULL, <1K LOC -> MINI
+```
+
+### Step 1: Ask the User (Preferred)
+
+When explicitly asked to create/save a plan, ask:
+
+> "Is this a big plan (multi-phase, 1K+ LOC, needs tracking) or a small plan (single PR, under ~1K LOC)?"
+
+The user's answer is authoritative. If they say "small" -> mini-plan. If they say "big" -> full plan.
+
+**When user says "big":** If already working on a PR, add the `plans` label immediately:
+
+```bash
+gh pr edit <number> --add-label "plans"
+```
+
+If a PR hasn't been opened yet, include a reminder in the plan output: "Remember to add the `plans` label when the PR is created." The agent should also add the label automatically when it later creates the PR during that session.
+
+### Step 2: PR Label Check (When Working on an Existing PR)
+
+If the agent is already working on a PR (e.g., from `gh pr checkout`), check for the `plans` label:
+
+```bash
+gh pr view <number> --json labels --jq '.labels[].name' | grep -q '^plans$'
+```
+
+- PR has `plans` label -> FULL plan (7-section, `docs/plans/`)
+- PR does NOT have `plans` label -> MINI-plan (4-section, `docs/plans/mini-plans/`)
+
+### Step 3: Fallback Heuristic (Only if No User Answer and No PR Context)
+
+Estimate the scope from the task description:
+
+- **Likely big:** Multiple new files, new config parameters, multiple services affected, needs CI changes
+- **Likely small:** Single file change, bug fix, test addition, refactoring one module
+- **When in doubt, ask the user** rather than guessing
+
+## When to Use
+
+- When asked to "generate an implementation plan", "draft a plan", or "save a plan"
+- When designing a multi-phase feature rollout for Argus (-> full plan)
+- When a complex change needs to be broken into PR-scoped steps (-> full plan)
+- When documenting a refactoring strategy before implementation (-> full plan)
+- When creating a roadmap for a new Argus capability (-> full plan)
+- When reviewing or improving an existing plan
+- When a small, single-PR change benefits from lightweight planning (-> mini-plan)
+- When working on a PR without a `plans` label and want to document approach (-> mini-plan)
+
+## When NOT to Use
+
+- For trivial changes that need no planning at all — just implement directly
+- For regular coding questions — answer them without plan structure
+- For documentation-only changes — edit the relevant file directly
+- For updating an existing plan's status — edit the plan file directly
+
+## The 7-Section Structure
+
+Every Argus plan follows this structure. See [plan-templates.md](references/plan-templates.md) for detailed templates and examples.
+
+| #   | Section               | Purpose                 | Key Rule                                                     |
+| --- | --------------------- | ----------------------- | ------------------------------------------------------------ |
+| 1   | Problem Statement     | What and why            | Include measurable pain points                               |
+| 2   | Current State         | What exists today       | MUST reference real files (verify with tools)                |
+| 3   | Goals                 | What success looks like | Numbered, measurable objectives                              |
+| 4   | Implementation Phases | How to get there        | PR-scoped (≤200 LOC), Importance levels, DoD per phase       |
+| 5   | Testing Requirements  | How to verify           | Unit, integration, and manual testing planned upfront        |
+| 6   | Success Criteria      | How to know it's done   | References DoD items; add plan-level criteria only if needed |
+| 7   | Risk Mitigation       | What could go wrong     | Likelihood, impact, mitigation for each risk                 |
+
+## Plan File Conventions
+
+| Convention | Rule                                           |
+| ---------- | ---------------------------------------------- |
+| Location   | `docs/plans/` directory                        |
+| Filename   | kebab-case, descriptive (e.g., `api-tests.md`) |
+| Format     | Markdown with `# Plan Title` as first line     |
+| Archiving  | Move completed plans to `docs/plans/archive/`  |
+
+## Argus-Specific Considerations
+
+When writing plans for Argus, consider these domain-specific areas:
+
+| Area              | What to Include                                                             |
+| ----------------- | --------------------------------------------------------------------------- |
+| **Backend**       | Flask blueprints in `argus/backend/`, service layer patterns                |
+| **Frontend**      | Svelte 5 components in `frontend/`, rune APIs, Rollup bundling              |
+| **Database**      | ScyllaDB/Cassandra models via CQLEngine (migrating to coodie)               |
+| **API**           | REST endpoints, JSON response contracts, httpx-based testing                |
+| **Client**        | Python client in `argus/client/`, CLI in `cli/`                             |
+| **CI/CD**         | GitHub Actions in `.github/workflows/`                                      |
+| **Testing**       | pytest in `argus/backend/tests/` and `argus/client/tests/`, Docker-based DB |
+| **MASTER.md**     | Register the plan in `docs/plans/MASTER.md` under the correct domain        |
+| **progress.json** | Add an entry to `docs/plans/progress.json` with plan metadata               |
+| **Related Plans** | Check MASTER.md for existing plans in the same domain that may overlap      |
+
+## Mini-Plan Format
+
+Mini-plans are a lightweight 4-section format for small changes. See [mini-plan-template.md](references/mini-plan-template.md) for the full template and example.
+
+| Aspect        | Full Plan              | Mini-Plan                                  |
+| ------------- | ---------------------- | ------------------------------------------ |
+| Sections      | 7                      | 4 (Problem, Approach, Files, Verification) |
+| Frontmatter   | Required               | None                                       |
+| MASTER.md     | Required               | None                                       |
+| progress.json | Required               | None                                       |
+| Location      | `docs/plans/`          | `docs/plans/mini-plans/`                   |
+| Filename      | `kebab-case-name.md`   | `YYYY-MM-DD-kebab-case-name.md`            |
+| Lifecycle     | Tracked until archived | Disposable after PR merge or 30 days       |
+
+## Anti-Pattern Quick Reference
+
+See [anti-patterns.md](references/anti-patterns.md) for the full catalog with before/after examples and the quick-reference table.
+
+## Reference Index
+
+| File                                                      | Content                                                                           |
+| --------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| [plan-templates.md](references/plan-templates.md)         | Complete plan skeleton, section-by-section templates with Argus-specific examples |
+| [anti-patterns.md](references/anti-patterns.md)           | Common plan writing mistakes with before/after fixes                              |
+| [frontmatter-fields.md](references/frontmatter-fields.md) | YAML frontmatter field definitions, valid values, and domain taxonomy             |
+| [mini-plan-template.md](references/mini-plan-template.md) | Mini-plan 4-section template with example and rules                               |
+
+| Workflow                                                 | Purpose                                                                                    |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| [create-a-plan.md](workflows/create-a-plan.md)           | 5-phase process for writing a full implementation plan from scratch                        |
+| [create-a-mini-plan.md](workflows/create-a-mini-plan.md) | 3-phase lightweight workflow for writing a mini-plan                                       |
+| [update-plan-status.md](workflows/update-plan-status.md) | 3-phase workflow for updating plan status across frontmatter, MASTER.md, and progress.json |
+
+## Supporting Documents
+
+| Document                          | Role                                                   |
+| --------------------------------- | ------------------------------------------------------ |
+| `docs/plans/INSTRUCTIONS.md`      | Authoritative source for plan structure and guidelines |
+| `docs/plans/api_tests.md`         | Reference example: API integration test plan           |
+| `docs/plans/ssh-tunnel-design.md` | Reference example: infrastructure design plan          |
+
+## Success Criteria
+
+### Full Plan
+
+- [ ] Passes `uv run ruff check` without issues
+- [ ] Follows the 7-section structure from `docs/plans/INSTRUCTIONS.md`
+- [ ] Has a Problem Statement with measurable pain points
+- [ ] Has a Current State section with verified file/class/method references
+- [ ] Has numbered, measurable goals
+- [ ] Has PR-scoped implementation phases (≤200 LOC each) with Importance levels and Definition of Done
+- [ ] Includes a documentation update phase or deliverable (docs, config, guides)
+- [ ] Has testing requirements covering unit, integration, and manual testing
+- [ ] Has success criteria that reference DoD items (no duplication)
+- [ ] Has risk mitigation with likelihood, impact, and mitigation for each risk
+- [ ] Marks unclear requirements as "Needs Investigation"
+- [ ] Is saved in `docs/plans/` with a kebab-case filename
+- [ ] Has valid YAML frontmatter (status, domain, created, last_updated, owner)
+- [ ] Is registered in `docs/plans/MASTER.md` under the correct domain
+- [ ] Has a corresponding entry in `docs/plans/progress.json`
+
+### Mini-Plan
+
+- [ ] Has exactly 4 sections: Problem, Approach, Files to Modify, Verification
+- [ ] Has no YAML frontmatter
+- [ ] All file paths in "Files to Modify" are code-verified (or marked as new)
+- [ ] Verification checklist has concrete, runnable checks
+- [ ] Includes `uv run ruff check` in verification
+- [ ] Is saved as `docs/plans/mini-plans/YYYY-MM-DD-kebab-case-name.md`
+- [ ] Is NOT registered in MASTER.md or progress.json

--- a/skills/writing-plans/references/anti-patterns.md
+++ b/skills/writing-plans/references/anti-patterns.md
@@ -1,0 +1,282 @@
+# Plan Anti-Patterns Catalog
+
+Common mistakes when writing Argus implementation plans. Each entry includes the symptom, why it's wrong, and a fix.
+
+---
+
+## Content Anti-Patterns
+
+### PAP-1: Too Much Code in the Plan
+
+**Symptom:** The plan includes full implementation code — complete functions, classes, or modules — instead of describing what to build.
+
+**Why it's wrong:** A plan is a roadmap, not a codebase. Embedding full implementations makes the plan brittle (code changes invalidate the plan), hard to review (reviewers must read code instead of design), and misleading (the code may not compile or handle edge cases). The actual implementation belongs in PRs.
+
+**Fix:** Use short code snippets (5-15 lines) only to illustrate interfaces, configuration formats, or API contracts. Describe behavior in prose; let the implementation phase produce the real code.
+
+**Before:**
+
+````markdown
+### Phase 2: Implement Caching Layer
+
+```python
+class ResultCache:
+    def __init__(self, ttl=300):
+        self.ttl = ttl
+        self._cache = {}
+        self._timestamps = {}
+
+    def get(self, key):
+        if key in self._cache:
+            if time.time() - self._timestamps[key] < self.ttl:
+                return self._cache[key]
+            del self._cache[key]
+        return None
+
+    def set(self, key, value):
+        self._cache[key] = value
+        self._timestamps[key] = time.time()
+        # ... 30 more lines
+```
+````
+
+````
+
+**After:**
+```markdown
+### Phase 2: Implement Caching Layer
+
+**Description**: Add TTL-based in-memory cache for release dashboard queries
+to reduce ScyllaDB load on frequently accessed data.
+
+**Key design decisions**:
+- Simple dict-based cache with TTL expiration (not Redis — single-process deployment)
+- 300-second default TTL, configurable per endpoint
+- Cache invalidation on write operations
+
+**Interface**:
+```python
+cache = ResultCache(ttl=300)
+cached = cache.get("release:uuid")  # Returns None on miss/expiry
+cache.set("release:uuid", data)
+````
+
+````
+
+---
+
+### PAP-2: Missing Diagrams for Complex Interactions
+
+**Symptom:** The plan describes a complex multi-component interaction (cross-service communication, state machines, multi-layer data flows) using only prose, without any visual representation.
+
+**Why it's wrong:** Prose alone cannot convey component relationships, data flows, or state transitions clearly. Readers (human and AI) miss dependencies, race conditions, or circular references that a diagram makes obvious.
+
+**Fix:** Add ASCII diagrams or Mermaid diagrams for any interaction involving 3+ components, state transitions, or data flows across system boundaries.
+
+**Before:**
+```markdown
+The client sends test results to the backend API which stores them in
+ScyllaDB. The frontend polls the API for updated results and renders
+them on the dashboard. The CLI tool also queries the API for status.
+````
+
+**After:**
+
+    Client (argus-client)
+        └── POST /api/v1/results ──► Backend (Flask)
+                                        ├── store ──► ScyllaDB
+                                        └── serve ──► GET /api/v1/results
+                                                        ├── ◄── Frontend (Svelte)
+                                                        └── ◄── CLI (argus-cli)
+
+**When to use diagrams**:
+
+- 3+ components interacting
+- State machines or lifecycle transitions
+- Data flows across system boundaries (e.g., client → backend → database → frontend)
+- Request/response sequences involving multiple services
+
+---
+
+### PAP-3: Overly Granular Phases
+
+**Symptom:** Phases include implementation-level details — specific function signatures, line-by-line changes, exact variable names — instead of design-level deliverables.
+
+**Why it's wrong:** Over-specifying in the plan constrains the implementer unnecessarily, becomes stale as soon as the code evolves, buries the design intent under implementation noise, and makes the plan unreadable for stakeholders who need the "what" and "why", not the "how".
+
+**Fix:** Phases should describe deliverables and design decisions, not line-by-line implementation. Leave the "how" for the PR.
+
+**Before:**
+
+```markdown
+### Phase 1: Add New API Endpoint
+
+1. Open `argus/backend/controller/api.py`
+2. Add route after line 342:
+   `@bp.route("/api/v1/releases/<release_id>/summary", methods=["GET"])`
+3. Add function `def get_release_summary(release_id):`
+4. Import `ReleaseSummaryService` on line 15
+5. Run `uv run ruff check` to fix formatting
+```
+
+**After:**
+
+```markdown
+### Phase 1: Add Release Summary Endpoint
+
+**Description**: Add `GET /api/v1/releases/<release_id>/summary` endpoint
+returning aggregated test results per release.
+
+**Deliverables**:
+
+- New route in `argus/backend/controller/api.py`
+- Service method in `argus/backend/service/results_service.py`
+- Response schema matching existing patterns
+
+**Definition of Done**:
+
+- [ ] Endpoint returns JSON with release summary data
+- [ ] Integration test covers happy path and 404 case
+- [ ] `uv run ruff check` passes
+```
+
+---
+
+### PAP-4: Vague or Unmeasurable Goals
+
+**Symptom:** Goals use words like "improve", "better", "optimize", "enhance" without concrete criteria for what success looks like.
+
+**Why it's wrong:** Vague goals cannot be validated. There is no way to know when the work is done. Different reviewers will have different interpretations of "improve performance." The plan has no accountability.
+
+**Fix:** Every goal must have a measurable criterion or a verifiable condition. If a metric is unknown, state the target condition explicitly.
+
+**Before:**
+
+```markdown
+## Goals
+
+1. Improve API performance
+2. Make the dashboard more responsive
+3. Better error handling
+4. Optimize database queries
+```
+
+**After:**
+
+```markdown
+## Goals
+
+1. **Reduce dashboard load time to under 2s** for releases with 500+ test runs
+2. **Eliminate N+1 queries** in release summary endpoint (currently 1 query per test run)
+3. **Return structured error responses** with error codes for all 4xx/5xx responses
+4. **Add query-level caching** with 5-minute TTL for read-heavy endpoints
+```
+
+---
+
+### PAP-5: Conflicting or Contradictory Requirements
+
+**Symptom:** Different sections of the plan state incompatible goals, design decisions, or constraints.
+
+**Why it's wrong:** Conflicting requirements cause implementation deadlocks — the implementer cannot satisfy both constraints and must guess which one the plan author actually intended. This leads to rework, incorrect implementations, or abandoned phases.
+
+**Fix:** Before finalizing, cross-check the plan for consistency:
+
+- Do all phases support the stated goals?
+- Does the risk mitigation section address risks that the implementation creates?
+- Are assumptions in one section contradicted by constraints in another?
+- If tradeoffs exist, state them explicitly with a chosen resolution.
+
+---
+
+## Structure Anti-Patterns
+
+### PAP-6: Missing "Current State" Code References
+
+**Symptom:** The Current State section describes how things work in general terms without pointing to specific files, classes, or methods.
+
+**Why it's wrong:** Without code references, reviewers cannot verify the analysis is accurate. The implementer may look at the wrong code. The plan may describe outdated behavior.
+
+**Fix:** Every claim about current behavior must cite a specific file path and optionally a class or method. Verify each reference exists using file-reading tools.
+
+**Before:**
+
+```markdown
+## Current State
+
+The backend handles test results through a service layer. Results are
+stored in the database and served via REST endpoints. The frontend
+displays them on the dashboard.
+```
+
+**After:**
+
+```markdown
+## Current State
+
+- `argus/backend/service/results_service.py:ResultsService` — CRUD operations for test results
+- `argus/backend/controller/api.py` — REST endpoints, routes defined with Flask blueprints
+- `argus/backend/db/testrun.py:SCTTestRun` — CQLEngine model for test run data
+- `frontend/WorkArea/TestRunPage.svelte` — Displays individual test run results
+```
+
+---
+
+### PAP-7: Phases Without Definition of Done
+
+**Symptom:** Phases describe what to build but have no checkboxes or verifiable criteria for completion.
+
+**Why it's wrong:** Without Definition of Done, there is no agreed boundary for "this phase is complete." PRs may be merged with partial work, or reviewers may block PRs that are actually complete but lack documented criteria.
+
+**Fix:** Every phase needs a `**Definition of Done**:` section with checkbox items (`- [ ] criterion`). Each criterion should be something a reviewer can verify.
+
+**Before:**
+
+```markdown
+### Phase 3: Add Integration Tests
+
+Write integration tests for the release API endpoints. Cover all
+the important scenarios and edge cases.
+```
+
+**After:**
+
+```markdown
+### Phase 3: Add Integration Tests
+
+**Importance**: Critical
+**Description**: Add httpx-based integration tests for release API
+endpoints, exercising real ScyllaDB via Docker.
+
+**Definition of Done**:
+
+- [ ] Tests cover GET, POST, PUT, DELETE for release endpoints
+- [ ] Tests assert on JSON response structure, not ORM objects
+- [ ] Tests run against Docker ScyllaDB instance
+- [ ] `uv run pytest argus/backend/tests/ -v` passes
+```
+
+---
+
+### PAP-8: Monolithic Phase Spanning Multiple PRs
+
+**Symptom:** A single phase contains too many deliverables to fit in one Pull Request — refactoring + new feature + tests + configuration + documentation all in one phase.
+
+**Why it's wrong:** Large PRs are hard to review, slow to merge, and risky to revert. They also create merge conflicts with other ongoing work.
+
+**Fix:** Split into smaller phases, each scoped to a single PR targeting ≤200 lines of code. Use dependencies to maintain order. A good phase produces 1-3 related deliverables.
+
+---
+
+## Quick Reference
+
+| ID    | Anti-Pattern                              | One-Line Fix                                                       |
+| ----- | ----------------------------------------- | ------------------------------------------------------------------ |
+| PAP-1 | Too much code in the plan                 | Use short snippets for interfaces only; describe behavior in prose |
+| PAP-2 | Missing diagrams for complex interactions | Add ASCII/Mermaid diagrams for 3+ component interactions           |
+| PAP-3 | Overly granular phases                    | Describe deliverables, not line-by-line changes                    |
+| PAP-4 | Vague or unmeasurable goals               | Add measurable criteria or verifiable conditions                   |
+| PAP-5 | Conflicting requirements                  | Cross-check goals, phases, and risks for consistency               |
+| PAP-6 | Missing code references in Current State  | Cite specific file paths, verify they exist                        |
+| PAP-7 | Phases without Definition of Done         | Add checkbox criteria to every phase                               |
+| PAP-8 | Monolithic phase spanning multiple PRs    | Split into single-PR-scoped phases                                 |

--- a/skills/writing-plans/references/frontmatter-fields.md
+++ b/skills/writing-plans/references/frontmatter-fields.md
@@ -1,0 +1,68 @@
+# Plan Frontmatter Fields
+
+Every plan file in `docs/plans/` must start with YAML frontmatter. This document defines the fields, valid values, and conventions.
+
+---
+
+## Required Fields
+
+```yaml
+---
+status: draft
+domain: backend
+created: 2026-01-15
+last_updated: 2026-03-15
+owner: null
+---
+```
+
+### `status`
+
+Current lifecycle state of the plan.
+
+| Value         | Meaning                                   | When to Use                                             |
+| ------------- | ----------------------------------------- | ------------------------------------------------------- |
+| `draft`       | Plan written, not yet started             | Default for new plans                                   |
+| `approved`    | Reviewed and approved for implementation  | After team review/sign-off                              |
+| `in_progress` | Active implementation underway            | At least one phase has started                          |
+| `blocked`     | Implementation blocked                    | External dependency or issue prevents progress          |
+| `complete`    | All phases implemented and verified       | All DoD items checked off                               |
+| `pending_pr`  | Plan exists in an open PR, not yet merged | Used only in MASTER.md/progress.json for unmerged plans |
+
+### `domain`
+
+The functional area of the codebase this plan affects. Must be one of:
+
+| Domain Key       | Covers                                           | Codebase Areas                                                          |
+| ---------------- | ------------------------------------------------ | ----------------------------------------------------------------------- |
+| `backend`        | Flask/FastAPI services, blueprints, server logic | `argus/backend/`                                                        |
+| `frontend`       | Svelte components, UI state, styles              | `frontend/`                                                             |
+| `api`            | REST endpoints, request/response contracts       | `argus/backend/controller/`, client-server interface                    |
+| `database`       | ScyllaDB/Cassandra models, migrations, schema    | `argus/backend/db/`                                                     |
+| `client`         | Python client library                            | `argus/client/`                                                         |
+| `testing`        | Test infrastructure, fixtures, reporters         | `argus/backend/tests/`, `argus/client/tests/`, `pytest-argus-reporter/` |
+| `ci-cd`          | GitHub Actions workflows, Docker builds          | `.github/workflows/`, `docker/`                                         |
+| `infrastructure` | Dev tooling, monitoring, operational concerns    | `dev-db/`, `scripts/`, deployment                                       |
+
+### `created`
+
+Date the plan was first written. Format: `YYYY-MM-DD`. Derive from `git log --diff-filter=A` if adding frontmatter to an existing plan.
+
+### `last_updated`
+
+Date of the most recent substantive change. Format: `YYYY-MM-DD`. Update this when modifying plan content or status.
+
+### `owner`
+
+GitHub username of the person responsible for driving implementation. Set to `null` if unassigned.
+
+---
+
+## Corresponding Tracking Files
+
+When creating or updating a plan's frontmatter, also update:
+
+1. **`docs/plans/MASTER.md`** — Add/update the plan's row in the correct domain table
+2. **`docs/plans/progress.json`** — Add/update the plan's entry with matching status
+
+See [update-plan-status.md](../workflows/update-plan-status.md) for the step-by-step workflow.

--- a/skills/writing-plans/references/mini-plan-template.md
+++ b/skills/writing-plans/references/mini-plan-template.md
@@ -1,0 +1,82 @@
+# Mini-Plan Template
+
+Mini-plans are lightweight alternatives to full 7-section plans. Use them for small, single-PR changes under ~1K LOC.
+
+## Key Differences from Full Plans
+
+| Aspect                 | Full Plan                                                          | Mini-Plan                                  |
+| ---------------------- | ------------------------------------------------------------------ | ------------------------------------------ |
+| Sections               | 7 (Problem, Current State, Goals, Phases, Testing, Success, Risks) | 4 (Problem, Approach, Files, Verification) |
+| YAML frontmatter       | Required                                                           | None                                       |
+| MASTER.md registration | Required                                                           | None                                       |
+| progress.json entry    | Required                                                           | None                                       |
+| Location               | `docs/plans/`                                                      | `docs/plans/mini-plans/`                   |
+| Filename               | `kebab-case-name.md`                                               | `YYYY-MM-DD-kebab-case-name.md`            |
+| Lifecycle              | Tracked until archived                                             | Disposable after PR merge or 30 days       |
+
+## Template
+
+```markdown
+# Mini-Plan: <Title>
+
+**Date:** YYYY-MM-DD
+**Estimated LOC:** <number>
+**Related PR:** #<number> (if applicable)
+
+## Problem
+
+<1-3 sentences: what needs to change and why>
+
+## Approach
+
+<Bulleted list of steps, in order>
+
+## Files to Modify
+
+- `path/to/file.py` -- <what changes>
+
+## Verification
+
+- [ ] <How to verify the change works>
+- [ ] `uv run ruff check` passes
+```
+
+## Example
+
+```markdown
+# Mini-Plan: Add Pagination to Release API
+
+**Date:** 2026-04-20
+**Estimated LOC:** 80
+**Related PR:** #256
+
+## Problem
+
+The GET /api/v1/releases endpoint returns all releases in a single response,
+causing slow load times when there are 500+ releases in the system.
+
+## Approach
+
+- Add `page` and `per_page` query parameters to the releases endpoint
+- Add pagination metadata to response (`total`, `page`, `per_page`, `pages`)
+- Update frontend ReleaseList component to use paginated requests
+
+## Files to Modify
+
+- `argus/backend/controller/api.py` -- Add pagination params to releases route
+- `argus/backend/service/releases_service.py` -- Add paginated query method
+- `frontend/WorkArea/ReleaseList.svelte` -- Add pagination controls
+
+## Verification
+
+- [ ] `uv run pytest argus/backend/tests/ -v` passes
+- [ ] API returns paginated results with correct metadata
+- [ ] `uv run ruff check` passes
+```
+
+## Rules
+
+1. **File paths must be code-verified** — use file-reading tools to confirm paths exist before listing them.
+2. **Verification must be concrete** — every checkbox should be something a person can actually check or run.
+3. **No YAML frontmatter** — mini-plans are intentionally lightweight.
+4. **No MASTER.md or progress.json** — mini-plans are not tracked in the plan registry.

--- a/skills/writing-plans/references/plan-templates.md
+++ b/skills/writing-plans/references/plan-templates.md
@@ -1,0 +1,365 @@
+# Argus Plan Templates
+
+Templates and examples for each section of an Argus implementation plan, based on the 7-section structure defined in `docs/plans/INSTRUCTIONS.md`.
+
+---
+
+## Complete Plan Skeleton
+
+Use this as a starting point for any new plan:
+
+```markdown
+---
+status: draft
+domain: <domain-key>
+created: <YYYY-MM-DD>
+last_updated: <YYYY-MM-DD>
+owner: null
+---
+
+# <Feature/Change Name> Plan
+
+## Problem Statement
+
+<What needs to change and why. Include business/technical need, pain points, and justification.>
+
+## Current State
+
+<Analysis of existing implementation. MUST reference specific files, classes, and methods.>
+
+### <Subsystem A>
+
+- `path/to/file.py` — <What it does, what needs to change>
+- `path/to/other.py:ClassName` — <Current behavior>
+
+### What's Missing
+
+- <Gap 1>
+- <Gap 2>
+
+## Goals
+
+1. **<Goal 1>**: <Measurable outcome>
+2. **<Goal 2>**: <Measurable outcome>
+3. **<Goal 3>**: <Measurable outcome>
+
+## Implementation Phases
+
+### Phase 1: <Name>
+
+**Importance**: Critical/Important/Nice-to-have
+**Description**: <What will be implemented>
+
+**Deliverables**:
+
+- <Specific output 1>
+- <Specific output 2>
+
+**Definition of Done**:
+
+- [ ] <Criterion 1>
+- [ ] <Criterion 2>
+
+---
+
+### Phase 2: <Name>
+
+**Importance**: Critical/Important/Nice-to-have
+**Description**: <What will be implemented>
+
+**Dependencies**: Phase 1
+
+**Deliverables**:
+
+- <Specific output>
+
+**Definition of Done**:
+
+- [ ] <Criterion>
+
+## Testing Requirements
+
+### Unit Tests
+
+- <What to test at unit level>
+
+### Integration Tests
+
+- <What to verify end-to-end>
+
+### Manual Testing
+
+- <What requires human verification>
+
+## Success Criteria
+
+Completing all Definition of Done items across phases constitutes success. Add plan-level criteria only if they go beyond individual phase DoD:
+
+1. <Plan-level measurable outcome not captured in any single phase DoD>
+
+## Risk Mitigation
+
+### Risk: <Risk Name>
+
+**Likelihood**: High/Medium/Low
+**Impact**: <What goes wrong>
+**Mitigation**: <How to prevent or handle it>
+
+## Related Plans
+
+<Optional — only include if actual dependencies or overlaps exist with other plans.>
+
+- [<related-plan-name>.md](<related-plan-name>.md) — <relationship description>
+
+## PR History
+
+| Phase   | PR  | Status      |
+| ------- | --- | ----------- |
+| Phase 1 | —   | Not started |
+```
+
+---
+
+## Section-by-Section Guidance
+
+### 1. Problem Statement
+
+**Purpose**: Explain what needs to change and why.
+
+**Must include**:
+
+- Business or technical need driving the change
+- Pain points with the current situation
+- Justification for why this work is necessary
+
+**Good example** (from `docs/plans/api_tests.md`):
+
+```markdown
+## Problem Statement
+
+Argus is planning a major refactor: moving from Flask to FastAPI and replacing
+CQLEngine with coodie. To guarantee no regressions, every public API endpoint
+must have an integration test that exercises the endpoint over HTTP, asserts on
+JSON response structure, and requires minimal changes after migration.
+```
+
+**Bad example**:
+
+```markdown
+## Problem Statement
+
+We need to add more tests.
+```
+
+The bad example lacks specifics: no measurable problem, no root cause, no justification.
+
+---
+
+### 2. Current State
+
+**Purpose**: Analyze the existing implementation with specific code references.
+
+**Critical rule**: You MUST use file-reading tools to inspect actual code. Do not guess or hallucinate file names.
+
+**Must include**:
+
+- References to specific files, classes, and methods
+- Description of how things currently work
+- What needs to change
+- Technical debt or limitations
+
+**Pattern for referencing code**:
+
+```markdown
+### Backend Services
+
+- `argus/backend/service/results_service.py` — Handles test result CRUD operations
+- `argus/backend/controller/api.py` — REST endpoint definitions
+- `argus/backend/db/models.py` — CQLEngine model definitions
+```
+
+---
+
+### 3. Goals
+
+**Purpose**: Define specific, measurable objectives.
+
+**Rules**:
+
+- Number each goal with bold title
+- Make goals measurable ("reduce by 90%", "cover 100% of endpoints")
+- Keep goals focused and achievable within the plan scope
+
+**Good example**:
+
+```markdown
+## Goals
+
+1. **100% endpoint coverage** — every public API endpoint has at least one integration test
+2. **Zero CQLEngine assertions** — tests verify JSON responses only, not ORM objects
+3. **Migration-safe tests** — tests require no changes after Flask-to-FastAPI migration
+```
+
+---
+
+### 4. Implementation Phases
+
+**Purpose**: Break the work into atomic, PR-scoped steps.
+
+**Rules**:
+
+- Phases should be scoped to single Pull Requests where possible
+- Large phases should be split into separate commits within the PR for easier review
+- Order by dependency: foundational work first
+- Each phase needs Importance, Description, Deliverables, and Definition of Done
+- Mark unclear steps as "Needs Investigation"
+- Definition of Done items should be verifiable and serve as the success criteria for the phase
+
+**Importance levels** — use these to indicate which phases are essential vs. optional:
+
+| Level            | Meaning                                       | Heuristic                                       |
+| ---------------- | --------------------------------------------- | ----------------------------------------------- |
+| **Critical**     | Must be completed for the plan to succeed     | Blocks other phases or is the core deliverable  |
+| **Important**    | Significantly improves the outcome            | Adds meaningful value but plan works without it |
+| **Nice-to-have** | Can be deferred or dropped if time is limited | Polish, optimization, or stretch goals          |
+
+**PR sizing rules** — based on industry best practices:
+
+- **Target ≤200 lines of code per PR.** Research shows PRs over 200 lines receive lower-quality reviews
+- **One logical change per PR.** Do not mix refactoring, new features, and config changes in a single PR
+- **Split large phases into sub-phases.** If a phase exceeds ~200 lines, break it into multiple PRs that each stand alone
+- **Use separate commits for distinct changes within a PR** (e.g., one commit for refactoring, another for new functionality, another for tests)
+- **Each PR must leave the codebase in a working state.** No broken intermediate states
+- **Prep work goes in separate PRs.** Pre-refactoring, dependency upgrades, or configuration changes should be submitted before the main feature PR
+
+**Phase template**:
+
+```markdown
+### Phase N: <Name>
+
+**Importance**: Critical/Important/Nice-to-have
+**Description**: <What will be implemented and why>
+
+**Dependencies**: <Which phases must be complete first>
+
+**Deliverables**:
+
+- <Concrete output 1>
+- <Concrete output 2>
+
+**Adaptation Notes**: <Optional: explain tradeoffs, deviations from the original design,
+or context that helps reviewers understand why this phase differs from initial expectations>
+
+**Definition of Done**:
+
+- [ ] <Verifiable criterion 1>
+- [ ] <Verifiable criterion 2>
+```
+
+---
+
+### 5. Testing Requirements
+
+**Purpose**: Define what testing is needed to verify each phase. Think about testing upfront, not as an afterthought.
+
+**Must include**:
+
+- Unit tests the LLM can write and run
+- Integration testing needs (what to verify end-to-end)
+- Manual testing procedures (what requires human verification)
+
+**Pattern**:
+
+```markdown
+## Testing Requirements
+
+### Unit Tests
+
+- Test service layer with mocked database calls
+- Test API endpoint response formats
+- Run with: `uv run pytest argus/backend/tests/ -v`
+
+### Integration Tests
+
+- Test with Docker-based ScyllaDB instance (see `dev-db/`)
+- Verify end-to-end API calls return correct data
+- Run with: `uv run pytest argus/backend/tests/ --docker-required`
+
+### Manual Testing
+
+- Verify UI renders correctly after API changes
+- Check release dashboard loads within acceptable time
+```
+
+---
+
+### 6. Success Criteria
+
+**Purpose**: Confirm overall plan completion. Completing all Definition of Done items across phases constitutes success.
+
+**Rules**:
+
+- Avoid duplicating DoD items — reference them instead
+- Only add plan-level criteria that span multiple phases or cannot be captured in a single phase's DoD
+- If all DoD items cover success fully, this section can simply state that
+
+**Good example**:
+
+```markdown
+## Success Criteria
+
+All Definition of Done items across phases are met. Additionally:
+
+1. No regressions in existing unit tests
+2. API documentation updated in `docs/api_usage.md`
+```
+
+---
+
+### 7. Risk Mitigation
+
+**Purpose**: Identify risks and mitigation strategies.
+
+**Must include**:
+
+- Potential blockers
+- Rollback strategies
+- Dependencies on external systems
+- Compatibility concerns
+
+**Pattern**:
+
+```markdown
+### Risk: <Name>
+
+**Likelihood**: High/Medium/Low
+**Impact**: <What goes wrong if this happens>
+**Mitigation**: <How to prevent it or what to do if it happens>
+```
+
+---
+
+## Argus-Specific Conventions for Plans
+
+| Convention       | Rule                                                                             |
+| ---------------- | -------------------------------------------------------------------------------- |
+| File location    | Store in `docs/plans/` directory                                                 |
+| Filename         | kebab-case, descriptive (e.g., `api-tests.md`)                                   |
+| Backend details  | Document impact on Flask blueprints, service layer, database models              |
+| Frontend details | Document impact on Svelte components, state management                           |
+| Test commands    | Use `uv run pytest argus/backend/tests/` and `uv run pytest argus/client/tests/` |
+| Linting          | Include `uv run ruff check` in testing steps                                     |
+| Code references  | Always point to real files — verify with file-reading tools                      |
+| Open questions   | Mark unclear requirements as "Needs Investigation"                               |
+| Archiving        | Move completed plans to `docs/plans/archive/`                                    |
+
+---
+
+## Existing Plan Examples
+
+Reference these for style and quality:
+
+| Plan                              | Type                  | Demonstrates                                             |
+| --------------------------------- | --------------------- | -------------------------------------------------------- |
+| `docs/plans/api_tests.md`         | Integration testing   | Measurable goals, phased approach, migration-safe design |
+| `docs/plans/ssh-tunnel-design.md` | Infrastructure design | Security considerations, detailed architecture           |

--- a/skills/writing-plans/workflows/create-a-mini-plan.md
+++ b/skills/writing-plans/workflows/create-a-mini-plan.md
@@ -1,0 +1,83 @@
+# Creating a Mini-Plan
+
+A 3-phase lightweight workflow for writing a mini-plan for small, single-PR changes.
+
+---
+
+## Phase 1: Route
+
+**Entry:** You have a task that needs a plan and need to confirm it qualifies as a mini-plan.
+
+**Actions:**
+
+1. **Check if user specified plan size.** If the user explicitly said "small plan" or "mini-plan", proceed. If they said "big plan", use the full plan workflow in [create-a-plan.md](create-a-plan.md) instead.
+
+2. **Check PR label (if working on a PR).** Run:
+
+    ```bash
+    gh pr view <number> --json labels --jq '.labels[].name' | grep -q '^plans$'
+    ```
+
+    - PR has `plans` label -> redirect to full plan workflow
+    - PR does NOT have `plans` label -> proceed with mini-plan
+
+3. **Estimate scope (if no user answer and no PR context).** Count files likely to be modified and estimate LOC:
+    - Multiple new files, new config parameters, multiple services affected, CI changes -> likely needs a full plan
+    - Single file change, bug fix, test addition, refactoring one module -> mini-plan is appropriate
+    - When in doubt, ask the user
+
+**Exit:** Confirmed this is a mini-plan. If not, redirected to the full plan workflow.
+
+---
+
+## Phase 2: Write the 4 Sections
+
+**Entry:** Phase 1 complete. Task qualifies as a mini-plan.
+
+**Actions:**
+
+1. **Set the header and metadata:**
+    - Title: `# Mini-Plan: <descriptive title>`
+    - Date: today's date in YYYY-MM-DD format
+    - Estimated LOC: rough estimate based on scope
+    - Related PR: include PR number if applicable
+
+2. **Write the Problem section.** 1-3 sentences explaining what needs to change and why. Be specific about the pain point.
+
+3. **Write the Approach section.** Bulleted list of steps in execution order. Each bullet should be a concrete action, not a vague goal.
+
+4. **Write the Files to Modify section.** For each file:
+    - **Verify the path exists** using file-reading tools before listing it
+    - Describe what changes in that file
+    - If creating a new file, note it as "(new file)"
+
+5. **Write the Verification section.** Include:
+    - At least one specific verification step for the change
+    - `uv run ruff check` passes (always include this)
+    - Unit test commands if tests are added
+
+6. **Save the file** as `docs/plans/mini-plans/YYYY-MM-DD-kebab-case-name.md`.
+
+**Exit:** All 4 sections written with verified file paths.
+
+---
+
+## Phase 3: Validate
+
+**Entry:** Phase 2 complete. Mini-plan written.
+
+**Actions:**
+
+1. **Verify all file paths resolve.** Re-check that every path in "Files to Modify" points to a real file (or is marked as new).
+
+2. **Verify the verification checklist is concrete.** Each checkbox should be something a person can actually run or check — no vague items like "it works" or "code is clean".
+
+3. **Confirm no full-plan artifacts.** The mini-plan should NOT have:
+    - YAML frontmatter
+    - MASTER.md registration
+    - progress.json entry
+    - More than 4 sections
+
+4. **Run linting.** Execute `uv run ruff check` to check formatting.
+
+**Exit:** Mini-plan is validated, saved in `docs/plans/mini-plans/`, and ready to use.

--- a/skills/writing-plans/workflows/create-a-plan.md
+++ b/skills/writing-plans/workflows/create-a-plan.md
@@ -1,0 +1,176 @@
+# Creating an Implementation Plan
+
+A 5-phase process for writing an Argus implementation plan following the 7-section structure.
+
+---
+
+## Before You Start: Check Plan Type Routing
+
+Before beginning Phase 1, determine whether this task needs a full plan or a mini-plan. Follow the routing decision tree in [SKILL.md](../SKILL.md#plan-type-routing):
+
+1. Did the user explicitly say "big" or "small"? Use their answer.
+2. Working on a PR? Check for the `plans` label: `gh pr view <number> --json labels --jq '.labels[].name' | grep -q '^plans$'`
+3. No PR context? Estimate scope — if under ~1K LOC and single PR, use the mini-plan workflow instead.
+
+**If this is a mini-plan**, stop here and follow [create-a-mini-plan.md](create-a-mini-plan.md) instead.
+
+**If this is a full plan**, continue to Phase 1 below.
+
+---
+
+## Phase 1: Gather Context
+
+**Entry:** You have a feature or change request that needs an implementation plan.
+
+**Actions:**
+
+1. **Read `docs/plans/INSTRUCTIONS.md` completely.** This is the authoritative source for plan structure and guidelines. Do not skip this step.
+
+2. **Identify the scope.** What problem is being solved? What areas of the codebase are affected? Which layers (backend, frontend, client, database) are impacted?
+
+3. **Inspect the codebase.** Use file-reading tools to examine relevant source files. Identify:
+    - Current implementations that will change
+    - Flask blueprints and service layer code in `argus/backend/`
+    - Test files in `argus/backend/tests/` or `argus/client/tests/` related to the area
+    - Svelte components in `frontend/` if UI is affected
+    - Existing documentation in `docs/`
+
+4. **Check MASTER.md for existing plans in the same domain.** Read `docs/plans/MASTER.md` and look for plans in the same domain that may overlap, depend on, or provide context for the new plan.
+
+5. **Review reference plans.** Read at least one existing plan (e.g., `docs/plans/api_tests.md`) to calibrate quality expectations.
+
+**Exit:** You understand the problem, have inspected relevant code, and know the plan structure.
+
+---
+
+## Phase 2: Write the Foundation Sections
+
+**Entry:** Phase 1 complete. Context gathered, code inspected.
+
+**Actions:**
+
+1. **Write the Problem Statement.** Include:
+    - The business or technical need
+    - Specific pain points (with measurements if available)
+    - Justification for why this work is necessary
+
+2. **Write the Current State section.** This is the most research-intensive section:
+    - Reference specific files, classes, and methods (verify they exist)
+    - Describe how things currently work
+    - Identify what needs to change
+    - Document technical debt or limitations
+    - **Never guess file names** — use tools to locate and verify
+
+3. **Write the Goals section.** Define 3-6 specific, measurable objectives:
+    - Number each goal with a bold title
+    - Include measurable criteria where possible
+    - Keep goals achievable within the plan scope
+
+**Exit:** Problem Statement, Current State, and Goals sections are complete with verified code references.
+
+---
+
+## Phase 3: Design the Implementation
+
+**Entry:** Phase 2 complete. Foundation sections written.
+
+**Actions:**
+
+1. **Break the work into phases.** Each phase should be:
+    - Atomic and scoped to a single Pull Request where possible
+    - Ordered by dependency (foundational work first)
+    - Marked with Importance level (Critical/Important/Nice-to-have)
+
+2. **Keep PRs small and focused.** Target ≤200 lines of code per PR. One logical change per PR — don't mix refactoring, new features, and config changes. Split large phases into sub-phases. Within a PR, use separate commits for logically distinct changes.
+
+3. **For each phase, write:**
+    - **Importance**: Critical/Important/Nice-to-have (see heuristics in templates)
+    - **Description**: What will be implemented and why
+    - **Dependencies**: Which phases must be complete first
+    - **Deliverables**: Concrete outputs (files, features, configurations)
+    - **Definition of Done**: Verifiable criteria using checkboxes — these serve as the success criteria for the phase
+
+4. **Mark uncertain steps.** If a requirement or dependency is unclear, mark it as "Needs Investigation" rather than making assumptions.
+
+5. **Include a documentation update phase.** Every plan should have a phase (or phase deliverable) covering:
+    - Updated or new entries in `docs/` for user-facing changes
+    - README or guide updates if the feature changes user workflows
+
+6. **Include Argus-specific details:**
+    - Backend impact (Flask blueprints, service layer in `argus/backend/`)
+    - Frontend impact (Svelte components in `frontend/`)
+    - Database changes (ScyllaDB models, schema migrations)
+    - API changes (endpoint contracts, response formats)
+    - Client library changes (`argus/client/`)
+
+7. **Add separation lines** (`---`) between phases for readability.
+
+**Exit:** Implementation Phases section complete with Definition of Done for each phase.
+
+---
+
+## Phase 4: Define Testing and Success
+
+**Entry:** Phase 3 complete. Implementation phases designed.
+
+**Actions:**
+
+1. **Write Testing Requirements.** Testing should be planned upfront, not as an afterthought:
+    - **Unit tests**: What to test in isolation, expected location in `argus/backend/tests/` or `argus/client/tests/`
+    - **Integration tests**: What to verify end-to-end, requiring a running ScyllaDB instance
+    - **Manual testing**: What requires human verification (UI behavior, API responses)
+
+2. **Write Success Criteria.** Completing all Definition of Done items across phases constitutes success. Only add plan-level criteria that span multiple phases or cannot be captured in any single phase's DoD.
+
+3. **Write Risk Mitigation.** For each risk:
+    - **Name**: Short description of the risk
+    - **Likelihood**: High/Medium/Low
+    - **Impact**: What goes wrong
+    - **Mitigation**: How to prevent or handle it
+
+4. **Common Argus risks to consider:**
+    - Database schema migration compatibility
+    - Backward compatibility with existing client library users
+    - Impact on CI/CD pipeline (GitHub Actions)
+    - Frontend/backend API contract breakage
+
+**Exit:** Testing Requirements, Success Criteria, and Risk Mitigation sections complete.
+
+---
+
+## Phase 5: Validate the Plan
+
+**Entry:** Phase 4 complete. All 7 sections written.
+
+**Actions:**
+
+1. **Verify the 7-section structure.** Confirm all sections are present:
+    - [ ] Problem Statement
+    - [ ] Current State (with code references)
+    - [ ] Goals
+    - [ ] Implementation Phases (with DoD per phase)
+    - [ ] Testing Requirements
+    - [ ] Success Criteria
+    - [ ] Risk Mitigation
+
+2. **Verify all code references.** Every file path mentioned in Current State must point to a real file. Use file-reading tools to confirm.
+
+3. **Check phase dependencies.** Ensure no phase references work from a later phase. Foundational work comes first.
+
+4. **Check for open questions.** If any requirement is unclear, it should be marked as "Needs Investigation" — not assumed.
+
+5. **Check Definition of Done criteria.** Each criterion should be verifiable (someone can check it off), not vague ("it works").
+
+6. **Review against an existing plan.** Compare structure and quality with `docs/plans/api_tests.md` or another reference plan.
+
+7. **Verify filename.** Plan should be saved as `docs/plans/<kebab-case-name>.md` with a descriptive name.
+
+8. **Verify YAML frontmatter.** Confirm the plan starts with valid frontmatter containing `status`, `domain`, `created`, `last_updated`, and `owner` fields. See [frontmatter-fields.md](../references/frontmatter-fields.md) for valid values.
+
+9. **Register in MASTER.md.** Add the plan to the correct domain table in `docs/plans/MASTER.md` with appropriate status.
+
+10. **Add progress.json entry.** Add an entry to `docs/plans/progress.json` with the plan's id, title, file, domain, status, created date, phases_total, and phases_done.
+
+11. **Run linting.** Execute `uv run ruff check` to verify no formatting issues.
+
+**Exit:** All 7 sections present, code references verified, phases ordered correctly, plan saved in `docs/plans/`, registered in MASTER.md, and tracked in progress.json.

--- a/skills/writing-plans/workflows/update-plan-status.md
+++ b/skills/writing-plans/workflows/update-plan-status.md
@@ -1,0 +1,61 @@
+# Updating Plan Status
+
+A 3-phase workflow for updating a plan's status across all tracking files.
+
+---
+
+## Phase 1: Update the Plan File
+
+**Entry:** A plan's status has changed (e.g., implementation started, phase completed, plan blocked).
+
+**Actions:**
+
+1. **Read the plan file** and locate the YAML frontmatter at the top.
+
+2. **Update the `status` field** to the new value. Valid values: `draft`, `approved`, `in_progress`, `blocked`, `complete`.
+
+3. **Update `last_updated`** to today's date (`YYYY-MM-DD`).
+
+4. **If completing a plan**, check all Definition of Done items in the Implementation Phases section.
+
+5. **If archiving a completed plan**, move the file to `docs/plans/archive/`.
+
+**Exit:** Plan file frontmatter reflects the new status.
+
+---
+
+## Phase 2: Update MASTER.md
+
+**Entry:** Phase 1 complete. Plan file updated.
+
+**Actions:**
+
+1. **Read `docs/plans/MASTER.md`** and locate the plan's row in its domain table.
+
+2. **Update the status badge** to match the new frontmatter status.
+
+3. **If the plan was archived**, update the file link to point to `archive/<filename>`.
+
+4. **If a pending_pr plan was merged**, change status from `pending_pr` to `draft` and add the file link.
+
+**Exit:** MASTER.md status matches the plan file.
+
+---
+
+## Phase 3: Update progress.json
+
+**Entry:** Phase 2 complete. MASTER.md updated.
+
+**Actions:**
+
+1. **Read `docs/plans/progress.json`** and locate the plan's entry by `id`.
+
+2. **Update the `status` field** to match the new frontmatter status.
+
+3. **Update `phases_done`** if a phase was completed. Count phases marked as done in the plan file.
+
+4. **Update `phases_total`** if it was previously `null` and the plan now has a defined number of phases.
+
+5. **Validate JSON syntax** — ensure the file is valid JSON after editing.
+
+**Exit:** progress.json entry matches the plan file and MASTER.md. All three tracking locations are consistent.


### PR DESCRIPTION
## Summary

- Backport the `writing-plans` skill (full 7-section plans + lightweight mini-plans) and the `designing-skills` meta-skill from scylla-cluster-tests, adapted for Argus
- Add plan infrastructure: `docs/plans/INSTRUCTIONS.md` (authoritative plan guide), `MASTER.md` (plan registry), `progress.json` (machine-readable tracking), `mini-plans/` directory
- Retrofit YAML frontmatter on existing plans (`api_tests.md`, `ssh-tunnel-design.md`) and register them in the new tracking system
- Update `AGENTS.md` with Skills and Implementation Plans sections

## What changed

All SCT-specific content (backends, nemesis, Jenkins pipelines, SCT commands) has been replaced with Argus equivalents (Flask blueprints, Svelte frontend, ScyllaDB models, GitHub Actions, `uv run ruff check`, `uv run pytest`). The domain taxonomy is new: `backend`, `frontend`, `api`, `database`, `client`, `testing`, `ci-cd`, `infrastructure`.

## New files (17)

```
skills/
├── writing-plans/
│   ├── SKILL.md
│   ├── references/ (4 files)
│   └── workflows/ (3 files)
└── designing-skills/
    ├── SKILL.md
    ├── references/ (2 files)
    └── workflows/ (2 files)

docs/plans/
├── INSTRUCTIONS.md
├── MASTER.md
├── progress.json
└── mini-plans/.gitkeep
```

## Modified files (3)

- `AGENTS.md` — added Skills and Implementation Plans sections
- `docs/plans/api_tests.md` — added YAML frontmatter
- `docs/plans/ssh-tunnel-design.md` — added YAML frontmatter