### PR TITLE
feature(cli/planner): PlannerService + list/get commands and name resolution

### DIFF
--- a/cli/cmd/planner.go
+++ b/cli/cmd/planner.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/scylladb/argus/cli/cmd/planner"
+	"github.com/spf13/cobra"
+)
+
+// plannerCmd is the parent command for release-plan management.
+var plannerCmd = &cobra.Command{
+	Use:   "planner",
+	Short: "Manage Argus release plans",
+	Long: `Create, inspect, and manage Argus release plans.
+
+Plans are referenced by their UUID or their human-friendly "releaseName#planNumber"
+key; releases, users, tests, and groups are referenced by name (or, for tests, by
+build_system_id) and resolved to UUIDs automatically.`,
+}
+
+func init() {
+	planner.Register(plannerCmd)
+	rootCmd.AddCommand(plannerCmd)
+}

--- a/cli/cmd/planner/get.go
+++ b/cli/cmd/planner/get.go
@@ -1,0 +1,51 @@
+package planner
+
+import (
+	"github.com/scylladb/argus/cli/internal/cmdctx"
+	"github.com/scylladb/argus/cli/internal/logging"
+	"github.com/scylladb/argus/cli/internal/models"
+	"github.com/scylladb/argus/cli/internal/services"
+	"github.com/spf13/cobra"
+)
+
+// registerGet adds the "get" sub-command to parent.
+func registerGet(parent *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Show a single release plan",
+		Long: `Show a single release plan addressed by its UUID or its
+human-friendly "releaseName#planNumber" key, e.g.:
+  argus planner get --plan-id scylla-2026.2#3
+  argus planner get --plan-id 7f3c1e90-...`,
+		RunE: runGet,
+	}
+
+	cmd.Flags().StringP("plan-id", "p", "", "Plan UUID or key (e.g. \"scylla-2026.2#3\") (required)")
+	_ = cmd.MarkFlagRequired("plan-id")
+
+	parent.AddCommand(cmd)
+}
+
+// runGet is the RunE handler for "planner get".
+func runGet(cmd *cobra.Command, _ []string) error {
+	cmd.SilenceUsage = true
+	ctx := cmd.Context()
+	client := cmdctx.APIClientFrom(ctx)
+	out := cmdctx.OutputterFrom(ctx)
+	c := cmdctx.CacheFrom(ctx)
+	log := logging.For(cmdctx.LoggerFrom(ctx), "planner-get")
+
+	planRef, _ := cmd.Flags().GetString("plan-id")
+	log.Debug().Str("plan_id", planRef).Msg("fetching plan")
+
+	svc := services.NewPlannerService(client, c)
+
+	plan, err := svc.GetPlan(ctx, planRef)
+	if err != nil {
+		log.Error().Err(err).Str("plan_id", planRef).Msg("failed to fetch plan")
+		return err
+	}
+
+	log.Info().Str("plan_id", planRef).Msg("plan fetched successfully")
+	return out.Write(models.NewKVTabular(plan))
+}

--- a/cli/cmd/planner/list.go
+++ b/cli/cmd/planner/list.go
@@ -1,0 +1,57 @@
+package planner
+
+import (
+	"github.com/scylladb/argus/cli/internal/cmdctx"
+	"github.com/scylladb/argus/cli/internal/logging"
+	"github.com/scylladb/argus/cli/internal/models"
+	"github.com/scylladb/argus/cli/internal/services"
+	"github.com/spf13/cobra"
+)
+
+// registerList adds the "list" sub-command to parent.
+func registerList(parent *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List release plans for a release",
+		Long: `List the release plans belonging to a release.
+
+The release is referenced by its name (not a UUID), e.g.:
+  argus planner list --release scylla-2026.2`,
+		RunE: runList,
+	}
+
+	cmd.Flags().StringP("release", "r", "", "Release name (required)")
+	_ = cmd.MarkFlagRequired("release")
+
+	parent.AddCommand(cmd)
+}
+
+// runList is the RunE handler for "planner list".
+func runList(cmd *cobra.Command, _ []string) error {
+	cmd.SilenceUsage = true
+	ctx := cmd.Context()
+	client := cmdctx.APIClientFrom(ctx)
+	out := cmdctx.OutputterFrom(ctx)
+	c := cmdctx.CacheFrom(ctx)
+	log := logging.For(cmdctx.LoggerFrom(ctx), "planner-list")
+
+	releaseRef, _ := cmd.Flags().GetString("release")
+	log.Debug().Str("release", releaseRef).Msg("listing plans for release")
+
+	svc := services.NewPlannerService(client, c)
+
+	releaseID, err := svc.ResolveReleaseID(ctx, releaseRef)
+	if err != nil {
+		log.Error().Err(err).Str("release", releaseRef).Msg("failed to resolve release")
+		return err
+	}
+
+	plans, err := svc.GetPlansForRelease(ctx, releaseID)
+	if err != nil {
+		log.Error().Err(err).Str("release", releaseRef).Msg("failed to list plans")
+		return err
+	}
+
+	log.Info().Str("release", releaseRef).Int("count", len(plans)).Msg("plans listed successfully")
+	return out.Write(models.NewTabularSlice(plans))
+}

