### PR TITLE
fix(client): support Python 3.10+ and normalize Z-suffixed timestamps

### DIFF
--- a/argus/client/session.py
+++ b/argus/client/session.py
@@ -4,7 +4,7 @@ import os
 import threading
 import time
 import weakref
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -226,7 +226,7 @@ class TunneledSession(requests.Session):
             self._tunnel = tunnel
             self._tunnel_config = config
             self._tunnel_port = local_port
-            self._tunnel_established_at = datetime.now(UTC).isoformat()
+            self._tunnel_established_at = datetime.now(timezone.utc).isoformat()
             self._tunnel_warning_emitted = False
             self._tunnel_disabled_until = 0.0
             LOGGER.info(

--- a/argus/client/tests/test_tunnel.py
+++ b/argus/client/tests/test_tunnel.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from io import StringIO
 from unittest.mock import Mock
 import os
@@ -11,6 +11,7 @@ from argus.client.tunnel import ssh as tunnel_ssh
 from argus.client.tunnel import state as tunnel_state
 from argus.client.session import TunneledSession
 from argus.client.tunnel import TunnelConfig
+from argus.client.tunnel.models import parse_datetime
 
 
 def _write_text(path: str, text: str) -> None:
@@ -48,7 +49,7 @@ def tunnel_state_dir(tmp_path, monkeypatch):
 
 
 def test_resolve_tunnel_config_registers_and_caches(tunnel_state_dir, monkeypatch):
-    expires_at = datetime.now(tz=UTC) + timedelta(hours=6)
+    expires_at = datetime.now(tz=timezone.utc) + timedelta(hours=6)
     config = TunnelConfig(
         proxy_host="proxy.example.com",
         proxy_port=22,
@@ -129,6 +130,38 @@ def test_tunnel_api_succeeds_with_valid_response():
         session=mock_session,
     )
     assert data["proxy_host"] == "proxy.example.com"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "2026-04-16T12:00:00Z",          # Zulu suffix as emitted by the tunnel API
+        "2026-04-16T12:00:00+00:00",     # explicit offset
+        "2026-04-16T12:00:00",           # naive -> assumed UTC
+    ],
+)
+def test_parse_datetime_normalizes_to_utc(value):
+    # Regression: Python 3.10's fromisoformat rejects the trailing "Z"; parse_datetime
+    # must accept it (and any of these forms) and return a UTC-aware datetime.
+    parsed = parse_datetime(value)
+    assert parsed.tzinfo is not None
+    assert parsed.utcoffset() == timedelta(0)
+    assert (parsed.year, parsed.month, parsed.day, parsed.hour) == (2026, 4, 16, 12)
+
+
+def test_from_api_response_accepts_zulu_expires_at():
+    config = TunnelConfig.from_api_response(
+        {
+            "proxy_host": "proxy.example.com",
+            "proxy_port": 22,
+            "proxy_user": "argus-proxy",
+            "target_host": "10.0.0.10",
+            "target_port": 8080,
+            "host_key_fingerprint": "SHA256:test",
+            "expires_at": "2026-04-16T12:00:00Z",
+        }
+    )
+    assert config.expires_at == datetime(2026, 4, 16, 12, 0, 0, tzinfo=timezone.utc)
 
 
 def test_establish_uses_strict_host_options_and_temp_known_hosts(tunnel_state_dir, monkeypatch):

--- a/argus/client/tunnel/models.py
+++ b/argus/client/tunnel/models.py
@@ -1,6 +1,6 @@
 from dataclasses import asdict, dataclass
-from datetime import UTC, datetime
-from typing import Any, NotRequired, TypedDict
+from datetime import datetime, timezone
+from typing import Any, TypedDict
 
 
 class TunnelClientError(Exception):
@@ -18,34 +18,45 @@ ALLOWED_HOST_KEY_TYPES = (
 )
 
 
-class _TunnelApiResponse(TypedDict):
-    """Live response shape from ``/client/ssh/tunnel`` (POST register / GET fetch)."""
+# Required/optional keys are split across a base class plus a ``total=False``
+# subclass instead of ``typing.NotRequired`` so the module imports on Python
+# 3.10 (``NotRequired`` only landed in ``typing`` in 3.11).
+class _TunnelApiResponseRequired(TypedDict):
+    """Required fields of the ``/client/ssh/tunnel`` response (POST register / GET fetch)."""
     proxy_host: str
     proxy_port: int
     proxy_user: str
     target_host: str
     target_port: int
     host_key_fingerprint: str
