### PR TITLE
perf(dashboard): cache release stats

### DIFF
--- a/argus/backend/controller/api.py
+++ b/argus/backend/controller/api.py
@@ -507,7 +507,6 @@ def release_stats_v2():
         "status": "ok",
         "response": stats
     })
-    res.cache_control.max_age = 300
     return res
 
 

--- a/argus/backend/controller/view_api.py
+++ b/argus/backend/controller/view_api.py
@@ -155,7 +155,6 @@ def view_stats():
         "status": "ok",
         "response": stats
     })
-    res.cache_control.max_age = 300
     return res
 
 

--- a/argus/backend/models/web.py
+++ b/argus/backend/models/web.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Optional
 from uuid import UUID, uuid1, uuid4
 from datetime import datetime
@@ -396,6 +397,31 @@ class WebFileStorage(Model):
     filename = columns.Text(min_length=1)
 
 
+class ReleaseStatsSnapshot(Model):
+    __table_name__ = "argus_release_stats_snapshot"
+    release_id = columns.UUID(partition_key=True)
+    filter_key = columns.Text(primary_key=True)
+    payload = columns.Text()
+    generated_at = columns.DateTime()
+
+
+_SNAPSHOT_LOGGER = logging.getLogger(__name__)
+
+
+def invalidate_release_snapshots(release_id: UUID) -> None:
+    """Full-partition delete of all ReleaseStatsSnapshot rows for a release.
+
+    Use this for structural or metadata changes that affect all filter
+    combinations (admin edits, group/test toggles, issue/comment/plan
+    mutations). The next stats request will regenerate the snapshots.
+    Version-scoped invalidation in PluginModelBase.invalidate_release_snapshot()
+    is used only for run lifecycle events (submit/finish).
+    """
+    try:
+        for snapshot in ReleaseStatsSnapshot.filter(release_id=release_id).all():
+            snapshot.delete()
+    except Exception:  # pylint: disable=broad-except
+        _SNAPSHOT_LOGGER.warning("Failed to invalidate release snapshots for %s", release_id, exc_info=True)
 USED_MODELS: list[Model] = [
     RuntimeStore,
     User,
@@ -435,6 +461,7 @@ USED_MODELS: list[Model] = [
     RunConfigParam,
     SSHTunnelKey,
     ProxyTunnelConfig,
+    ReleaseStatsSnapshot,
 ]
 
 USED_TYPES: list[UserType] = [

--- a/argus/backend/models/web.py
+++ b/argus/backend/models/web.py
@@ -405,6 +405,24 @@ class ReleaseStatsSnapshot(Model):
     generated_at = columns.DateTime()
 
 
+class ReleaseDistinctVersions(Model):
+    """Denormalized index: distinct scylla_version values seen for a release.
+    Replaces the expensive GSI scan in get_distinct_product_versions.
+    Keyed by release_id (partition) + version (clustering) for O(1) reads.
+    """
+    release_id = columns.UUID(partition_key=True)
+    version = columns.Text(primary_key=True)
+
+
+class ReleaseDistinctImages(Model):
+    """Denormalized index: distinct cloud image IDs seen for a release.
+    Replaces the expensive GSI scan + UDT deserialization in get_distinct_cloud_images_for_release.
+    Keyed by release_id (partition) + image_id (clustering) for O(1) reads.
+    """
+    release_id = columns.UUID(partition_key=True)
+    image_id = columns.Text(primary_key=True)
+
+
 _SNAPSHOT_LOGGER = logging.getLogger(__name__)
 
 
@@ -422,6 +440,8 @@ def invalidate_release_snapshots(release_id: UUID) -> None:
             snapshot.delete()
     except Exception:  # pylint: disable=broad-except
         _SNAPSHOT_LOGGER.warning("Failed to invalidate release snapshots for %s", release_id, exc_info=True)
+
+
 USED_MODELS: list[Model] = [
     RuntimeStore,
     User,
@@ -445,6 +465,8 @@ USED_MODELS: list[Model] = [
     ArgusBestResultData,
     ArgusReleasePlan,
     WidgetHighlights,
+    ReleaseDistinctVersions,
+    ReleaseDistinctImages,
     WidgetComment,
     ArgusGraphView,
     ErrorEventEmbeddings,  # to be deprecated

--- a/argus/backend/plugins/core.py
+++ b/argus/backend/plugins/core.py
@@ -173,7 +173,8 @@ class PluginModelBase(Model):
         for step in range(0, ceil(len(build_ids) / step_size)):
             start_pos = step*step_size
             next_slice = build_ids[start_pos:start_pos+step_size]
-            futures.append(cluster.session.execute_async(query=query, parameters=(next_slice,)))
+            futures.append(cluster.session.execute_async(query=query, parameters=(next_slice,),
+                                                         execution_profile="read_fast"))
 
         return futures
 

--- a/argus/backend/plugins/core.py
+++ b/argus/backend/plugins/core.py
@@ -4,7 +4,6 @@ from datetime import datetime, UTC
 from math import ceil
 from uuid import UUID
 from time import time
-
 from cassandra.cqlengine import columns
 from cassandra.cqlengine.models import Model
 from cassandra.cqlengine.usertype import UserType
@@ -19,7 +18,9 @@ from argus.backend.models.web import (
     ArgusScheduleGroup,
     ArgusSchedule,
     ArgusScheduleTest,
-    ArgusScheduleAssignee
+    ArgusScheduleAssignee,
+    ReleaseStatsSnapshot,
+    ReleaseDistinctVersions,
 )
 from argus.backend.util.common import chunk
 from argus.common.enums import TestInvestigationStatus, TestStatus
@@ -45,6 +46,7 @@ class PluginModelBase(Model):
     build_job_url = columns.Text()
     build_number = columns.Integer()
     product_version = columns.Text(index=True)
+    scylla_version = columns.Text()
 
     # Test Logs Collection
     logs = columns.List(value_type=columns.Tuple(columns.Text(), columns.Text()))
@@ -276,6 +278,27 @@ class PluginModelBase(Model):
 
     def sut_timestamp(self, sut_package_name) -> float:
         raise NotImplementedError()
+
+    def invalidate_release_snapshot(self) -> None:
+        if not self.release_id:
+            return
+        try:
+            version = self.scylla_version or ""
+            version_prefix = f"v={version}::"
+            all_versions_prefix = "v=::"
+            for snapshot in ReleaseStatsSnapshot.filter(release_id=self.release_id).all():
+                if snapshot.filter_key.startswith(version_prefix) or snapshot.filter_key.startswith(all_versions_prefix):
+                    snapshot.delete()
+        except Exception:
+            LOGGER.warning("Failed to invalidate stats snapshot for release %s", self.release_id, exc_info=True)
+
+    def index_version(self) -> None:
+        if not self.release_id or not self.scylla_version:
+            return
+        try:
+            ReleaseDistinctVersions.create(release_id=self.release_id, version=self.scylla_version)
+        except Exception:
+            LOGGER.warning("Failed to index version %s for release %s", self.scylla_version, self.release_id, exc_info=True)
 
 
 class PluginInfoBase:

--- a/argus/backend/plugins/driver_matrix_tests/model.py
+++ b/argus/backend/plugins/driver_matrix_tests/model.py
@@ -10,7 +10,7 @@ from xml.etree import ElementTree
 from cassandra.cqlengine import columns
 from cassandra.cqlengine.models import Model
 from argus.backend.db import ScyllaCluster
-from argus.backend.models.web import ArgusRelease
+from argus.backend.models.web import ArgusRelease, ReleaseDistinctVersions
 from argus.backend.plugins.core import PluginModelBase
 from argus.backend.plugins.driver_matrix_tests.udt import TestCollection, TestSuite, TestCase, EnvironmentInfo
 from argus.backend.plugins.driver_matrix_tests.raw_types import RawMatrixTestResult
@@ -98,7 +98,6 @@ def generic_adapter(xml: ElementTree.ElementTree) -> AdaptedXUnitData:
 class DriverTestRun(PluginModelBase):
     _plugin_name = "driver-matrix-tests"
     __table_name__ = "driver_test_run"
-    scylla_version = columns.Text()
     test_collection = columns.List(value_type=columns.UserDefinedType(user_type=TestCollection))
     environment_info = columns.List(value_type=columns.UserDefinedType(user_type=EnvironmentInfo))
 
@@ -177,6 +176,7 @@ class DriverTestRun(PluginModelBase):
 
         run.status = TestStatus.CREATED.value
         run.save()
+        run.invalidate_release_snapshot()
         return run
 
     @classmethod
@@ -443,11 +443,14 @@ class DriverTestRun(PluginModelBase):
             new_assignee = None
         if new_assignee:
             self.assignee = new_assignee
+        self.index_version()
 
     def finish_run(self, payload: dict = None):
         self.end_time = datetime.utcnow()
         status = payload.get("status", "passed")
         self.status = TestStatus(status).value
+        self.invalidate_release_snapshot()
+        self.index_version()
 
     def submit_logs(self, logs: list[dict]):
         pass

--- a/argus/backend/plugins/generic/model.py
+++ b/argus/backend/plugins/generic/model.py
@@ -10,7 +10,6 @@ from argus.backend.plugins.generic.types import GenericRunFinishRequest, Generic
 from argus.backend.util.common import get_build_number
 from argus.common.enums import TestStatus
 
-
 class GenericPluginException(Exception):
     pass
 
@@ -21,8 +20,6 @@ class GenericRun(PluginModelBase):
     logs = columns.Map(key_type=columns.Text(), value_type=columns.Text())
     started_by = columns.Text()
     sub_type = columns.Text() # Used to tell which framework the GenericRun belongs to
-    # TODO: Legacy field name, should be renamed to product_version and abstracted
-    scylla_version = columns.Text()
 
     @classmethod
     def _stats_query(cls) -> str:
@@ -50,6 +47,7 @@ class GenericRun(PluginModelBase):
             if new_assignee:
                 self.assignee = new_assignee
             self.set_full_version(version)
+            self.index_version()
 
     @classmethod
     def load_test_run(cls, run_id: UUID) -> 'GenericRun':
@@ -78,7 +76,7 @@ class GenericRun(PluginModelBase):
             run.submit_product_version(version)
         run.status = TestStatus.RUNNING.value
         run.save()
-
+        run.invalidate_release_snapshot()
         return run
 
     def finish_run(self, payload: GenericRunFinishRequest = None):
@@ -86,3 +84,5 @@ class GenericRun(PluginModelBase):
         self.status = TestStatus(payload["status"]).value
         if version := payload.get("scylla_version"):
             self.submit_product_version(version)
+        self.invalidate_release_snapshot()
+        self.index_version()

--- a/argus/backend/plugins/sct/testrun.py
+++ b/argus/backend/plugins/sct/testrun.py
@@ -216,19 +216,19 @@ class SCTTestRun(PluginModelBase):
         req = SCTTestRunSubmissionRequest(**request_data)
         run = cls.from_sct_config(req=req)
         run.invalidate_release_snapshot()
-        run._index_image(run)
+        run.index_image(run)
         return run
 
     @classmethod
     def get_distinct_product_versions(cls, release: ArgusRelease) -> list[str]:
+        rows = list(ReleaseDistinctVersions.filter(release_id=release.id).all())
+        if rows:
+            return sorted([r.version for r in rows], reverse=True)
+        # Fallback: index not yet populated — scan GSI directly
         cluster = ScyllaCluster.get()
-        statement = cluster.prepare(f"SELECT scylla_version FROM {
-                                    cls.table_name()} WHERE release_id = ?")
-        rows = cluster.session.execute(
-            query=statement, parameters=(release.id,))
-        unique_versions = {r["scylla_version"]
-                           for r in rows if r["scylla_version"]}
-
+        statement = cluster.prepare(f"SELECT scylla_version FROM {cls.table_name()} WHERE release_id = ?")
+        result = cluster.session.execute(query=statement, parameters=(release.id,))
+        unique_versions = {r["scylla_version"] for r in result if r["scylla_version"]}
         return sorted(list(unique_versions), reverse=True)
 
     @classmethod
@@ -248,13 +248,14 @@ class SCTTestRun(PluginModelBase):
 
     @classmethod
     def get_distinct_cloud_images_for_release(cls, release: ArgusRelease):
+        rows = list(ReleaseDistinctImages.filter(release_id=release.id).all())
+        if rows:
+            return sorted([r.image_id for r in rows], reverse=True)
+        # Fallback: index not yet populated — scan GSI + deserialize UDTs directly
         cluster = ScyllaCluster.get()
-        statement = cluster.prepare(f"SELECT cloud_setup FROM {
-                                    cls.table_name()} WHERE release_id = ?")
-        rows = cluster.session.execute(
-            query=statement, parameters=(release.id,))
-        unique_images = {cls.get_image(r) for r in rows if cls.get_image(r)}
-
+        statement = cluster.prepare(f"SELECT cloud_setup FROM {cls.table_name()} WHERE release_id = ?")
+        result = cluster.session.execute(query=statement, parameters=(release.id,))
+        unique_images = {cls.get_image(r) for r in result if cls.get_image(r)}
         return sorted(list(unique_images), reverse=True)
 
     @classmethod
@@ -419,7 +420,7 @@ class SCTTestRun(PluginModelBase):
         self.end_time = datetime.utcnow()
         self.invalidate_release_snapshot()
         self.index_version()
-        self._index_image(self)
+        self.index_image(self)
 
     def submit_logs(self, logs: list[dict]):
         for log in logs:
@@ -494,14 +495,14 @@ class SCTTestRun(PluginModelBase):
         return response
 
     @staticmethod
-    def _index_image(run: 'SCTTestRun') -> None:
+    def index_image(run: 'SCTTestRun') -> None:
         if not run.release_id:
             return
         try:
             image_id = run.cloud_setup and run.cloud_setup.db_node and run.cloud_setup.db_node.image_id
             if not image_id:
                 return
-            ReleaseDistinctImages.if_not_exists().create(release_id=run.release_id, image_id=image_id)
+            ReleaseDistinctImages.create(release_id=run.release_id, image_id=image_id)
         except Exception:
             LOGGER.warning("Failed to index image for release %s", run.release_id, exc_info=True)
 

--- a/argus/backend/plugins/sct/testrun.py
+++ b/argus/backend/plugins/sct/testrun.py
@@ -9,7 +9,7 @@ from uuid import UUID, uuid4
 from cassandra.cqlengine import columns
 from cassandra.cqlengine.models import _DoesNotExist, Model
 from argus.backend.db import ScyllaCluster
-from argus.backend.models.web import ArgusRelease, ArgusTest
+from argus.backend.models.web import ArgusRelease, ArgusTest, ReleaseDistinctVersions, ReleaseDistinctImages
 from argus.backend.plugins.core import PluginModelBase
 from argus.backend.plugins.sct.resource_setup import ResourceSetup
 from argus.backend.plugins.sct.udt import (
@@ -152,7 +152,6 @@ class SCTTestRun(PluginModelBase):
     config_files = columns.List(value_type=columns.Text())
     packages = columns.List(
         value_type=columns.UserDefinedType(user_type=PackageVersion))
-    scylla_version = columns.Text()
     version_source = columns.Text()
     yaml_test_duration = columns.Integer()
 
@@ -215,7 +214,10 @@ class SCTTestRun(PluginModelBase):
     @classmethod
     def submit_run(cls, request_data: dict) -> 'SCTTestRun':
         req = SCTTestRunSubmissionRequest(**request_data)
-        return cls.from_sct_config(req=req)
+        run = cls.from_sct_config(req=req)
+        run.invalidate_release_snapshot()
+        run._index_image(run)
+        return run
 
     @classmethod
     def get_distinct_product_versions(cls, release: ArgusRelease) -> list[str]:
@@ -411,9 +413,13 @@ class SCTTestRun(PluginModelBase):
             new_assignee = None
         if new_assignee:
             self.assignee = new_assignee
+        self.index_version()
 
     def finish_run(self, payload: dict = None):
         self.end_time = datetime.utcnow()
+        self.invalidate_release_snapshot()
+        self.index_version()
+        self._index_image(self)
 
     def submit_logs(self, logs: list[dict]):
         for log in logs:
@@ -486,6 +492,18 @@ class SCTTestRun(PluginModelBase):
         response["allocated_resources"] = list(
             SCTResource.filter(run_id=run_id).all())
         return response
+
+    @staticmethod
+    def _index_image(run: 'SCTTestRun') -> None:
+        if not run.release_id:
+            return
+        try:
+            image_id = run.cloud_setup and run.cloud_setup.db_node and run.cloud_setup.db_node.image_id
+            if not image_id:
+                return
+            ReleaseDistinctImages.if_not_exists().create(release_id=run.release_id, image_id=image_id)
+        except Exception:
+            LOGGER.warning("Failed to index image for release %s", run.release_id, exc_info=True)
 
 
 class SCTJunitReports(Model):

--- a/argus/backend/service/client_service.py
+++ b/argus/backend/service/client_service.py
@@ -23,7 +23,6 @@ from argus.common.enums import TestStatus
 LOGGER = logging.getLogger(__name__)
 
 
-
 class ClientException(Exception):
     pass
 
@@ -43,7 +42,6 @@ class ClientService:
     def submit_run(self, run_type: str, request_data: dict) -> str:
         model = self.get_model(run_type)
         run = model.submit_run(request_data=request_data)
-
         return "Created"
 
     def submit_pytest_result(self, request_data: PytestSubmitData) -> dict[str, str | UUID]:
@@ -131,6 +129,7 @@ class ClientService:
         run = model.load_test_run(UUID(run_id))
         run.finish_run(payload)
         run.save()
+
 
         return "Finalized"
 

--- a/argus/backend/service/client_service.py
+++ b/argus/backend/service/client_service.py
@@ -23,6 +23,7 @@ from argus.common.enums import TestStatus
 LOGGER = logging.getLogger(__name__)
 
 
+
 class ClientException(Exception):
     pass
 
@@ -41,7 +42,7 @@ class ClientService:
 
     def submit_run(self, run_type: str, request_data: dict) -> str:
         model = self.get_model(run_type)
-        model.submit_run(request_data=request_data)
+        run = model.submit_run(request_data=request_data)
 
         return "Created"
 

--- a/argus/backend/service/github_service.py
+++ b/argus/backend/service/github_service.py
@@ -9,7 +9,7 @@ from flask import current_app, g
 from github import Github, Auth
 
 from argus.backend.models.runtime_store import RuntimeStore
-from argus.backend.models.web import ArgusEventTypes, ArgusTest, ArgusUserView
+from argus.backend.models.web import ArgusEventTypes, ArgusTest, ArgusUserView, invalidate_release_snapshots
 from argus.backend.models.github_issue import GithubIssue, IssueAssignee, IssueLink, IssueLabel
 from argus.backend.plugins.core import PluginInfoBase
 from argus.backend.plugins.loader import AVAILABLE_PLUGINS
@@ -176,6 +176,7 @@ class GithubService:
             test_id=link.test_id
         )
 
+        invalidate_release_snapshots(test.release_id)
         response = {
             **dict(list(issue.items())),
             "title": issue.title,
@@ -248,6 +249,7 @@ class GithubService:
         if remaining_links == 0:
             issue.delete()
 
+        invalidate_release_snapshots(link.release_id)
         return {
             "deleted": issue_id if remaining_links == 0 else (link.run_id, link.issue_id)
         }

--- a/argus/backend/service/jira_service.py
+++ b/argus/backend/service/jira_service.py
@@ -12,7 +12,7 @@ from jira import JIRA
 
 from argus.backend.models.jira import JiraIssue
 from argus.backend.models.runtime_store import RuntimeStore
-from argus.backend.models.web import ArgusEventTypes, ArgusTest, ArgusUserView
+from argus.backend.models.web import ArgusEventTypes, ArgusTest, ArgusUserView, invalidate_release_snapshots
 from argus.backend.models.github_issue import IssueLink, IssueLabel
 from argus.backend.plugins.core import PluginInfoBase
 from argus.backend.plugins.loader import AVAILABLE_PLUGINS
@@ -156,6 +156,7 @@ class JiraService:
             test_id=link.test_id
         )
 
+        invalidate_release_snapshots(test.release_id)
         response = {
             **dict(list(issue.items())),
             "summary": issue.summary,
@@ -228,6 +229,7 @@ class JiraService:
         if remaining_links == 0:
             issue.delete()
 
+        invalidate_release_snapshots(link.release_id)
         return {
             "deleted": issue_id if remaining_links == 0 else (link.run_id, link.issue_id)
         }

--- a/argus/backend/service/planner_service.py
+++ b/argus/backend/service/planner_service.py
@@ -12,7 +12,7 @@ from flask import g
 from slugify import slugify
 
 from argus.backend.models.plan import ArgusReleasePlan
-from argus.backend.models.web import ArgusGroup, ArgusRelease, ArgusTest, ArgusUserView, User
+from argus.backend.models.web import ArgusGroup, ArgusRelease, ArgusTest, ArgusUserView, User, invalidate_release_snapshots
 from argus.backend.service.jenkins_service import JenkinsService
 from argus.backend.service.test_lookup import TestLookup
 from argus.backend.service.views import UserViewService
@@ -149,7 +149,7 @@ class PlanningService:
             view = self.update_view_for_plan(plan, existing=True)
 
         plan.save()
-
+        invalidate_release_snapshots(plan.release_id)
         return plan
 
     def update_plan(self, payload: dict[str, Any]) -> bool:
@@ -194,7 +194,7 @@ class PlanningService:
             plan.view_id = view.id
 
         plan.save()
-
+        invalidate_release_snapshots(plan.release_id)
         return True
 
     def update_view_for_plan(self, plan: ArgusReleasePlan, existing: bool = False) -> ArgusUserView:
@@ -355,7 +355,7 @@ class PlanningService:
         new_plan.view_id = view.id
 
         new_plan.save()
-
+        invalidate_release_snapshots(new_plan.release_id)
         return new_plan
 
     def check_plan_copy_eligibility(self, plan_id: str | UUID, target_release_id: str | UUID) -> dict:
@@ -428,6 +428,7 @@ class PlanningService:
                 view.save()
 
         plan.delete()
+        invalidate_release_snapshots(plan.release_id)
         return True
 
     def get_assignee_for_test(self, test_id: str | UUID, target_version: str = None) -> UUID | None:
@@ -493,6 +494,7 @@ class PlanningService:
         plan.completed = True
 
         plan.save()
+        invalidate_release_snapshots(plan.release_id)
         return plan.completed
 
     def resolve_plan(self, plan_id: str | UUID) -> list[dict[str, Any]]:

--- a/argus/backend/service/release_manager.py
+++ b/argus/backend/service/release_manager.py
@@ -3,7 +3,7 @@ from typing import TypedDict
 from uuid import UUID
 from argus.backend.db import ScyllaCluster
 from argus.backend.plugins.sct.testrun import SCTTestRun
-from argus.backend.models.web import ArgusRelease, ArgusGroup, ArgusTest
+from argus.backend.models.web import ArgusRelease, ArgusGroup, ArgusTest, ReleaseDistinctVersions, ReleaseDistinctImages, ReleaseStatsSnapshot, invalidate_release_snapshots
 
 LOGGER = logging.getLogger(__name__)
 
@@ -48,14 +48,14 @@ class ReleaseManagerService:
         test: ArgusTest = ArgusTest.get(id=test_id)
         test.enabled = new_state
         test.save()
-
+        invalidate_release_snapshots(test.release_id)
         return test
 
     def toggle_group_enabled(self, group_id: UUID, new_state: bool) -> bool:
         test: ArgusGroup = ArgusGroup.get(id=group_id)
         test.enabled = new_state
         test.save()
-
+        invalidate_release_snapshots(test.release_id)
         return test
 
     def create_release(self, release_name: str, pretty_name: str, perpetual: bool) -> ArgusRelease:
@@ -84,7 +84,7 @@ class ReleaseManagerService:
         new_group.release_id = release.id
         new_group.build_system_id = build_system_id
         new_group.save()
-
+        invalidate_release_snapshots(release.id)
         return new_group
 
     def create_test(self, test_name, pretty_name, build_id, build_url, group_id, release_id, plugin_name) -> ArgusTest:
@@ -102,6 +102,7 @@ class ReleaseManagerService:
         new_test.validate_build_system_id()
         new_test.save()
         self.move_test_runs(new_test)
+        invalidate_release_snapshots(release.id)
         return new_test
 
     def delete_group(self, group_id: str, delete_tests: bool = True, new_group_id: str = "") -> bool:
@@ -119,13 +120,13 @@ class ReleaseManagerService:
                 test.save()
 
         group_to_delete.delete()
-
+        invalidate_release_snapshots(group_to_delete.release_id)
         return True
 
     def delete_test(self, test_id: str) -> bool:
         test_to_delete = ArgusTest.get(id=test_id)
         test_to_delete.delete()
-
+        invalidate_release_snapshots(test_to_delete.release_id)
         return True
 
     def update_group(self, group_id: str, name: str, pretty_name: str, enabled: bool, build_system_id: str) -> bool:
@@ -137,7 +138,7 @@ class ReleaseManagerService:
         group.enabled = enabled
 
         group.save()
-
+        invalidate_release_snapshots(group.release_id)
         return True
 
     def update_test(self, test_id: str, name: str, pretty_name: str, plugin_name: str,
@@ -158,27 +159,28 @@ class ReleaseManagerService:
         test.validate_build_system_id()
         test.save()
         self.move_test_runs(test)
+        invalidate_release_snapshots(test.release_id)
         return True
 
     def set_release_state(self, release_id: str, state: bool) -> bool:
         release = ArgusRelease.get(id=UUID(release_id))
         release.enabled = state
         release.save()
-
+        invalidate_release_snapshots(release.id)
         return True
 
     def set_release_dormancy(self, release_id: str, dormant: bool) -> bool:
         release = ArgusRelease.get(id=UUID(release_id))
         release.dormant = dormant
         release.save()
-
+        invalidate_release_snapshots(release.id)
         return True
 
     def set_release_perpetuality(self, release_id: str, perpetual: bool) -> bool:
         release = ArgusRelease.get(id=UUID(release_id))
         release.perpetual = perpetual
         release.save()
-
+        invalidate_release_snapshots(release.id)
         return True
 
     def edit_release(self, payload: ReleaseEditPayload) -> bool:
@@ -192,6 +194,7 @@ class ReleaseManagerService:
         release.valid_version_regex = payload["valid_version_regex"]
 
         release.save()
+        invalidate_release_snapshots(release.id)
         return True
 
     def delete_release(self, release_id: str) -> bool:
@@ -203,6 +206,14 @@ class ReleaseManagerService:
 
         for entity in [*release_groups.all(), *release_tests.all()]:
             entity.delete()
+
+        # Clean up denormalized index tables so no orphaned rows remain
+        for row in ReleaseDistinctVersions.filter(release_id=release.id).all():
+            row.delete()
+        for row in ReleaseDistinctImages.filter(release_id=release.id).all():
+            row.delete()
+        for row in ReleaseStatsSnapshot.filter(release_id=release.id).all():
+            row.delete()
 
         release.delete()
         return True
@@ -217,6 +228,7 @@ class ReleaseManagerService:
             test.save()
             self.move_test_runs(test)
 
+        invalidate_release_snapshots(group.release_id)
         return True
 
     def move_test_runs(self, test: ArgusTest) -> None:

--- a/argus/backend/service/stats.py
+++ b/argus/backend/service/stats.py
@@ -3,10 +3,11 @@ from functools import reduce
 import json
 import logging
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any, TypedDict
 from uuid import UUID
 
+from flask import current_app
 from cassandra.cqlengine.models import Model
 from argus.backend.models.github_issue import GithubIssue, IssueLink
 from argus.backend.models.jira import JiraIssue
@@ -15,10 +16,14 @@ from argus.backend.plugins.loader import all_plugin_models
 from argus.backend.util.common import chunk, get_build_number, check_version
 from argus.common.enums import TestStatus, TestInvestigationStatus
 from argus.backend.models.web import ArgusRelease, ArgusGroup, ArgusScheduleTest, ArgusTest, \
-    ArgusTestRunComment, ArgusUserView
+    ArgusTestRunComment, ArgusUserView, ReleaseStatsSnapshot
 from argus.backend.db import ScyllaCluster
 
 LOGGER = logging.getLogger(__name__)
+
+
+def snapshot_filter_key(version: str | None, image_id: str | None, include_no_version: bool, limited: bool) -> str:
+    return f"v={version or ''}::img={image_id or ''}::nov={int(include_no_version)}::lim={int(limited)}"
 
 
 class TestRunStatRow(TypedDict):
@@ -536,6 +541,15 @@ class ReleaseStatsCollector:
 
     def collect(self, limited=False, force=False, include_no_version=False, image_id: str = None) -> dict:
         self.release: ArgusRelease = ArgusRelease.get(name=self.release_name)
+
+        if not force:
+            filter_key = snapshot_filter_key(self.release_version, image_id, include_no_version, limited)
+            try:
+                snapshot = ReleaseStatsSnapshot.get(release_id=self.release.id, filter_key=filter_key)
+                return json.loads(snapshot.payload)
+            except ReleaseStatsSnapshot.DoesNotExist:
+                pass
+
         all_tests: list[ArgusTest] = list(ArgusTest.filter(release_id=self.release.id).all())
         build_ids = reduce(lambda acc, test: acc[test.plugin_name or "unknown"].append(
             test.build_system_id) or acc, all_tests, defaultdict(list))
@@ -581,7 +595,20 @@ class ReleaseStatsCollector:
         self.release_stats = ReleaseStats(release=self.release)
         self.release_stats.collect(rows=self.release_rows, limited=limited, force=force,
                                    dict=self.release_dict, tests=all_tests, version_filter=self.release_version)
-        return self.release_stats.to_dict()
+        result = self.release_stats.to_dict()
+
+        filter_key = snapshot_filter_key(self.release_version, image_id, include_no_version, limited)
+        try:
+            ReleaseStatsSnapshot.create(
+                release_id=self.release.id,
+                filter_key=filter_key,
+                payload=current_app.json.dumps(result),
+                generated_at=datetime.now(UTC),
+            )
+        except Exception:
+            LOGGER.warning("Failed to write stats snapshot for release %s", self.release.id, exc_info=True)
+
+        return result
 
 
 class ViewStatsCollector:

--- a/argus/backend/service/testrun.py
+++ b/argus/backend/service/testrun.py
@@ -29,6 +29,7 @@ from argus.backend.models.web import (
     ArgusTest,
     ArgusTestRunComment,
     User,
+    invalidate_release_snapshots,
 )
 
 from argus.backend.plugins.core import PluginInfoBase, PluginModelBase
@@ -166,6 +167,7 @@ class TestRunService:
             test_id=test.id
         )
 
+        invalidate_release_snapshots(test.release_id)
         return {
             "test_run_id": run.id,
             "status": new_status
@@ -268,6 +270,7 @@ class TestRunService:
             test_id=test.id
         )
 
+        invalidate_release_snapshots(test.release_id)
         return {
             "test_run_id": run.id,
             "investigation_status": new_status
@@ -328,6 +331,7 @@ class TestRunService:
                     "build_number": run.build_number,
                 }
             )
+        invalidate_release_snapshots(test.release_id)
         return {
             "test_run_id": run.id,
             "assignee": str(new_assignee_user.id) if new_assignee_user else None
@@ -389,6 +393,7 @@ class TestRunService:
             "username": g.user.username
         }, user_id=g.user.id, run_id=run_id, release_id=release.id, test_id=test.id)
 
+        invalidate_release_snapshots(release.id)
         return self.get_run_comments(run_id=run_id)
 
     def delete_run_comment(self, comment_id: UUID, test_id: UUID, run_id: UUID):
@@ -402,6 +407,7 @@ class TestRunService:
             "username": g.user.username
         }, user_id=g.user.id, run_id=run_id, release_id=comment.release_id, test_id=test_id)
 
+        invalidate_release_snapshots(comment.release_id)
         return self.get_run_comments(run_id=run_id)
 
     def update_run_comment(self, comment_id: UUID, test_id: UUID, run_id: UUID, message: str, mentions: list[str], reactions: dict):
@@ -418,6 +424,7 @@ class TestRunService:
             "username": g.user.username
         }, user_id=g.user.id, run_id=run_id, release_id=comment.release_id, test_id=test_id)
 
