### PR TITLE
feature(client): add stable SSH tunnel data-path routing

### DIFF
--- a/argus/client/base.py
+++ b/argus/client/base.py
@@ -53,6 +53,12 @@ class ArgusClient:
     def close(self) -> None:
         self.session.close()
 
+    def __enter__(self) -> "ArgusClient":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
     @property
     def auth_token(self) -> str:
         return self._auth_token
@@ -105,10 +111,19 @@ class ArgusClient:
         }
 
     def get(self, endpoint: str, location_params: dict[str, str] = None, params: dict = None) -> requests.Response:
-        url = self.get_url_for_endpoint(endpoint=endpoint, location_params=location_params)
+        url = self.get_url_for_endpoint(
+            endpoint=endpoint,
+            location_params=location_params
+        )
         LOGGER.debug("GET Request: %s, params: %s", url, params)
-        response = self.session.get(url=url, params=params, headers=self.request_headers, timeout=self._timeout)
+        response = self.session.get(
+            url=url,
+            params=params,
+            headers=self.request_headers,
+            timeout=self._timeout
+        )
         LOGGER.debug("GET Response: %s %s", response.status_code, response.url)
+
         return response
 
     def post(
@@ -118,10 +133,20 @@ class ArgusClient:
         params: dict = None,
         body: dict = None,
     ) -> requests.Response:
-        url = self.get_url_for_endpoint(endpoint=endpoint, location_params=location_params)
+        url = self.get_url_for_endpoint(
+            endpoint=endpoint,
+            location_params=location_params
+        )
         LOGGER.debug("POST Request: %s, params: %s, body: %s", url, params, body)
-        response = self.session.post(url=url, params=params, json=body, headers=self.request_headers, timeout=self._timeout)
+        response = self.session.post(
+            url=url,
+            params=params,
+            json=body,
+            headers=self.request_headers,
+            timeout=self._timeout
+        )
         LOGGER.debug("POST Response: %s %s", response.status_code, response.url)
+
         return response
 
     def submit_run(self, run_type: str, run_body: dict) -> requests.Response:

--- a/argus/client/base.py
+++ b/argus/client/base.py
@@ -1,31 +1,18 @@
 import re
 import logging
-import os
-import threading
-import time
-import atexit
 from dataclasses import asdict
 from typing import Any, Type
 from uuid import UUID
 
 import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
 
 from argus.common.enums import TestStatus
-from argus.client.tunnel import (
-    SSHTunnel,
-    TunnelConfig,
-    delete_cached_tunnel_state,
-    resolve_tunnel_config_with_reason,
-)
+from argus.client.session import create_session
 from argus.client.generic_result import GenericResultTable
 from argus.client.sct.types import LogLink
 
 JSON = dict[str, Any] | list[Any] | int | str | float | bool | Type[None]
 LOGGER = logging.getLogger(__name__)
-TUNNEL_COOLDOWN_SECONDS = 30
-DEFAULT_TUNNEL_MONITOR_INTERVAL_SECONDS = 5.0
 
 
 class ArgusClientError(Exception):
@@ -50,240 +37,21 @@ class ArgusClient:
     def __init__(self, auth_token: str, base_url: str, api_version="v1", extra_headers: dict | None = None,
                  timeout: int = 60, max_retries: int = 3, use_tunnel: bool | None = None) -> None:
         self._auth_token = auth_token
-        self._original_base_url = base_url
         self._base_url = base_url
         self._api_ver = api_version
         self._timeout = timeout
-        self._use_tunnel = self._resolve_use_tunnel(use_tunnel)
-        self._tunnel: SSHTunnel | None = None
-        self._tunnel_config: TunnelConfig | None = None
-        self._tunnel_warning_emitted = False
-        self._last_tunnel_failure_reason: str | None = None
-        self._tunnel_disabled_until = 0.0
-        self._tunnel_lock = threading.RLock()
-        self._monitor_stop_event = threading.Event()
-        self._monitor_thread: threading.Thread | None = None
-        self._tunnel_monitor_interval = self._resolve_tunnel_monitor_interval()
-        self.session = requests.Session()
-
-        # Configure retry strategy
-        retry_strategy = Retry(
-            total=max_retries,
-            connect=max_retries,
-            read=max_retries,
-            status=0,
-            backoff_factor=1,
-            status_forcelist=(),
-            allowed_methods=["GET", "POST"],
+        self.session = create_session(
+            auth_token=auth_token,
+            base_url=base_url,
+            use_tunnel=use_tunnel,
+            max_retries=max_retries,
         )
-
-        # Mount adapter with retry strategy for both http and https
-        adapter = HTTPAdapter(max_retries=retry_strategy)
-        self.session.mount("http://", adapter)
-        self.session.mount("https://", adapter)
 
         if extra_headers:
             self.session.headers.update(extra_headers)
 
-        if self._use_tunnel:
-            self._start_tunnel_monitor()
-
-    @staticmethod
-    def _resolve_use_tunnel(use_tunnel: bool | None) -> bool:
-        if use_tunnel is not None:
-            return use_tunnel
-        return os.environ.get("ARGUS_USE_TUNNEL", "").strip().lower() in ("1", "true", "yes", "on")
-
-    def _resolve_tunnel_monitor_interval(self) -> float:
-        raw_value = os.environ.get("ARGUS_TUNNEL_MONITOR_INTERVAL")
-        if raw_value is None:
-            return DEFAULT_TUNNEL_MONITOR_INTERVAL_SECONDS
-        try:
-            interval = float(raw_value)
-            if interval <= 0:
-                raise ValueError("interval must be positive")
-            return interval
-        except ValueError:
-            LOGGER.warning(
-                "Invalid ARGUS_TUNNEL_MONITOR_INTERVAL=%s, using default %.1fs",
-                raw_value,
-                DEFAULT_TUNNEL_MONITOR_INTERVAL_SECONDS,
-            )
-            return DEFAULT_TUNNEL_MONITOR_INTERVAL_SECONDS
-
-    def _start_tunnel_monitor(self) -> None:
-        if self._monitor_thread and self._monitor_thread.is_alive():
-            return
-        self._monitor_stop_event.clear()
-        self._monitor_thread = threading.Thread(
-            target=self._tunnel_monitor_loop,
-            name="argus-tunnel-monitor",
-            daemon=True,
-        )
-        self._monitor_thread.start()
-        atexit.register(self._stop_tunnel_monitor)
-
-    def _stop_tunnel_monitor(self) -> None:
-        self._monitor_stop_event.set()
-        monitor = self._monitor_thread
-        if monitor and monitor.is_alive() and monitor is not threading.current_thread():
-            monitor.join(timeout=1.0)
-
-    def _tunnel_monitor_loop(self) -> None:
-        while not self._monitor_stop_event.wait(self._tunnel_monitor_interval):
-            try:
-                self._monitor_tunnel_health_once()
-            except Exception:  # noqa: BLE001
-                LOGGER.debug("SSH tunnel monitor loop failed", exc_info=True)
-
-    def _monitor_tunnel_health_once(self) -> None:
-        if not self._use_tunnel:
-            return
-
-        tunnel = self._tunnel
-        if tunnel is None:
-            return
-
-        if tunnel.is_alive():
-            return
-
-        LOGGER.warning("SSH tunnel monitor detected dead tunnel; attempting reconnection")
-        self._ensure_tunnel()
-
-    def _is_using_tunnel_base_url(self) -> bool:
-        return self._base_url.startswith("http://127.0.0.1:")
-
-    def _warn_and_backoff_tunnel(self, reason: str) -> None:
-        with self._tunnel_lock:
-            self._last_tunnel_failure_reason = reason
-            if not self._tunnel_warning_emitted:
-                LOGGER.warning(
-                    "SSH tunnel unavailable (%s); falling back to direct connection: %s",
-                    reason,
-                    self._original_base_url,
-                )
-                self._tunnel_warning_emitted = True
-
-            if self._tunnel:
-                self._tunnel.shutdown()
-
-            self._tunnel = None
-            self._tunnel_config = None
-            self._base_url = self._original_base_url
-            self._tunnel_disabled_until = time.monotonic() + TUNNEL_COOLDOWN_SECONDS
-
-    def _ensure_tunnel(self) -> None:
-        with self._tunnel_lock:
-            if not self._use_tunnel:
-                return
-
-            if time.monotonic() < self._tunnel_disabled_until:
-                return
-
-            if self._tunnel and self._tunnel.is_alive() and self._tunnel.local_port is not None:
-                self._base_url = f"http://127.0.0.1:{self._tunnel.local_port}"
-                return
-
-            if self._tunnel and self._tunnel_config:
-                reconnected_port, reconnect_reason = self._tunnel.reconnect(self._tunnel_config)
-                if reconnected_port is not None:
-                    self._base_url = f"http://127.0.0.1:{reconnected_port}"
-                    self._tunnel_warning_emitted = False
-                    self._last_tunnel_failure_reason = None
-                    return
-                if reconnect_reason:
-                    LOGGER.warning("SSH tunnel reconnect failed: %s", reconnect_reason)
-
-            force_refresh = self._tunnel is not None
-            config, config_reason = resolve_tunnel_config_with_reason(
-                auth_token=self._auth_token,
-                base_url=self._original_base_url,
-                force_refresh=force_refresh,
-            )
-            if config is None:
-                delete_cached_tunnel_state()
-                reason = config_reason or "failed to resolve tunnel configuration"
-                self._warn_and_backoff_tunnel(reason)
-                return
-
-            tunnel = SSHTunnel()
-            local_port, establish_reason = tunnel.establish(config)
-
-            if local_port is None and not force_refresh:
-                config, config_reason = resolve_tunnel_config_with_reason(
-                    auth_token=self._auth_token,
-                    base_url=self._original_base_url,
-                    force_refresh=True,
-                )
-                if config is not None:
-                    local_port, establish_reason = tunnel.establish(config)
-                else:
-                    establish_reason = config_reason
-
-            if local_port is None:
-                delete_cached_tunnel_state()
-                reason = establish_reason or "failed to establish tunnel"
-                self._warn_and_backoff_tunnel(reason)
-                return
-
-            self._tunnel = tunnel
-            self._tunnel_config = config
-            self._base_url = f"http://127.0.0.1:{local_port}"
-            self._tunnel_warning_emitted = False
-            self._last_tunnel_failure_reason = None
-            self._tunnel_disabled_until = 0.0
-
     def close(self) -> None:
-        self._stop_tunnel_monitor()
-        with self._tunnel_lock:
-            if self._tunnel:
-                self._tunnel.shutdown()
-                self._tunnel = None
-                self._tunnel_config = None
         self.session.close()
-
-    def _request_with_tunnel_recovery(
-        self,
-        method: str,
-        endpoint: str,
-        location_params: dict | None,
-        params: dict | None,
-        body: dict | None,
-    ) -> requests.Response:
-        url = self.get_url_for_endpoint(endpoint=endpoint, location_params=location_params)
-        request_kwargs = {
-            "url": url,
-            "params": params,
-            "headers": self.request_headers,
-            "timeout": self._timeout,
-        }
-        if method == "POST":
-            request_kwargs["json"] = body
-
-        request_fn = self.session.get if method == "GET" else self.session.post
-
-        try:
-            return request_fn(**request_kwargs)
-        except requests.ConnectionError as exc:
-            if not self._use_tunnel or not self._is_using_tunnel_base_url():
-                raise
-
-            LOGGER.warning(
-                "%s request through SSH tunnel failed (%s); attempting reconnect and one retry",
-                method,
-                exc,
-            )
-
-            self._ensure_tunnel()
-            retry_url = self.get_url_for_endpoint(endpoint=endpoint, location_params=location_params)
-            request_kwargs["url"] = retry_url
-
-            try:
-                return request_fn(**request_kwargs)
-            except requests.ConnectionError as retry_exc:
-                self._warn_and_backoff_tunnel(f"request retry failed: {retry_exc}")
-                request_kwargs["url"] = self.get_url_for_endpoint(endpoint=endpoint, location_params=location_params)
-                return request_fn(**request_kwargs)
 
     @property
     def auth_token(self) -> str:
@@ -337,18 +105,10 @@ class ArgusClient:
         }
 
     def get(self, endpoint: str, location_params: dict[str, str] = None, params: dict = None) -> requests.Response:
-        self._ensure_tunnel()
         url = self.get_url_for_endpoint(endpoint=endpoint, location_params=location_params)
         LOGGER.debug("GET Request: %s, params: %s", url, params)
-        response = self._request_with_tunnel_recovery(
-            method="GET",
-            endpoint=endpoint,
-            location_params=location_params,
-            params=params,
-            body=None,
-        )
+        response = self.session.get(url=url, params=params, headers=self.request_headers, timeout=self._timeout)
         LOGGER.debug("GET Response: %s %s", response.status_code, response.url)
-
         return response
 
     def post(
@@ -358,18 +118,10 @@ class ArgusClient:
         params: dict = None,
         body: dict = None,
     ) -> requests.Response:
-        self._ensure_tunnel()
         url = self.get_url_for_endpoint(endpoint=endpoint, location_params=location_params)
         LOGGER.debug("POST Request: %s, params: %s, body: %s", url, params, body)
-        response = self._request_with_tunnel_recovery(
-            method="POST",
-            endpoint=endpoint,
-            location_params=location_params,
-            params=params,
-            body=body,
-        )
+        response = self.session.post(url=url, params=params, json=body, headers=self.request_headers, timeout=self._timeout)
         LOGGER.debug("POST Response: %s %s", response.status_code, response.url)
-
         return response
 
     def submit_run(self, run_type: str, run_body: dict) -> requests.Response:

--- a/argus/client/base.py
+++ b/argus/client/base.py
@@ -1,5 +1,7 @@
 import re
 import logging
+import os
+import time
 from dataclasses import asdict
 from typing import Any, Type
 from uuid import UUID
@@ -9,11 +11,18 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from argus.common.enums import TestStatus
+from argus.client.tunnel import (
+    SSHTunnel,
+    TunnelConfig,
+    delete_cached_tunnel_state,
+    resolve_tunnel_config_with_reason,
+)
 from argus.client.generic_result import GenericResultTable
 from argus.client.sct.types import LogLink
 
 JSON = dict[str, Any] | list[Any] | int | str | float | bool | Type[None]
 LOGGER = logging.getLogger(__name__)
+TUNNEL_COOLDOWN_SECONDS = 30
 
 
 class ArgusClientError(Exception):
@@ -36,11 +45,18 @@ class ArgusClient:
         FINALIZE = "/testrun/$type/$id/finalize"
 
     def __init__(self, auth_token: str, base_url: str, api_version="v1", extra_headers: dict | None = None,
-                 timeout: int = 60, max_retries: int = 3) -> None:
+                 timeout: int = 60, max_retries: int = 3, use_tunnel: bool | None = None) -> None:
         self._auth_token = auth_token
+        self._original_base_url = base_url
         self._base_url = base_url
         self._api_ver = api_version
         self._timeout = timeout
+        self._use_tunnel = self._resolve_use_tunnel(use_tunnel)
+        self._tunnel: SSHTunnel | None = None
+        self._tunnel_config: TunnelConfig | None = None
+        self._tunnel_warning_emitted = False
+        self._last_tunnel_failure_reason: str | None = None
+        self._tunnel_disabled_until = 0.0
         self.session = requests.Session()
 
         # Configure retry strategy
@@ -61,6 +77,136 @@ class ArgusClient:
 
         if extra_headers:
             self.session.headers.update(extra_headers)
+
+    @staticmethod
+    def _resolve_use_tunnel(use_tunnel: bool | None) -> bool:
+        if use_tunnel is not None:
+            return use_tunnel
+        return os.environ.get("ARGUS_USE_TUNNEL", "").strip().lower() in ("1", "true", "yes", "on")
+
+    def _is_using_tunnel_base_url(self) -> bool:
+        return self._base_url.startswith("http://127.0.0.1:")
+
+    def _warn_and_backoff_tunnel(self, reason: str) -> None:
+        self._last_tunnel_failure_reason = reason
+        if not self._tunnel_warning_emitted:
+            LOGGER.warning(
+                "SSH tunnel unavailable (%s); falling back to direct connection: %s",
+                reason,
+                self._original_base_url,
+            )
+            self._tunnel_warning_emitted = True
+
+        if self._tunnel:
+            self._tunnel.shutdown()
+
+        self._tunnel = None
+        self._tunnel_config = None
+        self._base_url = self._original_base_url
+        self._tunnel_disabled_until = time.monotonic() + TUNNEL_COOLDOWN_SECONDS
+
+    def _ensure_tunnel(self) -> None:
+        if not self._use_tunnel:
+            return
+
+        if time.monotonic() < self._tunnel_disabled_until:
+            return
+
+        if self._tunnel and self._tunnel.is_alive() and self._tunnel.local_port is not None:
+            self._base_url = f"http://127.0.0.1:{self._tunnel.local_port}"
+            return
+
+        if self._tunnel and self._tunnel_config:
+            reconnected_port, reconnect_reason = self._tunnel.reconnect(self._tunnel_config)
+            if reconnected_port is not None:
+                self._base_url = f"http://127.0.0.1:{reconnected_port}"
+                self._tunnel_warning_emitted = False
+                self._last_tunnel_failure_reason = None
+                return
+            if reconnect_reason:
+                LOGGER.warning("SSH tunnel reconnect failed: %s", reconnect_reason)
+
+        force_refresh = self._tunnel is not None
+        config, config_reason = resolve_tunnel_config_with_reason(
+            auth_token=self._auth_token,
+            base_url=self._original_base_url,
+            force_refresh=force_refresh,
+        )
+        if config is None:
+            delete_cached_tunnel_state()
+            reason = config_reason or "failed to resolve tunnel configuration"
+            self._warn_and_backoff_tunnel(reason)
+            return
+
+        tunnel = SSHTunnel()
+        local_port, establish_reason = tunnel.establish(config)
+
+        if local_port is None and not force_refresh:
+            config, config_reason = resolve_tunnel_config_with_reason(
+                auth_token=self._auth_token,
+                base_url=self._original_base_url,
+                force_refresh=True,
+            )
+            if config is not None:
+                local_port, establish_reason = tunnel.establish(config)
+            else:
+                establish_reason = config_reason
+
+        if local_port is None:
+            delete_cached_tunnel_state()
+            reason = establish_reason or "failed to establish tunnel"
+            self._warn_and_backoff_tunnel(reason)
+            return
+
+        self._tunnel = tunnel
+        self._tunnel_config = config
+        self._base_url = f"http://127.0.0.1:{local_port}"
+        self._tunnel_warning_emitted = False
+        self._last_tunnel_failure_reason = None
+        self._tunnel_disabled_until = 0.0
+
+    def _request_with_tunnel_recovery(
+        self,
+        method: str,
+        endpoint: str,
+        location_params: dict | None,
+        params: dict | None,
+        body: dict | None,
+    ) -> requests.Response:
+        url = self.get_url_for_endpoint(endpoint=endpoint, location_params=location_params)
+        request_kwargs = {
+            "url": url,
+            "params": params,
+            "headers": self.request_headers,
+            "timeout": self._timeout,
+        }
+        if method == "POST":
+            request_kwargs["json"] = body
+
+        request_fn = self.session.get if method == "GET" else self.session.post
+
+        try:
+            return request_fn(**request_kwargs)
+        except requests.ConnectionError as exc:
+            if not self._use_tunnel or not self._is_using_tunnel_base_url():
+                raise
+
+            LOGGER.warning(
+                "%s request through SSH tunnel failed (%s); attempting reconnect and one retry",
+                method,
+                exc,
+            )
+
+            self._ensure_tunnel()
+            retry_url = self.get_url_for_endpoint(endpoint=endpoint, location_params=location_params)
+            request_kwargs["url"] = retry_url
+
+            try:
+                return request_fn(**request_kwargs)
+            except requests.ConnectionError as retry_exc:
+                self._warn_and_backoff_tunnel(f"request retry failed: {retry_exc}")
+                request_kwargs["url"] = self.get_url_for_endpoint(endpoint=endpoint, location_params=location_params)
+                return request_fn(**request_kwargs)
 
     @property
     def auth_token(self) -> str:
@@ -114,16 +260,15 @@ class ArgusClient:
         }
 
     def get(self, endpoint: str, location_params: dict[str, str] = None, params: dict = None) -> requests.Response:
-        url = self.get_url_for_endpoint(
-            endpoint=endpoint,
-            location_params=location_params
-        )
+        self._ensure_tunnel()
+        url = self.get_url_for_endpoint(endpoint=endpoint, location_params=location_params)
         LOGGER.debug("GET Request: %s, params: %s", url, params)
-        response = self.session.get(
-            url=url,
+        response = self._request_with_tunnel_recovery(
+            method="GET",
+            endpoint=endpoint,
+            location_params=location_params,
             params=params,
-            headers=self.request_headers,
-            timeout=self._timeout
+            body=None,
         )
         LOGGER.debug("GET Response: %s %s", response.status_code, response.url)
 
@@ -136,17 +281,15 @@ class ArgusClient:
         params: dict = None,
         body: dict = None,
     ) -> requests.Response:
-        url = self.get_url_for_endpoint(
-            endpoint=endpoint,
-            location_params=location_params
-        )
+        self._ensure_tunnel()
+        url = self.get_url_for_endpoint(endpoint=endpoint, location_params=location_params)
         LOGGER.debug("POST Request: %s, params: %s, body: %s", url, params, body)