-    expires_at: NotRequired[str | None]
-    key_id: NotRequired[str | None]
-    tunnel_id: NotRequired[str | None]
 
 
-class _TunnelCachePayload(TypedDict):
-    """On-disk cache shape written by :meth:`TunnelConfig.to_cache_payload`.
+class _TunnelApiResponse(_TunnelApiResponseRequired, total=False):
+    """Live response shape, with optional fields layered on the required base."""
+    expires_at: str | None
+    key_id: str | None
+    tunnel_id: str | None
+
+
+class _TunnelCachePayloadRequired(TypedDict):
+    """Required fields of the on-disk cache written by :meth:`TunnelConfig.to_cache_payload`."""
+    proxy_host: str
+    proxy_port: int
+    proxy_user: str
+    target_host: str
+    target_port: int
+    host_key_fingerprint: str
+
+
+class _TunnelCachePayload(_TunnelCachePayloadRequired, total=False):
+    """On-disk cache shape, with optional fields layered on the required base.
 
     Mirrors :class:`_TunnelApiResponse` but is independently typed so future
     cache-only fields don't leak into the API contract.
     """
-    proxy_host: str
-    proxy_port: int
-    proxy_user: str
-    target_host: str
-    target_port: int
-    host_key_fingerprint: str
-    expires_at: NotRequired[str | None]
-    key_id: NotRequired[str | None]
-    tunnel_id: NotRequired[str | None]
+    expires_at: str | None
+    key_id: str | None
+    tunnel_id: str | None
 
 
 # Required keys listed explicitly to avoid relying on TypedDict.__required_keys__
@@ -94,7 +105,7 @@ class TunnelConfig:
     def to_cache_payload(self) -> dict[str, Any]:
         payload = asdict(self)
         if self.expires_at is not None:
-            payload["expires_at"] = self.expires_at.astimezone(UTC).isoformat()
+            payload["expires_at"] = self.expires_at.astimezone(timezone.utc).isoformat()
         return payload
 
 
@@ -110,7 +121,12 @@ class TunnelStatePaths:
 def parse_datetime(value: str) -> datetime:
     if not value:
         raise ValueError("datetime value is required")
+    # Python 3.10's ``datetime.fromisoformat`` rejects the ``Z`` (Zulu) UTC suffix
+    # that the tunnel API emits (e.g. ``2026-04-16T12:00:00Z``); normalise it to the
+    # explicit ``+00:00`` offset that all supported versions accept.
+    if value.endswith("Z"):
+        value = f"{value[:-1]}+00:00"
     parsed = datetime.fromisoformat(value)
     if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=UTC)
-    return parsed.astimezone(UTC)
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)

--- a/argus/client/tunnel/state.py
+++ b/argus/client/tunnel/state.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import subprocess
 import tempfile
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 try:
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
@@ -128,14 +128,14 @@ def is_key_valid(paths: TunnelStatePaths) -> bool:
     except (OSError, json.JSONDecodeError, TypeError, ValueError):
         return False
 
-    now = datetime.now(tz=UTC)
+    now = datetime.now(tz=timezone.utc)
     return now < expires_at
 
 
 def write_key_meta(paths: TunnelStatePaths, expires_at: datetime | None) -> None:
     if expires_at is None:
         return
-    payload = {"expires_at": expires_at.astimezone(UTC).isoformat()}
+    payload = {"expires_at": expires_at.astimezone(timezone.utc).isoformat()}
     _write_text(paths.key_meta, json.dumps(payload))
     os.chmod(paths.key_meta, 0o600)
 
@@ -154,7 +154,7 @@ def read_cached_tunnel_config(paths: TunnelStatePaths) -> TunnelConfig | None:
     except TunnelClientError:
         return None
 
-    if config.expires_at is not None and datetime.now(tz=UTC) >= config.expires_at:
+    if config.expires_at is not None and datetime.now(tz=timezone.utc) >= config.expires_at:
         return None
 
     return config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 ]
 license = "Apache-2.0"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 dependencies = [
     "requests >= 2.26.0",
     "click >= 8.1.3",
@@ -95,7 +95,7 @@ lint.preview = true
 lint.explicit-preview-rules = true
 exclude = ["argus/"]
 
-target-version = "py312"
+target-version = "py310"
 
 force-exclude = true
 line-length = 120

--- a/pytest-argus-reporter/noxfile.py
+++ b/pytest-argus-reporter/noxfile.py
@@ -3,7 +3,7 @@ import nox
 nox.options.default_venv_backend = "uv"
 
 
-@nox.session(python=["3.12", "3.13", "3.14"])
+@nox.session(python=["3.10", "3.11", "3.12", "3.13", "3.14"])
 def tests(session):
     """Run the test suite with coverage."""
 

--- a/pytest-argus-reporter/pyproject.toml
+++ b/pytest-argus-reporter/pyproject.toml
@@ -17,7 +17,7 @@ keywords = [
     "pytest",
     "testing",
 ]
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 classifiers = [
         "Development Status :: 4 - Beta",
@@ -26,6 +26,8 @@ classifiers = [
         "Topic :: Software Development :: Testing",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: 3.14",


### PR DESCRIPTION
The argus client and pytest-argus-reporter are consumed by environments running Python 3.10/3.11 (e.g. SCT), but the tunnel client used 3.11+ only constructs that broke at import time:

- datetime.UTC -> timezone.utc (UTC alias is 3.11+)
- typing.NotRequired -> required base + total=False TypedDict split (3.11+)

Also fix tunnel timestamp parsing: Python 3.10's datetime.fromisoformat rejects the trailing 'Z' UTC designator that the tunnel API emits, so normalize 'Z' to '+00:00' before parsing. Covered by new regression tests.

Lower requires-python to >=3.10 for argus-alm and pytest-argus-reporter so the client installs on 3.10, and extend the plugin nox matrix to 3.10/3.11. The backend keeps targeting 3.12+ and is unchanged.

Closes: https://scylladb.atlassian.net/browse/ARGUS-174