### PR TITLE
improvement(cli): Add Pytest Results command

### DIFF
--- a/argus/backend/controller/views_widgets/pytest.py
+++ b/argus/backend/controller/views_widgets/pytest.py
@@ -41,6 +41,17 @@ def get_view_pytest_results(view_id: str):
         "response": res
     }
 
+@bp.route("/pytest/results", methods=["GET"])
+@api_login_required
+def get_pytest_results():
+    service = PytestViewService()
+    res = service.result_filter()
+    return {
+        "status": "ok",
+        "response": res
+    }
+
+
 @bp.route("/pytest/<path:test_name>/<string:id>/fields", methods=["GET"])
 @api_login_required
 def get_user_fields_for_test(test_name: str, id: str):

--- a/argus/backend/service/views_widgets/pytest.py
+++ b/argus/backend/service/views_widgets/pytest.py
@@ -27,6 +27,7 @@ class PytestResult(TypedDict):
     barChart: dict
     pieChart: dict
 
+
 class PytestViewService:
     def __init__(self) -> None:
         self.cluster = ScyllaCluster.get()
@@ -40,8 +41,9 @@ class PytestViewService:
             raise exc
 
     def get_user_fields_for_result(self, name: str, id: str):
-        field_rows = PytestUserField.filter(name=name,  id=datetime.fromisoformat(id)).all()
-        result = { row["field_name"]: row["field_value"] for row in field_rows }
+        field_rows = PytestUserField.filter(
+            name=name,  id=datetime.fromisoformat(id)).all()
+        result = {row["field_name"]: row["field_value"] for row in field_rows}
 
         return result
 
@@ -49,7 +51,7 @@ class PytestViewService:
     def do_user_field_filter(field: str, value: str, negated: bool, result: dict) -> bool:
 
         if not (field_value := (result["user_fields"] or {}).get(field)):
-            return field not in (result["user_fields"] or {}) if negated else field in (result["user_fields"]or {})
+            return field not in (result["user_fields"] or {}) if negated else field in (result["user_fields"] or {})
 
         res = field_value == value
 
@@ -86,7 +88,8 @@ class PytestViewService:
             end_date = date.fromtimestamp(before.timestamp())
 
         bucket_days = (end_date - start_date).days
-        buckets = {date.today() - timedelta(days=d): defaultdict(lambda: 0) for d in range(bucket_days)}
+        buckets = {date.today() - timedelta(days=d): defaultdict(lambda: 0)
+                   for d in range(bucket_days)}
         for hit in hits:
             if hit["session_timestamp"]:
                 key = date.fromtimestamp(hit["session_timestamp"].timestamp())
@@ -94,8 +97,8 @@ class PytestViewService:
                 bucket[hit["status"]] += 1
                 buckets[key] = bucket
 
