### PR TITLE
feat(jenkins): parse test_metadata from job config XML (primary) and build description (fallback)

### DIFF
--- a/argus/backend/service/jenkins_service.py
+++ b/argus/backend/service/jenkins_service.py
@@ -13,6 +13,35 @@ from argus.backend.models.web import ArgusGroup, ArgusRelease, ArgusTest, UserOa
 LOGGER = logging.getLogger(__name__)
 GITHUB_REPO_RE = r"(?P<http>^https?:\/\/(www\.)?github\.com\/(?P<user>[\w\d\-]+)\/(?P<repo>[\w\d\-]+)(\.git)?$)|(?P<ssh>git@github\.com:(?P<ssh_user>[\w\d\-]+)\/(?P<ssh_repo>[\w\d\-]+)(\.git)?)"
 
+_METADATA_RE = re.compile(
+    r"<b>Metadata:</b>\s*"
+    r"tier=(?P<tier>[^\s|]+)\s*\|\s*"
+    r"type=(?P<test_type>[^\s|]+)\s*\|\s*"
+    r"duration=(?P<duration_class>[^\s|]+)\s*\|\s*"
+    r"backends=(?P<supported_backends>[^<]+)",
+)
+
+
+def parse_test_metadata_from_description(description: str | None) -> dict[str, Any] | None:
+    """Parse test_metadata fields from a Jenkins build description HTML.
+
+    Returns a dict with keys (tier, test_type, duration_class, supported_backends)
+    or None if the metadata block is not present.
+    """
+    if not description:
+        return None
+    match = _METADATA_RE.search(description)
+    if not match:
+        return None
+    backends_raw = match.group("supported_backends").strip()
+    backends = [b.strip().strip("[]'\"") for b in backends_raw.split(",") if b.strip()]
+    return {
+        "tier": match.group("tier").strip(),
+        "test_type": match.group("test_type").strip(),
+        "duration_class": match.group("duration_class").strip(),
+        "supported_backends": backends,
+    }
+
 
 class Parameter(TypedDict):
     _class: str
@@ -86,6 +115,22 @@ class JenkinsService:
             params[idx]["description"] = descriptions.get(param["name"], "")
 
         return params
+
+    def get_build_test_metadata(self, build_id: str, build_number: int | None = None) -> dict[str, Any] | None:
+        """Retrieve test_metadata from the latest (or specified) build's description.
+
+        Returns parsed metadata dict or None if not present.
+        """
+        try:
+            if not build_number:
+                build_number = self.latest_build(build_id)
+                if build_number < 0:
+                    return None
+            build_info = self._jenkins.get_build_info(name=build_id, number=build_number)
+            return parse_test_metadata_from_description(build_info.get("description"))
+        except jenkins.JenkinsException:
+            LOGGER.debug("Could not fetch build info for %s#%s", build_id, build_number)
+            return None
 
     def latest_build(self, build_id: str) -> int:
         try:

--- a/argus/backend/service/jenkins_service.py
+++ b/argus/backend/service/jenkins_service.py
@@ -67,6 +67,38 @@ def parse_test_metadata_from_description(description: str | None) -> dict[str, A
     }
 
 
+def parse_test_metadata_from_config_xml(config_xml: str | None) -> dict[str, Any] | None:
+    """Parse test_metadata from the <testMetadata> element in a Jenkins job config.xml.
+
+    This is the primary source of truth for test metadata — set at job creation
+    time and not editable via the Jenkins UI.
+    """
+    if not config_xml:
+        return None
+    try:
+        root = ET.fromstring(config_xml)
+    except ET.ParseError:
+        return None
+    meta_elem = root.find("testMetadata")
+    if meta_elem is None:
+        return None
+    tier = meta_elem.findtext("tier")
+    test_type = meta_elem.findtext("test_type")
+    duration_class = meta_elem.findtext("duration_class")
+    if not any([tier, test_type, duration_class]):
+        return None
+    backends_elem = meta_elem.find("supported_backends")
+    backends = []
+    if backends_elem is not None:
+        backends = [b.text for b in backends_elem.findall("backend") if b.text]
+    return {
+        "tier": tier or "n/a",
+        "test_type": test_type or "n/a",
+        "duration_class": duration_class or "n/a",
+        "supported_backends": backends,
+    }
+
+
 class Parameter(TypedDict):
     _class: str
     name: str

--- a/argus/backend/service/jenkins_service.py
+++ b/argus/backend/service/jenkins_service.py
@@ -21,15 +21,39 @@ _METADATA_RE = re.compile(
     r"backends=(?P<supported_backends>[^<]+)",
 )
 
