### PR TITLE
fix(TestRun/Jenkins): Allow Scylla version without hotfix

### DIFF
--- a/frontend/TestRun/Jenkins/SCTParameterWizard.svelte
+++ b/frontend/TestRun/Jenkins/SCTParameterWizard.svelte
@@ -244,7 +244,7 @@
                     validated: true,
                     validationHelpText: "Incorrect version string: Use branch:timestamp format (or branch:latest) OR short version string such as 5.3.0~rc0",
                     validate: function (params) {
-                        const VERSION_RE = /^((?<branch>[\w\d\-.]+:((?<latest>latest)|(?<build_no>\d+)|(?<date>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)))$)|(?<version>(\d+\.\d+\.\d+))(?<rc>((~|-)rc\d))?$/;
+                        const VERSION_RE = /^((?<branch>[\w\d\-.]+:((?<latest>latest)|(?<build_no>\d+)|(?<date>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)))$)|(?<version>(\d+\.\d+(\.\d+)?))(?<rc>((~|-)rc\d))?$/;
                         return !!params[this.internalName] && VERSION_RE.test(params[this.internalName]);
                     },
                     condition: (params, defs) => (defs.scyllaVersion.currentSource == "scylla_version"),


### PR DESCRIPTION
A version like 2026.1 is valid, but the regex rejects it.

Example: 
Rebuilding from Argus fails at validation
https://argus.scylladb.com/tests/scylla-cluster-tests/ff96455a-0602-4ba6-8151-4a250c1e95b3
<img width="1188" height="177" alt="Screenshot 2026-04-23 164324" src="https://github.com/user-attachments/assets/b6f45fc1-8849-48e3-80c6-62f87e86b1c6" />