-
-        buckets = { k.strftime("%Y-%m-%d"): v for k, v in reversed(buckets.items())}
+        buckets = {k.strftime("%Y-%m-%d"): v for k,
+                   v in reversed(buckets.items())}
         datasets = []
         for status in PytestStatus:
             datasets.append({
@@ -113,13 +116,15 @@ class PytestViewService:
         test = request.args.get("test")
 
         unique_tests: list[str] = []
-        unique_tests.extend((row["name"] for row in db.session.execute(f"SELECT DISTINCT name FROM pytest_v2", timeout=60.0).all()))
+        unique_tests.extend((row["name"] for row in db.session.execute(
+            f"SELECT DISTINCT name FROM pytest_v2", timeout=60.0).all()))
 
         if test:
             LOGGER.warning(test)
-            unique_tests = [t for t in unique_tests if re.search(re.escape(test), t)]
+            unique_tests = [
+                t for t in unique_tests if re.search(re.escape(test), t)]
 
-        limit = request.args.get("limit", 500)
+        limit = int(request.args.get("limit", 500))
         before = request.args.get("before")
         after = request.args.get("after")
         enabled_statuses = request.args.getlist("status[]")
@@ -149,38 +154,50 @@ class PytestViewService:
             for partition_chunk in chunk(sequential_batch, 100):
                 parallel_filter = [*query_filters]
                 parallel_query = db_query
-                partition_filter = [("name IN ?", partition_chunk), *parallel_filter]
+                partition_filter = [
+                    ("name IN ?", partition_chunk), *parallel_filter]
                 parallel_query += " WHERE "
-                parallel_query += " AND ".join([f for f, _ in partition_filter])
+                parallel_query += " AND ".join([f for f,
+                                               _ in partition_filter])
                 prepared = db.prepare(parallel_query)
-                future = db.session.execute_async(prepared, parameters=[p for _, p in partition_filter], timeout=60.0, execution_profile="read_fast_named_tuple")
+                future = db.session.execute_async(prepared, parameters=[
+                                                  p for _, p in partition_filter], timeout=60.0, execution_profile="read_fast_named_tuple")
                 futures.append(future)
-            results.extend([row for future in futures for row in future.result()])
+            results.extend(
+                [row for future in futures for row in future.result()])
 
         if markers:
             for marker in markers:
-                results = [result for result in results if marker in (result.markers or [])]
+                results = [result for result in results if marker in (
+                    result.markers or [])]
         if query:
             pattern = re.compile(query.lower())
-            results = [result for result in results if re.search(pattern, self.stringify_result(result))]
+            results = [result for result in results if re.search(
+                pattern, self.stringify_result(result))]
         user_fields = {}
 
         if filters:
-            base_filter_query = db.prepare("SELECT * FROM pytest_user_field WHERE name IN ? AND id IN ?")
+            base_filter_query = db.prepare(
+                "SELECT * FROM pytest_user_field WHERE name IN ? AND id IN ?")
             futures = []
             for batch in chunk((r.name,  r.id) for r in results):
-                future = db.session.execute_async(base_filter_query, parameters=[[b[0] for b in batch], [b[1] for b in batch]], timeout=60.0, execution_profile="read_fast")
+                future = db.session.execute_async(base_filter_query, parameters=[[b[0] for b in batch], [
+                                                  b[1] for b in batch]], timeout=60.0, execution_profile="read_fast")
                 futures.append(future)
-            filter_rows = [row for future in futures for row in future.result()]
+            filter_rows = [
+                row for future in futures for row in future.result()]
             for row in filter_rows:
                 key = (row["name"], row["id"])
                 val = user_fields.get(key, {})
                 val[row["field_name"]] = row["field_value"]
                 user_fields[key] = val
-            results = [{**result._asdict(), "user_fields": user_fields.get((result.name, result.id), {})} for result in results]
-            filters = [(f[0] == "!", f.lstrip("!").split("=", 1)[0], f.lstrip("!").split("=", 1)[1]) for f in filters]
+            results = [{**result._asdict(), "user_fields": user_fields.get(
+                (result.name, result.id), {})} for result in results]
+            filters = [(f[0] == "!", f.lstrip("!").split("=", 1)[0],
+                        f.lstrip("!").split("=", 1)[1]) for f in filters]
             for negated, field, value in filters:
-                results = [result for result in results if self.do_user_field_filter(field, value, negated, result)]
+                results = [result for result in results if self.do_user_field_filter(
+                    field, value, negated, result)]
         else:
             results = [result._asdict() for result in results]
 

--- a/cli/cmd/pytest.go
+++ b/cli/cmd/pytest.go
@@ -1,0 +1,147 @@
+package cmd
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/scylladb/argus/cli/internal/api"
+	"github.com/scylladb/argus/cli/internal/cache"
+	"github.com/scylladb/argus/cli/internal/logging"
+	"github.com/scylladb/argus/cli/internal/models"
+	"github.com/spf13/cobra"
+)
+
+// ---------------------------------------------------------------------------
+// Parent command: pytest
+// ---------------------------------------------------------------------------
+
+var pytestCmd = &cobra.Command{
+	Use:   "pytest",
+	Short: "Commands for pytest result operations",
+	Long:  `Query and inspect pytest results tracked by Argus.`,
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand: pytest results
+// ---------------------------------------------------------------------------
+
+var pytestResultsCmd = &cobra.Command{
+	Use:   "results",
+	Short: "Query filtered pytest results",
+	Long: `Fetch pytest results with optional filtering by test name, status,
+time range, markers, user-defined fields, and free-text search.
+
+All flags are optional. Without any flags the endpoint returns the most
+recent 500 results across all tests.`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		cmd.SilenceUsage = true
+		ctx := cmd.Context()
+		client := APIClientFrom(ctx)
+		out := OutputterFrom(ctx)
+		c := CacheFrom(ctx)
+		log := logging.For(LoggerFrom(ctx), "pytest-results")
+
+		// Read flags.
+		test, _ := cmd.Flags().GetString("test")
+		limit, _ := cmd.Flags().GetInt("limit")
+		before, _ := cmd.Flags().GetInt64("before")
+		after, _ := cmd.Flags().GetInt64("after")
+		statuses, _ := cmd.Flags().GetStringSlice("status")
+		query, _ := cmd.Flags().GetString("query")
+		filters, _ := cmd.Flags().GetStringSlice("filter")
+		markers, _ := cmd.Flags().GetStringSlice("marker")
+
+		// Build query string.
+		params := url.Values{}
+		if test != "" {
+			params.Set("test", test)
+		}
+		if limit > 0 {
+			params.Set("limit", fmt.Sprint(limit))
+		}
+		if before > 0 {
+			params.Set("before", fmt.Sprint(before))
+		}
+		if after > 0 {
+			params.Set("after", fmt.Sprint(after))
+		}
+		for _, s := range statuses {
+			params.Add("status[]", s)
+		}
+		if query != "" {
+			params.Set("query", query)
+		}
+		for _, f := range filters {
+			params.Add("filters[]", f)
+		}
+		for _, m := range markers {
+			params.Add("markers[]", m)
+		}
+
+		qs := params.Encode()
+		route := api.PytestFilterResults
+		if qs != "" {
+			route += "?" + qs
+		}
+
+		log.Debug().Str("route", route).Msg("fetching filtered pytest results")
+
+		// Check cache.
+		cacheKey := cache.PytestFilterKey(qs)
+		if cached, _, err := cache.Get[models.PytestFilterResponse](c, cacheKey); isCacheable(err) {
+			log.Debug().Msg("pytest filter results served from cache")
+			return out.Write(cached)
+		}
+
+		req, err := client.NewRequest(ctx, "GET", route, nil)
+		if err != nil {
+			log.Error().Err(err).Str("route", route).Msg("failed to build request")
+			return err
+		}
+
+		result, err := api.DoJSON[models.PytestFilterResponse](client, req)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to fetch filtered pytest results")
+			return err
+		}
+
+		if cacheErr := cache.Set(c, cacheKey, result, route, cache.TTLPytestFilter); cacheErr != nil {
+			log.Warn().Err(cacheErr).Msg("failed to cache pytest filter results")
+		}
+
+		log.Info().Int("total", result.Total).Int("hits", len(result.Hits)).Msg("pytest filter results fetched successfully")
+		return out.Write(result)
+	},
+}
+
+// validPytestStatuses returns a comma-separated list of valid pytest status
+// values for use in help text.
+func validPytestStatuses() string {
+	return strings.Join([]string{
+		string(models.PytestStatusPassed),
+		string(models.PytestStatusFailure),
+		string(models.PytestStatusError),
+		string(models.PytestStatusSkipped),
+		string(models.PytestStatusXFailed),
+		string(models.PytestStatusXPass),
+		string(models.PytestStatusPassedError),
+		string(models.PytestStatusFailureError),
+		string(models.PytestStatusSkippedError),
+		string(models.PytestStatusErrorError),
+	}, ", ")
+}
+
+func init() {
+	pytestResultsCmd.Flags().String("test", "", "Filter test names by substring")
+	pytestResultsCmd.Flags().Int("limit", 500, "Maximum number of results to return")
+	pytestResultsCmd.Flags().Int64("before", 0, "Only results before this Unix timestamp")
+	pytestResultsCmd.Flags().Int64("after", 0, "Only results after this Unix timestamp")
+	pytestResultsCmd.Flags().StringSlice("status", nil, "Filter by status (repeatable): "+validPytestStatuses())
+	pytestResultsCmd.Flags().String("query", "", "Regex search pattern across result name/message/markers")
+	pytestResultsCmd.Flags().StringSlice("filter", nil, "User-field filter (repeatable, format: [!]field=value)")
+	pytestResultsCmd.Flags().StringSlice("marker", nil, "Pytest marker filter (repeatable)")
+
+	pytestCmd.AddCommand(pytestResultsCmd)
+	rootCmd.AddCommand(pytestCmd)
+}

