### PR TITLE
ARGUS-32: add copy-to-clipboard button for SCT commit SHA

### DIFF
--- a/frontend/TestRun/TestRunInfo.svelte
+++ b/frontend/TestRun/TestRunInfo.svelte
@@ -154,6 +154,17 @@
                 <li>
                     <span class="fw-bold">SCT commit sha:</span>
                     {test_run.scm_revision_id ?? "Unknown"}
+                    {#if test_run.scm_revision_id && navigator.clipboard}
+                        <button
+                            class="btn btn-sm btn-outline-secondary ms-1 py-0 px-1"
+                            title="Copy SCM revision to clipboard"
+                            onclick={() => {
+                                navigator.clipboard.writeText(test_run.scm_revision_id);
+                                sendMessage("success", `SCM revision \`${test_run.scm_revision_id}\` copied to clipboard`);
+                            }}>
+                            <Fa icon={faCopy} />
+                        </button>
+                    {/if}
                 </li>
                 <li>
                     <span class="fw-bold">SCT repository:</span>


### PR DESCRIPTION
Add a copy-to-clipboard button next to the scm_revision_id field in the TestRunInfo System Information panel. The button renders only when scm_revision_id is non-null and navigator.clipboard is available (HTTPS context). On click, copies the raw SHA string and shows a success toast: "SCM revision `<sha>` copied to clipboard".
<img width="622" height="207" alt="image" src="https://github.com/user-attachments/assets/211b97d1-b8d2-44f7-840c-1e1fc8da9f61" />

Fixes ARGUS-32