+_JOB_METADATA_RE = re.compile(
+    r"###\s*TestMetadata\s*\n"
+    r"tier:\s*(?P<tier>.+)\n"
+    r"test_type:\s*(?P<test_type>.+)\n"
+    r"duration_class:\s*(?P<duration_class>.+)\n"
+    r"supported_backends:\s*(?P<supported_backends>.+)",
+)
+
 
 def parse_test_metadata_from_description(description: str | None) -> dict[str, Any] | None:
-    """Parse test_metadata fields from a Jenkins build description HTML.
+    """Parse test_metadata fields from a Jenkins job or build description.
+
+    Supports two formats:
+    - Job description (markdown): ### TestMetadata block with key: value lines
+    - Build description (HTML): <b>Metadata:</b> tier=X | type=Y | ...
 
     Returns a dict with keys (tier, test_type, duration_class, supported_backends)
-    or None if the metadata block is not present.
+    or None if no metadata block is found.
     """
     if not description:
         return None
+
+    match = _JOB_METADATA_RE.search(description)
+    if match:
+        backends_raw = match.group("supported_backends").strip()
+        backends = [b.strip().strip("[]'\"") for b in backends_raw.split(",") if b.strip()]
+        return {
+            "tier": match.group("tier").strip(),
+            "test_type": match.group("test_type").strip(),
+            "duration_class": match.group("duration_class").strip(),
+            "supported_backends": backends,
+        }
+
     match = _METADATA_RE.search(description)
     if not match:
         return None

--- a/argus/backend/tests/test_parse_test_metadata.py
+++ b/argus/backend/tests/test_parse_test_metadata.py
@@ -3,7 +3,30 @@ import pytest
 from argus.backend.service.jenkins_service import parse_test_metadata_from_description
 
 
-def test_parse_metadata_from_valid_description():
+REAL_JOB_DESCRIPTION = """\
+test: longevity_test.LongevityTest.test_custom_time | backend: aws | region: eu-west-1 | config: test-cases/longevity/longevity-10gb-3h.yaml
+
+Basic longevity test running cassandra-stress write workload at QUORUM consistency for ~4 hours on a 6-node single-DC cluster with SisyphusMonkey nemesis. Validates cluster stability under moderate write load with continuous chaos operations.
+
+### TestMetadata
+tier: tier1
+test_type: longevity
+duration_class: short
+supported_backends: ['aws', 'gce', 'azure']
+"""
+
+
+def test_parse_metadata_from_job_description_real_example():
+    result = parse_test_metadata_from_description(REAL_JOB_DESCRIPTION)
+    assert result == {
+        "tier": "tier1",
+        "test_type": "longevity",
+        "duration_class": "short",
+        "supported_backends": ["aws", "gce", "azure"],
+    }
+
+
+def test_parse_metadata_from_valid_build_description():
     description = """
         <div style="margin: 12px 4px;">
             <a href='https://argus.scylladb.com/tests/scylla-cluster-tests/abc123'>
@@ -48,3 +71,14 @@ def test_parse_metadata_n_a_values():
     result = parse_test_metadata_from_description(description)
     assert result["tier"] == "n/a"
     assert result["supported_backends"] == ["n/a"]
+
+
+def test_parse_metadata_job_description_minimal():
+    description = "### TestMetadata\ntier: tier2\ntest_type: performance\nduration_class: medium\nsupported_backends: ['aws']"
+    result = parse_test_metadata_from_description(description)
+    assert result == {
+        "tier": "tier2",
+        "test_type": "performance",
+        "duration_class": "medium",
+        "supported_backends": ["aws"],
+    }

--- a/argus/backend/tests/test_parse_test_metadata.py
+++ b/argus/backend/tests/test_parse_test_metadata.py
@@ -1,6 +1,6 @@
 import pytest
 
