### PR TITLE
improvement(cli/internal): Add models and route definitions for Plans

### DIFF
--- a/argus/backend/service/planner_service.py
+++ b/argus/backend/service/planner_service.py
@@ -44,6 +44,7 @@ class TempPlanPayload:
     completed: bool
     description: str
     owner: str
+    key: str
     participants: list[str]
     target_version: str
     assignee_mapping: dict[str, str]

--- a/cli/internal/api/routes.go
+++ b/cli/internal/api/routes.go
@@ -56,4 +56,20 @@ const (
 	AdminSSHKeys              = "/admin/api/v1/ssh/keys"                      // GET  – list all registered keys with metadata
 	AdminSSHKeyDelete         = "/admin/api/v1/ssh/keys/%s"                   // DELETE – revoke a key (key_id)
 
+	// Release planner routes (planning_api blueprint, mounted at /api/v1/planning)
+	PlansForRelease = "/api/v1/planning/release/%s/all"           // GET    – list plans for a release (release_id)
+	PlanGet         = "/api/v1/planning/plan/%s/get"              // GET    – single plan (plan_id or key)
+	PlanCreate      = "/api/v1/planning/plan/create"              // POST   – create a plan (CreatePlanRequest)
+	PlanUpdate      = "/api/v1/planning/plan/update"              // POST   – update a plan (PlanDiffRequest)
+	PlanDelete      = "/api/v1/planning/plan/%s/delete"           // DELETE – delete a plan (plan_id); query param deleteView=0|1
+	PlanCopy        = "/api/v1/planning/plan/copy"                // POST   – copy a plan (CopyPlanRequest)
+	PlanCopyCheck   = "/api/v1/planning/plan/%s/copy/check"       // GET    – copy eligibility (plan_id); query param releaseId
+	PlanResolve     = "/api/v1/planning/plan/%s/resolve_entities" // GET  – resolve plan entities (plan_id)
+	PlanningSearch  = "/api/v1/planning/search"                   // GET    – search tests/groups/releases; query params query, releaseId
+	GroupExplode    = "/api/v1/planning/group/%s/explode"         // GET    – explode a group into its tests (group_id)
+	Gridview        = "/api/v1/planning/release/%s/gridview"      // GET    – release structure (enabled tests + groups) (release_id)
+
+	// Name-resolution routes
+	Releases = "/api/v1/releases" // GET – enabled releases (id/name); query param all=1 for every release
+	Users    = "/api/v1/users"    // GET – users keyed by id with username/full_name/email
 )