-        response = self.session.post(
-            url=url,
+        response = self._request_with_tunnel_recovery(
+            method="POST",
+            endpoint=endpoint,
+            location_params=location_params,
             params=params,
-            json=body,
-            headers=self.request_headers,
-            timeout=self._timeout
+            body=body,
         )
         LOGGER.debug("POST Response: %s %s", response.status_code, response.url)
 

--- a/argus/client/base.py
+++ b/argus/client/base.py
@@ -1,7 +1,9 @@
 import re
 import logging
 import os
+import threading
 import time
+import atexit
 from dataclasses import asdict
 from typing import Any, Type
 from uuid import UUID
@@ -23,6 +25,7 @@ from argus.client.sct.types import LogLink
 JSON = dict[str, Any] | list[Any] | int | str | float | bool | Type[None]
 LOGGER = logging.getLogger(__name__)
 TUNNEL_COOLDOWN_SECONDS = 30
+DEFAULT_TUNNEL_MONITOR_INTERVAL_SECONDS = 5.0
 
 
 class ArgusClientError(Exception):
@@ -57,6 +60,10 @@ class ArgusClient:
         self._tunnel_warning_emitted = False
         self._last_tunnel_failure_reason: str | None = None
         self._tunnel_disabled_until = 0.0
+        self._tunnel_lock = threading.RLock()
+        self._monitor_stop_event = threading.Event()
+        self._monitor_thread: threading.Thread | None = None
+        self._tunnel_monitor_interval = self._resolve_tunnel_monitor_interval()
         self.session = requests.Session()
 
         # Configure retry strategy
@@ -78,92 +85,162 @@ class ArgusClient:
         if extra_headers:
             self.session.headers.update(extra_headers)
 
+        if self._use_tunnel:
+            self._start_tunnel_monitor()
+
     @staticmethod
     def _resolve_use_tunnel(use_tunnel: bool | None) -> bool:
         if use_tunnel is not None:
             return use_tunnel
         return os.environ.get("ARGUS_USE_TUNNEL", "").strip().lower() in ("1", "true", "yes", "on")
 
+    def _resolve_tunnel_monitor_interval(self) -> float:
+        raw_value = os.environ.get("ARGUS_TUNNEL_MONITOR_INTERVAL")
+        if raw_value is None:
+            return DEFAULT_TUNNEL_MONITOR_INTERVAL_SECONDS
+        try:
+            interval = float(raw_value)
+            if interval <= 0:
+                raise ValueError("interval must be positive")
+            return interval
+        except ValueError:
+            LOGGER.warning(
+                "Invalid ARGUS_TUNNEL_MONITOR_INTERVAL=%s, using default %.1fs",
+                raw_value,
+                DEFAULT_TUNNEL_MONITOR_INTERVAL_SECONDS,
+            )
+            return DEFAULT_TUNNEL_MONITOR_INTERVAL_SECONDS
+
+    def _start_tunnel_monitor(self) -> None:
+        if self._monitor_thread and self._monitor_thread.is_alive():
+            return
+        self._monitor_stop_event.clear()
+        self._monitor_thread = threading.Thread(
+            target=self._tunnel_monitor_loop,
+            name="argus-tunnel-monitor",
+            daemon=True,
+        )
+        self._monitor_thread.start()
+        atexit.register(self._stop_tunnel_monitor)
+
+    def _stop_tunnel_monitor(self) -> None:
+        self._monitor_stop_event.set()
+        monitor = self._monitor_thread
+        if monitor and monitor.is_alive() and monitor is not threading.current_thread():
+            monitor.join(timeout=1.0)
+
+    def _tunnel_monitor_loop(self) -> None:
+        while not self._monitor_stop_event.wait(self._tunnel_monitor_interval):
+            try:
+                self._monitor_tunnel_health_once()
+            except Exception:  # noqa: BLE001
+                LOGGER.debug("SSH tunnel monitor loop failed", exc_info=True)
+
+    def _monitor_tunnel_health_once(self) -> None:
+        if not self._use_tunnel:
+            return
+
+        tunnel = self._tunnel
+        if tunnel is None:
+            return
+
+        if tunnel.is_alive():
+            return
+
+        LOGGER.warning("SSH tunnel monitor detected dead tunnel; attempting reconnection")
+        self._ensure_tunnel()
+
     def _is_using_tunnel_base_url(self) -> bool:
         return self._base_url.startswith("http://127.0.0.1:")
 
     def _warn_and_backoff_tunnel(self, reason: str) -> None:
-        self._last_tunnel_failure_reason = reason
-        if not self._tunnel_warning_emitted:
-            LOGGER.warning(
-                "SSH tunnel unavailable (%s); falling back to direct connection: %s",
-                reason,
-                self._original_base_url,
-            )
-            self._tunnel_warning_emitted = True
+        with self._tunnel_lock:
+            self._last_tunnel_failure_reason = reason
+            if not self._tunnel_warning_emitted:
+                LOGGER.warning(
+                    "SSH tunnel unavailable (%s); falling back to direct connection: %s",
+                    reason,
+                    self._original_base_url,
+                )
+                self._tunnel_warning_emitted = True
 
-        if self._tunnel:
-            self._tunnel.shutdown()
+            if self._tunnel:
+                self._tunnel.shutdown()
 
-        self._tunnel = None
-        self._tunnel_config = None
-        self._base_url = self._original_base_url
-        self._tunnel_disabled_until = time.monotonic() + TUNNEL_COOLDOWN_SECONDS
+            self._tunnel = None
+            self._tunnel_config = None
+            self._base_url = self._original_base_url
+            self._tunnel_disabled_until = time.monotonic() + TUNNEL_COOLDOWN_SECONDS
 
     def _ensure_tunnel(self) -> None:
-        if not self._use_tunnel:
-            return
-
-        if time.monotonic() < self._tunnel_disabled_until:
-            return
-
-        if self._tunnel and self._tunnel.is_alive() and self._tunnel.local_port is not None:
-            self._base_url = f"http://127.0.0.1:{self._tunnel.local_port}"
-            return
-
-        if self._tunnel and self._tunnel_config:
-            reconnected_port, reconnect_reason = self._tunnel.reconnect(self._tunnel_config)
-            if reconnected_port is not None:
-                self._base_url = f"http://127.0.0.1:{reconnected_port}"
-                self._tunnel_warning_emitted = False
-                self._last_tunnel_failure_reason = None
+        with self._tunnel_lock:
+            if not self._use_tunnel:
                 return
-            if reconnect_reason:
-                LOGGER.warning("SSH tunnel reconnect failed: %s", reconnect_reason)
 
-        force_refresh = self._tunnel is not None
-        config, config_reason = resolve_tunnel_config_with_reason(
-            auth_token=self._auth_token,
-            base_url=self._original_base_url,
-            force_refresh=force_refresh,
-        )
-        if config is None:
-            delete_cached_tunnel_state()
-            reason = config_reason or "failed to resolve tunnel configuration"
-            self._warn_and_backoff_tunnel(reason)
-            return
+            if time.monotonic() < self._tunnel_disabled_until:
+                return
 
-        tunnel = SSHTunnel()
-        local_port, establish_reason = tunnel.establish(config)
+            if self._tunnel and self._tunnel.is_alive() and self._tunnel.local_port is not None:
+                self._base_url = f"http://127.0.0.1:{self._tunnel.local_port}"
+                return
 
-        if local_port is None and not force_refresh:
+            if self._tunnel and self._tunnel_config:
+                reconnected_port, reconnect_reason = self._tunnel.reconnect(self._tunnel_config)
+                if reconnected_port is not None:
+                    self._base_url = f"http://127.0.0.1:{reconnected_port}"
+                    self._tunnel_warning_emitted = False
+                    self._last_tunnel_failure_reason = None
+                    return
+                if reconnect_reason:
+                    LOGGER.warning("SSH tunnel reconnect failed: %s", reconnect_reason)
+
+            force_refresh = self._tunnel is not None
             config, config_reason = resolve_tunnel_config_with_reason(
                 auth_token=self._auth_token,
                 base_url=self._original_base_url,
-                force_refresh=True,
+                force_refresh=force_refresh,
             )
-            if config is not None:
-                local_port, establish_reason = tunnel.establish(config)
-            else:
-                establish_reason = config_reason
+            if config is None:
+                delete_cached_tunnel_state()
+                reason = config_reason or "failed to resolve tunnel configuration"
+                self._warn_and_backoff_tunnel(reason)
+                return
 
-        if local_port is None:
-            delete_cached_tunnel_state()
-            reason = establish_reason or "failed to establish tunnel"
-            self._warn_and_backoff_tunnel(reason)
-            return
+            tunnel = SSHTunnel()
+            local_port, establish_reason = tunnel.establish(config)
 
-        self._tunnel = tunnel
-        self._tunnel_config = config
-        self._base_url = f"http://127.0.0.1:{local_port}"
-        self._tunnel_warning_emitted = False
-        self._last_tunnel_failure_reason = None
-        self._tunnel_disabled_until = 0.0
+            if local_port is None and not force_refresh:
+                config, config_reason = resolve_tunnel_config_with_reason(
+                    auth_token=self._auth_token,
+                    base_url=self._original_base_url,
+                    force_refresh=True,
+                )
+                if config is not None:
+                    local_port, establish_reason = tunnel.establish(config)
+                else:
+                    establish_reason = config_reason
+
+            if local_port is None:
+                delete_cached_tunnel_state()
+                reason = establish_reason or "failed to establish tunnel"
+                self._warn_and_backoff_tunnel(reason)
+                return
+
+            self._tunnel = tunnel
+            self._tunnel_config = config
+            self._base_url = f"http://127.0.0.1:{local_port}"
+            self._tunnel_warning_emitted = False
+            self._last_tunnel_failure_reason = None
+            self._tunnel_disabled_until = 0.0
+
+    def close(self) -> None:
+        self._stop_tunnel_monitor()
+        with self._tunnel_lock:
+            if self._tunnel:
+                self._tunnel.shutdown()
+                self._tunnel = None
+                self._tunnel_config = None
+        self.session.close()
 
     def _request_with_tunnel_recovery(
         self,

--- a/argus/client/driver_matrix_tests/cli.py
+++ b/argus/client/driver_matrix_tests/cli.py
@@ -17,35 +17,37 @@ def cli():
 
 
 def _submit_driver_result_internal(api_key: str, base_url: str, run_id: str, metadata_path: str,
-                                   extra_headers: dict):
+                                   extra_headers: dict, use_tunnel: bool | None = None):
     metadata = json.loads(Path(metadata_path).read_text(encoding="utf-8"))
     LOGGER.info("Submitting results for %s [%s/%s] to Argus...", run_id,
                 metadata["driver_name"], metadata["driver_type"])
     raw_xml = (Path(metadata_path).parent / metadata["junit_result"]).read_bytes()
-    client = ArgusDriverMatrixClient(
+    with ArgusDriverMatrixClient(
         run_id=run_id,
         auth_token=api_key,
         base_url=base_url,
         extra_headers=extra_headers,
-    )
-    client.submit_driver_result(
-        driver_name=metadata["driver_name"], driver_type=metadata["driver_type"], raw_junit_data=base64.encodebytes(raw_xml))
+        use_tunnel=use_tunnel,
+    ) as client:
+        client.submit_driver_result(
+            driver_name=metadata["driver_name"], driver_type=metadata["driver_type"], raw_junit_data=base64.encodebytes(raw_xml))
     LOGGER.info("Done.")
 
 
 def _submit_driver_failure_internal(api_key: str, base_url: str, run_id: str, metadata_path: str,
-                                    extra_headers: dict):
+                                    extra_headers: dict, use_tunnel: bool | None = None):
     metadata = json.loads(Path(metadata_path).read_text(encoding="utf-8"))
     LOGGER.info("Submitting failure for %s [%s/%s] to Argus...", run_id,
                 metadata["driver_name"], metadata["driver_type"])
-    client = ArgusDriverMatrixClient(
+    with ArgusDriverMatrixClient(
         run_id=run_id,
         auth_token=api_key,
         base_url=base_url,
         extra_headers=extra_headers,
-    )
-    client.submit_driver_failure(
-        driver_name=metadata["driver_name"], driver_type=metadata["driver_type"], failure_reason=metadata["failure_reason"])
+        use_tunnel=use_tunnel,
+    ) as client:
+        client.submit_driver_failure(
+            driver_name=metadata["driver_name"], driver_type=metadata["driver_type"], failure_reason=metadata["failure_reason"])
     LOGGER.info("Done.")
 
 
@@ -53,18 +55,20 @@ def _submit_driver_failure_internal(api_key: str, base_url: str, run_id: str, me
 @click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
 @click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
+@click.option("--use-tunnel/--no-use-tunnel", default=None, help="Route API calls through SSH tunnel")
 @click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--build-id", required=True, help="Unique job identifier in the build system, e.g. scylla-master/group/job for jenkins (The full path)")
 @click.option("--build-url", required=True, help="Job URL in the build system")
-def submit_driver_matrix_run(api_key: str, base_url: str, run_id: str, build_id: str, build_url: str, extra_headers: dict):
+def submit_driver_matrix_run(api_key: str, base_url: str, use_tunnel: bool | None, run_id: str, build_id: str, build_url: str, extra_headers: dict):
     LOGGER.info("Submitting %s (%s) to Argus...", build_id, run_id)
-    client = ArgusDriverMatrixClient(
+    with ArgusDriverMatrixClient(
         run_id=run_id,
         auth_token=api_key,
         base_url=base_url,
         extra_headers=extra_headers,
-    )
-    client.submit_driver_matrix_run(job_name=build_id, job_url=build_url)
+        use_tunnel=use_tunnel,
+    ) as client:
+        client.submit_driver_matrix_run(job_name=build_id, job_url=build_url)
     LOGGER.info("Done.")
 
 
@@ -72,56 +76,65 @@ def submit_driver_matrix_run(api_key: str, base_url: str, run_id: str, build_id:
 @click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
 @click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
+@click.option("--use-tunnel/--no-use-tunnel", default=None, help="Route API calls through SSH tunnel")
 @click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--metadata-path", required=True, help="Path to the metadata .json file that contains path to junit xml and other required information")
-def submit_driver_result(api_key: str, base_url: str, run_id: str, metadata_path: str, extra_headers: dict):
+def submit_driver_result(api_key: str, base_url: str, use_tunnel: bool | None, run_id: str, metadata_path: str, extra_headers: dict):
     _submit_driver_result_internal(api_key=api_key, base_url=base_url, run_id=run_id,
-                                   metadata_path=metadata_path, extra_headers=extra_headers)
+                                   metadata_path=metadata_path, extra_headers=extra_headers,
+                                   use_tunnel=use_tunnel)
 
 
 @click.command("fail-driver")
 @click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
 @click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
+@click.option("--use-tunnel/--no-use-tunnel", default=None, help="Route API calls through SSH tunnel")
 @click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--metadata-path", required=True, help="Path to the metadata .json file that contains path to junit xml and other required information")
-def submit_driver_failure(api_key: str, base_url: str, run_id: str, metadata_path: str, extra_headers: dict):
+def submit_driver_failure(api_key: str, base_url: str, use_tunnel: bool | None, run_id: str, metadata_path: str, extra_headers: dict):
     _submit_driver_failure_internal(api_key=api_key, base_url=base_url, run_id=run_id,
-                                    metadata_path=metadata_path, extra_headers=extra_headers)
+                                    metadata_path=metadata_path, extra_headers=extra_headers,
+                                    use_tunnel=use_tunnel)
 
 
 @click.command("submit-or-fail-driver")
 @click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
 @click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
+@click.option("--use-tunnel/--no-use-tunnel", default=None, help="Route API calls through SSH tunnel")
 @click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--metadata-path", required=True, help="Path to the metadata .json file that contains path to junit xml and other required information")
-def submit_or_fail_driver(api_key: str, base_url: str, run_id: str, metadata_path: str, extra_headers: dict):
+def submit_or_fail_driver(api_key: str, base_url: str, use_tunnel: bool | None, run_id: str, metadata_path: str, extra_headers: dict):
     metadata = json.loads(Path(metadata_path).read_text(encoding="utf-8"))
     if metadata.get("failure_reason"):
         _submit_driver_failure_internal(api_key=api_key, base_url=base_url, run_id=run_id,
-                                        metadata_path=metadata_path, extra_headers=extra_headers)
+                                        metadata_path=metadata_path, extra_headers=extra_headers,
+                                        use_tunnel=use_tunnel)
     else:
         _submit_driver_result_internal(api_key=api_key, base_url=base_url, run_id=run_id,
-                                       metadata_path=metadata_path, extra_headers=extra_headers)
+                                       metadata_path=metadata_path, extra_headers=extra_headers,
+                                       use_tunnel=use_tunnel)
 
 
 @click.command("submit-env")
 @click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
 @click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
+@click.option("--use-tunnel/--no-use-tunnel", default=None, help="Route API calls through SSH tunnel")
 @click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--env-path", required=True, help="Path to the Build-00.txt file that contains environment information about Scylla")
-def submit_driver_env(api_key: str, base_url: str, run_id: str, env_path: str, extra_headers: dict):
+def submit_driver_env(api_key: str, base_url: str, use_tunnel: bool | None, run_id: str, env_path: str, extra_headers: dict):
     LOGGER.info("Submitting environment for run %s to Argus...", run_id)
     raw_env = Path(env_path).read_text()
-    client = ArgusDriverMatrixClient(
+    with ArgusDriverMatrixClient(
         run_id=run_id,
         auth_token=api_key,
         base_url=base_url,
         extra_headers=extra_headers,
-    )
-    client.submit_env(raw_env)
+        use_tunnel=use_tunnel,
+    ) as client:
+        client.submit_env(raw_env)
     LOGGER.info("Done.")
 
 
@@ -129,16 +142,18 @@ def submit_driver_env(api_key: str, base_url: str, run_id: str, env_path: str, e
 @click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
 @click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
+@click.option("--use-tunnel/--no-use-tunnel", default=None, help="Route API calls through SSH tunnel")
 @click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--status", required=True, help="Resulting job status")
-def finish_driver_matrix_run(api_key: str, base_url: str, run_id: str, status: str, extra_headers: dict):
-    client = ArgusDriverMatrixClient(
+def finish_driver_matrix_run(api_key: str, base_url: str, use_tunnel: bool | None, run_id: str, status: str, extra_headers: dict):
+    with ArgusDriverMatrixClient(
         run_id=run_id,
         auth_token=api_key,
         base_url=base_url,
         extra_headers=extra_headers,
-    )
-    client.finalize_run(run_type=ArgusDriverMatrixClient.test_type, run_id=run_id, body={"status": TestStatus(status)})
+        use_tunnel=use_tunnel,
+    ) as client:
+        client.finalize_run(run_type=ArgusDriverMatrixClient.test_type, run_id=run_id, body={"status": TestStatus(status)})
 
 
 cli.add_command(submit_driver_matrix_run)

--- a/argus/client/driver_matrix_tests/cli.py
+++ b/argus/client/driver_matrix_tests/cli.py
@@ -17,7 +17,7 @@ def cli():
 
 
 def _submit_driver_result_internal(api_key: str, base_url: str, run_id: str, metadata_path: str,
-                                   extra_headers: dict, use_tunnel: bool | None):
+                                   extra_headers: dict):
     metadata = json.loads(Path(metadata_path).read_text(encoding="utf-8"))
     LOGGER.info("Submitting results for %s [%s/%s] to Argus...", run_id,
                 metadata["driver_name"], metadata["driver_type"])
@@ -27,7 +27,6 @@ def _submit_driver_result_internal(api_key: str, base_url: str, run_id: str, met
         auth_token=api_key,
         base_url=base_url,
         extra_headers=extra_headers,
-        use_tunnel=use_tunnel,
     )
     client.submit_driver_result(
         driver_name=metadata["driver_name"], driver_type=metadata["driver_type"], raw_junit_data=base64.encodebytes(raw_xml))
@@ -35,7 +34,7 @@ def _submit_driver_result_internal(api_key: str, base_url: str, run_id: str, met
 
 
 def _submit_driver_failure_internal(api_key: str, base_url: str, run_id: str, metadata_path: str,
-                                    extra_headers: dict, use_tunnel: bool | None):
+                                    extra_headers: dict):
     metadata = json.loads(Path(metadata_path).read_text(encoding="utf-8"))
     LOGGER.info("Submitting failure for %s [%s/%s] to Argus...", run_id,
                 metadata["driver_name"], metadata["driver_type"])
@@ -44,7 +43,6 @@ def _submit_driver_failure_internal(api_key: str, base_url: str, run_id: str, me
         auth_token=api_key,
         base_url=base_url,
         extra_headers=extra_headers,
-        use_tunnel=use_tunnel,
     )
     client.submit_driver_failure(
         driver_name=metadata["driver_name"], driver_type=metadata["driver_type"], failure_reason=metadata["failure_reason"])
@@ -55,19 +53,16 @@ def _submit_driver_failure_internal(api_key: str, base_url: str, run_id: str, me
 @click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
 @click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
-@click.option("--use-tunnel/--no-use-tunnel", default=None, help="Route API calls through SSH tunnel")
 @click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--build-id", required=True, help="Unique job identifier in the build system, e.g. scylla-master/group/job for jenkins (The full path)")
 @click.option("--build-url", required=True, help="Job URL in the build system")
-def submit_driver_matrix_run(api_key: str, base_url: str, use_tunnel: bool | None,
-                             run_id: str, build_id: str, build_url: str, extra_headers: dict):
+def submit_driver_matrix_run(api_key: str, base_url: str, run_id: str, build_id: str, build_url: str, extra_headers: dict):
     LOGGER.info("Submitting %s (%s) to Argus...", build_id, run_id)
     client = ArgusDriverMatrixClient(
         run_id=run_id,
         auth_token=api_key,
         base_url=base_url,
         extra_headers=extra_headers,
-        use_tunnel=use_tunnel,
     )
     client.submit_driver_matrix_run(job_name=build_id, job_url=build_url)
     LOGGER.info("Done.")
@@ -77,55 +72,47 @@ def submit_driver_matrix_run(api_key: str, base_url: str, use_tunnel: bool | Non
 @click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
 @click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
-@click.option("--use-tunnel/--no-use-tunnel", default=None, help="Route API calls through SSH tunnel")
 @click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--metadata-path", required=True, help="Path to the metadata .json file that contains path to junit xml and other required information")
-def submit_driver_result(api_key: str, base_url: str, use_tunnel: bool | None,
-                         run_id: str, metadata_path: str, extra_headers: dict):
+def submit_driver_result(api_key: str, base_url: str, run_id: str, metadata_path: str, extra_headers: dict):
     _submit_driver_result_internal(api_key=api_key, base_url=base_url, run_id=run_id,
-                                   metadata_path=metadata_path, extra_headers=extra_headers, use_tunnel=use_tunnel)
+                                   metadata_path=metadata_path, extra_headers=extra_headers)
 
 
 @click.command("fail-driver")
 @click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
 @click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
-@click.option("--use-tunnel/--no-use-tunnel", default=None, help="Route API calls through SSH tunnel")
 @click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--metadata-path", required=True, help="Path to the metadata .json file that contains path to junit xml and other required information")
-def submit_driver_failure(api_key: str, base_url: str, use_tunnel: bool | None,
-                          run_id: str, metadata_path: str, extra_headers: dict):
+def submit_driver_failure(api_key: str, base_url: str, run_id: str, metadata_path: str, extra_headers: dict):
     _submit_driver_failure_internal(api_key=api_key, base_url=base_url, run_id=run_id,
-                                    metadata_path=metadata_path, extra_headers=extra_headers, use_tunnel=use_tunnel)
+                                    metadata_path=metadata_path, extra_headers=extra_headers)
 
 
 @click.command("submit-or-fail-driver")
 @click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
 @click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