--- a/cli/cmd/planner/root.go
+++ b/cli/cmd/planner/root.go
@@ -1,0 +1,13 @@
+// Package planner provides the "planner list" and "planner get" cobra
+// sub-commands for managing Argus release plans. It is wired into the command
+// tree by the parent cmd package via [Register].
+package planner
+
+import "github.com/spf13/cobra"
+
+// Register adds the planner read sub-commands (list, get) to the given parent
+// command (typically the "planner" command owned by the cmd package).
+func Register(parent *cobra.Command) {
+	registerList(parent)
+	registerGet(parent)
+}

--- a/cli/internal/cache/keys.go
+++ b/cli/internal/cache/keys.go
@@ -47,6 +47,17 @@ const (
 	// Events are append-only once a run finishes, so a longer TTL is fine.
 	// During a live run we keep it short so new events appear quickly.
 	TTLSCTEvents = 5 * time.Minute
+
+	// TTLReleases is the TTL for the releases list used by name resolution.
+	// The set of releases changes rarely, so a short TTL is plenty.
+	TTLReleases = 5 * time.Minute
+
+	// TTLUsers is the TTL for the users list used by username resolution.
+	TTLUsers = 5 * time.Minute
+
+	// TTLGridview is the TTL for a release's gridview (enabled tests + groups),
+	// the source for client-side test/group name resolution and group expansion.
+	TTLGridview = 5 * time.Minute
 )
 
 // RunKey returns the cache key for a specific test run.
