### PR TITLE
feature(cli): build darwin/arm64 and linux/arm64 releases

### DIFF
--- a/cli/.goreleaser.yml
+++ b/cli/.goreleaser.yml
@@ -31,6 +31,7 @@ builds:
       - darwin
     goarch:
       - amd64
+      - arm64
     # Remove the entry below if you want to ship Windows arm64 in the future.
     ignore:
       - goos: windows


### PR DESCRIPTION
Add arm64 to the GoReleaser goarch matrix so each release ships macOS Apple Silicon and Linux arm64 binaries alongside the existing amd64 builds. CGO is disabled, so these cross-compile on the existing runner with no toolchain changes.

Closes https://scylladb.atlassian.net/browse/ARGUS-160