--- a/cli/internal/models/planner.go
+++ b/cli/internal/models/planner.go
@@ -1,0 +1,262 @@
+package models
+
+import "strconv"
+
+// ---------------------------------------------------------------------------
+// ReleasePlan – mirrors argus.backend.models.plan.ArgusReleasePlan
+// ---------------------------------------------------------------------------
+
+// ReleasePlan is a single release plan as returned by the planner endpoints.
+//
+// All UUID columns are serialised as strings by ArgusJSONEncoder; datetime
+// columns are ISO-8601 strings. AssigneeMapping maps an entity UUID (test or
+// group) to a user UUID.
+//
+// Key is the human-friendly "releaseName#planNumber" handle (e.g.
+// "scylla-2026.2#3") added by the backend plan-keying change; plan operations
+// accept it in place of a UUID.
+type ReleasePlan struct {
+	ID              string            `json:"id"`
+	Key             string            `json:"key"`
+	Name            string            `json:"name"`
+	Description     string            `json:"description"`
+	Owner           string            `json:"owner"`
+	Participants    []string          `json:"participants"`
+	TargetVersion   string            `json:"target_version"`
+	AssigneeMapping map[string]string `json:"assignee_mapping"`
+	ReleaseID       string            `json:"release_id"`
+	Tests           []string          `json:"tests"`
+	Groups          []string          `json:"groups"`
+	ViewID          string            `json:"view_id"`
+	CreatedFrom     string            `json:"created_from"`
+	Completed       bool              `json:"completed"`
+	CreationTime    string            `json:"creation_time"`
+	LastUpdated     string            `json:"last_updated"`
+	EndsAt          string            `json:"ends_at"`
+}
+
+// ReleasePlanList is the response payload for the plans-for-release endpoint.
+type ReleasePlanList = []ReleasePlan
+
+// Headers implements output.Tabular for ReleasePlan.
+func (ReleasePlan) Headers() []string {
+	return []string{"Key", "Name", "Target Version", "Owner", "Tests", "Groups", "Completed"}
+}
+
+// Rows implements output.Tabular for ReleasePlan.
+func (p ReleasePlan) Rows() [][]string {
+	return [][]string{{
+		p.Key,
+		p.Name,
+		p.TargetVersion,
+		p.Owner,
+		strconv.Itoa(len(p.Tests)),
+		strconv.Itoa(len(p.Groups)),
+		strconv.FormatBool(p.Completed),
+	}}
+}
+
+// ---------------------------------------------------------------------------
+// Write request payloads
+// ---------------------------------------------------------------------------
+
+// CreatePlanRequest is the JSON body for POST /planning/plan/create.
+//
+// It mirrors CreatePlanPayload (planner_service.py): Assignments maps an
+// entity UUID to a user UUID and is converted server-side into the plan's
+// assignee_mapping. ViewID is optional — a view is auto-created when absent.
+type CreatePlanRequest struct {
+	Name          string            `json:"name"`
+	Description   string            `json:"description"`
+	Owner         string            `json:"owner"`
+	Participants  []string          `json:"participants"`
+	TargetVersion string            `json:"target_version"`
+	ReleaseID     string            `json:"release_id"`
+	Tests         []string          `json:"tests"`
+	Groups        []string          `json:"groups"`
+	Assignments   map[string]string `json:"assignments"`
+	ViewID        string            `json:"view_id,omitempty"`
+	CreatedFrom   string            `json:"created_from,omitempty"`
+}
+
+// PlanDiffRequest is the JSON body for POST /planning/plan/update.
+//
+// It mirrors PlanDiffPayload (planner_service.py): only changed scalar fields
+// are sent (pointer fields, omitted when nil), and list/map mutations are
+// expressed as add/remove deltas. The server applies removes before adds.
+type PlanDiffRequest struct {
+	ID string `json:"id"`
+
+	// Scalar fields – only sent when changed (nil = no change).
+	Name          *string `json:"name,omitempty"`
+	Description   *string `json:"description,omitempty"`
+	Owner         *string `json:"owner,omitempty"`
+	TargetVersion *string `json:"target_version,omitempty"`
+	Completed     *bool   `json:"completed,omitempty"`
+	EndsAt        *string `json:"ends_at,omitempty"`
+	ViewID        *string `json:"view_id,omitempty"`
+
+	// List diffs.
+	TestsAdd           []string `json:"tests_add,omitempty"`
+	TestsRemove        []string `json:"tests_remove,omitempty"`
+	GroupsAdd          []string `json:"groups_add,omitempty"`
+	GroupsRemove       []string `json:"groups_remove,omitempty"`
+	ParticipantsAdd    []string `json:"participants_add,omitempty"`
+	ParticipantsRemove []string `json:"participants_remove,omitempty"`
+
+	// Map diff for assignee_mapping.
+	AssigneeMappingSet    map[string]string `json:"assignee_mapping_set,omitempty"`
+	AssigneeMappingRemove []string          `json:"assignee_mapping_remove,omitempty"`
+}
+
+// CopyPlanRequest is the JSON body for POST /planning/plan/copy.
+//
+// It mirrors CopyPlanPayload (planner_service.py): Plan is the source plan
+// (with name/version/description/owner overrides applied), Replacements maps a
+// missing source-entity UUID to a substitute target-entity UUID.
+type CopyPlanRequest struct {
+	Plan              ReleasePlan       `json:"plan"`
+	KeepParticipants  bool              `json:"keepParticipants"`
+	Replacements      map[string]string `json:"replacements"`
+	TargetReleaseID   string            `json:"targetReleaseId"`
+	TargetReleaseName string            `json:"targetReleaseName"`
+}
+
+// ---------------------------------------------------------------------------
+// Copy eligibility check response
+// ---------------------------------------------------------------------------
+
+// CopyCheckResponse is the payload of GET /planning/plan/<id>/copy/check.
+//
+// Status is "passed" or "failed"; Missing lists entities that have no
+// equivalent in the target release (by build_system_id remap).
+type CopyCheckResponse struct {
+	Status          string          `json:"status"`
+	TargetRelease   Release         `json:"targetRelease"`
+	OriginalRelease Release         `json:"originalRelease"`
+	Missing         MissingEntities `json:"missing"`
+}
+
+// MissingEntities groups the missing tests and groups of a copy eligibility check.
+type MissingEntities struct {
+	Tests  []GridEntity `json:"tests"`
+	Groups []GridEntity `json:"groups"`
+}
+
+// ---------------------------------------------------------------------------
+// Release / Gridview – name resolution and group expansion sources
+// ---------------------------------------------------------------------------
+
+// Release mirrors the subset of ArgusRelease returned by /api/v1/releases and
+// the copy-check endpoint.
+type Release struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	PrettyName string `json:"pretty_name"`
+	Enabled    bool   `json:"enabled"`
+}
+
+// ReleaseList is the response payload for GET /api/v1/releases.
+type ReleaseList = []Release
+
+// GridEntity is a single test or group in a release's gridview (and the shape
+// of index-mapped entities in copy-check "missing" lists).
+//
+// Group and Release are decorated *names* (strings) in the gridview, unlike
+// the search endpoint where they are nested objects (see SearchHit).
+type GridEntity struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	PrettyName    string `json:"pretty_name"`
+	BuildSystemID string `json:"build_system_id"`
+	GroupID       string `json:"group_id"`
+	ReleaseID     string `json:"release_id"`
+	Enabled       bool   `json:"enabled"`
+	Type          string `json:"type"`
+	Group         string `json:"group"`
+	Release       string `json:"release"`
+}
+
+// GridView is the response payload for GET /planning/release/<id>/gridview.
+//
+// Tests and Groups are keyed by entity UUID and contain only enabled entities;
+// TestByGroup maps a group UUID to its tests (including disabled ones) and is
+// deliberately not used for enabled-only expansion.
+type GridView struct {
+	Tests       map[string]GridEntity   `json:"tests"`
+	Groups      map[string]GridEntity   `json:"groups"`
+	TestByGroup map[string][]GridEntity `json:"testByGroup"`
+}
+
+// ---------------------------------------------------------------------------
+// PlanTemplate – editable create-spec (get --template / create --file schema)
+// ---------------------------------------------------------------------------
+
+// PlanTemplate is the release-independent, human-readable plan spec emitted by
+// `planner get --template` and consumed by `planner create --file`.
+//
+// Tests are group-qualified "group/test" strings, Owner/Participants are
+// usernames, and Assignments are keyed by "group/test".
+type PlanTemplate struct {
+	Name          string            `json:"name"`
+	Description   string            `json:"description,omitempty"`
+	Release       string            `json:"release"`
+	TargetVersion string            `json:"target_version,omitempty"`
+	Owner         string            `json:"owner,omitempty"`
+	Participants  []string          `json:"participants,omitempty"`
+	Tests         []string          `json:"tests"`
+	Assignments   map[string]string `json:"assignments,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// SearchHit – /planning/search result
+// ---------------------------------------------------------------------------
+
+// SearchRef is the nested group/release object attached to a search hit.
+// Unlike the gridview, the search endpoint returns these as objects, not
+// decorated name strings.
+type SearchRef struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	PrettyName string `json:"pretty_name"`
+	Enabled    bool   `json:"enabled"`
+}
+
+// SearchHit is a single result of GET /planning/search. Type is one of
+// "test", "group", "release", or "special" (the synthetic "Add all..." row,
+// which is filtered out before display).
+type SearchHit struct {
+	ID            string     `json:"id"`
+	Name          string     `json:"name"`
+	PrettyName    string     `json:"pretty_name"`
+	Type          string     `json:"type"`
+	BuildSystemID string     `json:"build_system_id"`
+	Enabled       bool       `json:"enabled"`
+	Group         *SearchRef `json:"group"`
+	Release       *SearchRef `json:"release"`
+}
+
+// SearchHitList is the response payload for GET /planning/search.
+type SearchHitList = []SearchHit
+
+// Headers implements output.Tabular for SearchHit.
+func (SearchHit) Headers() []string {
+	return []string{"Type", "Name", "Build System Id", "Group", "Release"}
+}
+
+// Rows implements output.Tabular for SearchHit.
+func (h SearchHit) Rows() [][]string {
+	name := h.PrettyName
+	if name == "" {
+		name = h.Name
+	}
+	group := ""
+	if h.Group != nil {
+		group = h.Group.Name
+	}
+	release := ""
+	if h.Release != nil {
+		release = h.Release.Name
+	}
+	return [][]string{{h.Type, name, h.BuildSystemID, group, release}}
+}

--- a/cli/internal/models/planner_test.go
+++ b/cli/internal/models/planner_test.go
@@ -1,0 +1,237 @@
+package models_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/scylladb/argus/cli/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sampleReleasePlanJSON mirrors a single plan as serialised by the backend
+// (UUIDs as strings, datetimes as ISO strings, snake_case keys).
+const sampleReleasePlanJSON = `{
+	"id": "7f3c1e90-0000-0000-0000-000000000001",
+	"key": "scylla-2026.2#3",
+	"name": "2026.2 Longevity",
+	"description": "Longevity suite",
+	"owner": "11111111-0000-0000-0000-000000000001",
+	"participants": ["22222222-0000-0000-0000-000000000002"],
+	"target_version": "2026.2.0~rc3",
+	"assignee_mapping": {"c4d00000-0000-0000-0000-00000000007a": "11111111-0000-0000-0000-000000000001"},
+	"release_id": "33333333-0000-0000-0000-000000000003",
+	"tests": ["c4d00000-0000-0000-0000-00000000007a", "b7e20000-0000-0000-0000-000000000009"],
+	"groups": ["9a1c0000-0000-0000-0000-000000000044"],
+	"view_id": "44444444-0000-0000-0000-000000000004",
+	"created_from": "",
+	"completed": false,
+	"creation_time": "2026-06-01T10:00:00.000000",
+	"last_updated": "2026-06-02T11:00:00.000000",
+	"ends_at": ""
+}`
+
+func TestReleasePlan_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	var plan models.ReleasePlan
+	require.NoError(t, json.Unmarshal([]byte(sampleReleasePlanJSON), &plan))
+
+	assert.Equal(t, "7f3c1e90-0000-0000-0000-000000000001", plan.ID)
+	assert.Equal(t, "scylla-2026.2#3", plan.Key)
+	assert.Equal(t, "2026.2 Longevity", plan.Name)
+	assert.Equal(t, "2026.2.0~rc3", plan.TargetVersion)
+	assert.Len(t, plan.Tests, 2)
+	assert.Len(t, plan.Groups, 1)
+	assert.Equal(t, "11111111-0000-0000-0000-000000000001",
+		plan.AssigneeMapping["c4d00000-0000-0000-0000-00000000007a"])
+	assert.False(t, plan.Completed)
+
+	// Marshal back and re-decode to confirm a stable round-trip.
+	raw, err := json.Marshal(plan)
+	require.NoError(t, err)
+	var again models.ReleasePlan
+	require.NoError(t, json.Unmarshal(raw, &again))
+	assert.Equal(t, plan, again)
+}
+
+func TestReleasePlan_TabularShape(t *testing.T) {
+	t.Parallel()
+
+	var plan models.ReleasePlan
+	require.NoError(t, json.Unmarshal([]byte(sampleReleasePlanJSON), &plan))
+
+	headers := plan.Headers()
+	rows := plan.Rows()
+	require.Len(t, rows, 1)
+	assert.Len(t, rows[0], len(headers), "row width must match header count")
+	assert.Equal(t, []string{
+		"scylla-2026.2#3", "2026.2 Longevity", "2026.2.0~rc3",
+		"11111111-0000-0000-0000-000000000001", "2", "1", "false",
+	}, rows[0])
+}
+
+func TestReleasePlanList_EmptySliceSerialisesAsArray(t *testing.T) {
+	t.Parallel()
+
+	list := []models.ReleasePlan{}
+	raw, err := json.Marshal(list)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(raw), "empty list must serialise as [] not null")
+}
+
+func TestPlanDiffRequest_OmitsUnsetOptionalScalars(t *testing.T) {
+	t.Parallel()
+
+	// Only the name changed; every other scalar/list/map must be absent.
+	name := "renamed"
+	diff := models.PlanDiffRequest{
+		ID:   "7f3c1e90-0000-0000-0000-000000000001",
+		Name: &name,
+	}
+	raw, err := json.Marshal(diff)
+	require.NoError(t, err)
+	s := string(raw)
+
+	assert.Contains(t, s, `"id"`)
+	assert.Contains(t, s, `"name":"renamed"`)
+
+	// Unset optionals / empty deltas must not appear on the wire.
+	for _, key := range []string{
+		"description", "owner", "target_version", "completed", "ends_at", "view_id",
+		"tests_add", "tests_remove", "groups_add", "groups_remove",
+		"participants_add", "participants_remove",
+		"assignee_mapping_set", "assignee_mapping_remove",
+	} {
+		assert.NotContainsf(t, s, `"`+key+`"`, "unset field %q must be omitted", key)
+	}
+}
+
+func TestPlanDiffRequest_ListAndMapDeltas(t *testing.T) {
+	t.Parallel()
+
+	diff := models.PlanDiffRequest{
+		ID:                 "id-1",
+		TestsAdd:           []string{"a", "b"},
+		GroupsRemove:       []string{"g"},
+		AssigneeMappingSet: map[string]string{"a": "u"},
+	}
+	raw, err := json.Marshal(diff)
+	require.NoError(t, err)
+	s := string(raw)
+
+	assert.Contains(t, s, `"tests_add":["a","b"]`)
+	assert.Contains(t, s, `"groups_remove":["g"]`)
+	assert.Contains(t, s, `"assignee_mapping_set":{"a":"u"}`)
+	// tests_remove was left empty and must be omitted.
+	assert.False(t, strings.Contains(s, `"tests_remove"`), "empty tests_remove must be omitted")
+}
+
+func TestCopyCheckResponse_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const raw = `{
+		"status": "failed",
+		"targetRelease": {"id": "t-1", "name": "scylla-2026.2", "pretty_name": "2026.2", "enabled": true},
+		"originalRelease": {"id": "o-1", "name": "scylla-2026.1", "pretty_name": "2026.1", "enabled": true},
+		"missing": {
+			"tests": [{"id": "x", "name": "longevity-100gb", "build_system_id": "scylla-2026.1/longevity/longevity-100gb", "type": "test", "release": "scylla-2026.1", "enabled": true}],
+			"groups": []
+		}
+	}`
+
+	var resp models.CopyCheckResponse
+	require.NoError(t, json.Unmarshal([]byte(raw), &resp))
+
+	assert.Equal(t, "failed", resp.Status)
+	assert.Equal(t, "scylla-2026.2", resp.TargetRelease.Name)
+	assert.Equal(t, "scylla-2026.1", resp.OriginalRelease.Name)
+	require.Len(t, resp.Missing.Tests, 1)
+	assert.Equal(t, "scylla-2026.1/longevity/longevity-100gb", resp.Missing.Tests[0].BuildSystemID)
+	assert.Empty(t, resp.Missing.Groups)
+}
+
+func TestGridView_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const raw = `{
+		"tests": {
+			"c4d0": {"id": "c4d0", "name": "longevity-100gb", "pretty_name": "Longevity 100GB", "build_system_id": "scylla-2026.2/longevity/longevity-100gb", "group_id": "g1", "release_id": "r1", "enabled": true, "type": "test", "group": "longevity", "release": "scylla-2026.2"}
+		},
+		"groups": {
+			"g1": {"id": "g1", "name": "longevity", "pretty_name": "Longevity", "build_system_id": "scylla-2026.2/longevity", "release_id": "r1", "enabled": true, "type": "group", "release": "scylla-2026.2"}
+		},
+		"testByGroup": {
+			"g1": [{"id": "c4d0", "name": "longevity-100gb", "group_id": "g1", "enabled": true}]
+		}
+	}`
+
+	var gv models.GridView
+	require.NoError(t, json.Unmarshal([]byte(raw), &gv))
+
+	test, ok := gv.Tests["c4d0"]
+	require.True(t, ok)
+	assert.Equal(t, "scylla-2026.2/longevity/longevity-100gb", test.BuildSystemID)
+	assert.Equal(t, "longevity", test.Group) // decorated name string, not an object
+	assert.Equal(t, "scylla-2026.2", test.Release)
+	assert.Equal(t, "longevity", gv.Groups["g1"].Name)
+	require.Len(t, gv.TestByGroup["g1"], 1)
+}
+
+func TestSearchHit_NestedRefsAndTabular(t *testing.T) {
+	t.Parallel()
+
+	const raw = `{
+		"id": "c4d0",
+		"name": "longevity-100gb",
+		"pretty_name": "Longevity 100GB",
+		"type": "test",
+		"build_system_id": "scylla-2026.2/longevity/longevity-100gb",
+		"enabled": true,
+		"group": {"id": "g1", "name": "longevity", "pretty_name": "Longevity", "enabled": true},
+		"release": {"id": "r1", "name": "scylla-2026.2", "pretty_name": "2026.2", "enabled": true}
+	}`
+
+	var hit models.SearchHit
+	require.NoError(t, json.Unmarshal([]byte(raw), &hit))
+
+	require.NotNil(t, hit.Group)
+	require.NotNil(t, hit.Release)
+	assert.Equal(t, "longevity", hit.Group.Name)
+	assert.Equal(t, "scylla-2026.2", hit.Release.Name)
+
+	rows := hit.Rows()
+	require.Len(t, rows, 1)
+	assert.Len(t, rows[0], len(hit.Headers()))
+	// Prefers pretty_name for display, surfaces build_system_id + nested names.
+	assert.Equal(t, []string{
+		"test", "Longevity 100GB",
+		"scylla-2026.2/longevity/longevity-100gb", "longevity", "scylla-2026.2",
+	}, rows[0])
+}
+
+func TestSearchHit_NilRefsRenderEmpty(t *testing.T) {
+	t.Parallel()
+
+	hit := models.SearchHit{Type: "release", Name: "scylla-2026.2"}
+	rows := hit.Rows()
+	require.Len(t, rows, 1)
+	assert.Equal(t, []string{"release", "scylla-2026.2", "", "", ""}, rows[0])
+}
+
+func TestCreatePlanRequest_OmitsOptionalEmptyFields(t *testing.T) {
+	t.Parallel()
+
+	req := models.CreatePlanRequest{
+		Name:      "p",
+		ReleaseID: "r1",
+		Tests:     []string{"a"},
+	}
+	raw, err := json.Marshal(req)
+	require.NoError(t, err)
+	s := string(raw)
+
+	assert.NotContains(t, s, `"view_id"`, "empty optional view_id must be omitted")
+	assert.NotContains(t, s, `"created_from"`, "empty optional created_from must be omitted")
+}


### PR DESCRIPTION
This commit adds new routes and models into CLI application that
describe envelopes and responses for endpoints corresponding to plan
management inside argus. It also adds some basic tests for model tabular
related methods.

Task: ARGUS-147
