### PR TITLE
feat(api): add email to public user JSON response

### DIFF
--- a/argus/backend/models/web.py
+++ b/argus/backend/models/web.py
@@ -116,6 +116,7 @@ class User(Model):
             "id": str(self.id),
             "username": self.username,
             "full_name": self.full_name,
+            "email": self.email,
             "picture_id": self.picture_id
         }
 


### PR DESCRIPTION
## Summary

- Adds the `email` field to `User.to_json()` so the public `/api/v1/users` endpoint includes user emails without requiring admin access.
- Previously, email was only available through the admin endpoint (`/admin/api/v1/users`), forcing consumers to request elevated privileges for basic contact info.