### PR TITLE
improvement(backend/planner): Introduce plan keys

### DIFF
--- a/argus/backend/models/plan.py
+++ b/argus/backend/models/plan.py
@@ -22,6 +22,7 @@ class ArgusReleasePlan(Model):
     creation_time = columns.DateTime(default=lambda: datetime.datetime.now(tz=datetime.UTC))
     last_updated = columns.DateTime(default=lambda: datetime.datetime.now(tz=datetime.UTC))
     ends_at = columns.DateTime()
+    key = columns.Text()
 
     def __eq__(self, other):
         if isinstance(other, ArgusReleasePlan):

--- a/argus/backend/service/planner_service.py
+++ b/argus/backend/service/planner_service.py
@@ -139,6 +139,23 @@ class PlanningService:
     def version(self):
         return "v1"
 
+    def _generate_plan_key(self, release_id: UUID | str) -> str:
+        release: ArgusRelease = ArgusRelease.get(id=release_id)
+        candidate = f"{release.name}#1"
+        release_plans = list(ArgusReleasePlan.filter(release_id=release.id).allow_filtering().all())
+        if len(release_plans) == 0:
+            return candidate
+        existing_keys = [int(p.key.split("#")[1]) for p in release_plans]
+        previous_number = max(existing_keys)
+
+        return f"{release.name}#{previous_number+1}"
+
+    def _resolve_plan(self, ref: str | UUID) -> ArgusReleasePlan:
+        try:
+            return ArgusReleasePlan.get(id=UUID(str(ref)))
+        except (ValueError, ArgusReleasePlan.DoesNotExist):
+            return ArgusReleasePlan.filter(key=str(ref)).allow_filtering().get()
+
     def create_plan(self, payload: dict[str, Any]) -> ArgusReleasePlan:
         plan_request = CreatePlanPayload(**payload)
 
@@ -171,6 +188,7 @@ class PlanningService:
             plan.view_id = plan_request.view_id
             view = self.update_view_for_plan(plan, existing=True)
 
+        plan.key = self._generate_plan_key(plan.release_id)
         plan.save()
         invalidate_release_snapshots(plan.release_id)
         return plan
@@ -178,7 +196,7 @@ class PlanningService:
     def update_plan(self, payload: dict[str, Any]) -> bool:
         plan_request = PlanDiffPayload(**payload)
 
-        plan: ArgusReleasePlan = ArgusReleasePlan.get(id=plan_request.id)
+        plan: ArgusReleasePlan = self._resolve_plan(plan_request.id)
 
         if plan_request.name is not None:
             plan.name = plan_request.name
@@ -196,7 +214,7 @@ class PlanningService:
         try:
             existing = ArgusReleasePlan.filter(
                 name=plan.name, target_version=plan.target_version).allow_filtering().get()
-            if existing and existing.id != UUID(plan_request.id):
+            if existing and existing.id != plan.id:
                 raise PlannerServiceException(
                     f"Found existing plan {existing.name} ({existing.target_version}) with the same name and version", existing, plan_request)
         except ArgusReleasePlan.DoesNotExist:
@@ -339,7 +357,7 @@ class PlanningService:
 
     def change_plan_owner(self, plan_id: UUID | str, new_owner: UUID | str) -> bool:
         user: User = User.get(id=new_owner)
-        plan: ArgusReleasePlan = ArgusReleasePlan.get(id=plan_id)
+        plan: ArgusReleasePlan = self._resolve_plan(plan_id)
 
         plan.owner = user.id
         plan.last_updated = datetime.datetime.now(tz=datetime.UTC)
@@ -348,7 +366,7 @@ class PlanningService:
         return True
 
     def get_plan(self, plan_id: str | UUID) -> ArgusReleasePlan:
-        return ArgusReleasePlan.get(id=plan_id)
+        return self._resolve_plan(plan_id)
 
     def get_gridview_for_release(self, release_id: str | UUID) -> dict[str, dict]:
         release = ArgusRelease.get(id=release_id)
@@ -391,8 +409,7 @@ class PlanningService:
         except ArgusReleasePlan.DoesNotExist:
             pass
 