-@click.option("--use-tunnel/--no-use-tunnel", default=None, help="Route API calls through SSH tunnel")
 @click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--metadata-path", required=True, help="Path to the metadata .json file that contains path to junit xml and other required information")
-def submit_or_fail_driver(api_key: str, base_url: str, use_tunnel: bool | None,
-                          run_id: str, metadata_path: str, extra_headers: dict):
+def submit_or_fail_driver(api_key: str, base_url: str, run_id: str, metadata_path: str, extra_headers: dict):
     metadata = json.loads(Path(metadata_path).read_text(encoding="utf-8"))
     if metadata.get("failure_reason"):
         _submit_driver_failure_internal(api_key=api_key, base_url=base_url, run_id=run_id,
-                                        metadata_path=metadata_path, extra_headers=extra_headers, use_tunnel=use_tunnel)
+                                        metadata_path=metadata_path, extra_headers=extra_headers)
     else:
         _submit_driver_result_internal(api_key=api_key, base_url=base_url, run_id=run_id,
-                                       metadata_path=metadata_path, extra_headers=extra_headers, use_tunnel=use_tunnel)
+                                       metadata_path=metadata_path, extra_headers=extra_headers)
 
 
 @click.command("submit-env")
 @click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
 @click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
-@click.option("--use-tunnel/--no-use-tunnel", default=None, help="Route API calls through SSH tunnel")
 @click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--env-path", required=True, help="Path to the Build-00.txt file that contains environment information about Scylla")
-def submit_driver_env(api_key: str, base_url: str, use_tunnel: bool | None,
-                      run_id: str, env_path: str, extra_headers: dict):
+def submit_driver_env(api_key: str, base_url: str, run_id: str, env_path: str, extra_headers: dict):
     LOGGER.info("Submitting environment for run %s to Argus...", run_id)
     raw_env = Path(env_path).read_text()
     client = ArgusDriverMatrixClient(
@@ -133,7 +120,6 @@ def submit_driver_env(api_key: str, base_url: str, use_tunnel: bool | None,
         auth_token=api_key,
         base_url=base_url,
         extra_headers=extra_headers,
-        use_tunnel=use_tunnel,
     )
     client.submit_env(raw_env)
     LOGGER.info("Done.")
@@ -143,17 +129,14 @@ def submit_driver_env(api_key: str, base_url: str, use_tunnel: bool | None,
 @click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
 @click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
-@click.option("--use-tunnel/--no-use-tunnel", default=None, help="Route API calls through SSH tunnel")
 @click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--status", required=True, help="Resulting job status")
-def finish_driver_matrix_run(api_key: str, base_url: str, use_tunnel: bool | None,
-                             run_id: str, status: str, extra_headers: dict):
+def finish_driver_matrix_run(api_key: str, base_url: str, run_id: str, status: str, extra_headers: dict):
     client = ArgusDriverMatrixClient(
         run_id=run_id,
         auth_token=api_key,
         base_url=base_url,
         extra_headers=extra_headers,
-        use_tunnel=use_tunnel,
     )
     client.finalize_run(run_type=ArgusDriverMatrixClient.test_type, run_id=run_id, body={"status": TestStatus(status)})
 

--- a/argus/client/driver_matrix_tests/cli.py
+++ b/argus/client/driver_matrix_tests/cli.py
@@ -16,22 +16,36 @@ def cli():
     pass
 
 
-def _submit_driver_result_internal(api_key: str, base_url: str, run_id: str, metadata_path: str, extra_headers: dict):
+def _submit_driver_result_internal(api_key: str, base_url: str, run_id: str, metadata_path: str,
+                                   extra_headers: dict, use_tunnel: bool | None):
     metadata = json.loads(Path(metadata_path).read_text(encoding="utf-8"))
     LOGGER.info("Submitting results for %s [%s/%s] to Argus...", run_id,
                 metadata["driver_name"], metadata["driver_type"])
     raw_xml = (Path(metadata_path).parent / metadata["junit_result"]).read_bytes()
-    client = ArgusDriverMatrixClient(run_id=run_id, auth_token=api_key, base_url=base_url, extra_headers=extra_headers)
+    client = ArgusDriverMatrixClient(
+        run_id=run_id,
+        auth_token=api_key,
+        base_url=base_url,
+        extra_headers=extra_headers,
+        use_tunnel=use_tunnel,
+    )
     client.submit_driver_result(
         driver_name=metadata["driver_name"], driver_type=metadata["driver_type"], raw_junit_data=base64.encodebytes(raw_xml))
     LOGGER.info("Done.")
 
 
-def _submit_driver_failure_internal(api_key: str, base_url: str, run_id: str, metadata_path: str, extra_headers: dict):
+def _submit_driver_failure_internal(api_key: str, base_url: str, run_id: str, metadata_path: str,
+                                    extra_headers: dict, use_tunnel: bool | None):
     metadata = json.loads(Path(metadata_path).read_text(encoding="utf-8"))
     LOGGER.info("Submitting failure for %s [%s/%s] to Argus...", run_id,
                 metadata["driver_name"], metadata["driver_type"])
-    client = ArgusDriverMatrixClient(run_id=run_id, auth_token=api_key, base_url=base_url, extra_headers=extra_headers)
+    client = ArgusDriverMatrixClient(
+        run_id=run_id,
+        auth_token=api_key,
+        base_url=base_url,
+        extra_headers=extra_headers,
+        use_tunnel=use_tunnel,
+    )
     client.submit_driver_failure(
         driver_name=metadata["driver_name"], driver_type=metadata["driver_type"], failure_reason=metadata["failure_reason"])
     LOGGER.info("Done.")
@@ -41,12 +55,20 @@ def _submit_driver_failure_internal(api_key: str, base_url: str, run_id: str, me
 @click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
 @click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
+@click.option("--use-tunnel/--no-use-tunnel", default=None, help="Route API calls through SSH tunnel")
 @click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--build-id", required=True, help="Unique job identifier in the build system, e.g. scylla-master/group/job for jenkins (The full path)")
 @click.option("--build-url", required=True, help="Job URL in the build system")
-def submit_driver_matrix_run(api_key: str, base_url: str, run_id: str, build_id: str, build_url: str, extra_headers: dict):
+def submit_driver_matrix_run(api_key: str, base_url: str, use_tunnel: bool | None,
+                             run_id: str, build_id: str, build_url: str, extra_headers: dict):
     LOGGER.info("Submitting %s (%s) to Argus...", build_id, run_id)
-    client = ArgusDriverMatrixClient(run_id=run_id, auth_token=api_key, base_url=base_url, extra_headers=extra_headers)
+    client = ArgusDriverMatrixClient(
+        run_id=run_id,
+        auth_token=api_key,
+        base_url=base_url,
+        extra_headers=extra_headers,
+        use_tunnel=use_tunnel,
+    )
     client.submit_driver_matrix_run(job_name=build_id, job_url=build_url)
     LOGGER.info("Done.")
 
@@ -55,50 +77,64 @@ def submit_driver_matrix_run(api_key: str, base_url: str, run_id: str, build_id:
 @click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
 @click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
+@click.option("--use-tunnel/--no-use-tunnel", default=None, help="Route API calls through SSH tunnel")
 @click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--metadata-path", required=True, help="Path to the metadata .json file that contains path to junit xml and other required information")
-def submit_driver_result(api_key: str, base_url: str, run_id: str, metadata_path: str, extra_headers: dict):
+def submit_driver_result(api_key: str, base_url: str, use_tunnel: bool | None,
+                         run_id: str, metadata_path: str, extra_headers: dict):
     _submit_driver_result_internal(api_key=api_key, base_url=base_url, run_id=run_id,
-                                   metadata_path=metadata_path, extra_headers=extra_headers)
+                                   metadata_path=metadata_path, extra_headers=extra_headers, use_tunnel=use_tunnel)
 
 
 @click.command("fail-driver")
 @click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
 @click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
+@click.option("--use-tunnel/--no-use-tunnel", default=None, help="Route API calls through SSH tunnel")
 @click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--metadata-path", required=True, help="Path to the metadata .json file that contains path to junit xml and other required information")
-def submit_driver_failure(api_key: str, base_url: str, run_id: str, metadata_path: str, extra_headers: dict):
+def submit_driver_failure(api_key: str, base_url: str, use_tunnel: bool | None,
+                          run_id: str, metadata_path: str, extra_headers: dict):
     _submit_driver_failure_internal(api_key=api_key, base_url=base_url, run_id=run_id,
-                                    metadata_path=metadata_path, extra_headers=extra_headers)
+                                    metadata_path=metadata_path, extra_headers=extra_headers, use_tunnel=use_tunnel)
 
 
 @click.command("submit-or-fail-driver")
 @click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
 @click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
+@click.option("--use-tunnel/--no-use-tunnel", default=None, help="Route API calls through SSH tunnel")
 @click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--metadata-path", required=True, help="Path to the metadata .json file that contains path to junit xml and other required information")
-def submit_or_fail_driver(api_key: str, base_url: str, run_id: str, metadata_path: str, extra_headers: dict):
+def submit_or_fail_driver(api_key: str, base_url: str, use_tunnel: bool | None,
+                          run_id: str, metadata_path: str, extra_headers: dict):
     metadata = json.loads(Path(metadata_path).read_text(encoding="utf-8"))
     if metadata.get("failure_reason"):
         _submit_driver_failure_internal(api_key=api_key, base_url=base_url, run_id=run_id,
-                                        metadata_path=metadata_path, extra_headers=extra_headers)
+                                        metadata_path=metadata_path, extra_headers=extra_headers, use_tunnel=use_tunnel)
     else:
         _submit_driver_result_internal(api_key=api_key, base_url=base_url, run_id=run_id,
-                                       metadata_path=metadata_path, extra_headers=extra_headers)
+                                       metadata_path=metadata_path, extra_headers=extra_headers, use_tunnel=use_tunnel)
 
 
 @click.command("submit-env")
 @click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
 @click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
+@click.option("--use-tunnel/--no-use-tunnel", default=None, help="Route API calls through SSH tunnel")
 @click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--env-path", required=True, help="Path to the Build-00.txt file that contains environment information about Scylla")
-def submit_driver_env(api_key: str, base_url: str, run_id: str, env_path: str, extra_headers: dict):
+def submit_driver_env(api_key: str, base_url: str, use_tunnel: bool | None,
+                      run_id: str, env_path: str, extra_headers: dict):
     LOGGER.info("Submitting environment for run %s to Argus...", run_id)
     raw_env = Path(env_path).read_text()
-    client = ArgusDriverMatrixClient(run_id=run_id, auth_token=api_key, base_url=base_url, extra_headers=extra_headers)
+    client = ArgusDriverMatrixClient(
+        run_id=run_id,
+        auth_token=api_key,
+        base_url=base_url,
+        extra_headers=extra_headers,
+        use_tunnel=use_tunnel,
+    )
     client.submit_env(raw_env)
     LOGGER.info("Done.")
 
@@ -107,10 +143,18 @@ def submit_driver_env(api_key: str, base_url: str, run_id: str, env_path: str, e
 @click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
 @click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
+@click.option("--use-tunnel/--no-use-tunnel", default=None, help="Route API calls through SSH tunnel")
 @click.option("--id", "run_id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--status", required=True, help="Resulting job status")
-def finish_driver_matrix_run(api_key: str, base_url: str, run_id: str, status: str, extra_headers: dict):
-    client = ArgusDriverMatrixClient(run_id=run_id, auth_token=api_key, base_url=base_url, extra_headers=extra_headers)
+def finish_driver_matrix_run(api_key: str, base_url: str, use_tunnel: bool | None,
+                             run_id: str, status: str, extra_headers: dict):
+    client = ArgusDriverMatrixClient(
+        run_id=run_id,
+        auth_token=api_key,
+        base_url=base_url,
+        extra_headers=extra_headers,
+        use_tunnel=use_tunnel,
+    )
     client.finalize_run(run_type=ArgusDriverMatrixClient.test_type, run_id=run_id, body={"status": TestStatus(status)})
 
 

--- a/argus/client/driver_matrix_tests/client.py
+++ b/argus/client/driver_matrix_tests/client.py
@@ -13,9 +13,9 @@ class ArgusDriverMatrixClient(ArgusClient):
         SUBMIT_ENV = "/driver_matrix/env/submit"
 
     def __init__(self, run_id: UUID, auth_token: str, base_url: str, api_version="v1", extra_headers: dict | None = None,
-                 timeout: int = 60, max_retries: int = 3) -> None:
+                 timeout: int = 60, max_retries: int = 3, use_tunnel: bool | None = None) -> None:
         super().__init__(auth_token, base_url, api_version, extra_headers=extra_headers,
-                         timeout=timeout, max_retries=max_retries)
+                         timeout=timeout, max_retries=max_retries, use_tunnel=use_tunnel)
         self.run_id = run_id
 
     def submit_driver_matrix_run(self, job_name: str, job_url: str) -> None:

--- a/argus/client/generic/cli.py
+++ b/argus/client/generic/cli.py
@@ -1,6 +1,6 @@
 import json
+import os
 from json.decoder import JSONDecodeError
-from pathlib import Path
 import click
 import logging
 
