### PR TITLE
fix: enable local development without Jira, GitHub, and email credentials

### DIFF
--- a/argus/backend/service/argus_service.py
+++ b/argus/backend/service/argus_service.py
@@ -51,10 +51,6 @@ class ArgusService:
         self.session = database_session if database_session else ScyllaCluster.get_session()
         self.database = ScyllaCluster.get()
         self.notification_manager = NotificationManagerService()
-        self.github_headers = {
-            "Accept": "application/vnd.github.v3+json",
-            "Authorization": f"token {current_app.config['GITHUB_ACCESS_TOKEN']}"
-        }
         self.build_id_and_url_statement = self.database.prepare(
             f"SELECT build_id, build_job_url, test_id FROM {SCTTestRun.table_name()} WHERE id = ?"
         )  # TODO: transfer to PluginModelBase

--- a/argus/backend/service/issue_service.py
+++ b/argus/backend/service/issue_service.py
@@ -1,4 +1,5 @@
 from uuid import UUID
+from flask import current_app
 from argus.backend.models.github_issue import GithubIssue, IssueLink
 from argus.backend.service.github_service import GithubService
 from argus.backend.service.issue_utils import build_version_map, filter_links_by_version
@@ -7,9 +8,11 @@ from argus.backend.service.jira_service import JiraService
 
 class IssueService:
 
-    def __init__(self, dry_run = False):
-        self.gh = GithubService(dry_run)
-        self.jira = JiraService(dry_run)
+    def __init__(self, dry_run: bool | None = None):
+        github_dry_run = dry_run if dry_run is not None else not current_app.config.get("GITHUB_ENABLED", True)
+        jira_dry_run = dry_run if dry_run is not None else not current_app.config.get("JIRA_ENABLED", True)
+        self.gh = GithubService(github_dry_run)
+        self.jira = JiraService(jira_dry_run)
 
     def _get_service(self, url):
         return self.gh if "github.com" in url else self.jira

--- a/argus/backend/service/notification_manager.py
+++ b/argus/backend/service/notification_manager.py
@@ -17,8 +17,9 @@ class NotificationManagerService:
     def __init__(self, notification_senders: list["NotificationSenderBase"] | None = None) -> None:
         self.notification_services: list["NotificationSenderBase"] = [
             ArgusDBNotificationSaver(),
-            EmailNotificationServiceSender()
         ]
+        if current_app.config.get("EMAIL_ENABLED", True):
+            self.notification_services.append(EmailNotificationServiceSender())
         if notification_senders:
             self.notification_services.extend(notification_senders)
 

--- a/argus/backend/tests/conftest.py
+++ b/argus/backend/tests/conftest.py
@@ -13,9 +13,7 @@ from flask.testing import FlaskClient
 from argus.backend.models.argus_ai import Vector
 from argus.backend.plugins.loader import all_plugin_models, all_plugin_types
 from argus.backend.plugins.sct.service import SCTService
-from argus.backend.service.github_service import GithubService
 from argus.backend.service.issue_service import IssueService
-from argus.backend.service.jira_service import JiraService
 from argus.backend.service.testrun import TestRunService
 from argus.backend.service.views_widgets.pytest import PytestViewService
 from argus.backend.util.config import Config
@@ -211,17 +209,6 @@ def results_service(argus_db):
 @fixture(scope='session')
 def issue_service(argus_db) -> IssueService:
     return IssueService(True)