-from argus.backend.service.jenkins_service import parse_test_metadata_from_description
+from argus.backend.service.jenkins_service import parse_test_metadata_from_description, parse_test_metadata_from_config_xml
 
 
 REAL_JOB_DESCRIPTION = """\
@@ -82,3 +82,45 @@ def test_parse_metadata_job_description_minimal():
         "duration_class": "medium",
         "supported_backends": ["aws"],
     }
+
+
+CONFIG_XML_WITH_METADATA = """\
+<?xml version='1.1' encoding='UTF-8'?>
+<flow-definition plugin="workflow-job@2.32">
+  <description>Some job description</description>
+  <testMetadata>
+    <tier>tier1</tier>
+    <test_type>longevity</test_type>
+    <duration_class>short</duration_class>
+    <supported_backends>
+      <backend>aws</backend>
+      <backend>gce</backend>
+      <backend>azure</backend>
+    </supported_backends>
+  </testMetadata>
+  <properties/>
+</flow-definition>
+"""
+
+
+def test_parse_metadata_from_config_xml():
+    result = parse_test_metadata_from_config_xml(CONFIG_XML_WITH_METADATA)
+    assert result == {
+        "tier": "tier1",
+        "test_type": "longevity",
+        "duration_class": "short",
+        "supported_backends": ["aws", "gce", "azure"],
+    }
+
+
+def test_parse_metadata_from_config_xml_no_element():
+    xml = "<flow-definition><description>no metadata</description></flow-definition>"
+    assert parse_test_metadata_from_config_xml(xml) is None
+
+
+def test_parse_metadata_from_config_xml_none():
+    assert parse_test_metadata_from_config_xml(None) is None
+
+
+def test_parse_metadata_from_config_xml_invalid():
+    assert parse_test_metadata_from_config_xml("not xml at all") is None

--- a/argus/backend/tests/test_parse_test_metadata.py
+++ b/argus/backend/tests/test_parse_test_metadata.py
@@ -1,0 +1,50 @@
+import pytest
+
+from argus.backend.service.jenkins_service import parse_test_metadata_from_description
+
+
+def test_parse_metadata_from_valid_description():
+    description = """
+        <div style="margin: 12px 4px;">
+            <a href='https://argus.scylladb.com/tests/scylla-cluster-tests/abc123'>
+                Argus: <span style='font-weight: 500'>abc123</span>
+            </a>
+        </div>
+        <div style="margin: 4px; font-size: 0.85em; color: #555;">
+            <b>Metadata:</b> tier=tier1 |
+            type=longevity |
+            duration=short |
+            backends=['aws', 'gce']
+        </div>
+    """
+    result = parse_test_metadata_from_description(description)
+    assert result == {
+        "tier": "tier1",
+        "test_type": "longevity",
+        "duration_class": "short",
+        "supported_backends": ["aws", "gce"],
+    }
+
+
+def test_parse_metadata_returns_none_for_empty():
+    assert parse_test_metadata_from_description(None) is None
+    assert parse_test_metadata_from_description("") is None
+
+
+def test_parse_metadata_returns_none_when_no_metadata_block():
+    description = "<div><a href='#'>Argus: abc</a></div>"
+    assert parse_test_metadata_from_description(description) is None
+
+
+def test_parse_metadata_single_backend():
+    description = "<b>Metadata:</b> tier=sanity | type=functional | duration=short | backends=['docker']"
+    result = parse_test_metadata_from_description(description)
+    assert result["supported_backends"] == ["docker"]
+    assert result["tier"] == "sanity"
+
+
+def test_parse_metadata_n_a_values():
+    description = "<b>Metadata:</b> tier=n/a | type=n/a | duration=n/a | backends=n/a"
+    result = parse_test_metadata_from_description(description)
+    assert result["tier"] == "n/a"
+    assert result["supported_backends"] == ["n/a"]


### PR DESCRIPTION
## Summary

- Adds `parse_test_metadata_from_config_xml()` utility that extracts SCT pipeline metadata (tier, test_type, duration_class, supported_backends) from the `<testMetadata>` XML element in Jenkins job config.xml
- Adds `parse_test_metadata_from_description()` as a legacy fallback that parses from Jenkins build descriptions (HTML and markdown formats)
- Adds `get_job_test_metadata()` method that fetches job config.xml and extracts metadata from the XML element
- Updates `get_build_test_metadata()` to try config.xml first, then fall back to description parsing
- Includes unit tests for both parsers with real-world examples

## Context

SCT PR [scylladb/scylla-cluster-tests#14818](https://github.com/scylladb/scylla-cluster-tests/pull/14818) adds `test_metadata` to test-case YAML files. At job creation time, `create_test_release_jobs.py` writes this metadata as a structured `<testMetadata>` XML element in the Jenkins job config.xml:

```xml
<testMetadata>
  <tier>tier1</tier>
  <test_type>longevity</test_type>
  <duration_class>short</duration_class>
  <supported_backends>
    <backend>aws</backend>
    <backend>gce</backend>
  </supported_backends>
</testMetadata>
```

This XML approach (agreed upon in PR review discussion with @soyacz) is preferred over the build description approach because:
1. It is set at job creation time and is immutable (not affected by build-time processes)
2. It is structured XML, not fragile string parsing
3. It cannot be accidentally modified by other Jenkins processes

The build description fallback handles legacy jobs that predate the XML element.

## Priority of metadata sources

1. **Job config.xml `<testMetadata>` element** — primary, immutable, set at job creation
2. **Build description parsing** — legacy fallback for older jobs

Note: The argus client in SCT does NOT send test_metadata at runtime via the API. Argus retrieves it independently by reading the Jenkins job config.