@@ -81,11 +81,11 @@ def finish_run(api_key: str, base_url: str, use_tunnel: bool | None, id: str, st
 @click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 def trigger_jobs(api_key: str, base_url: str, use_tunnel: bool | None, job_info_file: str, version: str,
                  plan_id: str, release: str, extra_headers: dict | None = None):
-    path = Path(job_info_file)
-    if not path.exists():
+    if not os.path.exists(job_info_file):
         LOGGER.error("File not found: %s", job_info_file)
         exit(128)
-    payload = json.load(path.open("rt", encoding="utf-8"))
+    with open(job_info_file, "rt", encoding="utf-8") as fh:
+        payload = json.load(fh)
     with ArgusGenericClient(
         auth_token=api_key,
         base_url=base_url,

--- a/argus/client/generic/cli.py
+++ b/argus/client/generic/cli.py
@@ -39,14 +39,14 @@ def cli():
 def submit_run(api_key: str, base_url: str, use_tunnel: bool | None, id: str, build_id: str, build_url: str, started_by: str,
                sub_type: str = None, scylla_version: str = None, extra_headers: dict | None = None):
     LOGGER.info("Submitting %s (%s) to Argus...", build_id, id)
-    client = ArgusGenericClient(
+    with ArgusGenericClient(
         auth_token=api_key,
         base_url=base_url,
         extra_headers=extra_headers,
         use_tunnel=use_tunnel,
-    )
-    client.submit_generic_run(build_id=build_id, run_id=id, started_by=started_by,
-                              build_url=build_url, scylla_version=scylla_version, sub_type=sub_type)
+    ) as client:
+        client.submit_generic_run(build_id=build_id, run_id=id, started_by=started_by,
+                                  build_url=build_url, scylla_version=scylla_version, sub_type=sub_type)
     LOGGER.info("Done.")
 
 
@@ -60,14 +60,14 @@ def submit_run(api_key: str, base_url: str, use_tunnel: bool | None, id: str, bu
 @click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 def finish_run(api_key: str, base_url: str, use_tunnel: bool | None, id: str, status: str,
                scylla_version: str = None, extra_headers: dict | None = None):
-    client = ArgusGenericClient(
+    with ArgusGenericClient(
         auth_token=api_key,
         base_url=base_url,
         extra_headers=extra_headers,
         use_tunnel=use_tunnel,
-    )
-    status = TestStatus(status)
-    client.finalize_generic_run(run_id=id, status=status, scylla_version=scylla_version)
+    ) as client:
+        status = TestStatus(status)
+        client.finalize_generic_run(run_id=id, status=status, scylla_version=scylla_version)
 
 
 @click.command("trigger-jobs")
@@ -81,18 +81,18 @@ def finish_run(api_key: str, base_url: str, use_tunnel: bool | None, id: str, st
 @click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
 def trigger_jobs(api_key: str, base_url: str, use_tunnel: bool | None, job_info_file: str, version: str,
                  plan_id: str, release: str, extra_headers: dict | None = None):
-    client = ArgusGenericClient(
-        auth_token=api_key,
-        base_url=base_url,
-        extra_headers=extra_headers,
-        use_tunnel=use_tunnel,
-    )
     path = Path(job_info_file)
     if not path.exists():
         LOGGER.error("File not found: %s", job_info_file)
         exit(128)
     payload = json.load(path.open("rt", encoding="utf-8"))
-    client.trigger_jobs({"release": release, "version": version, "plan_id": plan_id, **payload})
+    with ArgusGenericClient(
+        auth_token=api_key,
+        base_url=base_url,
+        extra_headers=extra_headers,
+        use_tunnel=use_tunnel,
+    ) as client:
+        client.trigger_jobs({"release": release, "version": version, "plan_id": plan_id, **payload})
 
 
 cli.add_command(submit_run)

--- a/argus/client/generic/cli.py
+++ b/argus/client/generic/cli.py
@@ -28,6 +28,7 @@ def cli():
 @click.command("submit")
 @click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
+@click.option("--use-tunnel/--no-use-tunnel", default=None, help="Route API calls through SSH tunnel")
 @click.option("--id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--build-id", required=True, help="Unique job identifier in the build system, e.g. scylla-master/group/job for jenkins (The full path)")
 @click.option("--build-url", required=True, help="Job URL in the build system")
@@ -35,9 +36,15 @@ def cli():
 @click.option("--sub-type", required=False, help="Sub-type of the generic test: pytest, dtest")
 @click.option("--scylla-version", required=False, default=None, help="Version of Scylla used for this job")
 @click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
-def submit_run(api_key: str, base_url: str, id: str, build_id: str, build_url: str, started_by: str, sub_type: str = None, scylla_version: str = None, extra_headers: dict | None = None):
+def submit_run(api_key: str, base_url: str, use_tunnel: bool | None, id: str, build_id: str, build_url: str, started_by: str,
+               sub_type: str = None, scylla_version: str = None, extra_headers: dict | None = None):
     LOGGER.info("Submitting %s (%s) to Argus...", build_id, id)
-    client = ArgusGenericClient(auth_token=api_key, base_url=base_url, extra_headers=extra_headers)
+    client = ArgusGenericClient(
+        auth_token=api_key,
+        base_url=base_url,
+        extra_headers=extra_headers,
+        use_tunnel=use_tunnel,
+    )
     client.submit_generic_run(build_id=build_id, run_id=id, started_by=started_by,
                               build_url=build_url, scylla_version=scylla_version, sub_type=sub_type)
     LOGGER.info("Done.")
@@ -46,12 +53,19 @@ def submit_run(api_key: str, base_url: str, id: str, build_id: str, build_url: s
 @click.command("finish")
 @click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
+@click.option("--use-tunnel/--no-use-tunnel", default=None, help="Route API calls through SSH tunnel")
 @click.option("--id", required=True, help="UUID (v4 or v1) unique to the job")
 @click.option("--status", required=True, help="Resulting job status")
 @click.option("--scylla-version", required=False, default=None, help="Version of Scylla used for this job")
 @click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
-def finish_run(api_key: str, base_url: str, id: str, status: str, scylla_version: str = None, extra_headers: dict | None = None):
-    client = ArgusGenericClient(auth_token=api_key, base_url=base_url, extra_headers=extra_headers)
+def finish_run(api_key: str, base_url: str, use_tunnel: bool | None, id: str, status: str,
+               scylla_version: str = None, extra_headers: dict | None = None):
+    client = ArgusGenericClient(
+        auth_token=api_key,
+        base_url=base_url,
+        extra_headers=extra_headers,
+        use_tunnel=use_tunnel,
+    )
     status = TestStatus(status)
     client.finalize_generic_run(run_id=id, status=status, scylla_version=scylla_version)
 
@@ -59,13 +73,20 @@ def finish_run(api_key: str, base_url: str, id: str, status: str, scylla_version
 @click.command("trigger-jobs")
 @click.option("--api-key", help="Argus API key for authorization", required=True, envvar='ARGUS_AUTH_TOKEN')
 @click.option("--base-url", default="https://argus.scylladb.com", help="Base URL for argus instance")
+@click.option("--use-tunnel/--no-use-tunnel", default=None, help="Route API calls through SSH tunnel")
 @click.option("--version", help="Scylla version to filter plans by", default=None, required=False)
 @click.option("--plan-id", help="Specific plan id for filtering", default=None, required=False)
 @click.option("--release", help="Release name to filter plans by", default=None, required=False)
 @click.option("--job-info-file", required=True, help="JSON file with trigger information (see detailed docs)")
 @click.option("--extra-headers", default={}, type=click.UNPROCESSED, callback=validate_extra_headers, help="extra headers to pass to argus, should be in json format", envvar='ARGUS_EXTRA_HEADERS')
-def trigger_jobs(api_key: str, base_url: str, job_info_file: str, version: str, plan_id: str, release: str, extra_headers: dict | None = None):
-    client = ArgusGenericClient(auth_token=api_key, base_url=base_url, extra_headers=extra_headers)
+def trigger_jobs(api_key: str, base_url: str, use_tunnel: bool | None, job_info_file: str, version: str,
+                 plan_id: str, release: str, extra_headers: dict | None = None):
+    client = ArgusGenericClient(
+        auth_token=api_key,
+        base_url=base_url,
+        extra_headers=extra_headers,
+        use_tunnel=use_tunnel,
+    )
     path = Path(job_info_file)
     if not path.exists():
         LOGGER.error("File not found: %s", job_info_file)

--- a/argus/client/generic/client.py
+++ b/argus/client/generic/client.py
@@ -13,9 +13,9 @@ class ArgusGenericClient(ArgusClient):
         TRIGGER_JOBS = "/planning/plan/trigger"
 
     def __init__(self, auth_token: str, base_url: str, api_version="v1", extra_headers: dict | None = None,
-                 timeout: int = 180, max_retries: int = 3) -> None:
+                 timeout: int = 180, max_retries: int = 3, use_tunnel: bool | None = None) -> None:
         super().__init__(auth_token, base_url, api_version, extra_headers=extra_headers,
-                         timeout=timeout, max_retries=max_retries)
+                         timeout=timeout, max_retries=max_retries, use_tunnel=use_tunnel)
 
     def submit_generic_run(self, build_id: str, run_id: str, started_by: str, build_url: str, sub_type: str = None, scylla_version: str | None = None):
         request_body = {

--- a/argus/client/sct/client.py
+++ b/argus/client/sct/client.py
@@ -37,9 +37,9 @@ class ArgusSCTClient(ArgusClient):
         SUBMIT_CONFIG = "/$id/config/submit"
 
     def __init__(self, run_id: UUID, auth_token: str, base_url: str, api_version="v1", extra_headers: dict | None = None,
-                 timeout: int = 60, max_retries: int = 3) -> None:
+                 timeout: int = 60, max_retries: int = 3, use_tunnel: bool | None = None) -> None:
         super().__init__(auth_token, base_url, api_version, extra_headers=extra_headers,
-                         timeout=timeout, max_retries=max_retries)
+                         timeout=timeout, max_retries=max_retries, use_tunnel=use_tunnel)
         self.run_id = run_id
 
     def submit_sct_run(self, job_name: str, job_url: str, started_by: str, commit_id: str,

--- a/argus/client/session.py
+++ b/argus/client/session.py
@@ -1,0 +1,247 @@
+import logging
+import os
+import threading
+import time
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+from argus.client.tunnel import (
+    SSHTunnel,
+    TunnelConfig,
+    delete_cached_tunnel_state,
+    resolve_tunnel_config_with_reason,
+)
+
+LOGGER = logging.getLogger(__name__)
+TUNNEL_COOLDOWN_SECONDS = 30
+_DEFAULT_MONITOR_INTERVAL = 5.0
+
+
+def _resolve_use_tunnel(use_tunnel: bool | None) -> bool:
+    if use_tunnel is not None:
+        return use_tunnel
+    return os.environ.get("ARGUS_USE_TUNNEL", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _resolve_monitor_interval() -> float:
+    raw = os.environ.get("ARGUS_TUNNEL_MONITOR_INTERVAL")
+    if raw is None:
+        return _DEFAULT_MONITOR_INTERVAL
+    try:
+        value = float(raw)
+        if value <= 0:
+            raise ValueError("interval must be positive")
+        return value
+    except ValueError:
+        LOGGER.warning(
+            "Invalid ARGUS_TUNNEL_MONITOR_INTERVAL=%r, using default %.1fs",
+            raw,
+            _DEFAULT_MONITOR_INTERVAL,
+        )
+        return _DEFAULT_MONITOR_INTERVAL
+
+
+def _build_retry_session(max_retries: int) -> requests.Session:
+    session = requests.Session()
+    retry_strategy = Retry(
+        total=max_retries,
+        connect=max_retries,
+        read=max_retries,
+        status=0,
+        backoff_factor=1,
+        status_forcelist=(),
+        allowed_methods=["GET", "POST"],
+    )
+    adapter = HTTPAdapter(max_retries=retry_strategy)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session
+
+
+class TunneledSession:
+    """requests.Session-compatible wrapper that transparently routes traffic through an SSH tunnel."""
+
+    def __init__(self, auth_token: str, original_base_url: str, max_retries: int = 3) -> None:
+        self._auth_token = auth_token
+        self._original_base_url = original_base_url
+
+        self._tunnel: SSHTunnel | None = None
+        self._tunnel_config: TunnelConfig | None = None
+        self._tunnel_port: int | None = None
+        self._tunnel_warning_emitted = False
+        self._tunnel_disabled_until = 0.0
+        self._lock = threading.RLock()
+
+        self._session = _build_retry_session(max_retries)
+
+        monitor_interval = _resolve_monitor_interval()
+        self._monitor_stop = threading.Event()
+        self._monitor_thread = threading.Thread(
+            target=self._monitor_loop,
+            args=(monitor_interval,),
+            name="argus-tunnel-monitor",
+            daemon=True,
+        )
+        self._monitor_thread.start()
+
+    @property
+    def headers(self):
+        return self._session.headers
+
+    def mount(self, prefix: str, adapter) -> None:
+        self._session.mount(prefix, adapter)
+
+    def _active_tunnel_url(self) -> str | None:
+        if self._tunnel_port is not None:
+            return f"http://127.0.0.1:{self._tunnel_port}"
+        return None
+
+    def _rewrite_url(self, url: str) -> str:
+        tunnel_url = self._active_tunnel_url()
+        if tunnel_url and url.startswith(self._original_base_url):
+            return tunnel_url + url[len(self._original_base_url):]
+        return url
+
+    def _ensure_tunnel(self) -> None:
+        with self._lock:
+            if time.monotonic() < self._tunnel_disabled_until:
+                return
+
+            if self._tunnel and self._tunnel.is_alive() and self._tunnel.local_port is not None:
+                self._tunnel_port = self._tunnel.local_port
+                return
+
+            if self._tunnel and self._tunnel_config:
+                reconnected_port, reconnect_reason = self._tunnel.reconnect(self._tunnel_config)
+                if reconnected_port is not None:
+                    self._tunnel_port = reconnected_port
+                    self._tunnel_warning_emitted = False
+                    return
+                if reconnect_reason:
+                    LOGGER.warning("SSH tunnel reconnect failed: %s", reconnect_reason)
+
+            force_refresh = self._tunnel is not None
+            config, config_reason = resolve_tunnel_config_with_reason(
+                auth_token=self._auth_token,
+                base_url=self._original_base_url,
+                force_refresh=force_refresh,
+                session=self._session,
+            )
+            if config is None:
+                delete_cached_tunnel_state()
+                self._backoff(config_reason or "failed to resolve tunnel configuration")
+                return
+
+            tunnel = SSHTunnel()
+            local_port, establish_reason = tunnel.establish(config)
+
+            if local_port is None and not force_refresh:
+                config, config_reason = resolve_tunnel_config_with_reason(
+                    auth_token=self._auth_token,
+                    base_url=self._original_base_url,
+                    force_refresh=True,
+                    session=self._session,
+                )
+                if config is not None:
+                    local_port, establish_reason = tunnel.establish(config)
+                else:
+                    establish_reason = config_reason
+
+            if local_port is None:
+                delete_cached_tunnel_state()
+                self._backoff(establish_reason or "failed to establish tunnel")
+                return
+
+            self._tunnel = tunnel
+            self._tunnel_config = config
+            self._tunnel_port = local_port
+            self._tunnel_warning_emitted = False
+            self._tunnel_disabled_until = 0.0
+
+    def _backoff(self, reason: str) -> None:
+        if not self._tunnel_warning_emitted:
+            LOGGER.warning(
+                "SSH tunnel unavailable (%s); falling back to direct connection: %s",
+                reason,
+                self._original_base_url,
+            )
+            self._tunnel_warning_emitted = True
+
+        if self._tunnel:
+            self._tunnel.shutdown()
+
+        self._tunnel = None
+        self._tunnel_config = None
+        self._tunnel_port = None
+        self._tunnel_disabled_until = time.monotonic() + TUNNEL_COOLDOWN_SECONDS
+
+    def _monitor_loop(self, interval: float) -> None:
+        while not self._monitor_stop.wait(interval):
+            try:
+                self._check_tunnel_health()
+            except Exception:  # noqa: BLE001
+                LOGGER.debug("SSH tunnel monitor failed", exc_info=True)
+
+    def _check_tunnel_health(self) -> None:
+        tunnel = self._tunnel
+        if tunnel is None or tunnel.is_alive():
+            return
+        LOGGER.warning("SSH tunnel monitor detected dead tunnel; reconnecting")
+        self._ensure_tunnel()
+
+    def get(self, url: str, **kwargs) -> requests.Response:
+        self._ensure_tunnel()
+        rewritten = self._rewrite_url(url)
+        try:
+            return self._session.get(rewritten, **kwargs)
+        except requests.ConnectionError:
+            if rewritten == url:
+                raise
+            LOGGER.warning("GET through SSH tunnel failed; reconnecting and retrying")
+            self._ensure_tunnel()
+            rewritten = self._rewrite_url(url)
+            try:
+                return self._session.get(rewritten, **kwargs)
+            except requests.ConnectionError as exc:
+                self._backoff(f"request retry failed: {exc}")
+                return self._session.get(self._rewrite_url(url), **kwargs)
+
+    def post(self, url: str, **kwargs) -> requests.Response:
+        self._ensure_tunnel()
+        rewritten = self._rewrite_url(url)
+        try:
+            return self._session.post(rewritten, **kwargs)
+        except requests.ConnectionError:
+            if rewritten == url:
+                raise
+            LOGGER.warning("POST through SSH tunnel failed; reconnecting and retrying")
+            self._ensure_tunnel()
+            rewritten = self._rewrite_url(url)
+            try:
+                return self._session.post(rewritten, **kwargs)
+            except requests.ConnectionError as exc:
+                self._backoff(f"request retry failed: {exc}")
+                return self._session.post(self._rewrite_url(url), **kwargs)
+
+    def close(self) -> None:
+        self._monitor_stop.set()
+        with self._lock:
+            if self._tunnel:
+                self._tunnel.shutdown()
+                self._tunnel = None
+                self._tunnel_config = None
+                self._tunnel_port = None
+        self._session.close()
+
+
+def create_session(
+    auth_token: str,
+    base_url: str,
+    use_tunnel: bool | None,
+    max_retries: int = 3,
+) -> "requests.Session | TunneledSession":
+    if _resolve_use_tunnel(use_tunnel):
+        return TunneledSession(auth_token=auth_token, original_base_url=base_url, max_retries=max_retries)
+    return _build_retry_session(max_retries)

--- a/argus/client/session.py
+++ b/argus/client/session.py
@@ -4,6 +4,7 @@ import os
 import threading
 import time
 import weakref
+from datetime import UTC, datetime
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -85,6 +86,7 @@ class TunneledSession(requests.Session):
         self._tunnel: SSHTunnel | None = None
         self._tunnel_config: TunnelConfig | None = None
         self._tunnel_port: int | None = None
+        self._tunnel_established_at: str | None = None
         self._tunnel_warning_emitted = False
         self._tunnel_disabled_until = 0.0
         # RLock is held while reconnecting; this can stall a request thread for
@@ -181,11 +183,21 @@ class TunneledSession(requests.Session):
                 self._backoff(establish_reason or "failed to establish tunnel")
                 return
 
+            assert config is not None  # guaranteed: local_port is set only when config is valid
             self._tunnel = tunnel
             self._tunnel_config = config
             self._tunnel_port = local_port
+            self._tunnel_established_at = datetime.now(UTC).isoformat()
             self._tunnel_warning_emitted = False
             self._tunnel_disabled_until = 0.0
+            LOGGER.info(
+                "SSH tunnel established: proxy=%s:%d, user=%s, key_id=%s, local_port=%d",
+                config.proxy_host,
+                config.proxy_port,
+                config.proxy_user,
+                config.key_id or "unknown",
+                local_port,
+            )
 
     def _backoff(self, reason: str) -> None:
         # We deliberately do NOT delete the cached keypair here. The keypair
@@ -208,6 +220,7 @@ class TunneledSession(requests.Session):
         self._tunnel = None
         self._tunnel_config = None
         self._tunnel_port = None
+        self._tunnel_established_at = None
         self._tunnel_disabled_until = time.monotonic() + TUNNEL_COOLDOWN_SECONDS
 
     def _monitor_loop(self, interval: float) -> None:
@@ -224,9 +237,27 @@ class TunneledSession(requests.Session):
         LOGGER.warning("SSH tunnel monitor detected dead tunnel; reconnecting")
         self._ensure_tunnel()
 
+    def _tunnel_headers(self) -> dict[str, str]:
+        """Return headers to attach when traffic flows through the SSH tunnel."""
+        if self._tunnel_port is None or self._tunnel_config is None:
+            return {}
+        headers = {
+            "User-Agent": "argus-client-ssh-tunnel",
+            "X-SSH-Tunnel-Origin": self._tunnel_config.proxy_host,
+            "X-Tunnel-Established-At": self._tunnel_established_at or "",
+        }
+        if self._tunnel_config.key_id:
+            headers["X-Forwarded-Key-ID"] = self._tunnel_config.key_id
+        return headers
+
     def request(self, method: str, url: str, *args, **kwargs) -> requests.Response:
         self._ensure_tunnel()
         rewritten = self._rewrite_url(url)
+        if rewritten != url:
+            # Traffic is going through the tunnel — inject tunnel headers
+            headers = kwargs.get("headers") or {}
+            headers.update(self._tunnel_headers())
+            kwargs["headers"] = headers
         try:
             return super().request(method, rewritten, *args, **kwargs)
         except requests.ConnectionError:
@@ -235,6 +266,10 @@ class TunneledSession(requests.Session):
             LOGGER.warning("%s through SSH tunnel failed; reconnecting and retrying", method)
             self._ensure_tunnel()
             rewritten = self._rewrite_url(url)
+            if rewritten != url:
+                headers = kwargs.get("headers") or {}
+                headers.update(self._tunnel_headers())
+                kwargs["headers"] = headers
             try:
                 return super().request(method, rewritten, *args, **kwargs)
             except requests.ConnectionError as exc:

--- a/argus/client/session.py
+++ b/argus/client/session.py
@@ -1,7 +1,9 @@
+import atexit
 import logging
 import os
 import threading
 import time
+import weakref
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -10,7 +12,6 @@ from urllib3.util.retry import Retry
 from argus.client.tunnel import (
     SSHTunnel,
     TunnelConfig,
-    delete_cached_tunnel_state,
     resolve_tunnel_config_with_reason,
 )
 
@@ -43,8 +44,7 @@ def _resolve_monitor_interval() -> float:
         return _DEFAULT_MONITOR_INTERVAL
 
 
-def _build_retry_session(max_retries: int) -> requests.Session:
-    session = requests.Session()
+def _build_retry_adapter(max_retries: int) -> HTTPAdapter:
     retry_strategy = Retry(
         total=max_retries,
         connect=max_retries,
@@ -54,16 +54,31 @@ def _build_retry_session(max_retries: int) -> requests.Session:
         status_forcelist=(),
         allowed_methods=["GET", "POST"],
     )
-    adapter = HTTPAdapter(max_retries=retry_strategy)
+    return HTTPAdapter(max_retries=retry_strategy)
+
+
+def _build_retry_session(max_retries: int) -> requests.Session:
+    session = requests.Session()
+    adapter = _build_retry_adapter(max_retries)
     session.mount("http://", adapter)
     session.mount("https://", adapter)
     return session
 
 
-class TunneledSession:
-    """requests.Session-compatible wrapper that transparently routes traffic through an SSH tunnel."""
+class TunneledSession(requests.Session):
+    """``requests.Session`` that transparently routes traffic through an SSH tunnel.
+
+    All HTTP verbs work out of the box because we subclass ``requests.Session``
+    and only override :meth:`request` to inject URL rewriting plus single-shot
+    reconnect-and-retry on connection errors.
+    """
 
     def __init__(self, auth_token: str, original_base_url: str, max_retries: int = 3) -> None:
+        super().__init__()
+        adapter = _build_retry_adapter(max_retries)
+        self.mount("http://", adapter)
+        self.mount("https://", adapter)
+
         self._auth_token = auth_token
         self._original_base_url = original_base_url
 
@@ -72,9 +87,11 @@ class TunneledSession:
         self._tunnel_port: int | None = None
         self._tunnel_warning_emitted = False
         self._tunnel_disabled_until = 0.0
+        # RLock is held while reconnecting; this can stall a request thread for
+        # up to ~100s during the SSH retry budget. Acceptable: concurrent
+        # request callers should observe a single coherent tunnel state and not
+        # race multiple SSH spawns.
         self._lock = threading.RLock()
-
-        self._session = _build_retry_session(max_retries)
 
         monitor_interval = _resolve_monitor_interval()
         self._monitor_stop = threading.Event()
@@ -86,12 +103,20 @@ class TunneledSession:
         )
         self._monitor_thread.start()
 
-    @property
-    def headers(self):
-        return self._session.headers
+        # Ensure the monitor thread is stopped at interpreter exit even if a
+        # caller forgets to invoke ``close()``. The atexit registration uses a
+        # weak reference so the session can be garbage collected normally.
+        self._atexit_ref = weakref.ref(self)
+        atexit.register(self._atexit_close, self._atexit_ref)
 
-    def mount(self, prefix: str, adapter) -> None:
-        self._session.mount(prefix, adapter)
+    @staticmethod
+    def _atexit_close(session_ref: weakref.ref) -> None:
+        session = session_ref()
+        if session is not None:
+            try:
+                session.close()
+            except Exception:  # noqa: BLE001
+                LOGGER.debug("SSH tunnel atexit close failed", exc_info=True)
 
     def _active_tunnel_url(self) -> str | None:
         if self._tunnel_port is not None:
@@ -127,10 +152,9 @@ class TunneledSession:
                 auth_token=self._auth_token,
                 base_url=self._original_base_url,
                 force_refresh=force_refresh,
-                session=self._session,
+                session=self,
             )
             if config is None:
-                delete_cached_tunnel_state()
                 self._backoff(config_reason or "failed to resolve tunnel configuration")
                 return
 
@@ -142,7 +166,7 @@ class TunneledSession:
                     auth_token=self._auth_token,
                     base_url=self._original_base_url,
                     force_refresh=True,
-                    session=self._session,
+                    session=self,
                 )
                 if config is not None:
                     local_port, establish_reason = tunnel.establish(config)
@@ -150,7 +174,6 @@ class TunneledSession:
                     establish_reason = config_reason
 
             if local_port is None:
-                delete_cached_tunnel_state()
                 self._backoff(establish_reason or "failed to establish tunnel")
                 return
 
@@ -161,6 +184,12 @@ class TunneledSession:
             self._tunnel_disabled_until = 0.0
 
     def _backoff(self, reason: str) -> None:
+        # We deliberately do NOT delete the cached keypair here. The keypair
+        # remains valid even when the proxy host is briefly unreachable, and
+        # regenerating it on every 30s cooldown would force an unnecessary
+        # re-registration round-trip. ``resolve_tunnel_config_with_reason``
+        # already issues ``force_refresh=True`` after the first failure, which
+        # re-fetches the live config without dropping the keypair.
         if not self._tunnel_warning_emitted:
             LOGGER.warning(
                 "SSH tunnel unavailable (%s); falling back to direct connection: %s",
@@ -191,39 +220,22 @@ class TunneledSession:
         LOGGER.warning("SSH tunnel monitor detected dead tunnel; reconnecting")
         self._ensure_tunnel()
 
-    def get(self, url: str, **kwargs) -> requests.Response:
+    def request(self, method: str, url: str, *args, **kwargs) -> requests.Response:
         self._ensure_tunnel()
         rewritten = self._rewrite_url(url)
         try:
-            return self._session.get(rewritten, **kwargs)
+            return super().request(method, rewritten, *args, **kwargs)
         except requests.ConnectionError:
             if rewritten == url:
                 raise
-            LOGGER.warning("GET through SSH tunnel failed; reconnecting and retrying")
+            LOGGER.warning("%s through SSH tunnel failed; reconnecting and retrying", method)
             self._ensure_tunnel()
             rewritten = self._rewrite_url(url)
             try:
-                return self._session.get(rewritten, **kwargs)
+                return super().request(method, rewritten, *args, **kwargs)
             except requests.ConnectionError as exc:
                 self._backoff(f"request retry failed: {exc}")
-                return self._session.get(self._rewrite_url(url), **kwargs)
-
-    def post(self, url: str, **kwargs) -> requests.Response:
-        self._ensure_tunnel()
-        rewritten = self._rewrite_url(url)
-        try:
-            return self._session.post(rewritten, **kwargs)
-        except requests.ConnectionError:
-            if rewritten == url:
-                raise
-            LOGGER.warning("POST through SSH tunnel failed; reconnecting and retrying")
-            self._ensure_tunnel()
-            rewritten = self._rewrite_url(url)
-            try:
-                return self._session.post(rewritten, **kwargs)
-            except requests.ConnectionError as exc:
-                self._backoff(f"request retry failed: {exc}")
-                return self._session.post(self._rewrite_url(url), **kwargs)
+                return super().request(method, self._rewrite_url(url), *args, **kwargs)
 
     def close(self) -> None:
         self._monitor_stop.set()
@@ -233,7 +245,11 @@ class TunneledSession:
                 self._tunnel = None
                 self._tunnel_config = None
                 self._tunnel_port = None
-        self._session.close()
+        try:
+            atexit.unregister(self._atexit_close)
+        except Exception:  # noqa: BLE001
+            pass
+        super().close()
 
 
 def create_session(
@@ -241,7 +257,7 @@ def create_session(
     base_url: str,
     use_tunnel: bool | None,
     max_retries: int = 3,
-) -> "requests.Session | TunneledSession":
+) -> requests.Session:
     if _resolve_use_tunnel(use_tunnel):
         return TunneledSession(auth_token=auth_token, original_base_url=base_url, max_retries=max_retries)
     return _build_retry_session(max_retries)

--- a/argus/client/session.py
+++ b/argus/client/session.py
@@ -148,11 +148,15 @@ class TunneledSession(requests.Session):
                     LOGGER.warning("SSH tunnel reconnect failed: %s", reconnect_reason)
 
             force_refresh = self._tunnel is not None
+            # Use None (creates a plain requests.Session inside tunnel_api) to
+            # avoid infinite recursion: passing `self` would trigger
+            # _ensure_tunnel() again when the tunnel API call invokes
+            # session.post().
             config, config_reason = resolve_tunnel_config_with_reason(
                 auth_token=self._auth_token,
                 base_url=self._original_base_url,
                 force_refresh=force_refresh,
-                session=self,
+                session=None,
             )
             if config is None:
                 self._backoff(config_reason or "failed to resolve tunnel configuration")
@@ -166,7 +170,7 @@ class TunneledSession(requests.Session):
                     auth_token=self._auth_token,
                     base_url=self._original_base_url,
                     force_refresh=True,
-                    session=self,
+                    session=None,
                 )
                 if config is not None:
                     local_port, establish_reason = tunnel.establish(config)

--- a/argus/client/sirenada/client.py
+++ b/argus/client/sirenada/client.py
@@ -46,10 +46,10 @@ class ArgusSirenadaClient(ArgusClient):
     }
 
     def __init__(self, auth_token: str, base_url: str, api_version="v1", extra_headers: dict | None = None,
-                 timeout: int = 60, max_retries: int = 3) -> None:
+                 timeout: int = 60, max_retries: int = 3, use_tunnel: bool | None = None) -> None:
         self.results_path: Path | None = None
         super().__init__(auth_token, base_url, api_version, extra_headers=extra_headers,
-                         timeout=timeout, max_retries=max_retries)
+                         timeout=timeout, max_retries=max_retries, use_tunnel=use_tunnel)
 
     def _verify_required_files_exist(self, results_path: Path):
         assert (results_path / self._junit_xml_filename).exists(), "Missing jUnit XML results file!"