@@ -177,6 +188,27 @@ func NemesesFilteredKey(runID, before, after string) string {
 func PytestFilterKey(queryString string) string {
 	h := sha256.Sum256([]byte(queryString))
 	return path.Join("pytest-filter", fmt.Sprintf("%x", h[:8]))
+}
+
+// ReleasesKey returns the cache key for the releases list.
+//
+// On disk: cache/releases/
+func ReleasesKey() string {
+	return "releases"
+}
+
+// UsersKey returns the cache key for the users list.
+//
+// On disk: cache/users/
+func UsersKey() string {
+	return "users"
+}
+
+// GridviewKey returns the cache key for a release's gridview structure.
+//
+// On disk: cache/gridview/{releaseID}/
+func GridviewKey(releaseID string) string {
+	return path.Join("gridview", releaseID)
 }
 
 // PrometheusLogKey returns the cache key for a downloaded monitor-set archive.

--- a/cli/internal/models/planner.go
+++ b/cli/internal/models/planner.go
@@ -159,6 +159,19 @@ type Release struct {
 // ReleaseList is the response payload for GET /api/v1/releases.
 type ReleaseList = []Release
 
+// User mirrors the subset of User returned by GET /api/v1/users (User.to_json).
+type User struct {
+	ID        string `json:"id"`
+	Username  string `json:"username"`
+	FullName  string `json:"full_name"`
+	Email     string `json:"email"`
+	PictureID string `json:"picture_id"`
+}
+
+// UsersMap is the response payload for GET /api/v1/users: a map keyed by the
+// user's UUID string with the user object as the value.
+type UsersMap = map[string]User
+
 // GridEntity is a single test or group in a release's gridview (and the shape
 // of index-mapped entities in copy-check "missing" lists).
 //

--- a/cli/internal/services/planner.go
+++ b/cli/internal/services/planner.go
@@ -1,0 +1,337 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/scylladb/argus/cli/internal/api"
+	"github.com/scylladb/argus/cli/internal/cache"
+	"github.com/scylladb/argus/cli/internal/models"
+)
+
+// EntityKind identifies whether an entity reference denotes a test or a group
+// when resolving names against a release's gridview.
+type EntityKind string
+
+const (
+	// KindTest selects test resolution (build_system_id / group/test / bare name).
+	KindTest EntityKind = "test"
+	// KindGroup selects group resolution (group name within the release).
+	KindGroup EntityKind = "group"
+)
+
+// PlannerService encapsulates release-plan reads and the client-side name
+// resolution (release/user/test/group) that turns human references into the
+// UUIDs the backend expects. Only UUIDs are ever sent to the backend.
+//
+// It memoises the releases list, users list, and per-release gridviews for the
+// lifetime of the service so that a single command resolves many references
+// with at most one network fetch of each.
+type PlannerService struct {
+	client *api.Client
+	cache  *cache.Cache
+
+	releases  models.ReleaseList
+	users     models.UsersMap
+	gridviews map[string]models.GridView
+}
+
+// NewPlannerService constructs a [PlannerService].
+func NewPlannerService(client *api.Client, c *cache.Cache) *PlannerService {
+	return &PlannerService{
+		client:    client,
+		cache:     c,
+		gridviews: map[string]models.GridView{},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Plan reads
+// ---------------------------------------------------------------------------
+
+// GetPlansForRelease returns every release plan for the given release UUID.
+func (s *PlannerService) GetPlansForRelease(ctx context.Context, releaseID string) (models.ReleasePlanList, error) {
+	route := fmt.Sprintf(api.PlansForRelease, releaseID)
+	req, err := s.client.NewRequest(ctx, "GET", route, nil)
+	if err != nil {
+		return nil, err
+	}
+	return api.DoJSON[models.ReleasePlanList](s.client, req)
+}
+
+// GetPlan returns a single plan addressed by UUID id or by its human-friendly
+// "releaseName#planNumber" key. The reference is passed through verbatim and
+// resolved server-side.
+func (s *PlannerService) GetPlan(ctx context.Context, planRef string) (models.ReleasePlan, error) {
+	// Plan keys contain '#' (e.g. "scylla-2026.2#3"); escape so it survives URL
+	// parsing as a path segment rather than being treated as a fragment.
+	route := fmt.Sprintf(api.PlanGet, url.PathEscape(planRef))
+	req, err := s.client.NewRequest(ctx, "GET", route, nil)
+	if err != nil {
+		return models.ReleasePlan{}, err
+	}
+	return api.DoJSON[models.ReleasePlan](s.client, req)
+}
+
+// ---------------------------------------------------------------------------
+// Release resolution
+// ---------------------------------------------------------------------------
+
+// getReleases returns the full releases list (including disabled releases so
+// plans on archived releases still resolve), memoised then disk-cached.
+func (s *PlannerService) getReleases(ctx context.Context) (models.ReleaseList, error) {
+	if s.releases != nil {
+		return s.releases, nil
+	}
+	if cached, _, err := cache.Get[models.ReleaseList](s.cache, cache.ReleasesKey()); err == nil {
+		s.releases = cached
+		return cached, nil
+	}
+
+	route := api.Releases + "?all=1"
+	req, err := s.client.NewRequest(ctx, "GET", route, nil)
+	if err != nil {
+		return nil, err
+	}
+	releases, err := api.DoJSON[models.ReleaseList](s.client, req)
+	if err != nil {
+		return nil, err
+	}
+	_ = cache.Set(s.cache, cache.ReleasesKey(), releases, route, cache.TTLReleases)
+	s.releases = releases
+	return releases, nil
+}
+
+// ResolveReleaseID resolves a release name (exact, case-insensitive) to its
+// UUID. Raw UUIDs are not accepted as input — a value that matches no release
+// name errors with the list of available releases.
+func (s *PlannerService) ResolveReleaseID(ctx context.Context, ref string) (string, error) {
+	releases, err := s.getReleases(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	var matches []models.Release
+	for _, r := range releases {
+		if strings.EqualFold(r.Name, ref) {
+			matches = append(matches, r)
+		}
+	}
+
+	switch len(matches) {
+	case 1:
+		return matches[0].ID, nil
+	case 0:
+		return "", fmt.Errorf("no release named %q (use the exact release name, e.g. scylla-2026.2)", ref)
+	default:
+		return "", fmt.Errorf("ambiguous release name %q (%d matches)", ref, len(matches))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// User resolution
+// ---------------------------------------------------------------------------
+
+// getUsers returns the users map, memoised then disk-cached.
+func (s *PlannerService) getUsers(ctx context.Context) (models.UsersMap, error) {
+	if s.users != nil {
+		return s.users, nil
+	}
+	if cached, _, err := cache.Get[models.UsersMap](s.cache, cache.UsersKey()); err == nil {
+		s.users = cached
+		return cached, nil
+	}
+
+	req, err := s.client.NewRequest(ctx, "GET", api.Users, nil)
+	if err != nil {
+		return nil, err
+	}
+	users, err := api.DoJSON[models.UsersMap](s.client, req)
+	if err != nil {
+		return nil, err
+	}
+	_ = cache.Set(s.cache, cache.UsersKey(), users, api.Users, cache.TTLUsers)
+	s.users = users
+	return users, nil
+}
+
+// ResolveUserID resolves a username (exact, case-insensitive) to its UUID.
+// Raw UUIDs are not accepted; 0 or >1 matches error with candidate usernames.
+func (s *PlannerService) ResolveUserID(ctx context.Context, ref string) (string, error) {
+	users, err := s.getUsers(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	var matches []string
+	for id, u := range users {
+		if strings.EqualFold(u.Username, ref) {
+			matches = append(matches, id)
+		}
+	}
+
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		return "", fmt.Errorf("no user named %q", ref)
+	default:
+		return "", fmt.Errorf("ambiguous username %q (%d matches)", ref, len(matches))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Gridview + test/group resolution
+// ---------------------------------------------------------------------------
+
+// GetReleaseStructure returns the gridview (enabled tests + groups) for a
+// release in a single call, memoised then disk-cached.
+func (s *PlannerService) GetReleaseStructure(ctx context.Context, releaseID string) (models.GridView, error) {
+	if gv, ok := s.gridviews[releaseID]; ok {
+		return gv, nil
+	}
+	key := cache.GridviewKey(releaseID)
+	if cached, _, err := cache.Get[models.GridView](s.cache, key); err == nil {
+		s.gridviews[releaseID] = cached
+		return cached, nil
+	}
+
+	route := fmt.Sprintf(api.Gridview, releaseID)
+	req, err := s.client.NewRequest(ctx, "GET", route, nil)
+	if err != nil {
+		return models.GridView{}, err
+	}
+	gv, err := api.DoJSON[models.GridView](s.client, req)
+	if err != nil {
+		return models.GridView{}, err
+	}
+	_ = cache.Set(s.cache, key, gv, route, cache.TTLGridview)
+	s.gridviews[releaseID] = gv
+	return gv, nil
+}
+
+// ResolveEntityID resolves a test or group reference (by name or
+// build_system_id) to its UUID within a release, using a single gridview fetch.
+//
+// Groups match by name (unique within a release). Tests resolve in priority
+// order: (1) exact build_system_id, (2) group-qualified "group/test",
+// (3) bare name (rejected when ambiguous, with a candidate list).
+func (s *PlannerService) ResolveEntityID(ctx context.Context, ref, releaseID string, kind EntityKind) (string, error) {
+	grid, err := s.GetReleaseStructure(ctx, releaseID)
+	if err != nil {
+		return "", err
+	}
+	if kind == KindGroup {
+		g, err := findGroup(grid, ref)
+		if err != nil {
+			return "", err
+		}
+		return g.ID, nil
+	}
+	return resolveTest(grid, ref)
+}
+
+// ExpandGroup resolves a group reference and returns the UUIDs of its enabled
+// member tests, taken from the gridview's enabled-only tests map (deliberately
+// not testByGroup / explode, which include disabled tests). The result is
+// sorted for deterministic output.
+func (s *PlannerService) ExpandGroup(ctx context.Context, releaseID, groupRef string) ([]string, error) {
+	grid, err := s.GetReleaseStructure(ctx, releaseID)
+	if err != nil {
+		return nil, err
+	}
+	g, err := findGroup(grid, groupRef)
+	if err != nil {
+		return nil, err
+	}
+
+	var ids []string
+	for id, t := range grid.Tests {
+		if t.GroupID == g.ID && t.Enabled {
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+	return ids, nil
+}
+
+// findGroup locates a group in the gridview by name (then pretty name),
+// case-insensitively.
+func findGroup(grid models.GridView, ref string) (models.GridEntity, error) {
+	var matches []models.GridEntity
+	for _, g := range grid.Groups {
+		if strings.EqualFold(g.Name, ref) || strings.EqualFold(g.PrettyName, ref) {
+			matches = append(matches, g)
+		}
+	}
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		return models.GridEntity{}, fmt.Errorf("no group named %q in this release", ref)
+	default:
+		return models.GridEntity{}, fmt.Errorf("ambiguous group name %q (%d matches)", ref, len(matches))
+	}
+}
+
+// resolveTest implements the test resolution priority described on
+// [PlannerService.ResolveEntityID].
+func resolveTest(grid models.GridView, ref string) (string, error) {
+	// (1) exact build_system_id — globally unique, never ambiguous.
+	for id, t := range grid.Tests {
+		if t.BuildSystemID == ref {
+			return id, nil
+		}
+	}
+
+	// (2) group-qualified "group/test".
+	if idx := strings.LastIndex(ref, "/"); idx != -1 {
+		groupPart, testName := ref[:idx], ref[idx+1:]
+		if g, err := findGroup(grid, groupPart); err == nil {
+			var matches []string
+			for id, t := range grid.Tests {
+				if t.GroupID == g.ID && strings.EqualFold(t.Name, testName) {
+					matches = append(matches, id)
+				}
+			}
+			if len(matches) == 1 {
+				return matches[0], nil
+			}
+			if len(matches) > 1 {
+				return "", fmt.Errorf("ambiguous test %q within group %q (%d matches)", testName, groupPart, len(matches))
+			}
+			return "", fmt.Errorf("no test %q in group %q", testName, groupPart)
+		}
+	}
+
+	// (3) bare name — resolve only when unique.
+	var matches []models.GridEntity
+	for _, t := range grid.Tests {
+		if strings.EqualFold(t.Name, ref) {
+			matches = append(matches, t)
+		}
+	}
+	switch len(matches) {
+	case 1:
+		return matches[0].ID, nil
+	case 0:
+		return "", fmt.Errorf("no test %q in this release (use build_system_id or group/test)", ref)
+	default:
+		return "", fmt.Errorf("ambiguous test %q (%d matches): use build_system_id or group/test\n%s",
+			ref, len(matches), formatTestCandidates(matches))
+	}
+}
+
+// formatTestCandidates renders ambiguous test matches as an indented list of
+// build_system_id, group, and UUID so the user can pick an unambiguous ref.
+func formatTestCandidates(matches []models.GridEntity) string {
+	sort.Slice(matches, func(i, j int) bool { return matches[i].BuildSystemID < matches[j].BuildSystemID })
+	var b strings.Builder
+	for _, t := range matches {
+		fmt.Fprintf(&b, "  - %s (group: %s, id: %s)\n", t.BuildSystemID, t.Group, t.ID)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/cli/internal/services/planner_test.go
+++ b/cli/internal/services/planner_test.go
@@ -1,0 +1,289 @@
+package services_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/scylladb/argus/cli/internal/api"
+	"github.com/scylladb/argus/cli/internal/cache"
+	"github.com/scylladb/argus/cli/internal/models"
+	"github.com/scylladb/argus/cli/internal/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// jsonErr writes the standard Argus error envelope.
+func jsonErr(t *testing.T, w http.ResponseWriter, message string) {
+	t.Helper()
+	env := map[string]json.RawMessage{
+		"status":   json.RawMessage(`"error"`),
+		"response": json.RawMessage(`{"exception":"PlannerServiceException","message":` + mustJSON(t, message) + `,"arguments":[]}`),
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	require.NoError(t, json.NewEncoder(w).Encode(env))
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	raw, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(raw)
+}
+
+func newPlannerSvc(t *testing.T, mux *http.ServeMux) *services.PlannerService {
+	t.Helper()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	client, err := api.New(srv.URL, api.WithHTTPClient(srv.Client()))
+	require.NoError(t, err)
+	ca := cache.New(t.TempDir(), cache.WithDisabled(true))
+	return services.NewPlannerService(client, ca)
+}
+
+// gridviewFixture builds a small release structure with an ambiguous bare test
+// name ("longevity-100gb" in two groups) and a disabled test in tier1.
+func gridviewFixture() models.GridView {
+	return models.GridView{
+		Groups: map[string]models.GridEntity{
+			"g1": {ID: "g1", Name: "tier1", PrettyName: "Tier 1", Type: "group"},
+			"g2": {ID: "g2", Name: "tier2", PrettyName: "Tier 2", Type: "group"},
+		},
+		Tests: map[string]models.GridEntity{
+			"t1": {ID: "t1", Name: "longevity-100gb", GroupID: "g1", Group: "Tier 1",
+				BuildSystemID: "scylla-2026.2/tier1/longevity-100gb", Enabled: true},
+			"t2": {ID: "t2", Name: "longevity-200gb", GroupID: "g1", Group: "Tier 1",
+				BuildSystemID: "scylla-2026.2/tier1/longevity-200gb", Enabled: true},
+			"t3": {ID: "t3", Name: "longevity-100gb", GroupID: "g2", Group: "Tier 2",
+				BuildSystemID: "scylla-2026.2/tier2/longevity-100gb", Enabled: true},
+			"t4": {ID: "t4", Name: "longevity-disabled", GroupID: "g1", Group: "Tier 1",
+				BuildSystemID: "scylla-2026.2/tier1/longevity-disabled", Enabled: false},
+		},
+	}
+}
+
+// --------------------------------------------------------------------------
+// Plan reads
+// --------------------------------------------------------------------------
+
+func TestPlannerService_GetPlansForRelease(t *testing.T) {
+	t.Parallel()
+	plans := []models.ReleasePlan{
+		{ID: "p1", Key: "scylla-2026.2#1", Name: "Longevity"},
+		{ID: "p2", Key: "scylla-2026.2#2", Name: "Upgrade"},
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/planning/release/rel-1/all", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		jsonOK(t, w, plans)
+	})
+	svc := newPlannerSvc(t, mux)
+
+	got, err := svc.GetPlansForRelease(context.Background(), "rel-1")
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "scylla-2026.2#1", got[0].Key)
+}
+
+func TestPlannerService_GetPlan(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/planning/plan/scylla-2026.2#3/get", func(w http.ResponseWriter, r *http.Request) {
+		jsonOK(t, w, models.ReleasePlan{ID: "p3", Key: "scylla-2026.2#3", Name: "GA"})
+	})
+	svc := newPlannerSvc(t, mux)
+
+	got, err := svc.GetPlan(context.Background(), "scylla-2026.2#3")
+	require.NoError(t, err)
+	assert.Equal(t, "p3", got.ID)
+}
+
+func TestPlannerService_GetPlan_BackendError(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/planning/plan/missing/get", func(w http.ResponseWriter, r *http.Request) {
+		jsonErr(t, w, "Plan not found")
+	})
+	svc := newPlannerSvc(t, mux)
+
+	_, err := svc.GetPlan(context.Background(), "missing")
+	require.Error(t, err)
+	var apiErr *api.APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, "Plan not found", apiErr.Body.Message)
+}
+
+// --------------------------------------------------------------------------
+// Release resolution
+// --------------------------------------------------------------------------
+
+func releasesMux(t *testing.T, calls *int32) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/releases", func(w http.ResponseWriter, r *http.Request) {
+		if calls != nil {
+			atomic.AddInt32(calls, 1)
+		}
+		jsonOK(t, w, []models.Release{
+			{ID: "rel-1", Name: "scylla-2026.2", Enabled: true},
+			{ID: "rel-2", Name: "scylla-2026.1", Enabled: false},
+		})
+	})
+	return mux
+}
+
+func TestPlannerService_ResolveReleaseID(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, releasesMux(t, nil))
+
+	// Exact name, case-insensitive.
+	id, err := svc.ResolveReleaseID(context.Background(), "Scylla-2026.2")
+	require.NoError(t, err)
+	assert.Equal(t, "rel-1", id)
+}
+
+func TestPlannerService_ResolveReleaseID_NoMatch(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, releasesMux(t, nil))
+
+	_, err := svc.ResolveReleaseID(context.Background(), "scylla-9999")
+	require.Error(t, err)
+}
+
+func TestPlannerService_ResolveReleaseID_RawUUIDRejected(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, releasesMux(t, nil))
+
+	// A raw UUID is not a release name and must not silently resolve.
+	_, err := svc.ResolveReleaseID(context.Background(), "7f3c1e90-0000-0000-0000-000000000000")
+	require.Error(t, err)
+}
+
+// --------------------------------------------------------------------------
+// User resolution
+// --------------------------------------------------------------------------
+
+func usersMux(t *testing.T) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/users", func(w http.ResponseWriter, r *http.Request) {
+		jsonOK(t, w, models.UsersMap{
+			"u1": {ID: "u1", Username: "alice"},
+			"u2": {ID: "u2", Username: "bob"},
+		})
+	})
+	return mux
+}
+
+func TestPlannerService_ResolveUserID(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, usersMux(t))
+
+	id, err := svc.ResolveUserID(context.Background(), "Alice")
+	require.NoError(t, err)
+	assert.Equal(t, "u1", id)
+}
+
+func TestPlannerService_ResolveUserID_NoMatch(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, usersMux(t))
+
+	_, err := svc.ResolveUserID(context.Background(), "carol")
+	require.Error(t, err)
+}
+
+// --------------------------------------------------------------------------
+// Test / group resolution
+// --------------------------------------------------------------------------
+
+func gridviewMux(t *testing.T, calls *int32) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/planning/release/rel-1/gridview", func(w http.ResponseWriter, r *http.Request) {
+		if calls != nil {
+			atomic.AddInt32(calls, 1)
+		}
+		jsonOK(t, w, gridviewFixture())
+	})
+	return mux
+}
+
+func TestPlannerService_ResolveEntityID_BuildSystemID(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, gridviewMux(t, nil))
+
+	id, err := svc.ResolveEntityID(context.Background(),
+		"scylla-2026.2/tier2/longevity-100gb", "rel-1", services.KindTest)
+	require.NoError(t, err)
+	assert.Equal(t, "t3", id)
+}
+
+func TestPlannerService_ResolveEntityID_GroupQualified(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, gridviewMux(t, nil))
+
+	// Bare name is ambiguous, but group-qualified disambiguates.
+	id, err := svc.ResolveEntityID(context.Background(),
+		"tier1/longevity-100gb", "rel-1", services.KindTest)
+	require.NoError(t, err)
+	assert.Equal(t, "t1", id)
+}
+
+func TestPlannerService_ResolveEntityID_BareUnique(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, gridviewMux(t, nil))
+
+	id, err := svc.ResolveEntityID(context.Background(),
+		"longevity-200gb", "rel-1", services.KindTest)
+	require.NoError(t, err)
+	assert.Equal(t, "t2", id)
+}
+
+func TestPlannerService_ResolveEntityID_BareAmbiguous(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, gridviewMux(t, nil))
+
+	_, err := svc.ResolveEntityID(context.Background(),
+		"longevity-100gb", "rel-1", services.KindTest)
+	require.Error(t, err)
+	// Candidate list surfaces build_system_id, group, and UUID.
+	assert.Contains(t, err.Error(), "scylla-2026.2/tier1/longevity-100gb")
+	assert.Contains(t, err.Error(), "scylla-2026.2/tier2/longevity-100gb")
+}
+
+func TestPlannerService_ResolveEntityID_Group(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, gridviewMux(t, nil))
+
+	id, err := svc.ResolveEntityID(context.Background(), "tier1", "rel-1", services.KindGroup)
+	require.NoError(t, err)
+	assert.Equal(t, "g1", id)
+}
+
+func TestPlannerService_ExpandGroup_EnabledOnly(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, gridviewMux(t, nil))
+
+	ids, err := svc.ExpandGroup(context.Background(), "rel-1", "tier1")
+	require.NoError(t, err)
+	// t1 + t2 are enabled in tier1; t4 is disabled and must be excluded.
+	assert.Equal(t, []string{"t1", "t2"}, ids)
+}
+
+func TestPlannerService_Resolution_SingleGridviewFetch(t *testing.T) {
+	t.Parallel()
+	var calls int32
+	svc := newPlannerSvc(t, gridviewMux(t, &calls))
+
+	ctx := context.Background()
+	_, err := svc.ResolveEntityID(ctx, "tier1/longevity-100gb", "rel-1", services.KindTest)
+	require.NoError(t, err)
+	_, err = svc.ResolveEntityID(ctx, "tier1", "rel-1", services.KindGroup)
+	require.NoError(t, err)
+	_, err = svc.ExpandGroup(ctx, "rel-1", "tier1")
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "gridview should be fetched once")
+}