-        original_plan: ArgusReleasePlan = ArgusReleasePlan.get(
-            id=payload.plan.id)
+        original_plan: ArgusReleasePlan = self._resolve_plan(payload.plan.id)
         target_release: ArgusRelease = ArgusRelease.get(
             id=payload.targetReleaseId)
         original_release: ArgusRelease = ArgusRelease.get(
@@ -452,13 +469,14 @@ class PlanningService:
         view = self.create_view_for_plan(new_plan)
         new_plan.view_id = view.id
 
+        new_plan.key = self._generate_plan_key(target_release.id)
         new_plan.save()
         invalidate_release_snapshots(new_plan.release_id)
         return new_plan
 
     def check_plan_copy_eligibility(self, plan_id: str | UUID, target_release_id: str | UUID) -> dict:
         target_release: ArgusRelease = ArgusRelease.get(id=target_release_id)
-        plan: ArgusReleasePlan = ArgusReleasePlan.get(id=plan_id)
+        plan: ArgusReleasePlan = self._resolve_plan(plan_id)
         original_release: ArgusRelease = ArgusRelease.get(id=plan.release_id)
 
         original_tests: list[ArgusTest] = ArgusTest.filter(
@@ -522,7 +540,7 @@ class PlanningService:
         return list(ArgusReleasePlan.filter(release_id=release_id).all())
 
     def delete_plan(self, plan_id: str | UUID, delete_view: bool = True):
-        plan: ArgusReleasePlan = ArgusReleasePlan.get(id=plan_id)
+        plan: ArgusReleasePlan = self._resolve_plan(plan_id)
         if plan.view_id:
             view: ArgusUserView = ArgusUserView.get(id=plan.view_id)
             if delete_view:
@@ -607,7 +625,7 @@ class PlanningService:
         return plan.completed
 
     def resolve_plan(self, plan_id: str | UUID) -> list[dict[str, Any]]:
-        plan: ArgusReleasePlan = ArgusReleasePlan.get(id=plan_id)
+        plan: ArgusReleasePlan = self._resolve_plan(plan_id)
 
         release: ArgusRelease = ArgusRelease.get(id=plan.release_id)
         tests: list[ArgusTest] = []

--- a/scripts/migration/migration_2026-06-16.py
+++ b/scripts/migration/migration_2026-06-16.py
@@ -1,0 +1,58 @@
+import logging
+from collections import defaultdict
+
+from argus.backend.db import ScyllaCluster
+from argus.backend.models.plan import ArgusReleasePlan
+from argus.backend.models.web import ArgusRelease
+from argus.backend.util.logsetup import setup_application_logging
+
+
+setup_application_logging(log_level=logging.INFO)
+LOGGER = logging.getLogger(__name__)
+DB = ScyllaCluster.get()
+
+
+def migrate():
+    """Backfill the `key` (releaseName#planNumber) field on existing release plans.
+
+    Plans are grouped by release and numbered by creation order (the TimeUUID `id`),
+    assigning `releaseName#1, #2, ...`. Plans that already have a key are skipped, so
+    the migration is safe to re-run.
+    """
+    plans_by_release: dict = defaultdict(list)
+    for plan in ArgusReleasePlan.objects.all():
+        plans_by_release[plan.release_id].append(plan)
+
+    LOGGER.info("Backfilling plan keys across %d release(s)...", len(plans_by_release))
+
+    release_names: dict = {}
+    total_assigned = 0
+
+    for release_id, plans in plans_by_release.items():
+        if release_id not in release_names:
+            try:
+                release_names[release_id] = ArgusRelease.get(id=release_id).name
+            except ArgusRelease.DoesNotExist:
+                LOGGER.warning("Release %s not found — skipping %d plan(s).", release_id, len(plans))
+                continue
+        release_name = release_names[release_id]
+
+        # TimeUUID id ~ creation order
+        plans.sort(key=lambda p: p.id)
+
+        number = 0
+        for plan in plans:
+            number += 1
+            if plan.key:
+                LOGGER.info("Plan %s already has key %s — skipping.", plan.id, plan.key)
+                continue
+            plan.key = f"{release_name}#{number}"
+            plan.save()
+            total_assigned += 1
+            LOGGER.info("Assigned key %s to plan %s", plan.key, plan.id)
+
+    LOGGER.info("Migration complete. Assigned %d plan key(s).", total_assigned)
+
+
+if __name__ == "__main__":
+    migrate()


### PR DESCRIPTION
This commit introduces a new mechanism to fetch a plan from backend,
using a human-readable 'key' in the form of 'release#number' to easily fetch
a specific plan by name. Other operations like copy, update, delete also
support fetching by key.

No tests were added as that part is handled by #982

Task: ARGUS-147