--- a/cli/internal/api/routes.go
+++ b/cli/internal/api/routes.go
@@ -30,7 +30,8 @@ const (
 	IssuesGet          = "/api/v1/issues/get"                   // GET  – list issues (filterKey, id query params)
 
 	// Pytest result routes
-	TestRunPytestResults = "/api/v1/run/%s/pytest/results" // GET  – pytest results for a run (run_id)
+	TestRunPytestResults = "/api/v1/run/%s/pytest/results"        // GET  – pytest results for a run (run_id)
+	PytestFilterResults  = "/api/v1/views/widgets/pytest/results" // GET  – filtered pytest results (query params: test, limit, before, after, status[], query, filters[], markers[])
 
 	// Log file routes
 	TestRunLogDownload = "/api/v1/tests/%s/%s/log/%s/download" // GET  – download log file, 302 to S3 (plugin_name, run_id, log_name)

--- a/cli/internal/cache/keys.go
+++ b/cli/internal/cache/keys.go
@@ -1,6 +1,8 @@
 package cache
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"path"
 	"time"
 )
@@ -28,6 +30,10 @@ const (
 
 	// TTLPytestResults is the TTL for pytest result lists.
 	TTLPytestResults = 5 * time.Minute
+
+	// TTLPytestFilter is the TTL for filtered pytest results.
+	// Shorter than per-run results since filters are dynamic.
+	TTLPytestFilter = 2 * time.Minute
 
 	// TTLVersion is the TTL for the API version response.
 	// The version only changes on a new server deployment.
@@ -157,4 +163,14 @@ func NemesesFilteredKey(runID, before, after string) string {
 		after = "none"
 	}
 	return path.Join("nemeses", runID, before, after)
+}
+
+// PytestFilterKey returns the cache key for a filtered pytest results query.
+// The queryString is hashed to produce a fixed-length directory name that
+// uniquely identifies the parameter combination.
+//
+// On disk: cache/pytest-filter/{hash}/
+func PytestFilterKey(queryString string) string {
+	h := sha256.Sum256([]byte(queryString))
+	return path.Join("pytest-filter", fmt.Sprintf("%x", h[:8]))
 }