--- a/docs/plans/MASTER.md
+++ b/docs/plans/MASTER.md
@@ -38,7 +38,7 @@ _No plans in this domain yet._
 | Plan                       | Status  | File                                             | Owner |
 | -------------------------- | ------- | ------------------------------------------------ | ----- |
 | SSH Tunnel Support         | `draft` | [ssh-tunnel-design.md](ssh-tunnel-design.md)     | null  |
-| CLI Release Plan Management | `draft` | [cli-planner-command.md](cli-planner-command.md) | null  |
+| CLI Release Plan Management | `in_progress` | [cli-planner-command.md](cli-planner-command.md) | null  |
 
 ## Testing
 

--- a/docs/plans/cli-planner-command.md
+++ b/docs/plans/cli-planner-command.md
@@ -1,8 +1,8 @@
 ---
-status: draft
+status: in_progress
 domain: client
 created: 2026-06-01
-last_updated: 2026-06-01
+last_updated: 2026-06-22
 owner: null
 ---
 
@@ -496,19 +496,20 @@ exceptions are `--plan-id` and `--view-id`). Add to `PlannerService`:
 - **DoD:**
   - [ ] `argus planner list --release <name>` returns plans (manual against staging).
   - [ ] `argus planner get --plan-id <id>` shows a single plan.
