### PR TITLE
feat(frontend): Make issue cards compact

### DIFF
--- a/frontend/Github/GithubIssue.svelte
+++ b/frontend/Github/GithubIssue.svelte
@@ -157,7 +157,7 @@
 <div class="row m-2">
     <div class="col rounded p-2 bg-white shadow-sm">
         <div class="d-flex">
-            <div class="ms-2 align-self-center">
+            <div class="ms-2 align-self-center flex-shrink-0" style="width: 10em;">
                 <div class="mb-1 py-1 shadow-sm rounded-pill d-inline-flex {GithubIssueColorMap[issue.state]}">
                     <div class="ms-2 me-1"><Fa icon={GithubIssueIcon[issue.state]} /></div>
                     <div class="me-2">{issue.state}</div>
@@ -184,7 +184,7 @@
                     </button>
                 {/each}
             </div>
-            <div class="ms-auto me-2">
+            <div class="ms-auto me-2 d-flex align-items-center gap-2">
                 {#if Object.keys(users).length > 0}
                     <div
                         class="text-muted d-flex align-items-center"
@@ -218,11 +218,11 @@
                     </div>
                 {/if}
                 {#if aggregated}
-                    <div class="text-end my-2">
+                    <div class="d-flex gap-1">
                         {#if runId}
-                            <button class="btn btn-primary" onclick={() => dispatch("submitToCurrent", issue.url)}>Add to current run</button>
+                            <button class="btn btn-sm btn-primary" onclick={() => dispatch("submitToCurrent", issue.url)}>Add to current run</button>
                         {/if}
-                        <button class="btn btn-primary" onclick={() => (showRuns = true)}>View {issue.links.length} runs</button>
+                        <button class="btn btn-sm btn-primary" onclick={() => (showRuns = true)}>View {issue.links.length} runs</button>
                     </div>
                 {/if}
             </div>

--- a/frontend/Jira/JiraIssue.svelte
+++ b/frontend/Jira/JiraIssue.svelte
@@ -174,7 +174,7 @@
 <div class="row m-2">
     <div class="col rounded p-2 bg-white shadow-sm">
         <div class="d-flex">
-            <div class="ms-2 align-self-center">
+            <div class="ms-2 align-self-center flex-shrink-0" style="width: 10em;">
                 <div class="mb-1 py-1 shadow-sm rounded-pill d-inline-flex {JiraIssueColorMap[issue.state] || JiraIssueColorMap["new"]}">
                     <div class="ms-2 me-1"><Fa icon={JiraIssueIcon[issue.state] || JiraIssueIcon["new"]} /></div>
                     <div class="me-2">{issue.state}</div>
@@ -201,7 +201,7 @@
                     </button>
                 {/each}
             </div>
-            <div class="ms-auto me-2">
+            <div class="ms-auto me-2 d-flex align-items-center gap-2">
                 {#if Object.keys(users).length > 0}
                     <div
                         class="text-muted d-flex align-items-center"
@@ -235,11 +235,11 @@
                     </div>
                 {/if}
                 {#if aggregated}
-                    <div class="text-end my-2">
+                    <div class="d-flex gap-1">
                         {#if runId}
-                            <button class="btn btn-primary" onclick={() => dispatch("submitToCurrent", issue.permalink)}>Add to current run</button>
+                            <button class="btn btn-sm btn-primary" onclick={() => dispatch("submitToCurrent", issue.permalink)}>Add to current run</button>
                         {/if}
-                        <button class="btn btn-primary" onclick={() => (showRuns = true)}>View {issue.links.length} runs</button>
+                        <button class="btn btn-sm btn-primary" onclick={() => (showRuns = true)}>View {issue.links.length} runs</button>
                     </div>
                 {/if}
             </div>


### PR DESCRIPTION
### Why

Current IssueCard is unnecessarily big, taking space while providng little information. This PR make it more compact while maintaining all of the information it provides

### Changes

- Move 'Add to current run' and 'View N runs' buttons inline with the 'Added by' metadata row instead of stacking below it, eliminating the extra row height in aggregated mode
- Downsize aggregated buttons from btn to btn-sm to match the delete button
- Replace my-2 wrapper with d-flex gap-1 to remove vertical margins
- Fix state pill wrapper to a shared width of 10em (flex-shrink-0) in both GithubIssue and JiraIssue so labels column-align consistently across mixed GitHub/Jira issue lists

Before:
<img width="3703" height="840" alt="Snímek obrazovky z 2026-04-21 11-47-59" src="https://github.com/user-attachments/assets/637550ab-29bf-4330-b0a0-a7f3430dda4b" />
After:
<img width="3723" height="724" alt="Snímek obrazovky z 2026-04-21 11-47-28" src="https://github.com/user-attachments/assets/aabdaad7-f180-4e86-8cfe-a86cb67a09e9" />