--- a/argus/client/tests/test_tunnel.py
+++ b/argus/client/tests/test_tunnel.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime, timedelta
 from io import StringIO
 from unittest.mock import Mock
+import os
 
 import pytest
 
@@ -10,6 +11,16 @@ from argus.client import tunnel_ssh
 from argus.client import tunnel_state
 from argus.client.session import TunneledSession
 from argus.client.tunnel import TunnelConfig
+
+
+def _write_text(path: str, text: str) -> None:
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(text)
+
+
+def _read_text(path: str) -> str:
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
 
 
 class _DummyProcess:
@@ -33,7 +44,7 @@ class _DummyProcess:
 @pytest.fixture
 def tunnel_state_dir(tmp_path, monkeypatch):
     monkeypatch.setenv("ARGUS_TUNNEL_STATE_DIR", str(tmp_path))
-    return tmp_path
+    return str(tmp_path)
 
 
 def test_resolve_tunnel_config_registers_and_caches(tunnel_state_dir, monkeypatch):
@@ -51,8 +62,8 @@ def test_resolve_tunnel_config_registers_and_caches(tunnel_state_dir, monkeypatc
     )
 
     def _fake_generate(paths):
-        paths.private_key.write_text("private", encoding="utf-8")
-        paths.public_key.write_text("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestKey", encoding="utf-8")
+        _write_text(paths.private_key, "private")
+        _write_text(paths.public_key, "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestKey")
 
     monkeypatch.setattr(tunnel_api, "generate_keypair_if_needed", _fake_generate)
     monkeypatch.setattr(tunnel_api, "_register_tunnel", lambda **kwargs: config)