+        invalidate_release_snapshots(comment.release_id)
         return self.get_run_comments(run_id=run_id)
 
     def get_run_events(self, run_id: UUID):
@@ -529,7 +536,7 @@ class TestRunService:
 
         cluster.session.execute(batch)
         event_batch.execute()
-
+        invalidate_release_snapshots(test.release_id)
         return jobs_affected
 
     def get_pytest_test_results(self, test_name: str, before: float = None, after: float = None) -> list[PytestResultTable]:

--- a/argus/backend/tests/test_stats_snapshot.py
+++ b/argus/backend/tests/test_stats_snapshot.py
@@ -1,0 +1,481 @@
+"""
+Tests for the release stats snapshot cache and targeted invalidation.
+
+Covers:
+- snapshot_filter_key format and determinism
+- PluginModelBase.invalidate_release_snapshot() targeted deletion logic
+- PluginModelBase.index_version() write path via ClientService
+- SCTTestRun.index_image() write path via ClientService
+- ReleaseStatsCollector.collect() cache miss → write → hit cycle
+- force=True bypass and overwrite behaviour
+- Per-version cache isolation (different filter keys cached separately)
+- Targeted invalidation: only the run's version + all-versions aggregate are dropped
+- Unaffected versions remain warm after a run finishes on another version
+- New run appears after invalidation (stale data regression)
+- Migration script idempotency
+- delete_release() cleanup of indexes and snapshots
+"""
+import importlib.util
+import json
+import time
+import types
+import uuid
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from argus.backend.models.web import (
+    ReleaseDistinctVersions,
+    ReleaseDistinctImages,
+    ReleaseStatsSnapshot,
+)
+from argus.backend.service.stats import snapshot_filter_key, ReleaseStatsCollector
+from argus.backend.tests.conftest import get_fake_test_run
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def get_snapshots(release_id) -> list[ReleaseStatsSnapshot]:
+    return list(ReleaseStatsSnapshot.filter(release_id=release_id).all())
+
+
+def write_snapshot(release_id, filter_key: str, payload: str = '{"dummy": true}'):
+    ReleaseStatsSnapshot.create(
+        release_id=release_id,
+        filter_key=filter_key,
+        payload=payload,
+        generated_at=datetime.now(timezone.utc),
+    )
+
+
+def make_mock_snapshot(filter_key: str) -> MagicMock:
+    s = MagicMock()
+    s.filter_key = filter_key
+    return s
+
+
+def plugin_run_stub(release_id, version: str | None) -> SimpleNamespace:
+    """Duck-typed stand-in for a PluginModelBase instance.
+
+    CQLEngine models cannot be instantiated without a live cluster and full
+    ORM initialisation, so we bind the real unbound methods to a plain
+    SimpleNamespace that carries only the attributes the methods read.
+    """
+    from argus.backend.plugins.core import PluginModelBase
+    obj = SimpleNamespace(release_id=release_id, scylla_version=version)
+    obj.invalidate_release_snapshot = types.MethodType(
+        PluginModelBase.invalidate_release_snapshot, obj
+    )
+    obj.index_version = types.MethodType(PluginModelBase.index_version, obj)
+    return obj
+
+
+@pytest.fixture(scope="module")
+def migration(argus_db):
+    """Loaded migration module, available for the whole test module."""
+    spec = importlib.util.spec_from_file_location(
+        "migration_2026_04_22",
+        Path(__file__).parents[3] / "scripts/migration/migration_2026-04-22.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Unit: snapshot_filter_key format and properties
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("version,image_id,nov,lim,expected", [
+    (None,    None,      True,  False, "v=::img=::nov=1::lim=0"),
+    ("5.2",   None,      True,  False, "v=5.2::img=::nov=1::lim=0"),
+    (None,    "ami-abc", False, True,  "v=::img=ami-abc::nov=0::lim=1"),
+    ("5.6.1", "ami-xyz", True,  True,  "v=5.6.1::img=ami-xyz::nov=1::lim=1"),
+    ("5.2",   None,      False, False, "v=5.2::img=::nov=0::lim=0"),
+])
+def test_snapshot_filter_key_format(version, image_id, nov, lim, expected):
+    assert snapshot_filter_key(version, image_id, nov, lim) == expected
+
+
+def test_snapshot_filter_key_is_deterministic():
+    assert snapshot_filter_key("5.2", "ami-abc", True, False) == snapshot_filter_key("5.2", "ami-abc", True, False)
+
+
+def test_snapshot_filter_key_no_collisions():
+    keys = {
+        snapshot_filter_key("5.2", None,    True,  False),
+        snapshot_filter_key("5.3", None,    True,  False),
+        snapshot_filter_key(None,  None,    True,  False),
+        snapshot_filter_key("5.2", None,    False, False),
+        snapshot_filter_key("5.2", None,    True,  True),
+        snapshot_filter_key("5.2", "ami-1", True,  False),
+    }
+    assert len(keys) == 6
+
+
+# ---------------------------------------------------------------------------
+# Unit: invalidate_release_snapshot targeted deletion
+# ---------------------------------------------------------------------------
+
+def test_invalidate_release_snapshot_deletes_matching_version_and_aggregate(argus_db):
+    snapshots = [
+        make_mock_snapshot("v=5.6.1::img=::nov=1::lim=0"),
+        make_mock_snapshot("v=5.6.1::img=::nov=0::lim=0"),
+        make_mock_snapshot("v=::img=::nov=1::lim=0"),       # all-versions aggregate
+        make_mock_snapshot("v=5.7.0::img=::nov=1::lim=0"),  # unrelated version
+    ]
+    with patch("argus.backend.models.web.ReleaseStatsSnapshot.filter") as mock_filter:
+        mock_filter.return_value.all.return_value = snapshots
+        plugin_run_stub(uuid.uuid4(), "5.6.1").invalidate_release_snapshot()
+
+    deleted = [s for s in snapshots if s.delete.called]
+    kept    = [s for s in snapshots if not s.delete.called]
+    assert len(deleted) == 3
+    assert len(kept) == 1
+    assert kept[0].filter_key == "v=5.7.0::img=::nov=1::lim=0"
+
+
+def test_invalidate_release_snapshot_versionless_run_only_wipes_aggregate(argus_db):
+    snapshots = [
+        make_mock_snapshot("v=5.6.1::img=::nov=1::lim=0"),
+        make_mock_snapshot("v=::img=::nov=1::lim=0"),
+        make_mock_snapshot("v=5.7.0::img=::nov=1::lim=0"),
+    ]
+    with patch("argus.backend.models.web.ReleaseStatsSnapshot.filter") as mock_filter:
+        mock_filter.return_value.all.return_value = snapshots
+        plugin_run_stub(uuid.uuid4(), None).invalidate_release_snapshot()
+
+    deleted = [s for s in snapshots if s.delete.called]
+    assert len(deleted) == 1
+    assert deleted[0].filter_key == "v=::img=::nov=1::lim=0"
+
+
+@pytest.mark.parametrize("release_id,version", [
+    (None,        "5.6.1"),  # no release_id — nothing to invalidate
+])
+def test_invalidate_release_snapshot_skips_without_release_id(argus_db, release_id, version):
+    with patch("argus.backend.models.web.ReleaseStatsSnapshot.filter") as mock_filter:
+        plugin_run_stub(release_id, version).invalidate_release_snapshot()
+        mock_filter.assert_not_called()
+
+
+def test_invalidate_release_snapshot_swallows_db_exception(argus_db):
+    with patch("argus.backend.models.web.ReleaseStatsSnapshot.filter", side_effect=Exception("db error")):
+        plugin_run_stub(uuid.uuid4(), "5.6.1").invalidate_release_snapshot()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Integration: index_version written through the real client pipeline
+# ---------------------------------------------------------------------------
+
+@pytest.mark.docker_required
+def test_index_version_written_on_submit_product_version(argus_db, fake_test, client_service, release):
+    run_type, run_req = get_fake_test_run(fake_test)
+    client_service.submit_run(run_type, asdict(run_req))
+    client_service.submit_product_version(run_type, run_req.run_id, "9.9.9-test")
+
+    versions = [r.version for r in ReleaseDistinctVersions.filter(release_id=release.id).all()]
+    assert "9.9.9-test" in versions
+
+
+@pytest.mark.docker_required
+def test_index_version_written_on_finish_run(argus_db, fake_test, client_service, release):
+    run_type, run_req = get_fake_test_run(fake_test)
+    client_service.submit_run(run_type, asdict(run_req))
+    client_service.submit_product_version(run_type, run_req.run_id, "8.8.8-test")
+    client_service.finish_run(run_type, run_req.run_id)
+
+    versions = [r.version for r in ReleaseDistinctVersions.filter(release_id=release.id).all()]
+    assert "8.8.8-test" in versions
+
+
+# ---------------------------------------------------------------------------
+# Unit: index_version guard conditions
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("release_id,version", [
+    (None,         "5.6.1"),  # no release_id
+    (uuid.uuid4(), None),     # no version
+])
+def test_index_version_skipped_when_required_fields_absent(argus_db, release_id, version):
+    with patch("argus.backend.models.web.ReleaseDistinctVersions.create") as mock_create:
+        plugin_run_stub(release_id, version).index_version()
+        mock_create.assert_not_called()
+
+
+def test_index_version_swallows_db_exception(argus_db):
+    with patch("argus.backend.models.web.ReleaseDistinctVersions.create", side_effect=Exception("db error")):
+        plugin_run_stub(uuid.uuid4(), "5.6.1").index_version()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Integration: index_image written through the real client pipeline
+# (SCTTestRun.index_image is SCT-specific; tested via direct static call with
+# a realistic stub since cloud_setup requires a full UDT to be materialised)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("cloud_setup,expected_call", [
+    (None, False),                               # no cloud_setup — nothing indexed
+    (SimpleNamespace(db_node=SimpleNamespace(image_id=None)), False),  # image_id absent
+])
+def test_index_image_skipped_when_image_unavailable(argus_db, cloud_setup, expected_call):
+    from argus.backend.plugins.sct.testrun import SCTTestRun
+    run = SimpleNamespace(release_id=uuid.uuid4(), cloud_setup=cloud_setup)
+    with patch("argus.backend.models.web.ReleaseDistinctImages.create") as mock_create:
+        SCTTestRun.index_image(run)
+        assert mock_create.called == expected_call
+
+
+def test_index_image_writes_row_when_image_present(argus_db):
+    from argus.backend.plugins.sct.testrun import SCTTestRun
+    run = SimpleNamespace(
+        release_id=uuid.uuid4(),
+        cloud_setup=SimpleNamespace(db_node=SimpleNamespace(image_id="ami-abc123")),
+    )
+    with patch("argus.backend.models.web.ReleaseDistinctImages.create") as mock_create:
+        SCTTestRun.index_image(run)
+        mock_create.assert_called_once_with(release_id=run.release_id, image_id="ami-abc123")
+
+
+# ---------------------------------------------------------------------------
+# Integration: snapshot cache miss → write → hit
+# ---------------------------------------------------------------------------
+
+@pytest.mark.docker_required
+def test_snapshot_cache_miss_writes_snapshot_and_hit_returns_consistent_counts(argus_db, fake_test, client_service, release):
+    run_type, run_req = get_fake_test_run(fake_test)
+    client_service.submit_run(run_type, asdict(run_req))
+
+    for row in get_snapshots(release.id):
+        row.delete()
+
+    collector = ReleaseStatsCollector(release.name)
+    result_miss = collector.collect(force=False, include_no_version=True)
+
+    filter_key = snapshot_filter_key(None, None, True, False)
+    assert any(s.filter_key == filter_key for s in get_snapshots(release.id)), \
+        "Snapshot not written after cache miss"
+
+    result_hit = collector.collect(force=False, include_no_version=True)
+    assert set(result_miss.keys()) == set(result_hit.keys())
+    assert result_miss.get("total") == result_hit.get("total")
+    assert result_miss.get("created") == result_hit.get("created")
+
+
+@pytest.mark.docker_required
+def test_snapshot_force_bypasses_stale_cache_and_overwrites(argus_db, fake_test, client_service, release):
+    run_type, run_req = get_fake_test_run(fake_test)
+    client_service.submit_run(run_type, asdict(run_req))
+
+    filter_key = snapshot_filter_key(None, None, True, False)
+    write_snapshot(release.id, filter_key, payload='{"bogus": true, "groups": []}')
+
+    result = ReleaseStatsCollector(release.name).collect(force=True, include_no_version=True)
+
+    assert result != {"bogus": True, "groups": []}
+    snap = ReleaseStatsSnapshot.get(release_id=release.id, filter_key=filter_key)
+    assert json.loads(snap.payload) != {"bogus": True, "groups": []}
+
+
+@pytest.mark.docker_required
+def test_snapshot_force_still_populates_cache_for_subsequent_hits(argus_db, fake_test, client_service, release):
+    run_type, run_req = get_fake_test_run(fake_test)
+    client_service.submit_run(run_type, asdict(run_req))
+
+    for s in get_snapshots(release.id):
+        s.delete()
+
+    collector = ReleaseStatsCollector(release.name)
+    collector.collect(force=True, include_no_version=True)
+
+    filter_key = snapshot_filter_key(None, None, True, False)
+    snap = ReleaseStatsSnapshot.get(release_id=release.id, filter_key=filter_key)
+    assert snap is not None and snap.payload
+
+    result = collector.collect(force=False, include_no_version=True)
+    assert result is not None
+
+
+@pytest.mark.docker_required
+@pytest.mark.parametrize("versions", [("5.2.0", "5.3.0"), ("6.0.0", "6.1.0")])
+def test_different_versions_cached_under_separate_filter_keys(argus_db, fake_test, client_service, release, versions):
+    ver_a, ver_b = versions
+    run_type, req_a = get_fake_test_run(fake_test)
+    run_type, req_b = get_fake_test_run(fake_test)
+    client_service.submit_run(run_type, asdict(req_a))
+    client_service.submit_run(run_type, asdict(req_b))
+    client_service.submit_product_version(run_type, req_a.run_id, ver_a)
+    client_service.submit_product_version(run_type, req_b.run_id, ver_b)
+
+    for s in get_snapshots(release.id):
+        s.delete()
+
+    ReleaseStatsCollector(release.name, release_version=ver_a).collect(force=False, include_no_version=False)
+    ReleaseStatsCollector(release.name, release_version=ver_b).collect(force=False, include_no_version=False)
+
+    keys = {s.filter_key for s in get_snapshots(release.id)}
+    assert snapshot_filter_key(ver_a, None, False, False) in keys
+    assert snapshot_filter_key(ver_b, None, False, False) in keys
+
+
+# ---------------------------------------------------------------------------
+# Integration: targeted invalidation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.docker_required
+def test_finish_run_invalidates_only_matching_version_and_aggregate(argus_db, fake_test, client_service, release):
+    run_type, run_req = get_fake_test_run(fake_test)
+    client_service.submit_run(run_type, asdict(run_req))
+
+    key_561 = snapshot_filter_key("5.6.1", None, True, False)
+    key_570 = snapshot_filter_key("5.7.0", None, True, False)
+    key_all = snapshot_filter_key(None,    None, True, False)
+    for k in (key_561, key_570, key_all):
+        write_snapshot(release.id, k)
+
+    client_service.submit_product_version(run_type, run_req.run_id, "5.6.1")
+    client_service.finish_run(run_type, run_req.run_id)
+
+    remaining = {s.filter_key for s in get_snapshots(release.id)}
+    assert key_561 not in remaining, "5.6.1 snapshot must be invalidated"
+    assert key_all not in remaining, "all-versions snapshot must be invalidated"
+    assert key_570 in remaining,     "5.7.0 snapshot must NOT be invalidated"
+
+
+@pytest.mark.docker_required
+def test_submit_run_invalidates_aggregate_but_not_version_snapshots(argus_db, fake_test, client_service, release):
+    key_561 = snapshot_filter_key("5.6.1", None, True, False)
+    key_570 = snapshot_filter_key("5.7.0", None, True, False)
+    key_all = snapshot_filter_key(None,    None, True, False)
+    for k in (key_561, key_570, key_all):
+        write_snapshot(release.id, k)
+
+    # New run has no version at submit time — only aggregate should be wiped
+    run_type, run_req = get_fake_test_run(fake_test)
+    client_service.submit_run(run_type, asdict(run_req))
+
+    remaining = {s.filter_key for s in get_snapshots(release.id)}
+    assert key_all not in remaining, "all-versions snapshot must be invalidated on submit_run"
+    assert key_561 in remaining,     "5.6.1 snapshot must survive unrelated submit_run"
+    assert key_570 in remaining,     "5.7.0 snapshot must survive unrelated submit_run"
+
+
+@pytest.mark.docker_required
+def test_run_finishing_on_one_release_does_not_invalidate_another(argus_db, fake_test, client_service, release, release_manager_service):
+    release_b = release_manager_service.create_release(f"release_b_{time.time_ns()}", "Release B", False)
+    group_b = release_manager_service.create_group(
+        f"group_b_{time.time_ns()}", "Group B",
+        build_system_id=release_b.name, release_id=str(release_b.id),
+    )
+    test_b = release_manager_service.create_test(
+        f"test_b_{time.time_ns()}", "test_b", "test_b", "test_b",
+        group_id=str(group_b.id), release_id=str(release_b.id), plugin_name="scylla-cluster-tests",
+    )
+
+    key = snapshot_filter_key(None, None, True, False)
+    write_snapshot(release.id,   key, '{"release": "a"}')
+    write_snapshot(release_b.id, key, '{"release": "b"}')
+
+    run_type, run_req = get_fake_test_run(test_b)
+    client_service.submit_run(run_type, asdict(run_req))
+    client_service.finish_run(run_type, run_req.run_id)
+
+    snap_a = ReleaseStatsSnapshot.get(release_id=release.id, filter_key=key)
+    assert json.loads(snap_a.payload) == {"release": "a"}
+
+
+# ---------------------------------------------------------------------------
+# Integration: stale data regression — new run visible after invalidation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.docker_required
+def test_new_run_visible_in_stats_after_cache_invalidation(argus_db, fake_test, client_service, release):
+    for s in get_snapshots(release.id):
+        s.delete()
+
+    def run_count(result: dict) -> int:
+        return sum(
+            len(g.get("tests", [])) for g in result.get("groups", {}).values()
+            if isinstance(g, dict)
+        )
+
+    collector = ReleaseStatsCollector(release.name)
+    count_before = run_count(collector.collect(force=False, include_no_version=True))
+
+    run_type, run_req = get_fake_test_run(fake_test)
+    client_service.submit_run(run_type, asdict(run_req))
+    client_service.finish_run(run_type, run_req.run_id)
+
+    key_all = snapshot_filter_key(None, None, True, False)
+    assert key_all not in {s.filter_key for s in get_snapshots(release.id)}, \
+        "Snapshot must be invalidated after finish_run"
+
+    count_after = run_count(collector.collect(force=False, include_no_version=True))
+    assert count_after >= count_before
+
+    count_cached = run_count(collector.collect(force=False, include_no_version=True))
+    assert count_cached == count_after
+
+
+@pytest.mark.docker_required
+def test_unaffected_version_snapshot_stays_warm_when_other_version_run_finishes(argus_db, fake_test, client_service, release):
+    run_type, req_561 = get_fake_test_run(fake_test)
+    run_type, req_570 = get_fake_test_run(fake_test)
+    client_service.submit_run(run_type, asdict(req_561))
+    client_service.submit_run(run_type, asdict(req_570))
+    client_service.submit_product_version(run_type, req_561.run_id, "5.6.1")
+    client_service.submit_product_version(run_type, req_570.run_id, "5.7.0")
+
+    ReleaseStatsCollector(release.name, release_version="5.6.1").collect(force=False, include_no_version=False)
+    ReleaseStatsCollector(release.name, release_version="5.7.0").collect(force=False, include_no_version=False)
+
+    key_570 = snapshot_filter_key("5.7.0", None, False, False)
+    assert any(s.filter_key == key_570 for s in get_snapshots(release.id)), \
+        "Pre-condition: 5.7.0 snapshot must be warm before test"
+
+    client_service.finish_run(run_type, req_561.run_id)
+
+    remaining = {s.filter_key for s in get_snapshots(release.id)}
+    assert key_570 in remaining, "5.7.0 snapshot must survive 5.6.1 run finishing"
+
+
+# ---------------------------------------------------------------------------
+# Regression: migration idempotency and release cleanup
+# ---------------------------------------------------------------------------
+
+@pytest.mark.docker_required
+def test_backfill_migration_is_idempotent(argus_db, fake_test, client_service, release, migration):
+    run_type, run_req = get_fake_test_run(fake_test)
+    client_service.submit_run(run_type, asdict(run_req))
+    client_service.submit_product_version(run_type, run_req.run_id, "7.7.7-backfill")
+    client_service.finish_run(run_type, run_req.run_id)
+
+    migration.migrate()
+    count_first = len(list(ReleaseDistinctVersions.filter(release_id=release.id).all()))
+
+    migration.migrate()
+    count_second = len(list(ReleaseDistinctVersions.filter(release_id=release.id).all()))
+
+    assert count_first == count_second
+
+
+@pytest.mark.docker_required
+def test_delete_release_removes_indexes_and_snapshots(argus_db, release_manager_service):
+    r = release_manager_service.create_release(f"cleanup_{time.time_ns()}", "Cleanup Test", False)
+    rid = r.id
+
+    ReleaseDistinctVersions.create(release_id=rid, version="1.0.0")
+    ReleaseDistinctImages.create(release_id=rid, image_id="ami-cleanup")
+    write_snapshot(rid, snapshot_filter_key(None, None, True, False))
+
+    release_manager_service.delete_release(str(rid))
+
+    assert list(ReleaseDistinctVersions.filter(release_id=rid).all()) == []
+    assert list(ReleaseDistinctImages.filter(release_id=rid).all()) == []
+    assert get_snapshots(rid) == []