--- a/cli/internal/models/tests.go
+++ b/cli/internal/models/tests.go
@@ -1,5 +1,11 @@
 package models
 
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
 // PytestStatus mirrors argus.common.enums.PytestStatus.
 type PytestStatus string
 
@@ -53,3 +59,63 @@ type PytestSubmitData struct {
 // PytestResultListResponse is the response payload for pytest result list
 // endpoints.
 type PytestResultListResponse = []PytestResult
+
+// PytestFilterHit is a single result from the pytest filter endpoint.
+// It extends PytestResult with optional user-defined fields.
+type PytestFilterHit struct {
+	Name             string            `json:"name"              table:"Name"`
+	Status           PytestStatus      `json:"status"            table:"Status"`
+	ID               string            `json:"id"                table:"ID"`
+	TestType         string            `json:"test_type"         table:"Test Type"`
+	RunID            string            `json:"run_id"            table:"Run ID"`
+	TestID           string            `json:"test_id"           table:"Test ID"`
+	Duration         float64           `json:"duration"          table:"Duration"`
+	Message          string            `json:"message"           table:"Message"`
+	SessionTimestamp string            `json:"session_timestamp" table:"Session Timestamp"`
+	Markers          []string          `json:"markers"           table:"Markers"`
+	UserFields       map[string]string `json:"user_fields"       table:"User Fields"`
+}
+
+// PytestFilterResponse is the response from the pytest filter endpoint.
+// Only Total and Hits are used for tabular output; chart data is preserved
+// for JSON output mode.
+type PytestFilterResponse struct {
+	Total    int               `json:"total"`
+	Hits     []PytestFilterHit `json:"hits"`
+	BarChart json.RawMessage   `json:"barChart"`
+	PieChart json.RawMessage   `json:"pieChart"`
+}
+
+// Headers implements the Tabular interface for PytestFilterResponse.
+func (PytestFilterResponse) Headers() []string {
+	return []string{"Name", "Status", "ID", "Test Type", "Run ID", "Duration", "Message", "Session Timestamp", "Markers", "User Fields"}
+}
+
+// Rows implements the Tabular interface for PytestFilterResponse.
+func (r PytestFilterResponse) Rows() [][]string {
+	rows := make([][]string, 0, len(r.Hits))
+	for _, h := range r.Hits {
+		markers := strings.Join(h.Markers, ", ")
+		var fields string
+		if len(h.UserFields) > 0 {
+			parts := make([]string, 0, len(h.UserFields))
+			for k, v := range h.UserFields {
+				parts = append(parts, k+"="+v)
+			}
+			fields = strings.Join(parts, ", ")
+		}
+		rows = append(rows, []string{
+			h.Name,
+			string(h.Status),
+			h.ID,
+			h.TestType,
+			h.RunID,
+			fmt.Sprintf("%.2f", h.Duration),
+			h.Message,
+			h.SessionTimestamp,
+			markers,
+			fields,
+		})
+	}
+	return rows
+}


### PR DESCRIPTION
This PR adds both a backend API endpoint and a Go Client command to
fetch test results globally using the provided user filters, same as
frontend implementation for the Pytest View Widget.