@@ -62,8 +73,8 @@ def test_resolve_tunnel_config_registers_and_caches(tunnel_state_dir, monkeypatc
     assert resolved.proxy_host == "proxy.example.com"
 
     paths = tunnel_state.get_tunnel_state_paths()
-    assert paths.config_cache.exists()
-    assert paths.key_meta.exists()
+    assert os.path.exists(paths.config_cache)
+    assert os.path.exists(paths.key_meta)
 
     monkeypatch.setattr(
         tunnel_api,
@@ -122,7 +133,7 @@ def test_tunnel_api_succeeds_with_valid_response():
 
 def test_establish_uses_strict_host_options_and_temp_known_hosts(tunnel_state_dir, monkeypatch):
     paths = tunnel_state.get_tunnel_state_paths()
-    paths.private_key.write_text("private", encoding="utf-8")
+    _write_text(paths.private_key, "private")
 
     host_blob = "AQIDBA=="
     expected_fingerprint = tunnel_ssh.derive_fingerprint(f"ssh-ed25519 {host_blob}")
@@ -166,15 +177,15 @@ def test_establish_uses_strict_host_options_and_temp_known_hosts(tunnel_state_di
 
     known_hosts_path = ssh_tunnel._known_hosts_path
     assert known_hosts_path is not None
-    assert known_hosts_path.exists()
+    assert os.path.exists(known_hosts_path)
 
     ssh_tunnel.shutdown()
-    assert not known_hosts_path.exists()
+    assert not os.path.exists(known_hosts_path)
 
 
 def test_establish_retries_on_local_bind_conflict(tunnel_state_dir, monkeypatch):
     paths = tunnel_state.get_tunnel_state_paths()
-    paths.private_key.write_text("private", encoding="utf-8")
+    _write_text(paths.private_key, "private")
 
     config = TunnelConfig(
         proxy_host="proxy.example.com",
@@ -399,9 +410,9 @@ def test_argus_client_works_as_context_manager(requests_mock, monkeypatch):
 
 def test_backoff_does_not_wipe_cached_tunnel_state(tunnel_state_dir, monkeypatch):
     paths = tunnel_state.get_tunnel_state_paths()
-    paths.private_key.write_text("private-key", encoding="utf-8")
-    paths.public_key.write_text("public-key", encoding="utf-8")
-    paths.config_cache.write_text('{"placeholder": "value"}', encoding="utf-8")
+    _write_text(paths.private_key, "private-key")
+    _write_text(paths.public_key, "public-key")
+    _write_text(paths.config_cache, '{"placeholder": "value"}')
 
     monkeypatch.setattr(
         "argus.client.session.resolve_tunnel_config_with_reason",
@@ -413,9 +424,9 @@ def test_backoff_does_not_wipe_cached_tunnel_state(tunnel_state_dir, monkeypatch
         session._ensure_tunnel()
         # Transient establish failure must NOT wipe the cached keypair —
         # otherwise every cooldown forces a fresh registration round-trip.
-        assert paths.private_key.exists()
-        assert paths.public_key.exists()
-        assert paths.config_cache.exists()
+        assert os.path.exists(paths.private_key)
+        assert os.path.exists(paths.public_key)
+        assert os.path.exists(paths.config_cache)
     finally:
         session.close()
 
@@ -453,13 +464,13 @@ def test_prepare_known_hosts_file_accepts_full_known_hosts_entry(tunnel_state_di
 
     path = tunnel_ssh.SSHTunnel._prepare_known_hosts_file(config)
     try:
-        contents = path.read_text(encoding="utf-8").strip()
+        contents = _read_text(path).strip()
         # Host token must be rewritten to the connection target with the
         # non-default port, not whatever the backend stored.
         assert contents.startswith("[proxy.example.com]:2222 ")
         assert "ssh-ed25519 AAAAdummybase64" in contents
     finally:
-        path.unlink(missing_ok=True)
+        tunnel_ssh._unlink(path)
 
 
 def test_prepare_known_hosts_file_rejects_unknown_format(tunnel_state_dir):

--- a/argus/client/tests/test_tunnel.py
+++ b/argus/client/tests/test_tunnel.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime, timedelta
 from io import StringIO
+from unittest.mock import Mock
 
 import pytest
 
@@ -7,6 +8,7 @@ from argus.client.base import ArgusClient
 from argus.client import tunnel_api
 from argus.client import tunnel_ssh
 from argus.client import tunnel_state
+from argus.client.session import TunneledSession
 from argus.client.tunnel import TunnelConfig
 
 
@@ -73,9 +75,21 @@ def test_resolve_tunnel_config_registers_and_caches(tunnel_state_dir, monkeypatc
     assert cached.proxy_host == "proxy.example.com"
 
 
-def test_tunnel_api_retries_requests(monkeypatch):
-    state = {"calls": 0}
+def test_tunnel_api_raises_on_connection_failure():
+    mock_session = Mock(spec=tunnel_api.requests.Session)
+    mock_session.get.side_effect = tunnel_api.requests.RequestException("connection refused")
 
+    with pytest.raises(tunnel_api.TunnelClientError, match="Tunnel API call failed"):
+        tunnel_api._call_tunnel_api(
+            method="GET",
+            url="https://argus.example.com/api/v1/client/ssh/tunnel",
+            auth_token="token",
+            payload=None,
+            session=mock_session,
+        )
+
+
+def test_tunnel_api_succeeds_with_valid_response():
     class _Response:
         status_code = 200
 
@@ -93,16 +107,17 @@ def test_tunnel_api_retries_requests(monkeypatch):
                 },
             }
 
-    def _flaky_get(*args, **kwargs):
-        state["calls"] += 1
-        if state["calls"] < 3:
-            raise tunnel_api.requests.RequestException("transient failure")
-        return _Response()
+    mock_session = Mock(spec=tunnel_api.requests.Session)
+    mock_session.get.return_value = _Response()
 
-    monkeypatch.setattr(tunnel_api.requests, "get", _flaky_get)
-    data = tunnel_api._call_tunnel_api(method="GET", url="https://argus.example.com/api/v1/client/ssh/tunnel", auth_token="token", payload=None)
+    data = tunnel_api._call_tunnel_api(
+        method="GET",
+        url="https://argus.example.com/api/v1/client/ssh/tunnel",
+        auth_token="token",
+        payload=None,
+        session=mock_session,
+    )
     assert data["proxy_host"] == "proxy.example.com"
-    assert state["calls"] == 3
 
 
 def test_establish_uses_strict_host_options_and_temp_known_hosts(tunnel_state_dir, monkeypatch):
@@ -203,8 +218,8 @@ def test_argus_client_warns_and_falls_back_when_tunnel_setup_fails(requests_mock
         status_code=200,
     )
 
-    monkeypatch.setattr("argus.client.base.resolve_tunnel_config_with_reason", lambda **kwargs: (None, "api unreachable"))
-    monkeypatch.setattr("argus.client.base.delete_cached_tunnel_state", lambda: None)
+    monkeypatch.setattr("argus.client.session.resolve_tunnel_config_with_reason", lambda **kwargs: (None, "api unreachable"))
+    monkeypatch.setattr("argus.client.session.delete_cached_tunnel_state", lambda: None)
 
     client = ArgusClient(auth_token="token", base_url="https://argus.scylladb.com", use_tunnel=True)
     with caplog.at_level("WARNING"):
@@ -214,7 +229,7 @@ def test_argus_client_warns_and_falls_back_when_tunnel_setup_fails(requests_mock
         )
 
     assert response.status_code == 200
-    assert client._use_tunnel is True
+    assert isinstance(client.session, TunneledSession)
     assert "api unreachable" in caplog.text
     assert "falling back to direct connection" in caplog.text
 
@@ -265,17 +280,18 @@ def test_argus_client_retries_tunnel_after_cooldown(requests_mock, monkeypatch):
 
     monotonic_values = iter([1000.0, 1001.0, 1032.0])
 
-    monkeypatch.setattr("argus.client.base.resolve_tunnel_config_with_reason", _resolve)
-    monkeypatch.setattr("argus.client.base.SSHTunnel", _FakeTunnel)
-    monkeypatch.setattr("argus.client.base.time.monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr("argus.client.session.resolve_tunnel_config_with_reason", _resolve)
+    monkeypatch.setattr("argus.client.session.SSHTunnel", _FakeTunnel)
+    monkeypatch.setattr("argus.client.session.time.monotonic", lambda: next(monotonic_values))
 
     client = ArgusClient(auth_token="token", base_url="https://argus.scylladb.com", use_tunnel=True)
 
     client.get(endpoint=ArgusClient.Routes.GET, location_params={"type": "test-type", "id": "test-id"})
+    assert client.session._tunnel_port is None
     assert client._base_url == "https://argus.scylladb.com"
 
     client.get(endpoint=ArgusClient.Routes.GET, location_params={"type": "test-type", "id": "test-id"})
-    assert client._base_url == "http://127.0.0.1:9191"
+    assert client.session._tunnel_port == 9191
 
 
 def test_request_level_recovery_reconnects_and_retries_once(requests_mock, monkeypatch):
@@ -286,16 +302,16 @@ def test_request_level_recovery_reconnects_and_retries_once(requests_mock, monke
     requests_mock.get(new_tunnel_url, json={"status": "ok", "response": {}}, status_code=200)
 
     client = ArgusClient(auth_token="token", base_url="https://argus.scylladb.com", use_tunnel=True)
-    client._base_url = "http://127.0.0.1:9191"
+    client.session._tunnel_port = 9191
 
     ensure_state = {"calls": 0}
 
     def _fake_ensure_tunnel():
         ensure_state["calls"] += 1
         if ensure_state["calls"] >= 2:
-            client._base_url = "http://127.0.0.1:9292"
+            client.session._tunnel_port = 9292
 
-    monkeypatch.setattr(client, "_ensure_tunnel", _fake_ensure_tunnel)
+    monkeypatch.setattr(client.session, "_ensure_tunnel", _fake_ensure_tunnel)
 
     response = client.get(
         endpoint=ArgusClient.Routes.GET,
@@ -304,4 +320,4 @@ def test_request_level_recovery_reconnects_and_retries_once(requests_mock, monke
 
     assert response.status_code == 200
     assert ensure_state["calls"] == 2
-    assert client._base_url == "http://127.0.0.1:9292"
+    assert client.session._tunnel_port == 9292

--- a/argus/client/tests/test_tunnel.py
+++ b/argus/client/tests/test_tunnel.py
@@ -1,0 +1,307 @@
+from datetime import UTC, datetime, timedelta
+from io import StringIO
+
+import pytest
+
+from argus.client.base import ArgusClient
+from argus.client import tunnel_api
+from argus.client import tunnel_ssh
+from argus.client import tunnel_state
+from argus.client.tunnel import TunnelConfig
+
+
+class _DummyProcess:
+    def __init__(self, stderr_text: str = ""):
+        self._alive = True
+        self.stderr = StringIO(stderr_text)
+
+    def poll(self):
+        return None if self._alive else 0
+
+    def terminate(self):
+        self._alive = False
+
+    def wait(self, timeout=None):
+        return 0
+
+    def kill(self):
+        self._alive = False
+
+
+@pytest.fixture
+def tunnel_state_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARGUS_TUNNEL_STATE_DIR", str(tmp_path))
+    return tmp_path
+
+
+def test_resolve_tunnel_config_registers_and_caches(tunnel_state_dir, monkeypatch):
+    expires_at = datetime.now(tz=UTC) + timedelta(hours=6)
+    config = TunnelConfig(
+        proxy_host="proxy.example.com",
+        proxy_port=22,
+        proxy_user="argus-proxy",
+        target_host="10.0.0.10",
+        target_port=8080,
+        host_key_fingerprint="SHA256:test",
+        expires_at=expires_at,
+        key_id="key-id",
+        tunnel_id="tunnel-id",
+    )
+
+    def _fake_generate(paths):
+        paths.private_key.write_text("private", encoding="utf-8")
+        paths.public_key.write_text("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestKey", encoding="utf-8")
+
+    monkeypatch.setattr(tunnel_api, "generate_keypair_if_needed", _fake_generate)
+    monkeypatch.setattr(tunnel_api, "_register_tunnel", lambda **kwargs: config)
+
+    resolved = tunnel_api.resolve_tunnel_config(auth_token="token", base_url="https://argus.example.com")
+    assert resolved is not None
+    assert resolved.proxy_host == "proxy.example.com"
+
+    paths = tunnel_state.get_tunnel_state_paths()
+    assert paths.config_cache.exists()
+    assert paths.key_meta.exists()
+
+    monkeypatch.setattr(
+        tunnel_api,
+        "_get_tunnel_connection",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("should not call GET when cache is valid")),
+    )
+    cached = tunnel_api.resolve_tunnel_config(auth_token="token", base_url="https://argus.example.com")
+    assert cached is not None
+    assert cached.proxy_host == "proxy.example.com"
+
+
+def test_tunnel_api_retries_requests(monkeypatch):
+    state = {"calls": 0}
+
+    class _Response:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {
+                "status": "ok",
+                "response": {
+                    "proxy_host": "proxy.example.com",
+                    "proxy_port": 22,
+                    "proxy_user": "argus-proxy",
+                    "target_host": "10.0.0.10",
+                    "target_port": 8080,
+                    "host_key_fingerprint": "SHA256:test",
+                },
+            }
+
+    def _flaky_get(*args, **kwargs):
+        state["calls"] += 1
+        if state["calls"] < 3:
+            raise tunnel_api.requests.RequestException("transient failure")
+        return _Response()
+
+    monkeypatch.setattr(tunnel_api.requests, "get", _flaky_get)
+    data = tunnel_api._call_tunnel_api(method="GET", url="https://argus.example.com/api/v1/client/ssh/tunnel", auth_token="token", payload=None)
+    assert data["proxy_host"] == "proxy.example.com"
+    assert state["calls"] == 3
+
+
+def test_establish_uses_strict_host_options_and_temp_known_hosts(tunnel_state_dir, monkeypatch):
+    paths = tunnel_state.get_tunnel_state_paths()
+    paths.private_key.write_text("private", encoding="utf-8")
+
+    host_blob = "AQIDBA=="
+    expected_fingerprint = tunnel_ssh.derive_fingerprint(f"ssh-ed25519 {host_blob}")
+    config = TunnelConfig(
+        proxy_host="proxy.example.com",
+        proxy_port=22,
+        proxy_user="argus-proxy",
+        target_host="10.0.0.10",
+        target_port=8080,
+        host_key_fingerprint=expected_fingerprint,
+    )
+
+    monkeypatch.setattr(tunnel_ssh.shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+    monkeypatch.setattr(
+        tunnel_ssh,
+        "scan_host_keys",
+        lambda host, port: [f"{host} ssh-ed25519 {host_blob}"],
+    )
+
+    captured = {"commands": []}
+
+    def _fake_popen(command, stdout, stderr, text):
+        captured["commands"].append(command)
+        return _DummyProcess()
+
+    monkeypatch.setattr(tunnel_ssh.subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(tunnel_ssh.SSHTunnel, "_wait_for_port_ready", staticmethod(lambda process, local_port: (True, "")))
+
+    ssh_tunnel = tunnel_ssh.SSHTunnel(key_path=paths.private_key)
+    local_port, reason = ssh_tunnel.establish(config)
+
+    assert reason is None
+    assert local_port is not None
+    assert ssh_tunnel.local_port == local_port
+    command = captured["commands"][0]
+    command_text = " ".join(command)
+    assert "StrictHostKeyChecking=yes" in command_text
+    assert "GlobalKnownHostsFile=/dev/null" in command_text
+    assert "HostKeyAlgorithms=ssh-ed25519,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521" in command_text
+    assert "ssh-rsa" not in command_text
+
+    known_hosts_path = ssh_tunnel._known_hosts_path
+    assert known_hosts_path is not None
+    assert known_hosts_path.exists()
+
+    ssh_tunnel.shutdown()
+    assert not known_hosts_path.exists()
+
+
+def test_establish_retries_on_local_bind_conflict(tunnel_state_dir, monkeypatch):
+    paths = tunnel_state.get_tunnel_state_paths()
+    paths.private_key.write_text("private", encoding="utf-8")
+
+    config = TunnelConfig(
+        proxy_host="proxy.example.com",
+        proxy_port=22,
+        proxy_user="argus-proxy",
+        target_host="10.0.0.10",
+        target_port=8080,
+        host_key_fingerprint="SHA256:test",
+    )
+
+    monkeypatch.setattr(tunnel_ssh.shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+    monkeypatch.setattr(
+        tunnel_ssh.SSHTunnel,
+        "_prepare_known_hosts_file",
+        staticmethod(lambda cfg: tunnel_ssh.write_temp_known_hosts("proxy ssh-ed25519 AQIDBA==")),
+    )
+
+    call_state = {"calls": 0}
+
+    def _fake_wait(process, local_port):
+        call_state["calls"] += 1
+        if call_state["calls"] == 1:
+            return False, "Address already in use"
+        return True, ""
+
+    monkeypatch.setattr(tunnel_ssh.SSHTunnel, "_wait_for_port_ready", staticmethod(_fake_wait))
+    monkeypatch.setattr(tunnel_ssh.subprocess, "Popen", lambda *args, **kwargs: _DummyProcess())
+
+    ssh_tunnel = tunnel_ssh.SSHTunnel(key_path=paths.private_key)
+    local_port, reason = ssh_tunnel.establish(config)
+
+    assert reason is None
+    assert local_port is not None
+    assert call_state["calls"] == 2
+
+
+def test_argus_client_warns_and_falls_back_when_tunnel_setup_fails(requests_mock, monkeypatch, caplog):
+    requests_mock.get(
+        "https://argus.scylladb.com/api/v1/client/testrun/test-type/test-id/get",
+        json={"status": "ok", "response": {}},
+        status_code=200,
+    )
+
+    monkeypatch.setattr("argus.client.base.resolve_tunnel_config_with_reason", lambda **kwargs: (None, "api unreachable"))
+    monkeypatch.setattr("argus.client.base.delete_cached_tunnel_state", lambda: None)
+
+    client = ArgusClient(auth_token="token", base_url="https://argus.scylladb.com", use_tunnel=True)
+    with caplog.at_level("WARNING"):
+        response = client.get(
+            endpoint=ArgusClient.Routes.GET,
+            location_params={"type": "test-type", "id": "test-id"},
+        )
+
+    assert response.status_code == 200
+    assert client._use_tunnel is True
+    assert "api unreachable" in caplog.text
+    assert "falling back to direct connection" in caplog.text
+
+
+def test_argus_client_retries_tunnel_after_cooldown(requests_mock, monkeypatch):
+    requests_mock.get(
+        "https://argus.scylladb.com/api/v1/client/testrun/test-type/test-id/get",
+        json={"status": "ok", "response": {}},
+        status_code=200,
+    )
+    requests_mock.get(
+        "http://127.0.0.1:9191/api/v1/client/testrun/test-type/test-id/get",
+        json={"status": "ok", "response": {}},
+        status_code=200,
+    )
+
+    config = TunnelConfig(
+        proxy_host="proxy.example.com",
+        proxy_port=22,
+        proxy_user="argus-proxy",
+        target_host="10.0.0.10",
+        target_port=8080,
+        host_key_fingerprint="SHA256:test",
+    )
+    resolve_state = {"calls": 0}
+
+    def _resolve(**kwargs):
+        resolve_state["calls"] += 1
+        if resolve_state["calls"] == 1:
+            return None, "first failure"
+        return config, None
+
+    class _FakeTunnel:
+        def __init__(self):
+            self.local_port = 9191
+
+        def establish(self, cfg):
+            return 9191, None
+
+        def is_alive(self):
+            return True
+
+        def reconnect(self, cfg):
+            return 9191, None
+
+        def shutdown(self):
+            return None
+
+    monotonic_values = iter([1000.0, 1001.0, 1032.0])
+
+    monkeypatch.setattr("argus.client.base.resolve_tunnel_config_with_reason", _resolve)
+    monkeypatch.setattr("argus.client.base.SSHTunnel", _FakeTunnel)
+    monkeypatch.setattr("argus.client.base.time.monotonic", lambda: next(monotonic_values))
+
+    client = ArgusClient(auth_token="token", base_url="https://argus.scylladb.com", use_tunnel=True)
+
+    client.get(endpoint=ArgusClient.Routes.GET, location_params={"type": "test-type", "id": "test-id"})
+    assert client._base_url == "https://argus.scylladb.com"
+
+    client.get(endpoint=ArgusClient.Routes.GET, location_params={"type": "test-type", "id": "test-id"})
+    assert client._base_url == "http://127.0.0.1:9191"
+
+
+def test_request_level_recovery_reconnects_and_retries_once(requests_mock, monkeypatch):
+    old_tunnel_url = "http://127.0.0.1:9191/api/v1/client/testrun/test-type/test-id/get"
+    new_tunnel_url = "http://127.0.0.1:9292/api/v1/client/testrun/test-type/test-id/get"
+
+    requests_mock.get(old_tunnel_url, exc=tunnel_api.requests.ConnectionError("old tunnel is down"))
+    requests_mock.get(new_tunnel_url, json={"status": "ok", "response": {}}, status_code=200)
+
+    client = ArgusClient(auth_token="token", base_url="https://argus.scylladb.com", use_tunnel=True)
+    client._base_url = "http://127.0.0.1:9191"
+
+    ensure_state = {"calls": 0}
+
+    def _fake_ensure_tunnel():
+        ensure_state["calls"] += 1
+        if ensure_state["calls"] >= 2:
+            client._base_url = "http://127.0.0.1:9292"
+
+    monkeypatch.setattr(client, "_ensure_tunnel", _fake_ensure_tunnel)
+
+    response = client.get(
+        endpoint=ArgusClient.Routes.GET,
+        location_params={"type": "test-type", "id": "test-id"},
+    )
+
+    assert response.status_code == 200
+    assert ensure_state["calls"] == 2
+    assert client._base_url == "http://127.0.0.1:9292"

--- a/argus/client/tests/test_tunnel.py
+++ b/argus/client/tests/test_tunnel.py
@@ -219,7 +219,6 @@ def test_argus_client_warns_and_falls_back_when_tunnel_setup_fails(requests_mock
     )
 
     monkeypatch.setattr("argus.client.session.resolve_tunnel_config_with_reason", lambda **kwargs: (None, "api unreachable"))
-    monkeypatch.setattr("argus.client.session.delete_cached_tunnel_state", lambda: None)
 
     client = ArgusClient(auth_token="token", base_url="https://argus.scylladb.com", use_tunnel=True)
     with caplog.at_level("WARNING"):
@@ -321,3 +320,157 @@ def test_request_level_recovery_reconnects_and_retries_once(requests_mock, monke
     assert response.status_code == 200
     assert ensure_state["calls"] == 2
     assert client.session._tunnel_port == 9292
+
+
+def test_request_level_recovery_falls_back_to_direct_when_retry_fails(requests_mock, monkeypatch):
+    direct_url = "https://argus.scylladb.com/api/v1/client/testrun/test-type/test-id/get"
+    tunnel_url = "http://127.0.0.1:9191/api/v1/client/testrun/test-type/test-id/get"
+
+    requests_mock.get(tunnel_url, exc=tunnel_api.requests.ConnectionError("tunnel is dead"))
+    requests_mock.get(direct_url, json={"status": "ok", "response": {}}, status_code=200)
+
+    client = ArgusClient(auth_token="token", base_url="https://argus.scylladb.com", use_tunnel=True)
+    client.session._tunnel_port = 9191
+
+    def _ensure_keeps_tunnel():
+        client.session._tunnel_port = 9191
+
+    backoff_calls = {"count": 0}
+
+    def _fake_backoff(reason):
+        backoff_calls["count"] += 1
+        client.session._tunnel_port = None
+
+    monkeypatch.setattr(client.session, "_ensure_tunnel", _ensure_keeps_tunnel)
+    monkeypatch.setattr(client.session, "_backoff", _fake_backoff)
+
+    response = client.get(
+        endpoint=ArgusClient.Routes.GET,
+        location_params={"type": "test-type", "id": "test-id"},
+    )
+
+    assert response.status_code == 200
+    assert backoff_calls["count"] == 1
+    assert client.session._tunnel_port is None
+
+
+def test_tunneled_session_starts_and_stops_monitor_thread():
+    session = TunneledSession(auth_token="token", original_base_url="https://argus.scylladb.com")
+    try:
+        assert session._monitor_thread.is_alive()
+    finally:
+        session.close()
+
+    session._monitor_thread.join(timeout=5)
+    assert not session._monitor_thread.is_alive()
+
+
+def test_tunneled_session_close_unregisters_atexit():
+    import atexit as _atexit
+
+    session = TunneledSession(auth_token="token", original_base_url="https://argus.scylladb.com")
+    callback = session._atexit_close
+    ref = session._atexit_ref
+    session.close()
+    # After close(), invoking the atexit callback must be a no-op (the session
+    # was unregistered, and even if called manually it should not blow up).
+    callback(ref)
+
+
+def test_argus_client_works_as_context_manager(requests_mock, monkeypatch):
+    requests_mock.get(
+        "https://argus.scylladb.com/api/v1/client/testrun/test-type/test-id/get",
+        json={"status": "ok", "response": {}},
+        status_code=200,
+    )
+    monkeypatch.setattr(
+        "argus.client.session.resolve_tunnel_config_with_reason",
+        lambda **kwargs: (None, "api unreachable"),
+    )
+
+    with ArgusClient(auth_token="token", base_url="https://argus.scylladb.com", use_tunnel=True) as client:
+        client.get(endpoint=ArgusClient.Routes.GET, location_params={"type": "test-type", "id": "test-id"})
+        session = client.session
+        assert session._monitor_thread.is_alive()
+
+    session._monitor_thread.join(timeout=5)
+    assert not session._monitor_thread.is_alive()
+
+
+def test_backoff_does_not_wipe_cached_tunnel_state(tunnel_state_dir, monkeypatch):
+    paths = tunnel_state.get_tunnel_state_paths()
+    paths.private_key.write_text("private-key", encoding="utf-8")
+    paths.public_key.write_text("public-key", encoding="utf-8")
+    paths.config_cache.write_text('{"placeholder": "value"}', encoding="utf-8")
+
+    monkeypatch.setattr(
+        "argus.client.session.resolve_tunnel_config_with_reason",
+        lambda **kwargs: (None, "transient failure"),
+    )
+
+    session = TunneledSession(auth_token="token", original_base_url="https://argus.scylladb.com")
+    try:
+        session._ensure_tunnel()
+        # Transient establish failure must NOT wipe the cached keypair —
+        # otherwise every cooldown forces a fresh registration round-trip.
+        assert paths.private_key.exists()
+        assert paths.public_key.exists()
+        assert paths.config_cache.exists()
+    finally:
+        session.close()
+
+
+def test_call_tunnel_api_rejects_non_dict_payload():
+    class _Response:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return ["unexpected", "list"]
+
+    mock_session = Mock(spec=tunnel_api.requests.Session)
+    mock_session.get.return_value = _Response()
+
+    with pytest.raises(tunnel_api.TunnelClientError, match="invalid format"):
+        tunnel_api._call_tunnel_api(
+            method="GET",
+            url="https://argus.example.com/api/v1/client/ssh/tunnel",
+            auth_token="token",
+            payload=None,
+            session=mock_session,
+        )
+
+
+def test_prepare_known_hosts_file_accepts_full_known_hosts_entry(tunnel_state_dir):
+    config = TunnelConfig(
+        proxy_host="proxy.example.com",
+        proxy_port=2222,
+        proxy_user="argus-proxy",
+        target_host="10.0.0.10",
+        target_port=8080,
+        host_key_fingerprint="some-other-name ssh-ed25519 AAAAdummybase64",
+    )
+
+    path = tunnel_ssh.SSHTunnel._prepare_known_hosts_file(config)
+    try:
+        contents = path.read_text(encoding="utf-8").strip()
+        # Host token must be rewritten to the connection target with the
+        # non-default port, not whatever the backend stored.
+        assert contents.startswith("[proxy.example.com]:2222 ")
+        assert "ssh-ed25519 AAAAdummybase64" in contents
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def test_prepare_known_hosts_file_rejects_unknown_format(tunnel_state_dir):
+    config = TunnelConfig(
+        proxy_host="proxy.example.com",
+        proxy_port=22,
+        proxy_user="argus-proxy",
+        target_host="10.0.0.10",
+        target_port=8080,
+        host_key_fingerprint="not-a-fingerprint",
+    )
+
+    with pytest.raises(tunnel_ssh.TunnelClientError, match="unrecognised format"):
+        tunnel_ssh.SSHTunnel._prepare_known_hosts_file(config)

--- a/argus/client/tunnel.py
+++ b/argus/client/tunnel.py
@@ -1,0 +1,13 @@
+from argus.client.tunnel_api import resolve_tunnel_config, resolve_tunnel_config_with_reason
+from argus.client.tunnel_models import TunnelClientError, TunnelConfig
+from argus.client.tunnel_ssh import SSHTunnel
+from argus.client.tunnel_state import delete_cached_tunnel_state
+
+__all__ = [
+    "SSHTunnel",
+    "TunnelClientError",
+    "TunnelConfig",
+    "delete_cached_tunnel_state",
+    "resolve_tunnel_config",
+    "resolve_tunnel_config_with_reason",
+]

--- a/argus/client/tunnel_api.py
+++ b/argus/client/tunnel_api.py
@@ -1,8 +1,9 @@
 import logging
-import time
 from typing import Any
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from argus.client.tunnel_models import DEFAULT_TUNNEL_TIMEOUT, TunnelClientError, TunnelConfig
 from argus.client.tunnel_state import (
@@ -19,17 +20,33 @@ LOGGER = logging.getLogger(__name__)
 TUNNEL_API_RETRIES = 3
 
 
+def _create_api_session() -> requests.Session:
+    session = requests.Session()
+    retry = Retry(
+        total=TUNNEL_API_RETRIES,
+        backoff_factor=0.5,
+        allowed_methods=["GET", "POST"],
+        status_forcelist=[500, 502, 503, 504],
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session
+
+
 def resolve_tunnel_config(
     auth_token: str,
     base_url: str,
     force_refresh: bool = False,
     ttl_seconds: int | None = None,
+    session: requests.Session | None = None,
 ) -> TunnelConfig | None:
     config, _reason = resolve_tunnel_config_with_reason(
         auth_token=auth_token,
         base_url=base_url,
         force_refresh=force_refresh,
         ttl_seconds=ttl_seconds,
+        session=session,
     )
     return config
 
@@ -39,6 +56,7 @@ def resolve_tunnel_config_with_reason(
     base_url: str,
     force_refresh: bool = False,
     ttl_seconds: int | None = None,
+    session: requests.Session | None = None,
 ) -> tuple[TunnelConfig | None, str | None]:
     """
     Resolve tunnel configuration while keeping Cloudflare bootstrap calls minimal.
@@ -57,7 +75,7 @@ def resolve_tunnel_config_with_reason(
 
     if is_key_valid(paths):
         try:
-            config = _get_tunnel_connection(auth_token=auth_token, base_url=base_url)
+            config = _get_tunnel_connection(auth_token=auth_token, base_url=base_url, session=session)
             write_tunnel_cache(paths, config)
             return config, None
         except TunnelClientError as exc:
@@ -71,6 +89,7 @@ def resolve_tunnel_config_with_reason(
             base_url=base_url,
             public_key=public_key,
             ttl_seconds=ttl_seconds,
+            session=session,
         )
         write_key_meta(paths, config.expires_at)
         write_tunnel_cache(paths, config)
@@ -80,7 +99,13 @@ def resolve_tunnel_config_with_reason(
         return None, str(exc)
 
 
-def _register_tunnel(auth_token: str, base_url: str, public_key: str, ttl_seconds: int | None = None) -> TunnelConfig:
+def _register_tunnel(
+    auth_token: str,
+    base_url: str,
+    public_key: str,
+    ttl_seconds: int | None = None,
+    session: requests.Session | None = None,
+) -> TunnelConfig:
     payload: dict[str, Any] = {"public_key": public_key}
     if ttl_seconds is not None:
         payload["ttl_seconds"] = ttl_seconds
@@ -89,77 +114,74 @@ def _register_tunnel(auth_token: str, base_url: str, public_key: str, ttl_second
         url=f"{base_url}/api/v1/client/ssh/tunnel",
         auth_token=auth_token,
         payload=payload,
+        session=session,
     )
     return TunnelConfig.from_api_response(response)
 
 
-def _get_tunnel_connection(auth_token: str, base_url: str) -> TunnelConfig:
+def _get_tunnel_connection(
+    auth_token: str,
+    base_url: str,
+    session: requests.Session | None = None,
+) -> TunnelConfig:
     response = _call_tunnel_api(
         method="GET",
         url=f"{base_url}/api/v1/client/ssh/tunnel",
         auth_token=auth_token,
         payload=None,
+        session=session,
     )
     return TunnelConfig.from_api_response(response)
 
 
-def _call_tunnel_api(method: str, url: str, auth_token: str, payload: dict[str, Any] | None) -> dict[str, Any]:
+def _call_tunnel_api(
+    method: str,
+    url: str,
+    auth_token: str,
+    payload: dict[str, Any] | None,
+    session: requests.Session | None = None,
+) -> dict[str, Any]:
     headers = {
         "Authorization": f"token {auth_token}",
         "Accept": "application/json",
         "Content-Type": "application/json",
     }
 
-    last_exception: TunnelClientError | None = None
-    for attempt in range(1, TUNNEL_API_RETRIES + 1):
+    own_session = session is None
+    if own_session:
+        session = _create_api_session()
+
+    try:
         try:
             if method == "POST":
-                response = requests.post(url=url, json=payload, headers=headers, timeout=DEFAULT_TUNNEL_TIMEOUT)
+                response = session.post(url=url, json=payload, headers=headers, timeout=DEFAULT_TUNNEL_TIMEOUT)
             elif method == "GET":
-                response = requests.get(url=url, headers=headers, timeout=DEFAULT_TUNNEL_TIMEOUT)
+                response = session.get(url=url, headers=headers, timeout=DEFAULT_TUNNEL_TIMEOUT)
             else:
                 raise TunnelClientError(f"Unsupported tunnel API method: {method}")
         except requests.RequestException as exc:
-            last_exception = TunnelClientError(f"Tunnel API call failed ({method} {url}): {exc}")
-            if attempt < TUNNEL_API_RETRIES:
-                time.sleep(0.5 * (2 ** (attempt - 1)))
-                continue
-            raise last_exception from exc
+            raise TunnelClientError(f"Tunnel API call failed ({method} {url}): {exc}") from exc
 
         if response.status_code != 200:
-            last_exception = TunnelClientError(
+            raise TunnelClientError(
                 f"Tunnel API call returned unexpected status code {response.status_code} ({method} {url})"
             )
-            if attempt < TUNNEL_API_RETRIES:
-                time.sleep(0.5 * (2 ** (attempt - 1)))
-                continue
-            raise last_exception
 
         try:
             response_payload = response.json()
         except ValueError as exc:
-            last_exception = TunnelClientError(f"Tunnel API response is not JSON ({method} {url})")
-            if attempt < TUNNEL_API_RETRIES:
-                time.sleep(0.5 * (2 ** (attempt - 1)))
-                continue
-            raise last_exception from exc
+            raise TunnelClientError(f"Tunnel API response is not JSON ({method} {url})") from exc
 
         if response_payload.get("status") != "ok":
             response_error = response_payload.get("response")
-            if isinstance(response_error, dict):
-                message = response_error.get("message")
-            else:
-                message = response_error
+            message = response_error.get("message") if isinstance(response_error, dict) else response_error
             raise TunnelClientError(f"Tunnel API returned error: {message}")
 
         response_data = response_payload.get("response")
         if not isinstance(response_data, dict):
-            last_exception = TunnelClientError("Tunnel API response payload has invalid format")
-            if attempt < TUNNEL_API_RETRIES:
-                time.sleep(0.5 * (2 ** (attempt - 1)))
-                continue
-            raise last_exception
+            raise TunnelClientError("Tunnel API response payload has invalid format")
 
         return response_data
-
-    raise last_exception or TunnelClientError("Tunnel API call failed unexpectedly")
+    finally:
+        if own_session:
+            session.close()

--- a/argus/client/tunnel_api.py
+++ b/argus/client/tunnel_api.py
@@ -83,7 +83,8 @@ def resolve_tunnel_config_with_reason(
 
     try:
         generate_keypair_if_needed(paths)
-        public_key = paths.public_key.read_text(encoding="utf-8").strip()
+        with open(paths.public_key, encoding="utf-8") as fh:
+            public_key = fh.read().strip()
         config = _register_tunnel(
             auth_token=auth_token,
             base_url=base_url,

--- a/argus/client/tunnel_api.py
+++ b/argus/client/tunnel_api.py
@@ -1,0 +1,165 @@
+import logging
+import time
+from typing import Any
+
+import requests
+
+from argus.client.tunnel_models import DEFAULT_TUNNEL_TIMEOUT, TunnelClientError, TunnelConfig
+from argus.client.tunnel_state import (
+    generate_keypair_if_needed,
+    get_tunnel_state_paths,
+    is_key_valid,
+    read_cached_tunnel_config,
+    write_key_meta,
+    write_tunnel_cache,
+)
+
+
+LOGGER = logging.getLogger(__name__)
+TUNNEL_API_RETRIES = 3
+
+
+def resolve_tunnel_config(
+    auth_token: str,
+    base_url: str,
+    force_refresh: bool = False,
+    ttl_seconds: int | None = None,
+) -> TunnelConfig | None:
+    config, _reason = resolve_tunnel_config_with_reason(
+        auth_token=auth_token,
+        base_url=base_url,
+        force_refresh=force_refresh,
+        ttl_seconds=ttl_seconds,
+    )
+    return config
+
+
+def resolve_tunnel_config_with_reason(
+    auth_token: str,
+    base_url: str,
+    force_refresh: bool = False,
+    ttl_seconds: int | None = None,
+) -> tuple[TunnelConfig | None, str | None]:
+    """
+    Resolve tunnel configuration while keeping Cloudflare bootstrap calls minimal.
+
+    Order:
+    1. Use cached config when key/cache are still valid and refresh is not forced.
+    2. Use GET /client/ssh/tunnel when key exists and remains valid.
+    3. Register/re-register via POST /client/ssh/tunnel.
+    """
+    paths = get_tunnel_state_paths()
+
+    if not force_refresh:
+        cached = read_cached_tunnel_config(paths)
+        if cached is not None and is_key_valid(paths):
+            return cached, None
+
+    if is_key_valid(paths):
+        try:
+            config = _get_tunnel_connection(auth_token=auth_token, base_url=base_url)
+            write_tunnel_cache(paths, config)
+            return config, None
+        except TunnelClientError as exc:
+            LOGGER.warning("Unable to refresh tunnel connection details via API: %s", exc)
+
+    try:
+        generate_keypair_if_needed(paths)
+        public_key = paths.public_key.read_text(encoding="utf-8").strip()
+        config = _register_tunnel(
+            auth_token=auth_token,
+            base_url=base_url,
+            public_key=public_key,
+            ttl_seconds=ttl_seconds,
+        )
+        write_key_meta(paths, config.expires_at)
+        write_tunnel_cache(paths, config)
+        return config, None
+    except (OSError, TunnelClientError) as exc:
+        LOGGER.warning("Unable to resolve SSH tunnel configuration: %s", exc)
+        return None, str(exc)
+
+
+def _register_tunnel(auth_token: str, base_url: str, public_key: str, ttl_seconds: int | None = None) -> TunnelConfig:
+    payload: dict[str, Any] = {"public_key": public_key}
+    if ttl_seconds is not None:
+        payload["ttl_seconds"] = ttl_seconds
+    response = _call_tunnel_api(
+        method="POST",
+        url=f"{base_url}/api/v1/client/ssh/tunnel",
+        auth_token=auth_token,
+        payload=payload,
+    )
+    return TunnelConfig.from_api_response(response)
+
+
+def _get_tunnel_connection(auth_token: str, base_url: str) -> TunnelConfig:
+    response = _call_tunnel_api(
+        method="GET",
+        url=f"{base_url}/api/v1/client/ssh/tunnel",
+        auth_token=auth_token,
+        payload=None,
+    )
+    return TunnelConfig.from_api_response(response)
+
+
+def _call_tunnel_api(method: str, url: str, auth_token: str, payload: dict[str, Any] | None) -> dict[str, Any]:
+    headers = {
+        "Authorization": f"token {auth_token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+
+    last_exception: TunnelClientError | None = None
+    for attempt in range(1, TUNNEL_API_RETRIES + 1):
+        try:
+            if method == "POST":
+                response = requests.post(url=url, json=payload, headers=headers, timeout=DEFAULT_TUNNEL_TIMEOUT)
+            elif method == "GET":
+                response = requests.get(url=url, headers=headers, timeout=DEFAULT_TUNNEL_TIMEOUT)
+            else:
+                raise TunnelClientError(f"Unsupported tunnel API method: {method}")
+        except requests.RequestException as exc:
+            last_exception = TunnelClientError(f"Tunnel API call failed ({method} {url}): {exc}")
+            if attempt < TUNNEL_API_RETRIES:
+                time.sleep(0.5 * (2 ** (attempt - 1)))
+                continue
+            raise last_exception from exc
+
+        if response.status_code != 200:
+            last_exception = TunnelClientError(
+                f"Tunnel API call returned unexpected status code {response.status_code} ({method} {url})"
+            )
+            if attempt < TUNNEL_API_RETRIES:
+                time.sleep(0.5 * (2 ** (attempt - 1)))
+                continue
+            raise last_exception
+
+        try:
+            response_payload = response.json()
+        except ValueError as exc:
+            last_exception = TunnelClientError(f"Tunnel API response is not JSON ({method} {url})")
+            if attempt < TUNNEL_API_RETRIES:
+                time.sleep(0.5 * (2 ** (attempt - 1)))
+                continue
+            raise last_exception from exc
+
+        if response_payload.get("status") != "ok":
+            response_error = response_payload.get("response")
+            if isinstance(response_error, dict):
+                message = response_error.get("message")
+            else:
+                message = response_error
+            raise TunnelClientError(f"Tunnel API returned error: {message}")
+
+        response_data = response_payload.get("response")
+        if not isinstance(response_data, dict):
+            last_exception = TunnelClientError("Tunnel API response payload has invalid format")
+            if attempt < TUNNEL_API_RETRIES:
+                time.sleep(0.5 * (2 ** (attempt - 1)))
+                continue
+            raise last_exception
+
+        return response_data
+
+    raise last_exception or TunnelClientError("Tunnel API call failed unexpectedly")

--- a/argus/client/tunnel_api.py
+++ b/argus/client/tunnel_api.py
@@ -172,6 +172,11 @@ def _call_tunnel_api(
         except ValueError as exc:
             raise TunnelClientError(f"Tunnel API response is not JSON ({method} {url})") from exc
 
+        if not isinstance(response_payload, dict):
+            raise TunnelClientError(
+                f"Tunnel API response payload has invalid format ({method} {url})"
+            )
+
         if response_payload.get("status") != "ok":
             response_error = response_payload.get("response")
             message = response_error.get("message") if isinstance(response_error, dict) else response_error

--- a/argus/client/tunnel_models.py
+++ b/argus/client/tunnel_models.py
@@ -48,10 +48,16 @@ class _TunnelCachePayload(TypedDict):
     tunnel_id: NotRequired[str | None]
 
 
-# Required keys are derived from the TypedDict at runtime via ``__required_keys__``;
-# kept as a module-level set so the dunder access is centralised and easy to swap
-# out if/when ``typing.get_type_hints``-based introspection becomes preferable.
-_TUNNEL_API_REQUIRED_KEYS: frozenset[str] = frozenset(_TunnelApiResponse.__required_keys__)
+# Required keys listed explicitly to avoid relying on TypedDict.__required_keys__
+# runtime behaviour, which changed in Python 3.14.
+_TUNNEL_API_REQUIRED_KEYS: tuple[str, ...] = (
+    "proxy_host",
+    "proxy_port",
+    "proxy_user",
+    "target_host",
+    "target_port",
+    "host_key_fingerprint",
+)
 
 
 @dataclass(frozen=True, slots=True)

--- a/argus/client/tunnel_models.py
+++ b/argus/client/tunnel_models.py
@@ -1,0 +1,88 @@
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+class TunnelClientError(Exception):
+    pass
+
+
+DEFAULT_TUNNEL_TIMEOUT = 10
+DEFAULT_RECONNECT_RETRIES = 3
+MAX_PORT_BIND_ATTEMPTS = 10
+ALLOWED_HOST_KEY_TYPES = (
+    "ssh-ed25519",
+    "ecdsa-sha2-nistp256",
+    "ecdsa-sha2-nistp384",
+    "ecdsa-sha2-nistp521",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class TunnelConfig:
+    proxy_host: str
+    proxy_port: int
+    proxy_user: str
+    target_host: str
+    target_port: int
+    host_key_fingerprint: str
+    expires_at: datetime | None = None
+    key_id: str | None = None
+    tunnel_id: str | None = None
+
+    @classmethod
+    def from_api_response(cls, response: dict[str, Any]) -> "TunnelConfig":
+        required_fields = (
+            "proxy_host",
+            "proxy_port",
+            "proxy_user",
+            "target_host",
+            "target_port",
+            "host_key_fingerprint",
+        )
+        missing = [name for name in required_fields if not response.get(name)]
+        if missing:
+            raise TunnelClientError(f"Missing required tunnel response fields: {', '.join(missing)}")
+
+        expires_at = response.get("expires_at")
+        return cls(
+            proxy_host=str(response["proxy_host"]),
+            proxy_port=int(response["proxy_port"]),
+            proxy_user=str(response["proxy_user"]),
+            target_host=str(response["target_host"]),
+            target_port=int(response["target_port"]),
+            host_key_fingerprint=str(response["host_key_fingerprint"]),
+            expires_at=parse_datetime(expires_at) if expires_at else None,
+            key_id=str(response["key_id"]) if response.get("key_id") else None,
+            tunnel_id=str(response["tunnel_id"]) if response.get("tunnel_id") else None,
+        )
+
+    def to_cache_payload(self) -> dict[str, Any]:
+        payload = asdict(self)
+        if self.expires_at is not None:
+            payload["expires_at"] = to_iso_z(self.expires_at)
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class TunnelStatePaths:
+    state_dir: Path
+    private_key: Path
+    public_key: Path
+    key_meta: Path
+    config_cache: Path
+
+
+def parse_datetime(value: str) -> datetime:
+    if not value:
+        raise ValueError("datetime value is required")
+    normalized = value.replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def to_iso_z(dt: datetime) -> str:
+    return dt.astimezone(UTC).isoformat().replace("+00:00", "Z")

--- a/argus/client/tunnel_models.py
+++ b/argus/client/tunnel_models.py
@@ -20,6 +20,7 @@ ALLOWED_HOST_KEY_TYPES = (
 
 
 class _TunnelApiResponse(TypedDict):
+    """Live response shape from ``/client/ssh/tunnel`` (POST register / GET fetch)."""
     proxy_host: str
     proxy_port: int
     proxy_user: str
@@ -29,6 +30,29 @@ class _TunnelApiResponse(TypedDict):
     expires_at: NotRequired[str | None]
     key_id: NotRequired[str | None]
     tunnel_id: NotRequired[str | None]
+
+
+class _TunnelCachePayload(TypedDict):
+    """On-disk cache shape written by :meth:`TunnelConfig.to_cache_payload`.
+
+    Mirrors :class:`_TunnelApiResponse` but is independently typed so future
+    cache-only fields don't leak into the API contract.
+    """
+    proxy_host: str
+    proxy_port: int
+    proxy_user: str
+    target_host: str
+    target_port: int
+    host_key_fingerprint: str
+    expires_at: NotRequired[str | None]
+    key_id: NotRequired[str | None]
+    tunnel_id: NotRequired[str | None]
+
+
+# Required keys are derived from the TypedDict at runtime via ``__required_keys__``;
+# kept as a module-level set so the dunder access is centralised and easy to swap
+# out if/when ``typing.get_type_hints``-based introspection becomes preferable.
+_TUNNEL_API_REQUIRED_KEYS: frozenset[str] = frozenset(_TunnelApiResponse.__required_keys__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -44,8 +68,8 @@ class TunnelConfig:
     tunnel_id: str | None = None
 
     @classmethod
-    def from_api_response(cls, response: "_TunnelApiResponse") -> "TunnelConfig":
-        missing = [k for k in _TunnelApiResponse.__required_keys__ if not response.get(k)]
+    def from_api_response(cls, response: "_TunnelApiResponse | _TunnelCachePayload") -> "TunnelConfig":
+        missing = [k for k in _TUNNEL_API_REQUIRED_KEYS if not response.get(k)]
         if missing:
             raise TunnelClientError(f"Missing required tunnel response fields: {', '.join(missing)}")
 

--- a/argus/client/tunnel_models.py
+++ b/argus/client/tunnel_models.py
@@ -1,7 +1,7 @@
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, NotRequired, TypedDict
 
 
 class TunnelClientError(Exception):
@@ -19,6 +19,18 @@ ALLOWED_HOST_KEY_TYPES = (
 )
 
 
+class _TunnelApiResponse(TypedDict):
+    proxy_host: str
+    proxy_port: int
+    proxy_user: str
+    target_host: str
+    target_port: int
+    host_key_fingerprint: str
+    expires_at: NotRequired[str | None]
+    key_id: NotRequired[str | None]
+    tunnel_id: NotRequired[str | None]
+
+
 @dataclass(frozen=True, slots=True)
 class TunnelConfig:
     proxy_host: str
@@ -32,16 +44,8 @@ class TunnelConfig:
     tunnel_id: str | None = None
 
     @classmethod
-    def from_api_response(cls, response: dict[str, Any]) -> "TunnelConfig":
-        required_fields = (
-            "proxy_host",
-            "proxy_port",
-            "proxy_user",
-            "target_host",
-            "target_port",
-            "host_key_fingerprint",
-        )
-        missing = [name for name in required_fields if not response.get(name)]
+    def from_api_response(cls, response: "_TunnelApiResponse") -> "TunnelConfig":
+        missing = [k for k in _TunnelApiResponse.__required_keys__ if not response.get(k)]
         if missing:
             raise TunnelClientError(f"Missing required tunnel response fields: {', '.join(missing)}")
 
@@ -61,7 +65,7 @@ class TunnelConfig:
     def to_cache_payload(self) -> dict[str, Any]:
         payload = asdict(self)
         if self.expires_at is not None:
-            payload["expires_at"] = to_iso_z(self.expires_at)
+            payload["expires_at"] = self.expires_at.astimezone(UTC).isoformat()
         return payload
 
 
@@ -77,12 +81,7 @@ class TunnelStatePaths:
 def parse_datetime(value: str) -> datetime:
     if not value:
         raise ValueError("datetime value is required")
-    normalized = value.replace("Z", "+00:00")
-    parsed = datetime.fromisoformat(normalized)
+    parsed = datetime.fromisoformat(value)
     if parsed.tzinfo is None:
         return parsed.replace(tzinfo=UTC)
     return parsed.astimezone(UTC)
-
-
-def to_iso_z(dt: datetime) -> str:
-    return dt.astimezone(UTC).isoformat().replace("+00:00", "Z")

--- a/argus/client/tunnel_models.py
+++ b/argus/client/tunnel_models.py
@@ -1,6 +1,5 @@
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
-from pathlib import Path
 from typing import Any, NotRequired, TypedDict
 
 
@@ -95,11 +94,11 @@ class TunnelConfig:
 
 @dataclass(frozen=True, slots=True)
 class TunnelStatePaths:
-    state_dir: Path
-    private_key: Path
-    public_key: Path
-    key_meta: Path
-    config_cache: Path
+    state_dir: str
+    private_key: str
+    public_key: str
+    key_meta: str
+    config_cache: str
 
 
 def parse_datetime(value: str) -> datetime:

--- a/argus/client/tunnel_ssh.py
+++ b/argus/client/tunnel_ssh.py
@@ -8,7 +8,6 @@ import socket
 import subprocess
 import tempfile
 import time
-from pathlib import Path
 
 from argus.client.tunnel_models import (
     ALLOWED_HOST_KEY_TYPES,
@@ -25,12 +24,12 @@ LOGGER = logging.getLogger(__name__)
 
 
 class SSHTunnel:
-    def __init__(self, key_path: Path | None = None) -> None:
+    def __init__(self, key_path: str | None = None) -> None:
         state_paths = get_tunnel_state_paths()
         self._key_path = key_path or state_paths.private_key
         self._process: subprocess.Popen[str] | None = None
         self._local_port: int | None = None
-        self._known_hosts_path: Path | None = None
+        self._known_hosts_path: str | None = None
         self._atexit_registered = False
 
     @property
@@ -47,7 +46,7 @@ class SSHTunnel:
             reason = "ssh-keyscan binary was not found on PATH"
             LOGGER.warning(reason)
             return None, reason
-        if not self._key_path.exists():
+        if not os.path.exists(self._key_path):
             reason = f"SSH private key does not exist: {self._key_path}"
             LOGGER.warning(reason)
             return None, reason
@@ -80,7 +79,7 @@ class SSHTunnel:
             except OSError as exc:
                 reason = f"failed to spawn ssh process: {exc}"
                 LOGGER.warning(reason)
-                known_hosts_path.unlink(missing_ok=True)
+                _unlink(known_hosts_path)
                 return None, reason
 
             ready, error_text = self._wait_for_port_ready(process=process, local_port=local_port)
@@ -103,12 +102,12 @@ class SSHTunnel:
 
             reason = f"establish attempt {attempt} failed: {error_text or 'unknown error'}"
             LOGGER.warning("SSH tunnel %s", reason)
-            known_hosts_path.unlink(missing_ok=True)
+            _unlink(known_hosts_path)
             return None, reason
 
         reason = f"establish failed after {MAX_PORT_BIND_ATTEMPTS} attempts"
         LOGGER.warning("SSH tunnel %s", reason)
-        known_hosts_path.unlink(missing_ok=True)
+        _unlink(known_hosts_path)
         return None, reason
 
     def is_alive(self) -> bool:
@@ -137,7 +136,7 @@ class SSHTunnel:
         self._local_port = None
 
         if self._known_hosts_path is not None:
-            self._known_hosts_path.unlink(missing_ok=True)
+            _unlink(self._known_hosts_path)
             self._known_hosts_path = None
 
     def _register_atexit(self) -> None:
@@ -146,7 +145,7 @@ class SSHTunnel:
         atexit.register(self.shutdown)
         self._atexit_registered = True
 
-    def _build_ssh_command(self, config: TunnelConfig, local_port: int, known_hosts_path: Path, ssh_bin: str = "ssh") -> list[str]:
+    def _build_ssh_command(self, config: TunnelConfig, local_port: int, known_hosts_path: str, ssh_bin: str = "ssh") -> list[str]:
         return [
             ssh_bin,
             "-N",
@@ -206,7 +205,7 @@ class SSHTunnel:
         return False, "Timed out waiting for local SSH tunnel port to become reachable"
 
     @staticmethod
-    def _prepare_known_hosts_file(config: TunnelConfig) -> Path:
+    def _prepare_known_hosts_file(config: TunnelConfig) -> str:
         """Build a temporary known_hosts file covering ``config.proxy_host``.
 
         Two input shapes are supported, both validated strictly:
@@ -336,13 +335,21 @@ def _normalise_known_hosts_entry(raw: str, host: str, port: int) -> str:
     return f"{host_token} {key_type} {key_blob}"
 
 
-def write_temp_known_hosts(known_host_line: str) -> Path:
+def write_temp_known_hosts(known_host_line: str) -> str:
     fd, temp_path = tempfile.mkstemp(prefix="argus-known-hosts-")
     os.close(fd)
-    path = Path(temp_path)
-    path.write_text(f"{known_host_line}\n", encoding="utf-8")
-    path.chmod(0o600)
-    return path
+    with open(temp_path, "w", encoding="utf-8") as fh:
+        fh.write(f"{known_host_line}\n")
+    os.chmod(temp_path, 0o600)
+    return temp_path
+
+
+def _unlink(path: str) -> None:
+    """Remove a file; silently ignore if it does not exist."""
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        pass
 
 
 def read_process_stderr(process: subprocess.Popen[str]) -> str:

--- a/argus/client/tunnel_ssh.py
+++ b/argus/client/tunnel_ssh.py
@@ -207,12 +207,39 @@ class SSHTunnel:
 
     @staticmethod
     def _prepare_known_hosts_file(config: TunnelConfig) -> Path:
-        host_lines = scan_host_keys(config.proxy_host, config.proxy_port)
-        matched_line = match_known_host_line(
-            scanned_lines=host_lines,
-            expected_fingerprint=config.host_key_fingerprint,
+        """Build a temporary known_hosts file covering ``config.proxy_host``.
+
+        Two input shapes are supported, both validated strictly:
+
+        1. **Full known_hosts entry** (``"host keytype keydata"``) — the format
+           returned once the backend stores entries directly. We rewrite the
+           leading host token to match the connection target (using
+           ``[host]:port`` for non-default ports).
+        2. **SHA256 fingerprint** (``"SHA256:..."``) — current backend format;
+           we run ``ssh-keyscan`` and match by fingerprint.
+
+        Anything else raises :class:`TunnelClientError` so strict host
+        verification stays enforced.
+        """
+        raw = (config.host_key_fingerprint or "").strip()
+        if not raw:
+            raise TunnelClientError("host_key_fingerprint is empty; refusing to skip host verification")
+
+        if _looks_like_known_hosts_entry(raw):
+            normalised = _normalise_known_hosts_entry(raw, config.proxy_host, config.proxy_port)
+            return write_temp_known_hosts(normalised)
+
+        if raw.startswith("SHA256:"):
+            host_lines = scan_host_keys(config.proxy_host, config.proxy_port)
+            matched_line = match_known_host_line(
+                scanned_lines=host_lines,
+                expected_fingerprint=raw,
+            )
+            return write_temp_known_hosts(matched_line)
+
+        raise TunnelClientError(
+            f"host_key_fingerprint has unrecognised format: {raw[:32]!r}"
         )
-        return write_temp_known_hosts(matched_line)
 
     @staticmethod
     def _terminate_process(process: subprocess.Popen[str]) -> None:
@@ -281,6 +308,32 @@ def derive_fingerprint(key_text: str) -> str:
     digest = hashlib.sha256(key_blob).digest()
     b64 = base64.b64encode(digest).rstrip(b"=").decode("ascii")
     return f"SHA256:{b64}"
+
+
+def _looks_like_known_hosts_entry(raw: str) -> bool:
+    parts = raw.split()
+    return len(parts) >= 3 and parts[1] in ALLOWED_HOST_KEY_TYPES
+
+
+def _normalise_known_hosts_entry(raw: str, host: str, port: int) -> str:
+    """Rewrite a known_hosts entry so the host token matches the connect address.
+
+    SSH matches the entry by the literal host string used to connect — so a
+    backend-provided entry of ``"some-other-name keytype keydata"`` would be
+    ignored. We canonicalise the leading host token to match what
+    :func:`SSHTunnel._build_ssh_command` connects to (and use ``[host]:port``
+    for non-default ports).
+    """
+    parts = raw.split()
+    if len(parts) < 3:
+        raise TunnelClientError("known_hosts entry must contain host, key type, and key data")
+    key_type = parts[1]
+    key_blob = parts[2]
+    if key_type not in ALLOWED_HOST_KEY_TYPES:
+        raise TunnelClientError(f"unsupported known_hosts key type: {key_type}")
+
+    host_token = host if port == 22 else f"[{host}]:{port}"
+    return f"{host_token} {key_type} {key_blob}"
 
 
 def write_temp_known_hosts(known_host_line: str) -> Path:

--- a/argus/client/tunnel_ssh.py
+++ b/argus/client/tunnel_ssh.py
@@ -1,0 +1,305 @@
+import atexit
+import base64
+import hashlib
+import logging
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+from argus.client.tunnel_models import (
+    ALLOWED_HOST_KEY_TYPES,
+    DEFAULT_RECONNECT_RETRIES,
+    DEFAULT_TUNNEL_TIMEOUT,
+    MAX_PORT_BIND_ATTEMPTS,
+    TunnelClientError,
+    TunnelConfig,
+)
+from argus.client.tunnel_state import get_tunnel_state_paths
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class SSHTunnel:
+    def __init__(self, key_path: Path | None = None) -> None:
+        state_paths = get_tunnel_state_paths()
+        self._key_path = key_path or state_paths.private_key
+        self._process: subprocess.Popen[str] | None = None
+        self._local_port: int | None = None
+        self._known_hosts_path: Path | None = None
+        self._atexit_registered = False
+
+    @property
+    def local_port(self) -> int | None:
+        return self._local_port
+
+    def establish(self, config: TunnelConfig) -> tuple[int | None, str | None]:
+        if shutil.which("ssh") is None:
+            reason = "ssh binary was not found on PATH"
+            LOGGER.warning(reason)
+            return None, reason
+        if shutil.which("ssh-keyscan") is None:
+            reason = "ssh-keyscan binary was not found on PATH"
+            LOGGER.warning(reason)
+            return None, reason
+        if not self._key_path.exists():
+            reason = f"SSH private key does not exist: {self._key_path}"
+            LOGGER.warning(reason)
+            return None, reason
+
+        self.shutdown()
+        try:
+            known_hosts_path = self._prepare_known_hosts_file(config)
+        except TunnelClientError as exc:
+            reason = f"strict host verification failed: {exc}"
+            LOGGER.warning("SSH tunnel %s", reason)
+            return None, reason
+
+        for attempt in range(1, MAX_PORT_BIND_ATTEMPTS + 1):
+            reserve_socket, local_port = self._reserve_local_port()
+            command = self._build_ssh_command(
+                config=config,
+                local_port=local_port,
+                known_hosts_path=known_hosts_path,
+            )
+
+            try:
+                reserve_socket.close()
+                process = subprocess.Popen(  # noqa: S603
+                    command,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                )
+            except OSError as exc:
+                reason = f"failed to spawn ssh process: {exc}"
+                LOGGER.warning(reason)
+                known_hosts_path.unlink(missing_ok=True)
+                return None, reason
+
+            ready, error_text = self._wait_for_port_ready(process=process, local_port=local_port)
+            if ready:
+                self._process = process
+                self._local_port = local_port
+                self._known_hosts_path = known_hosts_path
+                self._register_atexit()
+                return local_port, None
+
+            self._terminate_process(process)
+
+            if "Address already in use" in error_text:
+                LOGGER.warning(
+                    "SSH tunnel local bind conflict on attempt %s/%s, retrying with a new local port",
+                    attempt,
+                    MAX_PORT_BIND_ATTEMPTS,
+                )
+                continue
+
+            reason = f"establish attempt {attempt} failed: {error_text or 'unknown error'}"
+            LOGGER.warning("SSH tunnel %s", reason)
+            known_hosts_path.unlink(missing_ok=True)
+            return None, reason
+
+        reason = f"establish failed after {MAX_PORT_BIND_ATTEMPTS} attempts"
+        LOGGER.warning("SSH tunnel %s", reason)
+        known_hosts_path.unlink(missing_ok=True)
+        return None, reason
+
+    def is_alive(self) -> bool:
+        if not self._process or self._local_port is None:
+            return False
+        if self._process.poll() is not None:
+            return False
+        return is_local_port_open(self._local_port)
+
+    def reconnect(self, config: TunnelConfig) -> tuple[int | None, str | None]:
+        self.shutdown()
+        last_reason: str | None = None
+        for attempt in range(1, DEFAULT_RECONNECT_RETRIES + 1):
+            local_port, reason = self.establish(config)
+            if local_port is not None:
+                return local_port, None
+            last_reason = reason
+            time.sleep(2 ** (attempt - 1))
+        return None, last_reason or "reconnect exhausted"
+
+    def shutdown(self) -> None:
+        if self._process is not None:
+            self._terminate_process(self._process)
+            self._process = None
+
+        self._local_port = None
+
+        if self._known_hosts_path is not None:
+            self._known_hosts_path.unlink(missing_ok=True)
+            self._known_hosts_path = None
+
+    def _register_atexit(self) -> None:
+        if self._atexit_registered:
+            return
+        atexit.register(self.shutdown)
+        self._atexit_registered = True
+
+    def _build_ssh_command(self, config: TunnelConfig, local_port: int, known_hosts_path: Path) -> list[str]:
+        return [
+            "ssh",
+            "-N",
+            "-L",
+            f"127.0.0.1:{local_port}:{config.target_host}:{config.target_port}",
+            "-i",
+            str(self._key_path),
+            "-p",
+            str(config.proxy_port),
+            f"{config.proxy_user}@{config.proxy_host}",
+            "-o",
+            "ExitOnForwardFailure=yes",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "IdentitiesOnly=yes",
+            "-o",
+            f"UserKnownHostsFile={known_hosts_path}",
+            "-o",
+            "GlobalKnownHostsFile=/dev/null",
+            "-o",
+            "StrictHostKeyChecking=yes",
+            "-o",
+            "HostKeyAlgorithms=ssh-ed25519,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521",
+            "-o",
+            "PubkeyAcceptedAlgorithms=ssh-ed25519",
+            "-o",
+            f"ConnectTimeout={DEFAULT_TUNNEL_TIMEOUT}",
+            "-o",
+            "ServerAliveInterval=30",
+            "-o",
+            "ServerAliveCountMax=3",
+            "-o",
+            "TCPKeepAlive=yes",
+            "-o",
+            "ControlMaster=no",
+            "-o",
+            "LogLevel=ERROR",
+        ]
+
+    @staticmethod
+    def _reserve_local_port() -> tuple[socket.socket, int]:
+        reserve_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        reserve_socket.bind(("127.0.0.1", 0))
+        local_port = reserve_socket.getsockname()[1]
+        return reserve_socket, local_port
+
+    @staticmethod
+    def _wait_for_port_ready(process: subprocess.Popen[str], local_port: int) -> tuple[bool, str]:
+        deadline = time.monotonic() + DEFAULT_TUNNEL_TIMEOUT
+        while time.monotonic() < deadline:
+            if process.poll() is not None:
+                return False, read_process_stderr(process)
+            if is_local_port_open(local_port):
+                return True, ""
+            time.sleep(0.1)
+        return False, "Timed out waiting for local SSH tunnel port to become reachable"
+
+    @staticmethod
+    def _prepare_known_hosts_file(config: TunnelConfig) -> Path:
+        host_lines = scan_host_keys(config.proxy_host, config.proxy_port)
+        matched_line = match_known_host_line(
+            scanned_lines=host_lines,
+            expected_fingerprint=config.host_key_fingerprint,
+        )
+        return write_temp_known_hosts(matched_line)
+
+    @staticmethod
+    def _terminate_process(process: subprocess.Popen[str]) -> None:
+        if process.poll() is not None:
+            return
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+
+
+def scan_host_keys(host: str, port: int) -> list[str]:
+    try:
+        result = subprocess.run(  # noqa: S603
+            ["ssh-keyscan", "-T", "5", "-p", str(port), "-t", "ed25519,ecdsa", host],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=DEFAULT_TUNNEL_TIMEOUT,
+        )
+    except FileNotFoundError as exc:
+        raise TunnelClientError("ssh-keyscan binary is required for host verification") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise TunnelClientError(f"ssh-keyscan timed out for {host}:{port}") from exc
+
+    lines = [line.strip() for line in result.stdout.splitlines() if line.strip() and not line.startswith("#")]
+    if lines:
+        return lines
+
+    stderr = (result.stderr or "").strip()
+    raise TunnelClientError(f"Failed to scan SSH host key for {host}:{port}: {stderr or 'no host keys returned'}")
+
+
+def match_known_host_line(scanned_lines: list[str], expected_fingerprint: str) -> str:
+    for line in scanned_lines:
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        key_type = parts[1]
+        key_blob = parts[2]
+        if key_type not in ALLOWED_HOST_KEY_TYPES:
+            continue
+
+        derived = derive_fingerprint(f"{key_type} {key_blob}")
+        if derived == expected_fingerprint:
+            return line
+
+    raise TunnelClientError(
+        "Host key fingerprint mismatch during strict verification "
+        f"(expected {expected_fingerprint}, accepted key types: ed25519/ecdsa only)"
+    )
+
+
+def derive_fingerprint(key_text: str) -> str:
+    parts = key_text.strip().split()
+    if len(parts) < 2:
+        raise TunnelClientError("Invalid host key text format")
+
+    try:
+        key_blob = base64.b64decode(parts[1].encode("ascii"), validate=True)
+    except ValueError as exc:
+        raise TunnelClientError("Invalid base64 in scanned host key") from exc
+
+    digest = hashlib.sha256(key_blob).digest()
+    b64 = base64.b64encode(digest).rstrip(b"=").decode("ascii")
+    return f"SHA256:{b64}"
+
+
+def write_temp_known_hosts(known_host_line: str) -> Path:
+    fd, temp_path = tempfile.mkstemp(prefix="argus-known-hosts-")
+    os.close(fd)
+    path = Path(temp_path)
+    path.write_text(f"{known_host_line}\n", encoding="utf-8")
+    path.chmod(0o600)
+    return path
+
+
+def read_process_stderr(process: subprocess.Popen[str]) -> str:
+    if process.stderr is None:
+        return ""
+    try:
+        return process.stderr.read().strip()
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def is_local_port_open(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.settimeout(0.5)
+        return probe.connect_ex(("127.0.0.1", port)) == 0

--- a/argus/client/tunnel_ssh.py
+++ b/argus/client/tunnel_ssh.py
@@ -38,7 +38,8 @@ class SSHTunnel:
         return self._local_port
 
     def establish(self, config: TunnelConfig) -> tuple[int | None, str | None]:
-        if shutil.which("ssh") is None:
+        ssh_bin = shutil.which("ssh")
+        if ssh_bin is None:
             reason = "ssh binary was not found on PATH"
             LOGGER.warning(reason)
             return None, reason
@@ -65,6 +66,7 @@ class SSHTunnel:
                 config=config,
                 local_port=local_port,
                 known_hosts_path=known_hosts_path,
+                ssh_bin=ssh_bin,
             )
 
             try:
@@ -144,9 +146,9 @@ class SSHTunnel:
         atexit.register(self.shutdown)
         self._atexit_registered = True
 
-    def _build_ssh_command(self, config: TunnelConfig, local_port: int, known_hosts_path: Path) -> list[str]:
+    def _build_ssh_command(self, config: TunnelConfig, local_port: int, known_hosts_path: Path, ssh_bin: str = "ssh") -> list[str]:
         return [
-            "ssh",
+            ssh_bin,
             "-N",
             "-L",
             f"127.0.0.1:{local_port}:{config.target_host}:{config.target_port}",

--- a/argus/client/tunnel_state.py
+++ b/argus/client/tunnel_state.py
@@ -22,7 +22,7 @@ except ImportError:
     PrivateFormat = None
     PublicFormat = None
 
-from argus.client.tunnel_models import TunnelClientError, TunnelConfig, TunnelStatePaths, parse_datetime, to_iso_z
+from argus.client.tunnel_models import TunnelClientError, TunnelConfig, TunnelStatePaths, parse_datetime
 
 
 LOGGER = logging.getLogger(__name__)
@@ -136,7 +136,7 @@ def is_key_valid(paths: TunnelStatePaths) -> bool:
 def write_key_meta(paths: TunnelStatePaths, expires_at: datetime | None) -> None:
     if expires_at is None:
         return
-    payload = {"expires_at": to_iso_z(expires_at)}
+    payload = {"expires_at": expires_at.astimezone(UTC).isoformat()}
     paths.key_meta.write_text(json.dumps(payload), encoding="utf-8")
     paths.key_meta.chmod(0o600)
 

--- a/argus/client/tunnel_state.py
+++ b/argus/client/tunnel_state.py
@@ -88,7 +88,7 @@ def generate_keypair_if_needed(paths: TunnelStatePaths) -> None:
         raise TunnelClientError(f"ssh-keygen failed: {stderr or 'unknown error'}")
 
     paths.private_key.chmod(0o600)
-    paths.public_key.chmod(0o600)
+    paths.public_key.chmod(0o644)
 
 
 def _generate_keypair_with_cryptography(paths: TunnelStatePaths) -> bool:
@@ -112,7 +112,7 @@ def _generate_keypair_with_cryptography(paths: TunnelStatePaths) -> bool:
         paths.private_key.write_bytes(private_bytes)
         paths.public_key.write_bytes(public_bytes + b"\n")
         paths.private_key.chmod(0o600)
-        paths.public_key.chmod(0o600)
+        paths.public_key.chmod(0o644)
         return True
     except Exception as exc:  # noqa: BLE001
         LOGGER.warning("Falling back to ssh-keygen due to cryptography key generation failure: %s", exc)

--- a/argus/client/tunnel_state.py
+++ b/argus/client/tunnel_state.py
@@ -1,0 +1,202 @@
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+try:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    from cryptography.hazmat.primitives.serialization import (
+        Encoding,
+        NoEncryption,
+        PrivateFormat,
+        PublicFormat,
+    )
+except ImportError:
+    Ed25519PrivateKey = None
+    Encoding = None
+    NoEncryption = None
+    PrivateFormat = None
+    PublicFormat = None
+
+from argus.client.tunnel_models import TunnelClientError, TunnelConfig, TunnelStatePaths, parse_datetime, to_iso_z
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_tunnel_state_paths() -> TunnelStatePaths:
+    state_dir = _resolve_state_dir()
+    return TunnelStatePaths(
+        state_dir=state_dir,
+        private_key=state_dir / "id_argus_proxy",
+        public_key=state_dir / "id_argus_proxy.pub",
+        key_meta=state_dir / "id_argus_proxy.meta.json",
+        config_cache=state_dir / "tunnel_config.json",
+    )
+
+
+def delete_cached_tunnel_state() -> None:
+    """Delete cached tunnel key/config state used by the client."""
+    try:
+        paths = get_tunnel_state_paths()
+    except OSError:
+        return
+
+    for file_path in (paths.private_key, paths.public_key, paths.key_meta, paths.config_cache):
+        try:
+            file_path.unlink(missing_ok=True)
+        except OSError:
+            LOGGER.debug("Failed removing cached tunnel state file: %s", file_path, exc_info=True)
+
+
+def generate_keypair_if_needed(paths: TunnelStatePaths) -> None:
+    if is_key_valid(paths):
+        return
+
+    if _generate_keypair_with_cryptography(paths):
+        return
+
+    if shutil.which("ssh-keygen") is None:
+        raise TunnelClientError("ssh-keygen binary is required to generate SSH keypair")
+
+    paths.private_key.unlink(missing_ok=True)
+    paths.public_key.unlink(missing_ok=True)
+
+    result = subprocess.run(  # noqa: S603
+        [
+            "ssh-keygen",
+            "-q",
+            "-t",
+            "ed25519",
+            "-N",
+            "",
+            "-f",
+            str(paths.private_key),
+            "-C",
+            "argus-proxy",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        raise TunnelClientError(f"ssh-keygen failed: {stderr or 'unknown error'}")
+
+    paths.private_key.chmod(0o600)
+    paths.public_key.chmod(0o600)
+
+
+def _generate_keypair_with_cryptography(paths: TunnelStatePaths) -> bool:
+    if Ed25519PrivateKey is None:
+        return False
+
+    try:
+        private_key = Ed25519PrivateKey.generate()
+        public_key = private_key.public_key()
+
+        private_bytes = private_key.private_bytes(
+            encoding=Encoding.PEM,
+            format=PrivateFormat.OpenSSH,
+            encryption_algorithm=NoEncryption(),
+        )
+        public_bytes = public_key.public_bytes(
+            encoding=Encoding.OpenSSH,
+            format=PublicFormat.OpenSSH,
+        )
+
+        paths.private_key.write_bytes(private_bytes)
+        paths.public_key.write_bytes(public_bytes + b"\n")
+        paths.private_key.chmod(0o600)
+        paths.public_key.chmod(0o600)
+        return True
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("Falling back to ssh-keygen due to cryptography key generation failure: %s", exc)
+        return False
+
+
+def is_key_valid(paths: TunnelStatePaths) -> bool:
+    if not paths.private_key.exists() or not paths.public_key.exists() or not paths.key_meta.exists():
+        return False
+
+    try:
+        key_meta = json.loads(paths.key_meta.read_text(encoding="utf-8"))
+        expires_at = parse_datetime(key_meta.get("expires_at"))
+    except (OSError, json.JSONDecodeError, TypeError, ValueError):
+        return False
+
+    now = datetime.now(tz=UTC)
+    return now < expires_at
+
+
+def write_key_meta(paths: TunnelStatePaths, expires_at: datetime | None) -> None:
+    if expires_at is None:
+        return
+    payload = {"expires_at": to_iso_z(expires_at)}
+    paths.key_meta.write_text(json.dumps(payload), encoding="utf-8")
+    paths.key_meta.chmod(0o600)
+
+
+def read_cached_tunnel_config(paths: TunnelStatePaths) -> TunnelConfig | None:
+    if not paths.config_cache.exists():
+        return None
+
+    try:
+        payload = json.loads(paths.config_cache.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    try:
+        config = TunnelConfig.from_api_response(payload)
+    except TunnelClientError:
+        return None
+
+    if config.expires_at is not None and datetime.now(tz=UTC) >= config.expires_at:
+        return None
+
+    return config
+
+
+def write_tunnel_cache(paths: TunnelStatePaths, config: TunnelConfig) -> None:
+    paths.config_cache.write_text(json.dumps(config.to_cache_payload()), encoding="utf-8")
+    paths.config_cache.chmod(0o600)
+
+
+def _resolve_state_dir() -> Path:
+    candidates: list[Path] = []
+
+    if configured_dir := os.environ.get("ARGUS_TUNNEL_STATE_DIR"):
+        candidates.append(Path(configured_dir).expanduser())
+
+    candidates.append(Path.home() / ".ssh")
+
+    if runtime_dir := os.environ.get("XDG_RUNTIME_DIR"):
+        candidates.append(Path(runtime_dir) / "argus-tunnel")
+
+    candidates.append(Path(tempfile.gettempdir()) / f"argus-tunnel-{os.getuid()}")
+
+    for candidate in candidates:
+        if _prepare_state_dir(candidate):
+            return candidate
+
+    raise OSError("No writable directory available for SSH tunnel state")
+
+
+def _prepare_state_dir(path: Path) -> bool:
+    try:
+        if path.exists():
+            if not path.is_dir():
+                return False
+            if not os.access(path, os.W_OK | os.X_OK):
+                return False
+            return True
+
+        path.mkdir(parents=True, mode=0o700, exist_ok=True)
+        path.chmod(0o700)
+        return True
+    except OSError:
+        return False

--- a/argus/client/tunnel_state.py
+++ b/argus/client/tunnel_state.py
@@ -5,7 +5,6 @@ import shutil
 import subprocess
 import tempfile
 from datetime import UTC, datetime
-from pathlib import Path
 
 try:
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
@@ -32,10 +31,10 @@ def get_tunnel_state_paths() -> TunnelStatePaths:
     state_dir = _resolve_state_dir()
     return TunnelStatePaths(
         state_dir=state_dir,
-        private_key=state_dir / "id_argus_proxy",
-        public_key=state_dir / "id_argus_proxy.pub",
-        key_meta=state_dir / "id_argus_proxy.meta.json",
-        config_cache=state_dir / "tunnel_config.json",
+        private_key=os.path.join(state_dir, "id_argus_proxy"),
+        public_key=os.path.join(state_dir, "id_argus_proxy.pub"),
+        key_meta=os.path.join(state_dir, "id_argus_proxy.meta.json"),
+        config_cache=os.path.join(state_dir, "tunnel_config.json"),
     )
 
 
@@ -48,7 +47,7 @@ def delete_cached_tunnel_state() -> None:
 
     for file_path in (paths.private_key, paths.public_key, paths.key_meta, paths.config_cache):
         try:
-            file_path.unlink(missing_ok=True)
+            _unlink(file_path)
         except OSError:
             LOGGER.debug("Failed removing cached tunnel state file: %s", file_path, exc_info=True)
 
@@ -63,8 +62,8 @@ def generate_keypair_if_needed(paths: TunnelStatePaths) -> None:
     if shutil.which("ssh-keygen") is None:
         raise TunnelClientError("ssh-keygen binary is required to generate SSH keypair")
 
-    paths.private_key.unlink(missing_ok=True)
-    paths.public_key.unlink(missing_ok=True)
+    _unlink(paths.private_key)
+    _unlink(paths.public_key)
 
     result = subprocess.run(  # noqa: S603
         [
@@ -75,7 +74,7 @@ def generate_keypair_if_needed(paths: TunnelStatePaths) -> None:
             "-N",
             "",
             "-f",
-            str(paths.private_key),
+            paths.private_key,
             "-C",
             "argus-proxy",
         ],
@@ -87,8 +86,8 @@ def generate_keypair_if_needed(paths: TunnelStatePaths) -> None:
         stderr = (result.stderr or "").strip()
         raise TunnelClientError(f"ssh-keygen failed: {stderr or 'unknown error'}")
 
-    paths.private_key.chmod(0o600)
-    paths.public_key.chmod(0o644)
+    os.chmod(paths.private_key, 0o600)
+    os.chmod(paths.public_key, 0o644)
 
 
 def _generate_keypair_with_cryptography(paths: TunnelStatePaths) -> bool:
@@ -109,10 +108,10 @@ def _generate_keypair_with_cryptography(paths: TunnelStatePaths) -> bool:
             format=PublicFormat.OpenSSH,
         )
 
-        paths.private_key.write_bytes(private_bytes)
-        paths.public_key.write_bytes(public_bytes + b"\n")
-        paths.private_key.chmod(0o600)
-        paths.public_key.chmod(0o644)
+        _write_bytes(paths.private_key, private_bytes)
+        _write_bytes(paths.public_key, public_bytes + b"\n")
+        os.chmod(paths.private_key, 0o600)
+        os.chmod(paths.public_key, 0o644)
         return True
     except Exception as exc:  # noqa: BLE001
         LOGGER.warning("Falling back to ssh-keygen due to cryptography key generation failure: %s", exc)
@@ -120,11 +119,11 @@ def _generate_keypair_with_cryptography(paths: TunnelStatePaths) -> bool:
 
 
 def is_key_valid(paths: TunnelStatePaths) -> bool:
-    if not paths.private_key.exists() or not paths.public_key.exists() or not paths.key_meta.exists():
+    if not os.path.exists(paths.private_key) or not os.path.exists(paths.public_key) or not os.path.exists(paths.key_meta):
         return False
 
     try:
-        key_meta = json.loads(paths.key_meta.read_text(encoding="utf-8"))
+        key_meta = json.loads(_read_text(paths.key_meta))
         expires_at = parse_datetime(key_meta.get("expires_at"))
     except (OSError, json.JSONDecodeError, TypeError, ValueError):
         return False
@@ -137,16 +136,16 @@ def write_key_meta(paths: TunnelStatePaths, expires_at: datetime | None) -> None
     if expires_at is None:
         return
     payload = {"expires_at": expires_at.astimezone(UTC).isoformat()}
-    paths.key_meta.write_text(json.dumps(payload), encoding="utf-8")
-    paths.key_meta.chmod(0o600)
+    _write_text(paths.key_meta, json.dumps(payload))
+    os.chmod(paths.key_meta, 0o600)
 
 
 def read_cached_tunnel_config(paths: TunnelStatePaths) -> TunnelConfig | None:
-    if not paths.config_cache.exists():
+    if not os.path.exists(paths.config_cache):
         return None
 
     try:
-        payload = json.loads(paths.config_cache.read_text(encoding="utf-8"))
+        payload = json.loads(_read_text(paths.config_cache))
     except (OSError, json.JSONDecodeError):
         return None
 
@@ -162,22 +161,22 @@ def read_cached_tunnel_config(paths: TunnelStatePaths) -> TunnelConfig | None:
 
 
 def write_tunnel_cache(paths: TunnelStatePaths, config: TunnelConfig) -> None:
-    paths.config_cache.write_text(json.dumps(config.to_cache_payload()), encoding="utf-8")
-    paths.config_cache.chmod(0o600)
+    _write_text(paths.config_cache, json.dumps(config.to_cache_payload()))
+    os.chmod(paths.config_cache, 0o600)
 
 
-def _resolve_state_dir() -> Path:
-    candidates: list[Path] = []
+def _resolve_state_dir() -> str:
+    candidates: list[str] = []
 
     if configured_dir := os.environ.get("ARGUS_TUNNEL_STATE_DIR"):
-        candidates.append(Path(configured_dir).expanduser())
+        candidates.append(os.path.expanduser(configured_dir))
 
-    candidates.append(Path.home() / ".ssh")
+    candidates.append(os.path.join(os.path.expanduser("~"), ".ssh"))
 
     if runtime_dir := os.environ.get("XDG_RUNTIME_DIR"):
-        candidates.append(Path(runtime_dir) / "argus-tunnel")
+        candidates.append(os.path.join(runtime_dir, "argus-tunnel"))
 
-    candidates.append(Path(tempfile.gettempdir()) / f"argus-tunnel-{os.getuid()}")
+    candidates.append(os.path.join(tempfile.gettempdir(), f"argus-tunnel-{os.getuid()}"))
 
     for candidate in candidates:
         if _prepare_state_dir(candidate):
@@ -186,17 +185,44 @@ def _resolve_state_dir() -> Path:
     raise OSError("No writable directory available for SSH tunnel state")
 
 
-def _prepare_state_dir(path: Path) -> bool:
+def _prepare_state_dir(path: str) -> bool:
     try:
-        if path.exists():
-            if not path.is_dir():
+        if os.path.exists(path):
+            if not os.path.isdir(path):
                 return False
             if not os.access(path, os.W_OK | os.X_OK):
                 return False
             return True
 
-        path.mkdir(parents=True, mode=0o700, exist_ok=True)
-        path.chmod(0o700)
+        os.makedirs(path, mode=0o700, exist_ok=True)
+        os.chmod(path, 0o700)
         return True
     except OSError:
         return False
+
+
+# ---------------------------------------------------------------------------
+# Small helpers to replace pathlib method calls with plain os / builtins
+# ---------------------------------------------------------------------------
+
+def _unlink(path: str) -> None:
+    """Remove a file; silently ignore if it does not exist."""
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        pass
+
+
+def _read_text(path: str, encoding: str = "utf-8") -> str:
+    with open(path, encoding=encoding) as fh:
+        return fh.read()
+
+
+def _write_text(path: str, text: str, encoding: str = "utf-8") -> None:
+    with open(path, "w", encoding=encoding) as fh:
+        fh.write(text)
+
+
+def _write_bytes(path: str, data: bytes) -> None:
+    with open(path, "wb") as fh:
+        fh.write(data)


### PR DESCRIPTION
## Summary
- add a dedicated client SSH tunnel stack (`tunnel_models`, `tunnel_state`, `tunnel_api`, `tunnel_ssh`) and a compatibility facade in `argus/client/tunnel.py`.
- route Argus client data-path requests through `http://127.0.0.1:<local_port>` when tunnel mode is enabled, with strict temp-file host key verification (`ed25519` + `ecdsa`, no RSA), free-port allocation, reconnect, request-level retry, and warning-based fallback.
- thread `use_tunnel` through client constructors and both CLIs (`generic` + `driver-matrix`) and add focused tunnel tests covering API retries, strict host checking, bind conflicts, cooldown retry behavior, and request-level recovery.

## Validation
- `uv run pytest argus/client/tests`
- `uv run python -m py_compile argus/client/base.py argus/client/tunnel.py argus/client/tunnel_api.py argus/client/tunnel_models.py argus/client/tunnel_ssh.py argus/client/tunnel_state.py argus/client/generic/cli.py argus/client/driver_matrix_tests/cli.py argus/client/generic/client.py argus/client/driver_matrix_tests/client.py argus/client/sct/client.py argus/client/sirenada/client.py argus/client/tests/test_tunnel.py`