### PR TITLE
fix(jenkins): default billing_project to empty instead of first choice

### DIFF
--- a/argus/backend/service/jenkins_service.py
+++ b/argus/backend/service/jenkins_service.py
@@ -28,6 +28,9 @@ class JenkinsServiceError(Exception):
 
 class JenkinsService:
     RESERVED_PARAMETER_NAME = "requested_by_user"
+    # Choice parameters that must default to an explicit "unset" (empty) value
+    # instead of silently selecting the first option from the Jenkins job.
+    OPTIONAL_CHOICE_PARAMETERS = frozenset({"billing_project"})
 
     SETTINGS_CONFIG_MAP = {
         "scylla-cluster-tests": {
@@ -98,17 +101,39 @@ class JenkinsService:
         else:
             default_params = next((prop for prop in job_info["property"] if prop.get(
                 "_class", "") == "hudson.model.ParametersDefinitionProperty"), {}).get("parameterDefinitions", {})
-            params = [{"name": param["name"], "value": param.get("defaultParameterValue", {}).get(
-                "value", "")} for param in default_params if param["name"] != self.RESERVED_PARAMETER_NAME]
+            params = [{"name": param["name"],
+                       "value": "" if param["name"] in self.OPTIONAL_CHOICE_PARAMETERS
+                       else param.get("defaultParameterValue", {}).get("value", "")}
+                      for param in default_params if param["name"] != self.RESERVED_PARAMETER_NAME]
+        self._apply_choice_defaults(params, choices, descriptions)
+
+        return params
+
+    @classmethod
+    def _apply_choice_defaults(cls, params: list[Parameter], choices: dict[str, list[str]],
+                               descriptions: dict[str, str]) -> None:
+        """Attach descriptions/choices to params and resolve each default value.
+
+        Regular choice parameters fall back to the first choice when their value
+        is unknown. Optional choice parameters (e.g. billing_project) instead get
+        an explicit empty option and default to it, so a run is never silently
+        charged to the first project in the list.
+        """
         for idx, param in enumerate(params):
             params[idx]["description"] = descriptions.get(param["name"], "")
-            if param["name"] in choices:
-                param_choices = choices[param["name"]]
+            if param["name"] not in choices:
+                continue
+            param_choices = choices[param["name"]]
+            if param["name"] in cls.OPTIONAL_CHOICE_PARAMETERS:
+                if "" not in param_choices:
+                    param_choices = ["", *param_choices]
+                params[idx]["choices"] = param_choices
+                if param.get("value") not in param_choices:
+                    params[idx]["value"] = ""
+            else:
                 params[idx]["choices"] = param_choices
                 if param_choices and param.get("value") not in param_choices:
                     params[idx]["value"] = param_choices[0]
-
-        return params
 
     def latest_build(self, build_id: str) -> int:
         try:

--- a/argus/backend/tests/jenkins_service/test_jenkins_service.py
+++ b/argus/backend/tests/jenkins_service/test_jenkins_service.py
@@ -79,3 +79,38 @@ def test_extract_choice_parameters_none():
     config = ET.fromstring(CONFIG_NO_CHOICES)
     choices = JenkinsService._extract_choice_parameters(config)
     assert choices == {}
+
+
+def _apply(params, choices, descriptions=None):
+    JenkinsService._apply_choice_defaults(params, choices, descriptions or {})
+    return params
+
+
+def test_optional_choice_param_defaults_to_empty():
+    # billing_project with no value must default to empty, not the first project.
+    params = [{"name": "billing_project", "value": ""}]
+    _apply(params, {"billing_project": ["sct", "qa", "perf"]})
+    assert params[0]["value"] == ""
+    assert params[0]["choices"] == ["", "sct", "qa", "perf"]
+
+
+def test_optional_choice_param_unknown_value_resets_to_empty():
+    params = [{"name": "billing_project", "value": "stale"}]
+    _apply(params, {"billing_project": ["sct", "qa"]})
+    assert params[0]["value"] == ""
+
+
+def test_optional_choice_param_preserves_explicit_selection():
+    # A real prior selection (e.g. cloned run) is kept.
+    params = [{"name": "billing_project", "value": "qa"}]
+    _apply(params, {"billing_project": ["sct", "qa", "perf"]})
+    assert params[0]["value"] == "qa"
+    assert params[0]["choices"] == ["", "sct", "qa", "perf"]
+
+
+def test_regular_choice_param_defaults_to_first():
+    # Non-optional choice params keep the old first-choice fallback.
+    params = [{"name": "region", "value": "unknown"}]
+    _apply(params, {"region": ["us-east-1", "eu-west-1"]})
+    assert params[0]["value"] == "us-east-1"
+    assert params[0]["choices"] == ["us-east-1", "eu-west-1"]


### PR DESCRIPTION
## Problem

After billing project support was added, runs are silently charged to the **first** project in the Jenkins list when the field was previously empty/unset.

Two origins in `jenkins_service.py`:
1. Jenkins exposes `billing_project` as a `ChoiceParameter`; its `defaultParameterValue` is the first choice, so fresh/next-build params arrive pre-set to the first project.
2. The choice-defaulting loop also auto-selected `param_choices[0]` when the value wasn't in the list.

## Fix

Treat `billing_project` as an *optional* choice param (`OPTIONAL_CHOICE_PARAMETERS`):
- prepend an empty `""` option (selectable "unset")
- default to empty instead of the first project
- never auto-pick the first choice

An explicit prior selection (cloned/re-run) is still preserved. All other choice params keep the existing first-choice fallback.

Defaulting logic extracted into the testable `_apply_choice_defaults` classmethod.

## Frontend

No change needed — `DummySelectParam.svelte` uses `value={definition.args.value ?? definition.values[0]}`; `??` keeps `""`, and the new empty choice renders as the first blank option.

## Tests

`argus/backend/tests/jenkins_service/test_jenkins_service.py` — 4 new cases:
- empty value defaults to empty
- stale/unknown value resets to empty
- explicit selection preserved
- regular (non-optional) choice param still defaults to first

All 7 tests pass.