### PR TITLE
feature(cli): Implement full generic results command

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -50,6 +50,7 @@ var (
 	cacheTTL       string
 	nonInteractive bool
 	verbosity      int
+	noColor        bool
 )
 
 func init() {
@@ -63,6 +64,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cacheTTL, "cache-ttl", "", "override the default cache TTL (e.g. 10m, 1h); ignored when --no-cache is set")
 	rootCmd.PersistentFlags().BoolVar(&nonInteractive, "non-interactive", false, "disable interactive prompts; return an error instead of triggering re-authentication")
 	rootCmd.PersistentFlags().CountVarP(&verbosity, "verbose", "v", "increase log verbosity: -v/-vv mirrors info logs to stderr, -vvv mirrors debug logs to stdout")
+	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "disable colored output; use bracket status indicators instead (e.g. (OK), (FAIL))")
 }
 
 var rootCmd = &cobra.Command{

--- a/cli/cmd/testrun.go
+++ b/cli/cmd/testrun.go
@@ -515,12 +515,29 @@ var resultsCmd = &cobra.Command{
 
 		testID, _ := cmd.Flags().GetString("test-id")
 		runID, _ := cmd.Flags().GetString("run-id")
+
+		// Auto-resolve test-id from the run when not provided.
+		if testID == "" {
+			log.Debug().Str("run_id", runID).Msg("resolving test-id from run")
+			fetcher := newRunFetcher()
+			resolved, err := services.ResolveTestID(ctx, client, c, fetcher, runID, "")
+			if err != nil {
+				log.Error().Err(err).Str("run_id", runID).Msg("failed to resolve test-id")
+				return fmt.Errorf("resolving test-id: %w", err)
+			}
+			testID = resolved
+			log.Debug().Str("run_id", runID).Str("test_id", testID).Msg("test-id resolved from run")
+		}
+
 		log.Debug().Str("test_id", testID).Str("run_id", runID).Msg("fetching run results")
 
 		cacheKey := cache.ResultsKey(testID, runID)
 
 		if cached, _, err := cache.Get[models.FetchResultsResponse](c, cacheKey); isCacheable(err) {
 			log.Debug().Str("run_id", runID).Msg("results served from cache")
+			showURLs, _ := cmd.Flags().GetBool("show-urls")
+			cached.ShowURLs = showURLs
+			cached.NoColor = noColor
 			return out.Write(cached)
 		}
 
@@ -558,11 +575,14 @@ var resultsCmd = &cobra.Command{
 			return err
 		}
 
-		result := models.FetchResultsResponse{Tables: envelope.Tables}
+		result := models.FetchResultsResponse{ResultTables: envelope.Tables}
+		showURLs, _ := cmd.Flags().GetBool("show-urls")
+		result.ShowURLs = showURLs
+		result.NoColor = noColor
 		if cacheErr := cache.Set(c, cacheKey, result, route, cache.TTLResults); cacheErr != nil {
 			log.Warn().Err(cacheErr).Str("run_id", runID).Msg("failed to cache results")
 		}
-		log.Info().Str("test_id", testID).Str("run_id", runID).Int("table_count", len(result.Tables)).Msg("results fetched successfully")
+		log.Info().Str("test_id", testID).Str("run_id", runID).Int("table_count", len(result.ResultTables)).Msg("results fetched successfully")
 		return out.Write(result)
 	},
 }
@@ -742,9 +762,9 @@ func init() {
 	_ = activityCmd.MarkFlagRequired("run-id")
 
 	// run results
-	resultsCmd.Flags().String("test-id", "", "Test UUID (required)")
+	resultsCmd.Flags().String("test-id", "", "Test UUID (optional, auto-resolved from run-id if omitted)")
 	resultsCmd.Flags().String("run-id", "", "Run UUID (required)")
-	_ = resultsCmd.MarkFlagRequired("test-id")
+	resultsCmd.Flags().Bool("show-urls", false, "Display full URLs in cell values instead of 'link'")
 	_ = resultsCmd.MarkFlagRequired("run-id")
 
 	// run comments

--- a/cli/internal/models/runs.go
+++ b/cli/internal/models/runs.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/scylladb/argus/cli/internal/output"
 )
 
 // ---------------------------------------------------------------------------