-
-
-@fixture(scope='session')
-def github_service(argus_db) -> GithubService:
-    return GithubService()
-
-
-@fixture(scope='session')
-def jira_service(argus_db) -> JiraService:
-    return JiraService()
-
 
 
 def get_fake_test_run(

--- a/argus/backend/tests/conftest.py
+++ b/argus/backend/tests/conftest.py
@@ -126,8 +126,7 @@ def argus_db():
          """)
     config = {"SCYLLA_KEYSPACE_NAME": "test_argus", "SCYLLA_CONTACT_POINTS": [container_ip],
               "SCYLLA_USERNAME": "cassandra", "SCYLLA_PASSWORD": "cassandra", "APP_LOG_LEVEL": "INFO",
-              "EMAIL_SENDER": "unit tester", "EMAIL_SENDER_PASS": "pass", "EMAIL_SENDER_USER": "qa",
-              "EMAIL_SERVER": "fake", "EMAIL_SERVER_PORT": 25}
+              "EMAIL_ENABLED": False}
     Config.CONFIG = config  # patch config for whole test to avoid using Config.load_yaml_config() required by app context
     database = ScyllaCluster.get(config)
     if need_sync_models:

--- a/argus/backend/util/send_email.py
+++ b/argus/backend/util/send_email.py
@@ -29,7 +29,6 @@ class Email:
         self._server_host: str = ""
         self._server_port: int = 0
         self._connection: smtplib.SMTP | None = None
-        self._retrieve_credentials()
         if init_connection:
             self._connect()
 
@@ -41,6 +40,7 @@ class Email:
         self._server_port = int(current_app.config["EMAIL_SERVER_PORT"])
 
     def _connect(self):
+        self._retrieve_credentials()
         try:
             self._connection = smtplib.SMTP(host=self._server_host, port=self._server_port)
             self._connection.ehlo()

--- a/argus_web.example.yaml
+++ b/argus_web.example.yaml
@@ -77,6 +77,11 @@ EMAIL_SENDER_USER: ""
 EMAIL_SENDER_PASS: ""
 EMAIL_SERVER: "smtp.gmail.com"
 EMAIL_SERVER_PORT: "587"
+# Enable/disable email notifications (default: true).
+# When false, EMAIL_SENDER, EMAIL_SENDER_USER, EMAIL_SENDER_PASS,
+# EMAIL_SERVER, and EMAIL_SERVER_PORT are not required.
+# In-app (DB-backed) notifications are unaffected.
+EMAIL_ENABLED: true
 
 # Used to determine whether or not assigned job is still considered valid.
 # TODO: Move to user settings

--- a/argus_web.example.yaml
+++ b/argus_web.example.yaml
@@ -2,9 +2,9 @@
 BASE_URL: "https://argus.scylladb.com"
 # Main DB Cluster contact points
 SCYLLA_CONTACT_POINTS:
-  - 1.1.1.1
-  - 2.2.2.2
-  - 3.3.3.3
+    - 1.1.1.1
+    - 2.2.2.2
+    - 3.3.3.3
 # Username
 SCYLLA_USERNAME: user
 # Password
@@ -17,9 +17,9 @@ SCYLLA_KEYSPACE_NAME: mykeyspacename
 # Which login methods to enable
 # Enable Cloudflare Access JWT auth by adding "cf" to LOGIN_METHODS.
 LOGIN_METHODS:
-  - password
-  - gh
-  - cf
+    - password
+    - gh
+    - cf
 
 # Application log level
 APP_LOG_LEVEL: INFO
@@ -27,13 +27,13 @@ APP_LOG_LEVEL: INFO
 SECRET_KEY: MUSTBEUNIQUE
 # Allowed buckets for S3 proxying
 S3_ALLOWED_BUCKETS:
-  - my-bucket-name
+    - my-bucket-name
 
 # Allowed mime types for S3 proxying
 S3_ALLOWED_MIME:
-  - image/png
-  - application/zstd
-  - application/gzip
+    - image/png
+    - application/zstd
+    - application/gzip
 
 # AWS Client ID
 AWS_CLIENT_ID: ABCDE
@@ -49,9 +49,13 @@ GITHUB_CLIENT_SECRET: YOUR_GITHUB_CLIENT_SECRET
 GITHUB_ACCESS_TOKEN: YOUR_GITHUB_PERSONAL_ACCESS_TOKEN
 # List of required organization names (Comment out to disable organization requirement)
 GITHUB_REQUIRED_ORGANIZATIONS:
-  # at least one is required for user to successfully authenticate
-  - myorg
-  - otherorg
+    # at least one is required for user to successfully authenticate
+    - myorg
+    - otherorg
+# Enable/disable remote GitHub issue-tracking calls (default: true).
+# When false, GITHUB_ACCESS_TOKEN is not required for issue tracking.
+# Note: GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET are still needed for OAuth login.
+GITHUB_ENABLED: true
 
 # JIRA Server address
 JIRA_SERVER: https://your.jira.instance
@@ -59,6 +63,9 @@ JIRA_SERVER: https://your.jira.instance
 JIRA_EMAIL: user@your.jira.instance
 # API Token of the service user
 JIRA_TOKEN: base64Token
+# Enable/disable remote Jira calls (default: true).
+# When false, JIRA_SERVER, JIRA_EMAIL, and JIRA_TOKEN are not required.
+JIRA_ENABLED: true
 
 JENKINS_URL: https://your_jenkins_hostname
 JENKINS_USER: user

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -86,26 +86,31 @@ SECRET_KEY: MUSTBEUNIQUE
 LOGIN_METHODS:
     - password
 
-# Placeholders -- the app requires these keys at startup even if you
-# aren't using GitHub or email features. Without them every API call
-# fails with a KeyError.
-GITHUB_CLIENT_ID: "dev-placeholder"
-GITHUB_CLIENT_SECRET: "dev-placeholder"
-GITHUB_ACCESS_TOKEN: "dev-placeholder"
+# Disable remote issue-tracking integrations not needed locally.
+# When false, the corresponding credentials are not required.
+GITHUB_ENABLED: false
+JIRA_ENABLED: false
 
-EMAIL_SENDER: "dev@localhost"
-EMAIL_SENDER_USER: ""
-EMAIL_SENDER_PASS: ""
-EMAIL_SERVER: "localhost"
-EMAIL_SERVER_PORT: "587"
+# Disable email notifications. When false, EMAIL_* keys are not required.
+# In-app (DB-backed) notifications are unaffected.
+EMAIL_ENABLED: false
 
 JOB_VALIDITY_PERIOD_DAYS: 30
 ```
 
-**Why the placeholders?** `ArgusService.__init__` eagerly reads
-`GITHUB_ACCESS_TOKEN`, and `NotificationManagerService` reads the
-`EMAIL_*` keys at init time. Without them every API request returns a
-`KeyError`.
+**`GITHUB_ENABLED: false` / `JIRA_ENABLED: false`** disables all remote
+calls to GitHub issue tracking and Jira respectively. In this mode no
+credentials are needed for those integrations and attempting to create a
+new remote issue returns an error, while all local DB reads continue to
+work normally.
+
+> **Note:** `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` are only needed
+> when `gh` is included in `LOGIN_METHODS`. With password-only login they
+> can be omitted entirely.
+
+**`EMAIL_ENABLED: false`** skips instantiation of the email notification
+sender entirely. In-app DB-backed notifications still work; no `EMAIL_*`
+keys are required.
 
 ### 3. Start the database and seed it
 
@@ -256,11 +261,11 @@ docker exec dev-db-alpha-1 cqlsh 172.18.0.2 -u cassandra -p cassandra \
   -e "DESCRIBE KEYSPACES"
 ```
 
-### `KeyError: 'EMAIL_SENDER'` or `KeyError: 'GITHUB_ACCESS_TOKEN'`
+### `KeyError: 'EMAIL_SENDER'`
 
-Your `argus_web.yaml` is missing required keys. The app reads these
-eagerly at startup. Add the placeholder values shown in the config
-section above.
+Your `argus_web.yaml` is missing email keys and `EMAIL_ENABLED` is not
+set to `false`. Either add the `EMAIL_*` values or disable email entirely
+with `EMAIL_ENABLED: false`.
 
 ### ScyllaDB won't start -- permission denied
 

--- a/docs/plans/local-dev-without-jira-github.md
+++ b/docs/plans/local-dev-without-jira-github.md
@@ -1,0 +1,183 @@
+# Plan: Enable Local Development Without Jira, GitHub, and Email Access
+
+## Problem
+
+Running Argus locally requires valid credentials for Jira, GitHub, and email (SMTP)
+even when the developer does not need any of these integrations. Three distinct issues
+block a clean local setup:
+
+1. `ArgusService.__init__` reads `current_app.config['GITHUB_ACCESS_TOKEN']` eagerly
+   using a hard key lookup. The value is assigned to `self.github_headers` which is
+   **never used anywhere** in the class. This dead assignment causes a `KeyError` on
+   every API request if the key is absent.
+
+2. There is no way to activate `dry_run=True` on `IssueService` (and by extension
+   `JiraService` / `GithubService`) through configuration. A developer must patch
+   calling code by hand.
+
+3. `Email.__init__` always calls `_retrieve_credentials()` which reads all five
+   `EMAIL_*` config keys with hard `[]` lookups. This happens inside
+   `EmailNotificationServiceSender.__init__`, which is unconditionally instantiated
+   by `NotificationManagerService.__init__`, which is called by both `ArgusService`
+   and `TestRunService` on every request. There is no way to disable email through
+   configuration.
+
+## Goal
+
+Allow a developer to start the full Argus backend locally with only ScyllaDB
+available, by setting per-integration config flags. Jira, GitHub, and email are each
+enabled by default and can be disabled independently — no credentials are required for
+a disabled integration. In-app (DB-backed) notifications continue to work regardless
+of the email flag.
+
+---
+
+## Changes
+
+### 1. Remove dead `github_headers` from `ArgusService`
+
+**File:** `argus/backend/service/argus_service.py`
+
+Remove lines 54-57:
+
+```python
+self.github_headers = {
+    "Accept": "application/vnd.github.v3+json",
+    "Authorization": f"token {current_app.config['GITHUB_ACCESS_TOKEN']}"
+}
+```
+
+This is a dead assignment — `github_headers` is never referenced outside `__init__`.
+Removing it eliminates the `KeyError` that fires when `GITHUB_ACCESS_TOKEN` is absent.
+
+---
+
+### 2. Add per-integration `ENABLED` config flags for GitHub and Jira
+
+**File:** `argus/backend/service/issue_service.py`
+
+Update `IssueService.__init__` to read separate flags for each integration when no
+explicit `dry_run` argument is passed:
+
+```python
+def __init__(self, dry_run: bool | None = None):
+    github_dry_run = dry_run if dry_run is not None else not current_app.config.get("GITHUB_ENABLED", True)
+    jira_dry_run = dry_run if dry_run is not None else not current_app.config.get("JIRA_ENABLED", True)
+    self.gh = GithubService(dry_run=github_dry_run)
+    self.jira = JiraService(dry_run=jira_dry_run)
+```
+
+Existing callers that pass `dry_run=True` explicitly (e.g., the test fixture in
+`conftest.py`) continue to disable both integrations, which is the correct behaviour
+for tests.
+
+---
+
+### 3. Make email credential read lazy
+
+**File:** `argus/backend/util/send_email.py`
+
+Move `_retrieve_credentials()` out of `__init__` and into `_connect()` so that
+credentials are only read when an SMTP connection is actually being established:
+
+```python
+def __init__(self, init_connection=True):
+    self.sender: str = ""
+    self._password: str = ""
+    self._user: str = ""
+    self._server_host: str = ""
+    self._server_port: int = 0
+    self._connection: smtplib.SMTP | None = None
+    if init_connection:
+        self._connect()
+
+def _connect(self):
+    self._retrieve_credentials()  # moved here from __init__
+    try:
+        self._connection = smtplib.SMTP(host=self._server_host, port=self._server_port)
+        ...
+```
+
+This means `EMAIL_*` keys are only required at the moment an email is dispatched, not
+at service construction time. Since `EmailNotificationServiceSender.send_notification`
+already wraps everything in a broad `except Exception` that logs the error, a missing
+key at send time is silently swallowed rather than crashing the request.
+
+---
+
+### 4. Add `EMAIL_ENABLED` flag to `NotificationManagerService`
+
+**File:** `argus/backend/service/notification_manager.py`
+
+Skip instantiating `EmailNotificationServiceSender` when `EMAIL_ENABLED` is false:
+
+```python
+def __init__(self, notification_senders=None):
+    self.notification_services = [ArgusDBNotificationSaver()]
+    if current_app.config.get("EMAIL_ENABLED", True):
+        self.notification_services.append(EmailNotificationServiceSender())
+    if notification_senders:
+        self.notification_services.extend(notification_senders)
+```
+
+When `EMAIL_ENABLED: false`, `Email()` is never constructed and no credentials are
+ever read — lazy credential read (Change 3) is irrelevant in this path but remains
+correct for the enabled path. In-app DB notifications (`ArgusDBNotificationSaver`)
+continue to work regardless.
+
+---
+
+### 5. Update example config
+
+**File:** `argus_web.example.yaml`
+
+Add all three new flags with documentation comments inline in the commits that
+introduce each flag.
+
+---
+
+### 6. Update test config and dev-setup guide
+
+**File:** `argus/backend/tests/conftest.py`
+
+The test app config provides fake `EMAIL_*` values only to satisfy the eager credential
+read. With `EMAIL_ENABLED: false` in the test config those keys are never read and the
+fake values can be removed:
+
+```python
+# before
+"EMAIL_SENDER": "unit tester", "EMAIL_SENDER_PASS": "pass",
+"EMAIL_SENDER_USER": "qa", "EMAIL_SERVER": "fake", "EMAIL_SERVER_PORT": 25
+
+# after — replaced with:
+"EMAIL_ENABLED": False
+```
+
+**File:** `docs/dev-setup.md`
+
+Update the minimal dev config to use `EMAIL_ENABLED: false` and remove the
+`EMAIL_*` placeholder values. Update the troubleshooting section accordingly.
+
+---
+
+## Out of Scope
+
+- `jenkins_service.py:126` already uses `config.get(...)` so it is safe; no change needed.
+- GitHub OAuth login (`GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`) is a separate
+  concern from issue tracking and is not changed here.
+- The hardcoded `scylladb.atlassian.net` URL pattern in `jira_service.py:83` is not
+  changed; it is only relevant when `JIRA_ENABLED` is true.
+
+---
+
+## Affected Files Summary
+
+| File                                            | Change                                                                                         |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `argus/backend/service/argus_service.py`        | Remove dead `github_headers` assignment                                                        |
+| `argus/backend/service/issue_service.py`        | Read `GITHUB_ENABLED` / `JIRA_ENABLED` from config as per-integration defaults                 |
+| `argus/backend/util/send_email.py`              | Move `_retrieve_credentials()` from `__init__` to `_connect()`                                 |
+| `argus/backend/service/notification_manager.py` | Skip `EmailNotificationServiceSender` when `EMAIL_ENABLED: false`                              |
+| `argus_web.example.yaml`                        | Document `GITHUB_ENABLED`, `JIRA_ENABLED`, and `EMAIL_ENABLED` flags inline per feature commit |
+| `argus/backend/tests/conftest.py`               | Replace fake `EMAIL_*` values with `EMAIL_ENABLED: false`; remove dead fixtures                |
+| `docs/dev-setup.md`                             | Add `EMAIL_ENABLED: false` to minimal dev config; remove `EMAIL_*` placeholders                |


### PR DESCRIPTION
## Problem Statement

Running Argus locally requires valid credentials for three external integrations — Jira, GitHub issue tracking, and SMTP email — even when none of them are needed for development. This creates unnecessary friction for local setup and makes it impossible to run the backend with only ScyllaDB available.

Three distinct issues contribute to this:

1. **Dead code causing a `KeyError` on every request:** `ArgusService.__init__` eagerly reads `GITHUB_ACCESS_TOKEN` from config via a hard `[]` lookup and assigns it to `self.github_headers`. This attribute is never referenced anywhere else in the class, making it dead code that silently crashes the server if the key is absent.

2. **No config-level way to disable Jira/GitHub clients:** `JiraService` and `GithubService` both support a `dry_run=True` mode that skips instantiating remote clients, but there is no way to activate this through configuration. Developers have to patch calling code by hand.

3. **Email credentials required at every request:** `Email.__init__` unconditionally calls `_retrieve_credentials()`, which reads all five `EMAIL_*` config keys via hard lookups. This is triggered on every request through `NotificationManagerService`, which is instantiated by both `ArgusService` and `TestRunService`. There is no way to disable email through configuration.

## Summary

This PR makes all three external integrations independently opt-out through configuration flags, so a developer can start the full backend with only ScyllaDB available.

### Changes

- **Remove dead `github_headers` assignment** from `ArgusService.__init__` (`argus/backend/service/argus_service.py`). The attribute was set but never read, and caused a `KeyError` on startup when `GITHUB_ACCESS_TOKEN` was absent.

- **Add `GITHUB_ENABLED` and `JIRA_ENABLED` config flags** (`argus/backend/service/issue_service.py`). Both default to `true`. When set to `false`, the corresponding remote client is not instantiated — no credentials are required, and local DB reads continue to work normally. Existing code that passes `dry_run=True` explicitly (e.g. tests) is unaffected.

- **Make email credential read lazy** (`argus/backend/util/send_email.py`). Move `_retrieve_credentials()` from `__init__` into `_connect()` so that `EMAIL_*` keys are only read when an SMTP connection is actually being established, not at service construction time.

- **Add `EMAIL_ENABLED` config flag** (`argus/backend/service/notification_manager.py`). Defaults to `true`. When `false`, `EmailNotificationServiceSender` is not instantiated at all — no credentials are read. In-app DB-backed notifications (`ArgusDBNotificationSaver`) are unaffected.

- **Remove dead test fixtures** (`argus/backend/tests/conftest.py`). The `github_service` and `jira_service` fixtures instantiated live clients without `dry_run=True` despite never being used by any test. Removed entirely.

- **Update test app config** (`argus/backend/tests/conftest.py`). Replace fake `EMAIL_*` placeholder values with `EMAIL_ENABLED: False`.

- **Update `argus_web.example.yaml` and `docs/dev-setup.md`** to document all three flags and provide a minimal credential-free local dev config.

### Minimal local dev config (no external credentials required)

```yaml
GITHUB_ENABLED: false
JIRA_ENABLED: false
EMAIL_ENABLED: false
```