-  - [ ] Release/user name resolution unit-tested with an `httptest` server (name hit,
+  - [x] Release/user name resolution unit-tested with an `httptest` server (name hit,
         ambiguous error, no-match error); a raw UUID passed as a name errors (not
         silently accepted).
-  - [ ] Test by `build_system_id` resolves to one UUID; group by name resolves within
+  - [x] Test by `build_system_id` resolves to one UUID; group by name resolves within
         release (unit tests).
-  - [ ] Ambiguous bare test name aborts with a candidate list incl.
+  - [x] Ambiguous bare test name aborts with a candidate list incl.
         `build_system_id`+group+UUID; group-qualified `group/test` resolves an
         otherwise-ambiguous name (unit tests).
-  - [ ] `ExpandGroup` returns only the group's **enabled** test UUIDs (a disabled
+  - [x] `ExpandGroup` returns only the group's **enabled** test UUIDs (a disabled
         member is excluded), using the single cached gridview fetch (unit test).
-  - [ ] Resolution uses a single cached gridview fetch per release (unit test asserts
+  - [x] Resolution uses a single cached gridview fetch per release (unit test asserts
         one GET).
-  - [ ] `--text` and JSON modes both render.
+  - [x] `--text` and JSON modes both render (covered by `TestReleasePlan_TabularShape`
+        + `TestReleasePlan_JSONRoundTrip` and the tested output package).
 
 ### Phase 3 — Discovery: top-level `argus search`
 **Importance: Critical** (create/update depend on discoverable IDs)

--- a/docs/plans/progress.json
+++ b/docs/plans/progress.json
@@ -24,9 +24,9 @@
         "title": "Release Planning Management in the Argus Go CLI",
         "file": "docs/plans/cli-planner-command.md",
         "domain": "client",
-        "status": "draft",
+        "status": "in_progress",
         "created": "2026-06-01",
         "phases_total": 8,
-        "phases_done": 0
+        "phases_done": 3
     }
 ]


### PR DESCRIPTION
Add the PlannerService with client-side name->UUID resolution (release,
user, test, group) backed by a single memoised gridview fetch per
release, plus the read-only 'argus planner list' and 'argus planner get'
commands. Tests/groups are referenced by name or build_system_id only;
ExpandGroup returns enabled members exclusively. Escapes '#' in plan keys
so 'releaseName#planNumber' refs survive URL parsing.

Implements Phase 2 of docs/plans/cli-planner-command.md.