@@ -491,12 +493,16 @@ func (a ActivityResponse) Rows() [][]string {
 type ResultCell struct {
 	Value  any    `json:"value"`
 	Status string `json:"status"`
+	Type   string `json:"type,omitempty"`
 }
 
 // ResultColumnMeta describes one column in a ResultTable.
 type ResultColumnMeta struct {
-	Name   string `json:"name"`
-	Status string `json:"status"`
+	Name           string `json:"name"`
+	Unit           string `json:"unit,omitempty"`
+	Type           string `json:"type,omitempty"`
+	HigherIsBetter *bool  `json:"higher_is_better,omitempty"`
+	Visible        *bool  `json:"visible,omitempty"`
 }
 
 // ResultTable is one performance/result table returned by the fetch_results
@@ -505,26 +511,170 @@ type ResultTable struct {
 	Description string                           `json:"description"`
 	TableData   map[string]map[string]ResultCell `json:"table_data"`
 	Columns     []ResultColumnMeta               `json:"columns"`
-	Rows        []string                         `json:"rows"`
+	RowNames    []string                         `json:"rows"`
 	TableStatus string                           `json:"table_status"`
+	ShowURLs    bool                             `json:"-"`
+	NoColor     bool                             `json:"-"`
 }
 
 // Headers implements output.Tabular for ResultTable.  The first column is the
 // row name; subsequent columns come from the table's Columns metadata.
+// When a column has a unit defined, it is appended in brackets (e.g. "latency [ms]").
 func (rt ResultTable) Headers() []string {
 	h := make([]string, 0, 1+len(rt.Columns))
 	h = append(h, "Row")
 	for _, c := range rt.Columns {
-		h = append(h, c.Name)
+		if c.Unit != "" {
+			h = append(h, fmt.Sprintf("%s [%s]", c.Name, strings.ReplaceAll(c.Unit, " ", "")))
+		} else {
+			h = append(h, c.Name)
+		}
 	}
 	return h
 }
 
+// ANSI escape sequences for cell status highlighting.
+const (
+	ansiReset  = "\033[0m"
+	ansiGreen  = "\033[32m"
+	ansiRed    = "\033[31m"
+	ansiYellow = "\033[33m"
+)
+
+// colorByStatus wraps s with ANSI color codes matching the cell status,
+// mirroring the frontend ResultCellStatusStyleMap.  When noColor is true,
+// a bracket status indicator is appended instead (e.g. "(OK)", "(FAIL)").
+func colorByStatus(s, status string, noColor bool) string {
+	if noColor {
+		switch status {
+		case "PASS":
+			return s + " (OK)"
+		case "ERROR":
+			return s + " (FAIL)"
+		case "WARNING":
+			return s + " (WARN)"
+		default:
+			return s
+		}
+	}
+	switch status {
+	case "PASS":
+		return ansiGreen + s + ansiReset
+	case "ERROR":
+		return ansiRed + s + ansiReset
+	case "WARNING":
+		return ansiYellow + s + ansiReset
+	default:
+		return s
+	}
+}
+
+// formatCellValue formats a cell's value according to its type, mirroring the
+// frontend Cell.svelte formatting logic.
+//
+//   - FLOAT   → 2 decimal places (e.g. "3.14")
+//   - INTEGER → locale-style thousands separators (e.g. "1,234,567")
+//   - DURATION → HH:MM:SS
+//   - URLs    → "link" (since terminals can't click)
+//   - nil     → "N/A"
+//   - default → fmt.Sprint
+func formatCellValue(cell ResultCell, showURLs bool) string {
+	if cell.Value == nil {
+		return "N/A"
+	}
+
+	// String values: detect URLs / images like the frontend does.
+	if s, ok := cell.Value.(string); ok {
+		if isURL(s) && !showURLs {
+			return "link"
+		}
+		return s
+	}
+
+	// Numeric values: format based on the column type stored in the cell.
+	num, ok := toFloat64(cell.Value)
+	if !ok {
+		return fmt.Sprint(cell.Value)
+	}
+
+	switch cell.Type {
+	case "FLOAT":
+		return strconv.FormatFloat(num, 'f', 2, 64)
+	case "INTEGER":
+		return formatInteger(int64(num))
+	case "DURATION":
+		return formatDuration(num)
+	default:
+		return fmt.Sprint(cell.Value)
+	}
+}
+
+// isURL checks whether s looks like an HTTP(S) URL.
+func isURL(s string) bool {
+	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
+}
+
+// toFloat64 converts a JSON-decoded numeric value (float64 or json.Number) to float64.
+func toFloat64(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case json.Number:
+		f, err := n.Float64()
+		return f, err == nil
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	default:
+		return 0, false
+	}
+}
+
+// formatInteger formats an integer with comma-separated thousands groups
+// (e.g. 1234567 → "1,234,567"), matching Number.toLocaleString() in JS.
+func formatInteger(n int64) string {
+	s := strconv.FormatInt(n, 10)
+	if n < 0 {
+		return "-" + insertCommas(s[1:])
+	}
+	return insertCommas(s)
+}
+
+func insertCommas(s string) string {
+	if len(s) <= 3 {
+		return s
+	}
+	remainder := len(s) % 3
+	var b strings.Builder
+	if remainder > 0 {
+		b.WriteString(s[:remainder])
+		b.WriteByte(',')
+	}
+	for i := remainder; i < len(s); i += 3 {
+		if i > remainder {
+			b.WriteByte(',')
+		}
+		b.WriteString(s[i : i+3])
+	}
+	return b.String()
+}
+
+// formatDuration converts seconds to HH:MM:SS, matching the frontend
+// durationToStr helper.
+func formatDuration(seconds float64) string {
+	total := int(seconds)
+	h := total / 3600
+	m := (total % 3600) / 60
+	s := total % 60
+	return fmt.Sprintf("%02d:%02d:%02d", h, m, s)
+}
+
 // Rows implements output.Tabular for ResultTable.  Row order follows
