### PR TITLE
fix(pytest-argus-reporter): support log_dir/use_tunnel, require py>=3.12

### DIFF
--- a/pytest-argus-reporter/noxfile.py
+++ b/pytest-argus-reporter/noxfile.py
@@ -3,11 +3,14 @@ import nox
 nox.options.default_venv_backend = "uv"
 
 
-@nox.session(python=["3.10", "3.11", "3.12", "3.13", "3.14"])
+@nox.session(python=["3.12", "3.13", "3.14"])
 def tests(session):
     """Run the test suite with coverage."""
 
-    session.install(".[dev]")
+    # Install the in-repo argus client (editable) so the reporter is tested
+    # against this repo's argus-alm rather than a cached/published wheel that
+    # may lag behind the client API the reporter targets.
+    session.install("-e", "..", ".[dev]")
     session.run(
         "pytest",
         "-p",
@@ -20,7 +23,7 @@ def tests(session):
     )
 
 
-@nox.session(python=["3.10", "3.11", "3.12", "3.13", "3.14"])
+@nox.session(python=["3.12", "3.13", "3.14"])
 def pre_commit(session):
     """Run pre-commit checks."""
     session.install(".[dev]")

--- a/pytest-argus-reporter/pyproject.toml
+++ b/pytest-argus-reporter/pyproject.toml
@@ -17,7 +17,7 @@ keywords = [
     "pytest",
     "testing",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 license = "Apache-2.0"
 classifiers = [
         "Development Status :: 4 - Beta",
@@ -26,10 +26,9 @@ classifiers = [
         "Topic :: Software Development :: Testing",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Operating System :: OS Independent",
 ]
 dependencies = [

--- a/pytest-argus-reporter/pytest_argus_reporter.py
+++ b/pytest-argus-reporter/pytest_argus_reporter.py
@@ -99,6 +99,30 @@ def pytest_addoption(parser):
     )
 
     group.addoption(
+        "--argus-log-dir",
+        action="store",
+        dest="log_dir",
+        default=os.environ.get("ARGUS_LOG_DIR", "."),
+        help="Directory for the argus_replay_log JSONL file",
+    )
+
+    group.addoption(
+        "--argus-use-tunnel",
+        action="store_true",
+        dest="use_tunnel",
+        default=None,
+        help="Route API calls through the Argus SSH tunnel",
+    )
+
+    group.addoption(
+        "--argus-no-use-tunnel",
+        action="store_false",
+        dest="use_tunnel",
+        default=None,
+        help="Don't route API calls through the Argus SSH tunnel",
+    )
+
+    group.addoption(
         "--argus-slices",
         action="store_true",
         dest="slices",
@@ -164,6 +188,8 @@ class ArgusReporter(object):  # pylint: disable=too-many-instance-attributes
         self.base_url = config.getoption("base_url")
         self.api_key = config.getoption("api_key")
         self.extra_headers = config.getoption("extra_headers")
+        self.log_dir = config.getoption("log_dir")
+        self.use_tunnel = config.getoption("use_tunnel")
         self.max_splice_time = config.getoption("max_splice_time")
         self.default_test_time = config.getoption("default_test_time")
         if self.post_reports:
@@ -186,6 +212,8 @@ class ArgusReporter(object):  # pylint: disable=too-many-instance-attributes
         return ArgusGenericClient(
             auth_token=self.api_key,
             base_url=self.base_url,
+            log_dir=self.log_dir,
+            use_tunnel=self.use_tunnel,
             extra_headers=self.extra_headers,
         )
 


### PR DESCRIPTION
argus-alm 0.15.17 made log_dir a required ArgusGenericClient argument (the request replay log feature) and also bumped its own minimum Python to 3.12. The reporter still constructed the client without log_dir, and advertised support for Python 3.10/3.11 where argus-alm>=0.15.17 cannot be installed -- so those runners silently fell back to an old client without log_dir, yielding "unexpected keyword argument 'log_dir'".

- Forward the new client knobs: --argus-log-dir (env ARGUS_LOG_DIR, default ".") -> log_dir --argus-use-tunnel / --argus-no-use-tunnel -> use_tunnel (defaults to None so the existing ARGUS_USE_TUNNEL env fallback is preserved)
- Raise requires-python to >=3.12 to match argus-alm; trim the nox matrix and classifiers to 3.12-3.14.
- nox tests now install the in-repo argus client (-e ..) so the reporter is verified against this repo's client API, not a published/cached wheel.