### PR TITLE
fix(pytest-argus-reporter): forward log_dir and use_tunnel to client

### DIFF
--- a/pytest-argus-reporter/pytest_argus_reporter.py
+++ b/pytest-argus-reporter/pytest_argus_reporter.py
@@ -99,6 +99,30 @@ def pytest_addoption(parser):
     )
 
     group.addoption(
+        "--argus-log-dir",
+        action="store",
+        dest="log_dir",
+        default=os.environ.get("ARGUS_LOG_DIR", "."),
+        help="Directory for the argus_replay_log JSONL file",
+    )
+
+    group.addoption(
+        "--argus-use-tunnel",
+        action="store_true",
+        dest="use_tunnel",
+        default=None,
+        help="Route API calls through the Argus SSH tunnel",
+    )
+
+    group.addoption(
+        "--argus-no-use-tunnel",
+        action="store_false",
+        dest="use_tunnel",
+        default=None,
+        help="Don't route API calls through the Argus SSH tunnel",
+    )
+
+    group.addoption(
         "--argus-slices",
         action="store_true",
         dest="slices",
@@ -164,6 +188,8 @@ class ArgusReporter(object):  # pylint: disable=too-many-instance-attributes
         self.base_url = config.getoption("base_url")
         self.api_key = config.getoption("api_key")
         self.extra_headers = config.getoption("extra_headers")
+        self.log_dir = config.getoption("log_dir")
+        self.use_tunnel = config.getoption("use_tunnel")
         self.max_splice_time = config.getoption("max_splice_time")
         self.default_test_time = config.getoption("default_test_time")
         if self.post_reports:
@@ -186,6 +212,8 @@ class ArgusReporter(object):  # pylint: disable=too-many-instance-attributes
         return ArgusGenericClient(
             auth_token=self.api_key,
             base_url=self.base_url,
+            log_dir=self.log_dir,
+            use_tunnel=self.use_tunnel,
             extra_headers=self.extra_headers,
         )
 


### PR DESCRIPTION
v0.15.17 made log_dir a required argument on ArgusGenericClient (the request replay log feature), which broke the pytest reporter's unit tests since it constructed the client without it.

Wire both new client knobs through the plugin:
- --argus-log-dir (env ARGUS_LOG_DIR, default ".") -> log_dir
- --argus-use-tunnel / --argus-no-use-tunnel -> use_tunnel, defaulting to None so the existing ARGUS_USE_TUNNEL env fallback is preserved