--- a/dev-db/bulk_seed_runs.py
+++ b/dev-db/bulk_seed_runs.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Bulk-seed test runs to reproduce dashboard slowness at scale.
+
+Usage:
+    python dev-db/bulk_seed_runs.py --runs 1000
+    python dev-db/bulk_seed_runs.py --runs 10000
+    python dev-db/bulk_seed_runs.py --runs 1000 --release seed-release
+
+Adds N runs spread evenly across all tests of the given release.
+Runs from the repository root so argus_web.yaml is found automatically.
+"""
+
+import argparse
+import logging
+import os
+import random
+from datetime import UTC, datetime, timedelta
+from time import time
+from uuid import uuid4
+
+os.environ["CQLENG_ALLOW_SCHEMA_MANAGEMENT"] = "1"
+
+from argus.backend.db import ScyllaCluster
+from argus.backend.models.web import ArgusRelease, ArgusTest, User
+from argus.backend.plugins.sct.testrun import SCTTestRun
+from argus.backend.plugins.sct.udt import CloudSetupDetails, CloudNodesInfo
+from argus.backend.util.config import Config
+from argus.common.enums import TestInvestigationStatus, TestStatus
+from argus.backend.cli import sync_models
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+LOGGER = logging.getLogger("bulk_seed")
+
+STATUSES = [
+    (TestStatus.PASSED, TestInvestigationStatus.NOT_INVESTIGATED),
+    (TestStatus.PASSED, TestInvestigationStatus.NOT_INVESTIGATED),
+    (TestStatus.FAILED, TestInvestigationStatus.IN_PROGRESS),
+    (TestStatus.ERROR, TestInvestigationStatus.INVESTIGATED),
+    (TestStatus.ABORTED, TestInvestigationStatus.NOT_INVESTIGATED),
+]
+BRANCHES = ["master", "branch-2025.1", "next", "enterprise", "branch-6.2"]
+COMMITTERS = ["jenkins-bot", "dev-user", "ci-runner", "test-automation"]
+REGIONS = [["us-east-1"], ["eu-west-1"], ["us-west-2"]]
+VERSIONS = [f"6.{minor}.{patch}" for minor in range(3) for patch in range(10)]
+IMAGE_IDS = [
+    "ami-0abcdef1234567890",
+    "ami-0fedcba9876543210",
+    "ami-0a1b2c3d4e5f67890",
+    "ami-0deadbeefcafe0000",
+    "ami-0cafebabe12345678",
+]
+
+
+def setup_db():
+    Config.load_yaml_config()
+    cluster = ScyllaCluster.get()
+    sync_models(cluster.config["SCYLLA_KEYSPACE_NAME"])
+    return cluster
+
+
+def bulk_seed(release_name: str, total_runs: int, batch_log: int = 500):
+    tests = list(ArgusTest.filter(release_id=ArgusRelease.filter(name=release_name).get().id).all())
+    if not tests:
+        LOGGER.error("No tests found for release '%s'", release_name)
+        return
+
+    admin = list(User.filter(username="admin").limit(1))
+    admin_user = admin[0] if admin else None
+
+    LOGGER.info("Found %d tests in release '%s'. Creating %d runs...", len(tests), release_name, total_runs)
+    now = datetime.now(UTC)
+    created = 0
+
+    for i in range(total_runs):
+        test = tests[i % len(tests)]
+        status, inv_status = random.choice(STATUSES)
+        start = now - timedelta(days=random.randint(1, 365), hours=random.randint(0, 23))
+        end = (
+            start + timedelta(minutes=random.randint(30, 360))
+            if status != TestStatus.RUNNING
+            else datetime.fromtimestamp(0, UTC)
+        )
+        build_number = random.randint(1, 9999)
+
+        SCTTestRun.create(
+            build_id=test.build_system_id,
+            start_time=start,
+            id=uuid4(),
+            release_id=test.release_id,
+            group_id=test.group_id,
+            test_id=test.id,
+            assignee=admin_user.id if admin_user else uuid4(),
+            status=status.value,
+            investigation_status=inv_status.value,
+            heartbeat=int(time()),
+            end_time=end,
+            build_job_url=f"http://jenkins.localhost/job/{test.build_system_id}/{build_number}",
+            build_number=build_number,
+            product_version=f"2025.1.{random.randint(0, 9)}",
+            test_name=test.name,
+            scm_revision_id=f"{random.randint(0, 0xFFFFFFFF):08x}{random.randint(0, 0xFFFFFFFF):08x}",
+            branch_name=random.choice(BRANCHES),
+            origin_url="https://github.com/scylladb/scylla-cluster-tests.git",
+            started_by=random.choice(COMMITTERS),
+            config_files=[f"test-cases/{test.name}.yaml"],
+            scylla_version=random.choice(VERSIONS),
+            region_name=random.choice(REGIONS),
+            cloud_setup=CloudSetupDetails(
+                backend="aws",
+                db_node=CloudNodesInfo(
+                    image_id=random.choice(IMAGE_IDS),
+                    instance_type="i3.2xlarge",
+                    node_amount=3,
+                    post_behaviour="keep",
+                ),
+            ),
+        )
+        created += 1
+        if created % batch_log == 0:
+            LOGGER.info("  %d / %d runs created...", created, total_runs)
+
+    LOGGER.info("Done. Created %d runs across %d tests.", created, len(tests))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Bulk-seed test runs for performance testing.")
+    parser.add_argument("--runs", type=int, default=1000, help="Number of runs to create (default: 1000)")
+    parser.add_argument("--release", default="seed-release", help="Release name (default: seed-release)")
+    args = parser.parse_args()
+
+    setup_db()
+    bulk_seed(args.release, args.runs)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/plans/dashboard-performance-optimization.md
+++ b/docs/plans/dashboard-performance-optimization.md
@@ -1,0 +1,496 @@
+# Dashboard Performance Optimization Plan
+
+## Problem Statement
+
+The Argus release dashboard was unacceptably slow. Three endpoints were identified as bottlenecks:
+
+| Endpoint                            | Baseline | Root Cause                                                                                                                   |
+| ----------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `GET /api/v1/release/stats/v2`      | ~1.7s    | Full fan-out scan: `SELECT ... WHERE build_id IN ?` across all plugin tables, streaming up to 500K rows, filtering in Python |
+| `GET /api/v1/release/<id>/versions` | ~2.1s    | GSI scan on `release_id` index across entire SCT table to collect distinct `scylla_version` values                           |
+| `GET /api/v1/release/<id>/images`   | ~2.1s    | Same GSI scan + UDT deserialization of `cloud_setup` on every row to extract `db_node.image_id`                              |
+
+Additionally, the frontend was bypassing any potential caching by hardcoding `force=1` on every stats request.
+
+---
+
+## Changes Implemented
+
+### Lever F — CL=ONE Read Profile for Stats Fan-out
+
+**File:** `argus/backend/plugins/core.py`
+
+`get_stats_for_release()` executes batched async queries (`build_id IN ?`, step size 90). These previously used the default consistency level. Changed to use the `read_fast` execution profile (CL=ONE, dict factory) already defined in `db.py`.
+
+On a single-node local cluster this is a ~5% improvement. On production multi-node RF>1 clusters this avoids coordinator round-trips to a replica, giving a meaningful latency reduction.
+
+```python
+futures.append(cluster.session.execute_async(
+    query=query,
+    parameters=(next_slice,),
+    execution_profile="read_fast",   # CL=ONE
+))
+```
+
+---
+
+### Lever B — Denormalized Index Tables for Versions and Images
+
+**Files:** `argus/backend/models/web.py`, `argus/backend/plugins/sct/testrun.py`, `argus/backend/service/release_manager.py`, `argus/backend/cli.py`
+
+#### Models
+
+Two new Scylla tables are written to incrementally as runs progress:
+
+```
+argus_release_distinct_versions
+  release_id  UUID  (partition key)
+  version     TEXT  (clustering key)
+
+argus_release_distinct_images
+  release_id  UUID  (partition key)
+  image_id    TEXT  (clustering key)
+```
+
+Each partition holds only the distinct values seen for that release. A read is a single partition scan returning O(distinct values) rows — typically 5–50 — instead of scanning the entire plugin table.
+
+#### Write Hooks
+
+Writes are best-effort (exceptions are logged, not raised) and are owned directly by each plugin model, which calls inherited helpers from `PluginModelBase`. No central dispatcher.
+
+| Hook                       | Where called                     | Snapshot invalidation                                              | Versions index                                   | Images index                        |
+| -------------------------- | -------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------ | ----------------------------------- |
+| `submit_run()`             | Each plugin model's `submit_run` | `self.invalidate_release_snapshot()` — new run visible immediately | —                                                | SCT only: `self._index_image(self)` |
+| `submit_product_version()` | Each plugin model's override     | —                                                                  | `self.index_version()` — version arrives mid-run | —                                   |
+| `finish_run()`             | Each plugin model's `finish_run` | `self.invalidate_release_snapshot()` — final status visible        | `self.index_version()` — final version           | SCT only: `self._index_image(self)` |
+
+`if_not_exists().create()` is used for idempotency — re-submitting the same version/image is a no-op at the Scylla level (LWT check). This means writes can be retried safely.
+
+#### Plugin Ownership
+
+Side-effect logic lives on `PluginModelBase` (`argus/backend/plugins/core.py`) as instance methods:
+
+- `invalidate_release_snapshot()` — targeted snapshot invalidation (see Lever A)
+- `index_version()` — writes `scylla_version` to `ReleaseDistinctVersions` (universal — all plugins have `scylla_version`)
+
+SCT-specific logic stays on `SCTTestRun` only:
+
+- `_index_image(run)` — extracts `cloud_setup.db_node.image_id` and writes to `ReleaseDistinctImages` (SCT-only field)
+
+`ClientService` is a thin dispatcher: it calls the plugin method and `save()` only. No side-effect logic lives there.
+
+#### Read Path
+
+`SCTTestRun.get_distinct_product_versions()` and `get_distinct_cloud_images_for_release()` in `argus/backend/plugins/sct/testrun.py` read from the index tables first. If the index partition is empty (pre-backfill or new release), they fall back to the original GSI scan. This makes the transition safe with zero downtime.
+
+#### Cleanup
+
+`delete_release()` in `release_manager.py` deletes the `ReleaseDistinctVersions` and `ReleaseDistinctImages` partitions for the release to prevent orphaned rows.
+
+#### Backfill
+
+`scripts/migration/migration_2026-04-22.py` populates the index tables from existing run data. Pages through the SCT table per release with `fetch_size=2000`. The script checks whether `ReleaseDistinctVersions` already contains any rows; if so it exits immediately (idempotent). Run once after deploying to an existing environment via `uv run scripts/migration/migration_2026-04-22.py`.
+
+**Result:** `/versions` 2.1s → ~7ms, `/images` 2.1s → ~6ms (-99.7%).
+
+---
+
+### Lever A — Release Stats Snapshot Cache
+
+**Files:** `argus/backend/models/web.py`, `argus/backend/service/stats.py`
+
+#### Model
+
+```
+argus_release_stats_snapshot
+  release_id   UUID      (partition key)
+  filter_key   TEXT      (clustering key)
+  payload      TEXT      (JSON blob of ReleaseStats.to_dict())
+  generated_at TIMESTAMP
+```
+
+`filter_key` is a deterministic human-readable string encoding the full set of query parameters:
+
+```
+v=<productVersion>::img=<imageId>::nov=<0|1>::lim=<0|1>
+```
+
+Examples:
+
+- `v=::img=::nov=1::lim=0` — unfiltered, include-no-version
+- `v=5.2::img=::nov=1::lim=0` — version-filtered
+- `v=::img=ami-0abc1234::nov=0::lim=0` — image-filtered
+
+Each distinct filter combination gets its own clustering row within the release's partition. A typical release will have 1–10 rows depending on how many filter combinations users have accessed.
+
+#### Cache Read Path
+
+`ReleaseStatsCollector.collect()` checks for a snapshot before executing the slow fan-out:
+
+```
+if not force:
+    try snapshot = ReleaseStatsSnapshot.get(release_id, filter_key)
+    if hit: return json.loads(snapshot.payload)   # ~5ms
+    # else: fall through to slow path
+```
+
+The `force` parameter bypasses the cache entirely — used by the UI's manual refresh button.
+
+#### Cache Write Path
+
+After computing stats the slow way, the result is serialized using Flask's `ArgusJSONProvider` (which handles UUID, datetime, Cassandra UDTs, and enum keys) and written to the snapshot table:
+
+```python
+ReleaseStatsSnapshot.create(
+    release_id=self.release.id,
+    filter_key=filter_key,
+    payload=current_app.json.dumps(result),
+    generated_at=datetime.utcnow(),
+)
+```
+
+Write failures are caught and logged — a failed snapshot write does not affect the response returned to the caller.
+
+#### Cache Invalidation Architecture
+
+Invalidation is **explicit, event-driven, and version-scoped**. It is triggered by `submit_run()` and `finish_run()` on each plugin model via the inherited `invalidate_release_snapshot()` method on `PluginModelBase`. No TTL, no background refresh, no scheduler.
+
+```
+finish_run() / submit_run()  [on plugin model instance]
+  ├── self.invalidate_release_snapshot()
+  │     ├── fetch all snapshot rows for self.release_id  (single partition scan)
+  │     ├── delete rows where filter_key starts with "v=<self.scylla_version>::"
+  │     └── delete rows where filter_key starts with "v=::"  (all-versions aggregate)
+  ├── self.index_version()                    (on finish_run / submit_product_version)
+  └── self._index_image(self)                 (SCT only, on submit_run / finish_run)
+```
+
+**Targeted invalidation — which rows are deleted:**
+
+When a run with `scylla_version = "5.6.1"` finishes, only two groups of snapshots are invalidated:
+
+1. `v=5.6.1::*` — every cached filter combination for that specific version (different `img`, `nov`, `lim` values)
+2. `v=::*` — the all-versions aggregate view, since it includes data from `5.6.1`
+
+All other version snapshots (`v=5.7.0::*`, `v=5.5.0::*`, etc.) are **left intact**. This means switching to an unaffected version remains fast (~5ms) even when another version is actively receiving new runs.
+
+**Edge case — versionless runs:**
+
+If `scylla_version` is `None` or empty, `version_prefix` becomes `"v=::"`, which is identical to `all_versions_prefix`. Only the all-versions aggregate is invalidated. This is correct — a run with no version does not belong to any specific version bucket.
+
+**Why also invalidate `v=::*`?**
+
+The unfiltered view aggregates all runs regardless of version. Any run finishing on any version changes run counts, statuses, and `last_run` pointers in the all-versions view — so its snapshot must be invalidated too.
+
+**Why NOT invalidate other version snapshots?**
+
+A run for version `5.6.1` does not change the data visible under version `5.7.0`. Leaving other version snapshots intact means:
+
+- Users browsing an unaffected version see ~5ms response times even during active CI on other versions
+- Only the specific version snapshot and the aggregate require recomputation
+- The snapshot partition typically contains O(10) rows; the scan + selective delete is negligible
+
+**Invalidation frequency:**
+
+Invalidation fires at two points per run lifecycle: `submit_run()` (run created) and `finish_run()` (run completed). On an active release, only the snapshots for the run's specific version and the all-versions aggregate are dropped. Snapshots for other versions remain warm.
+
+**Dormant releases:**
+
+A release with no active runs never gets invalidated. All snapshots persist indefinitely and every load is served from cache. This is correct behaviour — the data is not changing.
+
+**`?force=1` semantics:**
+
+The `force` query parameter bypasses the cache read (always recomputes) but still writes a fresh snapshot on completion. This is used by the manual refresh button in the UI. It does not delete the existing snapshot before computing — it simply overwrites it at the end.
+
+---
+
+### Frontend Fix — Remove Hardcoded `force=true`
+
+**File:** `frontend/ReleaseDashboard/TestDashboard.svelte`
+
+`fetchReleaseStats()` and `fetchViewStats()` were hardcoding `force: new Number(true)` in their query params on every request — including the initial page load and the 5-minute auto-refresh interval. This meant every single request bypassed the snapshot cache, and the cache was written but never read.
+
+Fixed to pass the `force` argument through:
+
+```js
+// Before
+force: new Number(true),
+
+// After
+force: new Number(force),   // force defaults to false; refresh button passes true
+```
+
+---
+
+## Architecture Diagram
+
+```
+UI: page load
+  │
+  ├─ GET /api/v1/release/<id>/versions  ──→ ReleaseDistinctVersions (single partition, ~5ms)
+  ├─ GET /api/v1/release/<id>/images    ──→ ReleaseDistinctImages   (single partition, ~5ms)
+  └─ GET /api/v1/release/stats/v2?force=0
+       │
+       ├─ cache HIT  ──→ ReleaseStatsSnapshot.get(release_id, filter_key) → json.loads() ~5ms
+       └─ cache MISS
+            │
+            ├─ fan-out: SELECT ... WHERE build_id IN ? (CL=ONE, batched async) ~1.7s
+            ├─ Python-side filtering (version, image, no-version)
+            ├─ ReleaseStats.collect() + to_dict()
+            ├─ ReleaseStatsSnapshot.create(...)  ← write snapshot
+            └─ return result
+
+CI/CD runner: run finishes (e.g. scylla_version = "5.6.1")
+  └─ POST /api/v1/client/finish_run
+       └─ plugin_model.finish_run()   [PluginModelBase method]
+            ├─ invalidate_release_snapshot()
+            │    ├─ scan release snapshot partition (few rows)
+            │    ├─ delete rows matching "v=5.6.1::*"   ← only this version
+            │    └─ delete rows matching "v=::*"         ← all-versions aggregate
+            ├─ index_version()              ← upsert "5.6.1" to ReleaseDistinctVersions
+            └─ _index_image(self)           ← SCT only: upsert to ReleaseDistinctImages
+```
+
+---
+
+## Benchmark Results
+
+All measurements on a single-node local ScyllaDB cluster with ~500K seeded runs across 6 tests.
+
+| Endpoint        | Before | After (cold) | After (warm) |
+| --------------- | ------ | ------------ | ------------ |
+| `GET /stats/v2` | ~1.7s  | ~1.7s        | **~5–12ms**  |
+| `GET /versions` | ~2.1s  | n/a          | **~7ms**     |
+| `GET /images`   | ~2.1s  | n/a          | **~6ms**     |
+
+Total dashboard API time on a warm cache: **~20ms** vs ~6s before.
+
+---
+
+## Test Plan
+
+### Unit Tests
+
+#### `test_snapshot_filter_key`
+
+Location: `argus/backend/tests/test_stats_snapshot.py`
+
+- Verify `_snapshot_filter_key(None, None, True, False)` returns `"v=::img=::nov=1::lim=0"`
+- Verify `_snapshot_filter_key("5.2", None, True, False)` returns `"v=5.2::img=::nov=1::lim=0"`
+- Verify `_snapshot_filter_key(None, "ami-abc", False, True)` returns `"v=::img=ami-abc::nov=0::lim=1"`
+- Verify two calls with the same args produce identical keys (determinism)
+- Verify two calls with different args produce different keys (no collisions between version/image/nov/limited)
+
+#### `test_invalidate_snapshot_targeted`
+
+Location: `argus/backend/tests/test_stats_snapshot.py`
+
+Test that invalidation only removes snapshots for the run's version and the all-versions aggregate:
+
+- Mock `ReleaseStatsSnapshot.filter().all()` returning rows with keys:
+    - `v=5.6.1::img=::nov=1::lim=0`
+    - `v=5.6.1::img=::nov=0::lim=0`
+    - `v=::img=::nov=1::lim=0` (all-versions aggregate)
+    - `v=5.7.0::img=::nov=1::lim=0`
+- Call `invalidate_release_snapshot()` on a run with `scylla_version="5.6.1"`
+- Assert `.delete()` called exactly 3 times (the two `5.6.1` rows + the all-versions row)
+- Assert the `v=5.7.0::*` row is **not** deleted
+
+#### `test_invalidate_snapshot_no_version`
+
+- Mock rows as above
+- Call `invalidate_release_snapshot()` on a run with `scylla_version=None`
+- Assert only the `v=::*` row is deleted (versionless run only affects aggregate)
+- Assert `v=5.6.1::*` and `v=5.7.0::*` rows are untouched
+
+#### `test_invalidate_snapshot_no_release_id`
+
+- Call `invalidate_release_snapshot()` with `release_id=None` → assert no DB calls made
+
+#### `test_invalidate_snapshot_exception_swallowed`
+
+- Mock `ReleaseStatsSnapshot.filter()` raising an exception → assert function returns without raising, warning logged
+
+#### `test_index_version_helper`
+
+Location: `argus/backend/tests/test_stats_snapshot.py`
+
+- Call with valid `release_id` and `scylla_version` → assert `ReleaseDistinctVersions.if_not_exists().create()` called with correct args
+- Call with `scylla_version=None` → assert no DB calls made
+- Call with `release_id=None` → assert no DB calls made
+- Mock create raising exception → assert function returns without raising
+
+#### `test_index_image_helper`
+
+Location: `argus/backend/tests/test_stats_snapshot.py`
+
+- Mock SCT run with valid `cloud_setup.db_node.image_id` → assert `ReleaseDistinctImages.if_not_exists().create()` called
+- Mock run with `cloud_setup=None` → assert no DB call
+- Mock run with `db_node=None` → assert no DB call
+- Mock run with `image_id=None` → assert no DB call
+
+---
+
+### Integration Tests
+
+#### `test_stats_cache_miss_then_hit`
+
+Location: `argus/backend/tests/test_stats_snapshot.py`
+
+Setup: empty `argus_release_stats_snapshot` table, seeded release with known runs.
+
+1. Call `ReleaseStatsCollector("seed-release").collect(force=False)` → verify slow path executed (full fan-out), snapshot row written to DB
+2. Call same collector again with `force=False` → verify snapshot row read, result identical to step 1, no fan-out queries executed (mock/spy the fan-out)
+3. Assert `ReleaseStatsSnapshot.get(release_id, filter_key)` returns the row written in step 1
+
+#### `test_stats_force_bypasses_cache`
+
+1. Write a stale snapshot row with known bogus payload directly to DB
+2. Call `collect(force=True)` → verify result does NOT match bogus payload (real data returned)
+3. Verify snapshot row overwritten with fresh data
+
+#### `test_stats_force_writes_fresh_snapshot`
+
+1. Call `collect(force=True)` → snapshot written
+2. Call `collect(force=False)` → snapshot served (proves force still populates cache)
+
+#### `test_different_filter_keys_cached_separately`
+
+1. Call `collect(release_version="5.2", force=False)` → snapshot written with key `v=5.2::...`
+2. Call `collect(release_version="5.3", force=False)` → snapshot written with key `v=5.3::...`
+3. Assert two distinct rows exist in `argus_release_stats_snapshot` for the same `release_id`
+4. Assert each returns the correct version-filtered result
+
+#### `test_finish_run_invalidates_only_matching_version`
+
+Location: `argus/backend/tests/test_stats_snapshot.py`
+
+Setup: pre-write snapshot rows for multiple versions:
+
+- `v=5.6.1::img=::nov=1::lim=0`
+- `v=5.7.0::img=::nov=1::lim=0`
+- `v=::img=::nov=1::lim=0`
+
+Steps:
+
+1. Call `finish_run()` with a run carrying `scylla_version="5.6.1"`
+2. Assert `v=5.6.1::*` snapshot is deleted
+3. Assert `v=::*` (all-versions) snapshot is deleted
+4. Assert `v=5.7.0::*` snapshot is **still present** (unaffected version)
+5. Assert `ReleaseDistinctVersions` row written for `5.6.1`
+
+#### `test_submit_run_also_invalidates`
+
+Setup: pre-write snapshot for a release.
+
+1. Call `submit_run()` with a run carrying `scylla_version="5.6.1"`
+2. Assert `v=5.6.1::*` and `v=::*` snapshots are deleted
+3. Assert `v=<other>::*` snapshots are untouched
+
+#### `test_new_run_appears_after_invalidation`
+
+Location: `argus/backend/tests/test_stats_snapshot.py`
+
+This is the critical stale-data test.
+
+1. Seed release with N runs for version `5.6.1` → call `collect(release_version="5.6.1", force=False)` → snapshot written, assert run count = N
+2. Also call `collect(release_version=None, force=False)` → all-versions snapshot written
+3. Submit a new run via `submit_run()` + `finish_run()` with `scylla_version="5.6.1"`
+4. Assert `v=5.6.1::*` and `v=::*` snapshots deleted
+5. Call `collect(release_version="5.6.1", force=False)` → cache miss, recompute
+6. Assert run count in result = N+1 (new run visible)
+7. Call same again → cache hit, run count still N+1
+
+#### `test_unaffected_version_cache_stays_warm`
+
+This is the key regression test for the targeted invalidation improvement.
+
+1. Seed release with runs for `5.6.1` and `5.7.0`
+2. Warm both version snapshots: `collect("5.6.1")`, `collect("5.7.0")`
+3. Submit and finish a new run with `scylla_version="5.6.1"`
+4. Assert `v=5.7.0::*` snapshot is **still present** in DB (was not deleted)
+5. Call `collect("5.7.0", force=False)` → assert it serves from cache (no fan-out), response time < 50ms
+6. Call `collect("5.6.1", force=False)` → assert cache miss (fan-out executed), then snapshot re-written
+
+#### `test_run_from_different_release_does_not_invalidate`
+
+Setup: two releases A and B, each with a snapshot.
+
+1. Call `finish_run()` with a run belonging to release A
+2. Assert release A's matching snapshots are deleted
+3. Assert release B's snapshots are untouched
+
+#### `test_dormant_release_snapshot_persists`
+
+1. Set release `dormant=True`
+2. Call `collect(force=False)` → snapshot written
+3. Do NOT call `finish_run()` (no active runs)
+4. Call `collect(force=False)` 5 more times → assert same snapshot row returned each time (no recompute)
+
+---
+
+### Regression Tests
+
+#### `test_versions_endpoint_returns_correct_values`
+
+Location: `argus/backend/tests/test_argus_service.py`
+
+- Backfill `ReleaseDistinctVersions` with known set
+- Assert `get_distinct_release_versions(release_id)` returns exactly those values, sorted descending
+- Drop all rows from `ReleaseDistinctVersions` partition → assert fallback to GSI scan returns same values
+
+#### `test_images_endpoint_returns_correct_values`
+
+- Backfill `ReleaseDistinctImages` with known set
+- Assert `get_distinct_release_images(release_id)` returns exactly those values
+- Drop all rows from `ReleaseDistinctImages` partition → assert fallback to GSI scan returns same values
+
+#### `test_backfill_idempotent`
+
+- Run `migration_2026-04-22.migrate()` twice on the same data
+- Assert row counts unchanged after second run (second call exits early on idempotency check)
+- Assert no LWT exceptions raised
+
+#### `test_delete_release_cleans_up_indexes`
+
+- Create release with versions/images indexed and a snapshot cached
+- Call `delete_release()`
+- Assert `ReleaseDistinctVersions` partition empty
+- Assert `ReleaseDistinctImages` partition empty
+- Assert `ReleaseStatsSnapshot` partition empty
+
+---
+
+## Operational Notes
+
+### Running the Backfill
+
+After deploying to an existing environment, run the migration script to populate the index tables:
+
+```bash
+CQLENG_ALLOW_SCHEMA_MANAGEMENT=1 uv run scripts/migration/migration_2026-04-22.py
+```
+
+The script checks whether `ReleaseDistinctVersions` already contains any rows and exits immediately if so — safe to re-run at any time.
+
+### Warming the Cache
+
+The snapshot cache is populated lazily on first request. For high-traffic releases, the cache can be pre-warmed after deployment by hitting the stats endpoint once per release:
+
+```bash
+curl "https://<host>/api/v1/release/stats/v2?release=<name>&limited=0&includeNoVersion=1&force=0" \
+  -H "Authorization: token <token>"
+```
+
+### Monitoring Stale Data
+
+Signs that the snapshot cache contains stale data:
+
+- A run completed but does not appear in the dashboard → check `finish_run()` logs for invalidation failures
+- Run count in dashboard does not match DB → manually invalidate with `?force=1` on the stats URL
+
+To force a full cache refresh for a release:
+
+```
+GET /api/v1/release/stats/v2?release=<name>&force=1&limited=0&includeNoVersion=1
+```

--- a/frontend/ReleaseDashboard/TestDashboard.svelte
+++ b/frontend/ReleaseDashboard/TestDashboard.svelte
@@ -251,13 +251,12 @@
         let params = queryString.stringify({
             release: dashboardObject.name,
             limited: new Number(false),
-            force: new Number(true),
+            force: new Number(force),
             imageId: imageId,
             includeNoVersion: new Number(versionsIncludeNoVersion),
             productVersion: productVersion ?? (settings.productVersion || ""),
         });
-        let opts = force ? {cache: "reload"} : {};
-        let response = await fetch(PANEL_MODES.release.statRoute() + "?" + params, opts);
+         let response = await fetch(PANEL_MODES.release.statRoute() + "?" + params);
         let json = await response.json();
         if (json.status != "ok") {
             return false;
@@ -284,14 +283,13 @@
         let params = queryString.stringify({
             viewId: dashboardObject.id,
             limited: new Number(false),
-            force: new Number(true),
+            force: new Number(force),
             widgetId: widgetId,
             imageId: imageId,
             includeNoVersion: new Number(versionsIncludeNoVersion),
             productVersion: productVersion ?? "",
         });
-        let opts = force ? {cache: "reload"} : {};
-        let response = await fetch(PANEL_MODES.view.statRoute() + "?" + params, opts);
+        let response = await fetch(PANEL_MODES.view.statRoute() + "?" + params);
         let json = await response.json();
         if (json.status != "ok") {
             return false;

--- a/scripts/migration/migration_2026-04-22.py
+++ b/scripts/migration/migration_2026-04-22.py
@@ -1,0 +1,56 @@
+import logging
+
+from argus.backend.db import ScyllaCluster
+from argus.backend.models.web import ArgusRelease, ReleaseDistinctVersions, ReleaseDistinctImages
+from argus.backend.plugins.loader import AVAILABLE_PLUGINS
+from argus.backend.util.logsetup import setup_application_logging
+
+
+setup_application_logging(log_level=logging.INFO)
+LOGGER = logging.getLogger(__name__)
+DB = ScyllaCluster.get()
+
+
+def migrate():
+    # Idempotency check: if any row exists in ReleaseDistinctVersions the
+    # backfill has already run — skip entirely.
+    existing = ReleaseDistinctVersions.objects.limit(1).all()
+    if list(existing):
+        LOGGER.info("ReleaseDistinctVersions already populated — skipping migration.")
+        return
+
+    sct_model = AVAILABLE_PLUGINS["scylla-cluster-tests"].model
+    table = sct_model.table_name()
+    releases = list(ArgusRelease.objects.all())
+    LOGGER.info("Backfilling release indexes for %d release(s)...", len(releases))
+
+    for release in releases:
+        LOGGER.info("Processing release: %s (%s)", release.name, release.id)
+
+        # --- Versions ---
+        version_stmt = DB.prepare(f"SELECT scylla_version FROM {table} WHERE release_id = ?")
+        version_stmt.fetch_size = 2000
+        seen_versions = set()
+        for row in DB.session.execute(version_stmt, (release.id,)):
+            v = row["scylla_version"]
+            if v and v not in seen_versions:
+                ReleaseDistinctVersions.create(release_id=release.id, version=v)
+                seen_versions.add(v)
+        LOGGER.info("  versions: %d distinct", len(seen_versions))
+
+        # --- Images ---
+        image_stmt = DB.prepare(f"SELECT cloud_setup FROM {table} WHERE release_id = ?")
+        image_stmt.fetch_size = 2000
+        seen_images = set()
+        for row in DB.session.execute(image_stmt, (release.id,)):
+            image_id = sct_model.get_image(row)
+            if image_id and image_id not in seen_images:
+                ReleaseDistinctImages.create(release_id=release.id, image_id=image_id)
+                seen_images.add(image_id)
+        LOGGER.info("  images:   %d distinct", len(seen_images))
+
+    LOGGER.info("Migration complete.")
+
+
+if __name__ == "__main__":
+    migrate()


### PR DESCRIPTION
## Summary

Three independent performance levers targeting the release dashboard, which was making 3 slow serial API calls on every page load (~6s total). All measurements on a **single-node local ScyllaDB cluster with ~500K seeded runs across 6 tests** (`dev-db/bulk_seed_runs.py`).

| Endpoint | Before | After (cold) | After (warm cache) |
|---|---|---|---|
| `GET /api/v1/release/stats/v2` | ~1.7s | ~1.7s | **~5–12ms** |
| `GET /api/v1/release/<id>/versions` | ~2.1s | ~2.1s | **~7ms** |
| `GET /api/v1/release/<id>/images` | ~2.1s | ~2.1s | **~6ms** |
| **Total dashboard load** | **~6s** | **~6s (first load)** | **~20ms** |

---

### Lever A — CL=ONE read profile for stats fan-out (`39001c9`)

Fan-out queries in `ReleaseStatsCollector` switched from default QUORUM to the `read_fast` CL=ONE execution profile. ~5% improvement on a single-node local cluster; more meaningful on production multi-node RF>1 deployments where it avoids coordinator round-trips to a replica.

### Lever B — Release stats snapshot cache (`15f4891`)

Persist the serialized `ReleaseStats.to_dict()` result in a new `argus_release_stats_snapshot` Scylla table keyed by `(release_id, filter_key)`. Cache hit returns in ~5ms instead of ~1.7s.

Cache invalidation is **explicit, event-driven, and version-scoped**: each plugin model calls `invalidate_release_snapshot()` (inherited from `PluginModelBase`) on `submit_run()` and `finish_run()`. Only snapshots matching the run's `scylla_version` and the all-versions aggregate (`v=::*`) are dropped — other version snapshots stay warm.

Also fixes a bug where `fetchReleaseStats()` and `fetchViewStats()` in the frontend were hardcoding `force: new Number(true)` on every request (including the 5-minute auto-refresh), which meant the cache was written but never read.

### Lever C — Denormalized index tables for distinct versions and images (`1e2735c`)

Two new tables — `argus_release_distinct_versions` and `argus_release_distinct_images` — hold the set of distinct values per release. Version/image filter dropdown reads now hit a single-partition index returning O(5–50) rows instead of scanning the full SCT table (~500K rows, ~2.1s).

Write side-effects are owned by each plugin model (`index_version()` on `PluginModelBase`; SCT-specific `index_image()` on `SCTTestRun`). A fallback to the original GSI scan is in place when the index partition is empty. Backfill via `scripts/migration/migration_2026-04-22.py` (idempotent).

---

## Local testing

### Automated tests

```bash
# Start single-node ScyllaDB
docker compose -f dev-db/docker-compose.yml up -d

# Seed ~500K runs
uv run python dev-db/bulk_seed_runs.py --runs 500000 --release <release-name>

# Run the test suite (31 tests, requires running ScyllaDB)
uv run pytest argus/backend/tests/test_stats_snapshot.py -v
# 31 passed in ~24s

# After deploying to an existing environment, run migration once:
uv run scripts/migration/migration_2026-04-22.py
```

### Manual UI testing

Start the dev server and open a release dashboard with a seeded release:

```bash
FLASK_ENV=development FLASK_APP=argus_backend:start_server CQLENG_ALLOW_SCHEMA_MANAGEMENT=1 uv run flask run
# In a separate terminal:
ROLLUP_ENV=development yarn rollup -c --watch
```

Things to verify in the browser:

1. **Initial page load** — open a release dashboard, observe the stats table loads. Open DevTools Network tab and confirm `stats/v2`, `versions`, and `images` all return quickly on the second load (~5–20ms vs ~2s before).
2. **Version filter** — switch between versions in the filter dropdown; each selection should return near-instantly from cache after the first load.
3. **Refresh button** — click the manual refresh button (⟳); confirm it bypasses the cache (`force=true`) and recomputes fresh stats, then subsequent loads are fast again.
4. **Auto-refresh** — leave the page open for 5+ minutes; confirm the auto-refresh no longer forces a full recompute on every tick (was broken before this fix).
5. **Release deletion** — delete a release via the admin panel and confirm no orphaned rows remain in `argus_release_stats_snapshot`, `argus_release_distinct_versions`, or `argus_release_distinct_images`.

## Files changed

| File | Change |
|---|---|
| `argus/backend/models/web.py` | `ReleaseStatsSnapshot`, `ReleaseDistinctVersions`, `ReleaseDistinctImages` models |
| `argus/backend/plugins/core.py` | `invalidate_release_snapshot()` (version-scoped), `index_version()` on `PluginModelBase` |
| `argus/backend/plugins/sct/testrun.py` | `index_image()` (renamed public); call sites in `submit_run`/`finish_run` |
| `argus/backend/plugins/driver_matrix_tests/model.py` | `submit_run`/`finish_run` side-effect hooks |
| `argus/backend/plugins/generic/model.py` | `submit_run`/`finish_run` side-effect hooks |
| `argus/backend/service/stats.py` | Snapshot read/write in `ReleaseStatsCollector.collect()` |
| `argus/backend/service/client_service.py` | Thin dispatcher — no side-effect logic |
| `argus/backend/service/release_manager.py` | `delete_release()` cleans all three new table types |
| `frontend/ReleaseDashboard/TestDashboard.svelte` | Stop hardcoding `force=true` on every load |
| `scripts/migration/migration_2026-04-22.py` | Idempotent backfill for index tables |
| `dev-db/bulk_seed_runs.py` | Helper script to seed runs for performance testing |
| `argus/backend/tests/test_stats_snapshot.py` | 31 tests (unit + integration via real ScyllaDB) |
| `docs/plans/dashboard-performance-optimization.md` | Design doc |