-// rt.Rows; column order follows rt.Columns.
-func (rt ResultTable) TableRows() [][]string {
-	out := make([][]string, 0, len(rt.Rows))
-	for _, rowName := range rt.Rows {
+// rt.RowNames; column order follows rt.Columns.
+func (rt ResultTable) Rows() [][]string {
+	out := make([][]string, 0, len(rt.RowNames))
+	for _, rowName := range rt.RowNames {
 		row := make([]string, 0, 1+len(rt.Columns))
 		row = append(row, rowName)
 		colData := rt.TableData[rowName]
@@ -533,7 +683,7 @@ func (rt ResultTable) TableRows() [][]string {
 			if !ok {
 				row = append(row, "")
 			} else {
-				row = append(row, fmt.Sprint(cell.Value))
+				row = append(row, colorByStatus(formatCellValue(cell, rt.ShowURLs), cell.Status, rt.NoColor))
 			}
 		}
 		out = append(out, row)
@@ -543,43 +693,96 @@ func (rt ResultTable) TableRows() [][]string {
 
 // FetchResultsEnvelope is the non-standard envelope returned by the
 // fetch_results endpoint.  Unlike other endpoints the payload key is "tables"
-// rather than "response".
+// rather than "response".  Each element is a single-key map from the table
+// name to its data.
 type FetchResultsEnvelope struct {
-	Status string        `json:"status"`
-	Tables []ResultTable `json:"tables"`
+	Status string                   `json:"status"`
+	Tables []map[string]ResultTable `json:"tables"`
 }
 
-// FetchResultsResponse wraps []ResultTable to implement output.Tabular by
-// rendering all tables sequentially.
+// FetchResultsResponse wraps the result tables for output.  In JSON mode a
+// compact representation is produced via MarshalJSON; in text mode each table
+// is rendered separately via the MultiTabular interface.
 type FetchResultsResponse struct {
-	Tables []ResultTable
+	ResultTables []map[string]ResultTable `json:"tables"`
+	ShowURLs     bool                     `json:"-"`
+	NoColor      bool                     `json:"-"`
 }
 
-// Headers implements output.Tabular.  Uses the first table's headers or
-// returns a single "Table" column when empty.
-func (f FetchResultsResponse) Headers() []string {
-	if len(f.Tables) == 0 {
-		return []string{"Table"}
-	}
-	// Prefix with "Table" column to distinguish between tables.
-	h := []string{"Table"}
-	h = append(h, f.Tables[0].Headers()...)
-	return h
+// jsonCell is the compact JSON representation of a single result cell.
+type jsonCell struct {
+	Value  any    `json:"value"`
+	Status string `json:"status"`
 }
 
-// Rows implements output.Tabular.  Each result table's rows are emitted with
-// the table description prepended as the first column.
-func (f FetchResultsResponse) Rows() [][]string {
-	var rows [][]string
-	for _, tbl := range f.Tables {
-		for _, r := range tbl.TableRows() {
-			row := make([]string, 0, 1+len(r))
-			row = append(row, tbl.Description)
-			row = append(row, r...)
-			rows = append(rows, row)
+// jsonRow is the compact JSON representation of a single result row.
+type jsonRow struct {
+	Name  string              `json:"name"`
+	Cells map[string]jsonCell `json:"cells"`
+}
+
+// jsonTable is the compact JSON representation of a single result table.
+type jsonTable struct {
+	Name        string    `json:"name"`
+	Description string    `json:"description,omitempty"`
+	Status      string    `json:"status"`
+	Rows        []jsonRow `json:"rows"`
+}
+
+// MarshalJSON produces a compact JSON array of tables with inlined row data,
+// suitable for consumption by tools like jq.
+func (f FetchResultsResponse) MarshalJSON() ([]byte, error) {
+	tables := make([]jsonTable, 0, len(f.ResultTables))
+	for _, entry := range f.ResultTables {
+		for name, tbl := range entry {
+			jt := jsonTable{
+				Name:        name,
+				Description: tbl.Description,
+				Status:      tbl.TableStatus,
+				Rows:        make([]jsonRow, 0, len(tbl.RowNames)),
+			}
+			for _, rowName := range tbl.RowNames {
+				jr := jsonRow{
+					Name:  rowName,
+					Cells: make(map[string]jsonCell, len(tbl.Columns)),
+				}
+				colData := tbl.TableData[rowName]
+				for _, col := range tbl.Columns {
+					if cell, ok := colData[col.Name]; ok {
+						jr.Cells[col.Name] = jsonCell{
+							Value:  cell.Value,
+							Status: cell.Status,
+						}
+					}
+				}
+				jt.Rows = append(jt.Rows, jr)
+			}
+			tables = append(tables, jt)
 		}
 	}
-	return rows
+	return json.Marshal(tables)
+}
+
+// Tables implements output.MultiTabular.  Each result table is returned as a
+// NamedTable whose name is the table's description (falling back to the map
+// key when no description is set).
+func (f FetchResultsResponse) Tables() []output.NamedTable {
+	out := make([]output.NamedTable, 0, len(f.ResultTables))
+	for _, entry := range f.ResultTables {
+		for name, tbl := range entry {
+			tbl.ShowURLs = f.ShowURLs
+			tbl.NoColor = f.NoColor
+			title := name
+			if tbl.Description != "" && tbl.Description != name {
+				title = fmt.Sprintf("%s\n%s", name, tbl.Description)
+			}
+			out = append(out, output.NamedTable{
+				Name: title,
+				Tab:  tbl,
+			})
+		}
+	}
+	return out
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/internal/output/output.go
+++ b/cli/internal/output/output.go
@@ -18,6 +18,20 @@ type Tabular interface {
 	Rows() [][]string
 }
 
+// NamedTable pairs a human-readable name with a [Tabular] value so that
+// multi-table outputs can label each table independently.
+type NamedTable struct {
+	Name string
+	Tab  Tabular
+}
+
+// MultiTabular is implemented by values that contain several independent
+// tables.  The text renderer prints each table separately with a header line;
+// the JSON renderer ignores this and marshals the value directly.
+type MultiTabular interface {
+	Tables() []NamedTable
+}
+
 // Outputter writes a value to the configured destination in the
 // implementation-specific format.
 //

--- a/cli/internal/output/text.go
+++ b/cli/internal/output/text.go
@@ -46,6 +46,11 @@ func newText(w io.Writer) Outputter {
 // Write renders v as a text table.  v should implement [Tabular] for
 // meaningful column output; non-Tabular values fall back to a raw JSON row.
 func (t *textOutputter) Write(v any) error {
+	// Multi-table values get one table per entry with a header line.
+	if mt, ok := v.(MultiTabular); ok {
+		return t.writeMulti(mt)
+	}
+
 	tab, ok := v.(Tabular)
 	if !ok {
 		switch v := v.(type) {
@@ -104,6 +109,44 @@ func (t *textOutputter) writeRawJSON(v any) error {
 		return fmt.Errorf("%w: %w", ErrTextOutputJSONFallbackRender, err)
 	}
 
+	return nil
+}
+
+// writeMulti renders a [MultiTabular] as a sequence of labelled tables.
+func (t *textOutputter) writeMulti(mt MultiTabular) error {
+	for i, nt := range mt.Tables() {
+		if i > 0 {
+			if _, err := fmt.Fprintln(t.w); err != nil {
+				return fmt.Errorf("%w: %w", ErrTextOutputRow, err)
+			}
+		}
+		if _, err := fmt.Fprintf(t.w, "\n## %s\n\n", nt.Name); err != nil {
+			return fmt.Errorf("%w: %w", ErrTextOutputRow, err)
+		}
+
+		table := tablewriter.NewTable(t.w)
+		configureTableWidths(table)
+
+		if headers := nt.Tab.Headers(); len(headers) > 0 {
+			table.Header(headers)
+		}
+
+		for _, row := range nt.Tab.Rows() {
+			if err := table.Append(row); err != nil {
+				_ = table.Close()
+				return fmt.Errorf("%w: %w", ErrTextOutputRow, err)
+			}
+		}
+
+		if err := table.Render(); err != nil {
+			_ = table.Close()
+			return fmt.Errorf("%w: %w", ErrTextOutputRender, err)
+		}
+
+		if err := table.Close(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
This commit implements the argus run results command, replacing the stub
with a full implmentation that tries to mimic frontent response as much
as possible - Output is provided as multiple tables, each table uses
ANSI escape sequences to display the result status.
