### PR TITLE
fix(sct/service): Provide owner and repo fields for similar event issues

### DIFF
--- a/argus/backend/plugins/sct/service.py
+++ b/argus/backend/plugins/sct/service.py
@@ -819,6 +819,8 @@ class SCTService:
                             "state": issue.state,
                             "title": issue.title,
                             "url": issue.url,
+                            "owner": issue.owner,
+                            "repo": issue.repo,
                         } if isinstance(issue, GithubIssue) else {
                             "subtype": "jira",
                             "key": issue.key,


### PR DESCRIPTION
This commit fixes an issue where IssueBadge.svelte would not receive
owner and repo fields for github issues from SctSimilarEvents table.

Fixes ARGUS-143
