### PR TITLE
feature(jenkins): billing_project choices from Jenkins in SCT wizard

### DIFF
--- a/argus/backend/service/jenkins_service.py
+++ b/argus/backend/service/jenkins_service.py
@@ -1,6 +1,6 @@
 import re
 import requests
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 from uuid import UUID
 import xml.etree.ElementTree as ET
 import jenkins
@@ -19,6 +19,7 @@ class Parameter(TypedDict):
     name: str
     description: str
     value: Any
+    choices: NotRequired[list[str]]
 
 
 class JenkinsServiceError(Exception):
@@ -51,6 +52,22 @@ class JenkinsService:
                                         username=current_app.config["JENKINS_USER"],
                                         password=current_app.config["JENKINS_API_TOKEN"])
 
+    @staticmethod
+    def _extract_choice_parameters(config: ET.Element) -> dict[str, list[str]]:
+        """Map each ChoiceParameterDefinition name to its list of choices.
+
+        Handles both the nested ArrayList form
+        (<choices class="..."><a><string>..) and the flat form
+        (<choices><string>..).
+        """
+        choices: dict[str, list[str]] = {}
+        for define in config.iterfind(".//hudson.model.ChoiceParameterDefinition"):
+            name = define.findtext("name")
+            if not name:
+                continue
+            choices[name] = [s.text for s in define.findall("choices//string") if s.text is not None]
+        return choices
+
     def retrieve_job_parameters(self, build_id: str, build_number: int | None) -> list[Parameter]:
         job_info = self._jenkins.get_job_info(name=build_id)
         if not build_number:
@@ -73,6 +90,7 @@ class JenkinsService:
             }
         else:
             descriptions = {}
+        choices = self._extract_choice_parameters(config)
         params = next((a for a in build_info["actions"] if a.get(
             "_class", "#NONE") == "hudson.model.ParametersAction"), None)
         if params:
@@ -84,6 +102,11 @@ class JenkinsService:
                 "value", "")} for param in default_params if param["name"] != self.RESERVED_PARAMETER_NAME]
         for idx, param in enumerate(params):
             params[idx]["description"] = descriptions.get(param["name"], "")
+            if param["name"] in choices:
+                param_choices = choices[param["name"]]
+                params[idx]["choices"] = param_choices
+                if param_choices and param.get("value") not in param_choices:
+                    params[idx]["value"] = param_choices[0]
 
         return params
 

--- a/argus/backend/tests/jenkins_service/test_jenkins_service.py
+++ b/argus/backend/tests/jenkins_service/test_jenkins_service.py
@@ -1,0 +1,81 @@
+import xml.etree.ElementTree as ET
+
+from argus.backend.service.jenkins_service import JenkinsService
+
+
+CONFIG_WITH_CHOICES = """<?xml version='1.1' encoding='UTF-8'?>
+<flow-definition plugin="workflow-job">
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>billing_project</name>
+          <description>GCP billing project</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>sct</string>
+              <string>qa</string>
+              <string>perf</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>scylla_version</name>
+          <description>Scylla version</description>
+          <defaultValue>master:latest</defaultValue>
+        </hudson.model.StringParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+</flow-definition>
+"""
+
+CONFIG_FLAT_CHOICES = """<?xml version='1.1' encoding='UTF-8'?>
+<flow-definition>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>billing_project</name>
+          <choices>
+            <string>sct</string>
+            <string>qa</string>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+</flow-definition>
+"""
+
+CONFIG_NO_CHOICES = """<?xml version='1.1' encoding='UTF-8'?>
+<flow-definition>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>scylla_version</name>
+        </hudson.model.StringParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+</flow-definition>
+"""
+
+
+def test_extract_choice_parameters_nested_arraylist():
+    config = ET.fromstring(CONFIG_WITH_CHOICES)
+    choices = JenkinsService._extract_choice_parameters(config)
+    assert choices == {"billing_project": ["sct", "qa", "perf"]}
+
+
+def test_extract_choice_parameters_flat():
+    config = ET.fromstring(CONFIG_FLAT_CHOICES)
+    choices = JenkinsService._extract_choice_parameters(config)
+    assert choices == {"billing_project": ["sct", "qa"]}
+
+
+def test_extract_choice_parameters_none():
+    config = ET.fromstring(CONFIG_NO_CHOICES)
+    choices = JenkinsService._extract_choice_parameters(config)
+    assert choices == {}

--- a/frontend/TestRun/Jenkins/ParameterEditor.svelte
+++ b/frontend/TestRun/Jenkins/ParameterEditor.svelte
@@ -76,7 +76,13 @@
                 {#if param.value || paramTab == 2}
                     <div class="mb-1">
                         <label class="form-label fw-bold" for={param.name}>{param.name}</label>
-                         {#if (param._class || "").includes("TextParameter")}
+                         {#if param.choices?.length}
+                            <select class="form-select" id={param.name} bind:value={buildParams[param.name]}>
+                                {#each param.choices as choice}
+                                    <option value={choice}>{choice}</option>
+                                {/each}
+                            </select>
+                        {:else if (param._class || "").includes("TextParameter")}
                             <textarea class="form-control" id={param.name} bind:value={buildParams[param.name]} rows="4"></textarea>
                         {:else}
                             <input class="form-control" id={param.name} type="text" bind:value={buildParams[param.name]}>

--- a/frontend/TestRun/Jenkins/SCTParameterWizard.svelte
+++ b/frontend/TestRun/Jenkins/SCTParameterWizard.svelte
@@ -186,6 +186,17 @@
                     values: ["spot", "on_demand", "spot_fleet"],
                     labels: ["Spot", "On Demand", "Spot Fleet"]
                 },
+                billingProject: {
+                    name: "Billing Project",
+                    description: "Billing project to charge the run to. Choices come from the Jenkins job.",
+                    type: SelectParam,
+                    internalName: "billing_project",
+                    condition: (params, defs) => true,
+                    onChange: function (e, params) {
+                        //empty
+                    },
+                    values: rawParams.find(p => p.name === "billing_project")?.choices ?? [],
+                },
             }
         },
         scyllaVersion: {


### PR DESCRIPTION
## What

Adds `billing_project` to the SCT run/rebuild wizard as a dropdown whose options come directly from the Jenkins job, keeping Argus choices in sync with Jenkins.

## Changes

- **`jenkins_service.py`**: new `_extract_choice_parameters()` parses `ChoiceParameterDefinition` choices from the job config XML (handles both nested `ArrayList` and flat `<choices><string>` forms). `retrieve_job_parameters()` attaches `choices` to the returned parameters; `Parameter` TypedDict gains a `choices` field.
- **`SCTParameterWizard.svelte`**: new `billing_project` `SelectParam` in the Environment section, populated from `rawParams[...].choices`. Auto-hidden when the job does not define the parameter (existing `internalName in params` gate).
- **tests**: unit coverage for choice extraction (nested / flat / none).

## Notes

- Choices are fetched live from Jenkins — no hardcoded list, no drift.
- Backward compatible: non-choice params keep rendering as before.

closes ARGUS-104