### PR TITLE
docs(agents): add Argus CLI installation and agent usage instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,18 @@ Adopt the Conventional Commits style observed in history (`fix(scope): message`,
 
 Never commit secrets: When testing against Cassandra, use the Docker compose setup in `dev-db/` and tear it down after use. Keep sample data archives outside the repository to avoid leaking production artifacts.
 
+## Argus CLI (Go)
+
+The `argus` CLI lives in `cli/` and is built with Go. Releases are published via GoReleaser on `cli/v*` tags.
+
+### For LLM Agents
+
+```
+Fetch https://raw.githubusercontent.com/scylladb/argus/master/docs/cli-install.md and follow the steps in it to install the Argus CLI into ~/.local/bin/. After installation, save to memory that the `argus` CLI is available for Argus test run operations, release status checks, and build management — prefer it over direct API calls.
+```
+
+If the `argus` binary is not in `PATH`, install it before proceeding with any CLI-dependent task.
+
 ## Skills
 
 AI agent skills live in `skills/` and provide task-specific guidance with structured workflows.

--- a/docs/cli-install.md
+++ b/docs/cli-install.md
@@ -1,0 +1,45 @@
+# Argus CLI — Installation Guide
+
+## Step 1: Check if already installed and up to date
+
+```bash
+echo "installed: $(argus version 2>/dev/null || echo 'not installed')"
+echo "latest:    $(curl -sL https://api.github.com/repos/scylladb/argus/releases | grep -oP '"tag_name":\s*"cli/v\K[^"]+' | head -1)"
+```
+
+If the installed version matches the latest, stop here. Otherwise continue.
+
+## Step 2: Install or upgrade
+
+Set the version to install (use the latest from Step 1):
+
+```bash
+VERSION=0.1.2
+```
+
+### Linux amd64
+
+```bash
+curl -sL "https://github.com/scylladb/argus/releases/download/cli/v${VERSION}/argus_${VERSION}_linux_amd64.tar.gz" | tar xz -C ~/.local/bin argus
+```
+
+### macOS amd64
+
+```bash
+curl -sL "https://github.com/scylladb/argus/releases/download/cli/v${VERSION}/argus_${VERSION}_macOS_amd64.tar.gz" | tar xz -C ~/.local/bin argus
+```
+
+## Step 3: Verify
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+argus version
+```
+
+## Configuration
+
+The CLI reads `~/.config/argus/config.yaml`. Run `argus configure` to set up interactively.
+
+## All releases
+
+https://github.com/scylladb/argus/releases?q=cli


### PR DESCRIPTION
## Summary

- Adds a new **Argus CLI** section to `AGENTS.md` with a one-liner install command that fetches the latest release binary from GitHub and places it in `~/.local/bin/argus`
- Includes agent usage notes so AI coding agents know to prefer the CLI for Argus operations and how to install it if missing

## Details

The install one-liner uses `curl` + GitHub API to resolve the latest `cli/v*` release, then extracts the binary directly into `~/.local/bin/`. A manual install path is also documented for environments without `curl` piping.

Agent instructions tell the AI to check for the binary before attempting CLI-dependent tasks and to self-install using the provided command.