### PR TITLE
cli/planner commands management

### DIFF
--- a/cli/cmd/planner/create.go
+++ b/cli/cmd/planner/create.go
@@ -1,0 +1,180 @@
+package planner
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/scylladb/argus/cli/internal/cmdctx"
+	"github.com/scylladb/argus/cli/internal/logging"
+	"github.com/scylladb/argus/cli/internal/models"
+	"github.com/scylladb/argus/cli/internal/services"
+	"github.com/spf13/cobra"
+)
+
+// registerCreate adds the "create" sub-command to parent.
+func registerCreate(parent *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a release plan",
+		Long: `Create a release plan from a JSON file and/or flags.
+
+The plan can be described by a --file (the same schema 'get --template' emits)
+and/or built up with flags; flags override matching fields from the file. Every
+reference is by name (or, for tests, build_system_id) and resolved to a UUID
+automatically — raw UUIDs are not accepted.
+
+  # From an edited template (release-independent round-trip):
+  argus planner create --file plan.json
+
+  # From flags:
+  argus planner create --release scylla-2026.2 --name "2026.2 Longevity" \
+    --owner alice --test scylla-2026.2/tier1/longevity-100gb \
+    --group tier2 --assign tier1/longevity-200gb=bob
+
+Groups (from a file or --group) are always expanded to their enabled tests; an
+assignment on a group fans out to each of those tests. Tests that do not exist
+in the target release are reported and omitted, and the plan is created anyway.`,
+		RunE: runCreate,
+	}
+
+	cmd.Flags().StringP("file", "f", "", "Plan spec JSON file (\"-\" for stdin)")
+	cmd.Flags().StringP("release", "r", "", "Release name")
+	cmd.Flags().String("name", "", "Plan name")
+	cmd.Flags().String("description", "", "Plan description")
+	cmd.Flags().String("owner", "", "Owner username")
+	cmd.Flags().StringArray("participant", nil, "Participant username (repeatable)")
+	cmd.Flags().String("target-version", "", "Target version")
+	cmd.Flags().String("view-id", "", "Existing view UUID to attach (optional)")
+	cmd.Flags().StringArray("test", nil, "Test by build_system_id or group/test (repeatable)")
+	cmd.Flags().StringArray("group", nil, "Group name to expand into its enabled tests (repeatable)")
+	cmd.Flags().StringArray("assign", nil, "Assignment as entity=username (repeatable)")
+
+	parent.AddCommand(cmd)
+}
+
+// runCreate is the RunE handler for "planner create".
+func runCreate(cmd *cobra.Command, _ []string) error {
+	cmd.SilenceUsage = true
+	ctx := cmd.Context()
+	client := cmdctx.APIClientFrom(ctx)
+	out := cmdctx.OutputterFrom(ctx)
+	c := cmdctx.CacheFrom(ctx)
+	log := logging.For(cmdctx.LoggerFrom(ctx), "planner-create")
+
+	tmpl, err := loadTemplate(cmd)
+	if err != nil {
+		return err
+	}
+	if err := overlayFlags(cmd, &tmpl); err != nil {
+		return err
+	}
+	groups, _ := cmd.Flags().GetStringArray("group")
+	viewID, _ := cmd.Flags().GetString("view-id")
+
+	svc := services.NewPlannerService(client, c)
+
+	req, warnings, err := svc.BuildCreateRequest(ctx, tmpl, groups)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to build create request")
+		return err
+	}
+	req.ViewID = viewID
+	for _, w := range warnings {
+		log.Warn().Msg(w)
+	}
+
+	plan, err := svc.CreatePlan(ctx, req)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to create plan")
+		return err
+	}
+
+	log.Info().Str("plan_id", plan.ID).Str("key", plan.Key).Msg("plan created successfully")
+	return out.Write(models.NewKVTabular(plan))
+}
+
+// loadTemplate reads the --file plan spec (path or stdin) into a PlanTemplate.
+// Returns a zero template when --file is not set.
+func loadTemplate(cmd *cobra.Command) (models.PlanTemplate, error) {
+	var tmpl models.PlanTemplate
+	path, _ := cmd.Flags().GetString("file")
+	if path == "" {
+		return tmpl, nil
+	}
+
+	var raw []byte
+	var err error
+	if path == "-" {
+		raw, err = io.ReadAll(bufio.NewReader(os.Stdin))
+	} else {
+		raw, err = os.ReadFile(path)
+	}
+	if err != nil {
+		return tmpl, fmt.Errorf("reading plan file: %w", err)
+	}
+	if err := json.Unmarshal(raw, &tmpl); err != nil {
+		return tmpl, fmt.Errorf("parsing plan file: %w", err)
+	}
+	return tmpl, nil
+}
+
+// overlayFlags applies command-line flags onto tmpl. Scalar flags override the
+// file value only when explicitly set; --test/--participant/--assign augment
+// the corresponding file collections.
+func overlayFlags(cmd *cobra.Command, tmpl *models.PlanTemplate) error {
+	if cmd.Flags().Changed("release") {
+		tmpl.Release, _ = cmd.Flags().GetString("release")
+	}
+	if cmd.Flags().Changed("name") {
+		tmpl.Name, _ = cmd.Flags().GetString("name")
+	}
+	if cmd.Flags().Changed("description") {
+		tmpl.Description, _ = cmd.Flags().GetString("description")
+	}
+	if cmd.Flags().Changed("owner") {
+		tmpl.Owner, _ = cmd.Flags().GetString("owner")
+	}
+	if cmd.Flags().Changed("target-version") {
+		tmpl.TargetVersion, _ = cmd.Flags().GetString("target-version")
+	}
+	if cmd.Flags().Changed("participant") {
+		ps, _ := cmd.Flags().GetStringArray("participant")
+		tmpl.Participants = append(tmpl.Participants, ps...)
+	}
+	if cmd.Flags().Changed("test") {
+		ts, _ := cmd.Flags().GetStringArray("test")
+		tmpl.Tests = append(tmpl.Tests, ts...)
+	}
+	if cmd.Flags().Changed("assign") {
+		assigns, _ := cmd.Flags().GetStringArray("assign")
+		merged, err := parseAssignments(assigns, tmpl.Assignments)
+		if err != nil {
+			return err
+		}
+		tmpl.Assignments = merged
+	}
+	return nil
+}
+
+// parseAssignments parses repeatable "entity=username" flag values, merging
+// them onto base (which may be nil). The entity key may contain "/" but not
+// "=", so the first "=" separates entity from username.
+func parseAssignments(raw []string, base map[string]string) (map[string]string, error) {
+	out := map[string]string{}
+	for k, v := range base {
+		out[k] = v
+	}
+	for _, a := range raw {
+		entity, user, ok := strings.Cut(a, "=")
+		entity, user = strings.TrimSpace(entity), strings.TrimSpace(user)
+		if !ok || entity == "" || user == "" {
+			return nil, fmt.Errorf("invalid --assign %q: expected entity=username", a)
+		}
+		out[entity] = user
+	}
+	return out, nil
+}

--- a/cli/cmd/planner/create.go
+++ b/cli/cmd/planner/create.go
@@ -91,7 +91,12 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 	}
 
 	log.Info().Str("plan_id", plan.ID).Str("key", plan.Key).Msg("plan created successfully")
-	return out.Write(models.NewKVTabular(plan))
+	created, err := svc.BuildTemplate(ctx, plan)
+	if err != nil {
+		log.Error().Err(err).Str("plan_id", plan.ID).Msg("failed to build plan template")
+		return err
+	}
+	return out.Write(models.NewKVTabular(created))
 }
 
 // loadTemplate reads the --file plan spec (path or stdin) into a PlanTemplate.

--- a/cli/cmd/planner/create.go
+++ b/cli/cmd/planner/create.go
@@ -32,12 +32,13 @@ automatically — raw UUIDs are not accepted.
 
   # From flags:
   argus planner create --release scylla-2026.2 --name "2026.2 Longevity" \
-    --owner alice --test scylla-2026.2/tier1/longevity-100gb \
-    --group tier2 --assign tier1/longevity-200gb=bob
+    --owner alice --assign tier1/longevity-200gb=bob \
+    --assign tier2/longevity-100gb=$owner
 
-Groups (from a file or --group) are always expanded to their enabled tests; an
-assignment on a group fans out to each of those tests. Tests that do not exist
-in the target release are reported and omitted, and the plan is created anyway.`,
+Plan membership comes entirely from assignments: each entity is a test or group
+(groups fan out to their enabled tests); use $owner to add a test without
+assigning it to a specific participant. Tests not present in the target release
+are reported and omitted, and the plan is created anyway.`,
 		RunE: runCreate,
 	}
 
@@ -46,12 +47,9 @@ in the target release are reported and omitted, and the plan is created anyway.`
 	cmd.Flags().String("name", "", "Plan name")
 	cmd.Flags().String("description", "", "Plan description")
 	cmd.Flags().String("owner", "", "Owner username")
-	cmd.Flags().StringArray("participant", nil, "Participant username (repeatable)")
 	cmd.Flags().String("target-version", "", "Target version")
 	cmd.Flags().String("view-id", "", "Existing view UUID to attach (optional)")
-	cmd.Flags().StringArray("test", nil, "Test by build_system_id or group/test (repeatable)")
-	cmd.Flags().StringArray("group", nil, "Group name to expand into its enabled tests (repeatable)")
-	cmd.Flags().StringArray("assign", nil, "Assignment as entity=username (repeatable)")
+	cmd.Flags().StringArray("assign", nil, "Assignment as entity=username (use $owner to leave unassigned, repeatable)")
 
 	parent.AddCommand(cmd)
 }
@@ -72,20 +70,19 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 	if err := overlayFlags(cmd, &tmpl); err != nil {
 		return err
 	}
-	groups, _ := cmd.Flags().GetStringArray("group")
 	viewID, _ := cmd.Flags().GetString("view-id")
 
 	svc := services.NewPlannerService(client, c)
 
-	req, warnings, err := svc.BuildCreateRequest(ctx, tmpl, groups)
+	req, warnings, err := svc.BuildCreateRequest(ctx, tmpl)
+	for _, w := range warnings {
+		log.Warn().Msg(w)
+	}
 	if err != nil {
 		log.Error().Err(err).Msg("failed to build create request")
 		return err
 	}
 	req.ViewID = viewID
-	for _, w := range warnings {
-		log.Warn().Msg(w)
-	}
 
 	plan, err := svc.CreatePlan(ctx, req)
 	if err != nil {
@@ -123,8 +120,7 @@ func loadTemplate(cmd *cobra.Command) (models.PlanTemplate, error) {
 }
 
 // overlayFlags applies command-line flags onto tmpl. Scalar flags override the
-// file value only when explicitly set; --test/--participant/--assign augment
-// the corresponding file collections.
+// file value only when explicitly set; --assign augments the file assignments.
 func overlayFlags(cmd *cobra.Command, tmpl *models.PlanTemplate) error {
 	if cmd.Flags().Changed("release") {
 		tmpl.Release, _ = cmd.Flags().GetString("release")
@@ -140,14 +136,6 @@ func overlayFlags(cmd *cobra.Command, tmpl *models.PlanTemplate) error {
 	}
 	if cmd.Flags().Changed("target-version") {
 		tmpl.TargetVersion, _ = cmd.Flags().GetString("target-version")
-	}
-	if cmd.Flags().Changed("participant") {
-		ps, _ := cmd.Flags().GetStringArray("participant")
-		tmpl.Participants = append(tmpl.Participants, ps...)
-	}
-	if cmd.Flags().Changed("test") {
-		ts, _ := cmd.Flags().GetStringArray("test")
-		tmpl.Tests = append(tmpl.Tests, ts...)
 	}
 	if cmd.Flags().Changed("assign") {
 		assigns, _ := cmd.Flags().GetStringArray("assign")

--- a/cli/cmd/planner/create.go
+++ b/cli/cmd/planner/create.go
@@ -22,7 +22,7 @@ func registerCreate(parent *cobra.Command) {
 		Short: "Create a release plan",
 		Long: `Create a release plan from a JSON file and/or flags.
 
-The plan can be described by a --file (the same schema 'get --template' emits)
+The plan can be described by a --file (the same schema 'get' emits by default)
 and/or built up with flags; flags override matching fields from the file. Every
 reference is by name (or, for tests, build_system_id) and resolved to a UUID
 automatically — raw UUIDs are not accepted.

--- a/cli/cmd/planner/delete.go
+++ b/cli/cmd/planner/delete.go
@@ -1,0 +1,84 @@
+package planner
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/scylladb/argus/cli/internal/cmdctx"
+	"github.com/scylladb/argus/cli/internal/logging"
+	"github.com/scylladb/argus/cli/internal/services"
+	"github.com/spf13/cobra"
+)
+
+// registerDelete adds the "delete" sub-command to parent.
+func registerDelete(parent *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete a release plan",
+		Long: `Delete a release plan addressed by its UUID or "releaseName#planNumber" key.
+
+By default the plan's associated view is detached and kept; pass --delete-view
+to delete the view as well. A confirmation prompt is shown unless --yes is given.
+
+  argus planner delete --plan-id scylla-2026.2#3 --yes
+  argus planner delete --plan-id 7f3c1e90-... --delete-view --yes`,
+		RunE: runDelete,
+	}
+
+	cmd.Flags().StringP("plan-id", "p", "", "Plan UUID or key (required)")
+	cmd.Flags().Bool("delete-view", false, "Also delete the plan's associated view")
+	cmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
+	_ = cmd.MarkFlagRequired("plan-id")
+
+	parent.AddCommand(cmd)
+}
+
+// runDelete is the RunE handler for "planner delete".
+func runDelete(cmd *cobra.Command, _ []string) error {
+	cmd.SilenceUsage = true
+	ctx := cmd.Context()
+	client := cmdctx.APIClientFrom(ctx)
+	out := cmdctx.OutputterFrom(ctx)
+	c := cmdctx.CacheFrom(ctx)
+	log := logging.For(cmdctx.LoggerFrom(ctx), "planner-delete")
+
+	planRef, _ := cmd.Flags().GetString("plan-id")
+	deleteView, _ := cmd.Flags().GetBool("delete-view")
+	yes, _ := cmd.Flags().GetBool("yes")
+
+	if !yes {
+		ok, err := confirm(cmd, fmt.Sprintf("Delete plan %q?", planRef))
+		if err != nil {
+			return err
+		}
+		if !ok {
+			log.Info().Str("plan_id", planRef).Msg("deletion aborted by user")
+			return out.Write(map[string]string{"status": "aborted", "plan_id": planRef})
+		}
+	}
+
+	svc := services.NewPlannerService(client, c)
+	if err := svc.DeletePlan(ctx, planRef, deleteView); err != nil {
+		log.Error().Err(err).Str("plan_id", planRef).Msg("failed to delete plan")
+		return err
+	}
+
+	log.Info().Str("plan_id", planRef).Bool("delete_view", deleteView).Msg("plan deleted successfully")
+	return out.Write(map[string]string{"status": "deleted", "plan_id": planRef})
+}
+
+// confirm prints prompt to stderr and reads a y/N answer from stdin.
+func confirm(cmd *cobra.Command, prompt string) (bool, error) {
+	fmt.Fprintf(os.Stderr, "%s [y/N]: ", prompt)
+	scanner := bufio.NewScanner(os.Stdin)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return false, fmt.Errorf("reading confirmation: %w", err)
+		}
+		return false, nil
+	}
+	answer := strings.ToLower(strings.TrimSpace(scanner.Text()))
+	return answer == "y" || answer == "yes", nil
+}

--- a/cli/cmd/planner/delete.go
+++ b/cli/cmd/planner/delete.go
@@ -19,16 +19,16 @@ func registerDelete(parent *cobra.Command) {
 		Short: "Delete a release plan",
 		Long: `Delete a release plan addressed by its UUID or "releaseName#planNumber" key.
 
-By default the plan's associated view is detached and kept; pass --delete-view
-to delete the view as well. A confirmation prompt is shown unless --yes is given.
+By default the plan's associated view is deleted as well; pass --no-delete-view
+to detach and keep it. A confirmation prompt is shown unless --yes is given.
 
   argus planner delete --plan-id scylla-2026.2#3 --yes
-  argus planner delete --plan-id 7f3c1e90-... --delete-view --yes`,
+  argus planner delete --plan-id 7f3c1e90-... --no-delete-view --yes`,
 		RunE: runDelete,
 	}
 
 	cmd.Flags().StringP("plan-id", "p", "", "Plan UUID or key (required)")
-	cmd.Flags().Bool("delete-view", false, "Also delete the plan's associated view")
+	cmd.Flags().Bool("no-delete-view", false, "Keep the plan's associated view (default is to delete it)")
 	cmd.Flags().Bool("yes", false, "Skip the confirmation prompt")
 	_ = cmd.MarkFlagRequired("plan-id")
 
@@ -45,7 +45,8 @@ func runDelete(cmd *cobra.Command, _ []string) error {
 	log := logging.For(cmdctx.LoggerFrom(ctx), "planner-delete")
 
 	planRef, _ := cmd.Flags().GetString("plan-id")
-	deleteView, _ := cmd.Flags().GetBool("delete-view")
+	noDeleteView, _ := cmd.Flags().GetBool("no-delete-view")
+	deleteView := !noDeleteView
 	yes, _ := cmd.Flags().GetBool("yes")
 
 	if !yes {

--- a/cli/cmd/planner/delete.go
+++ b/cli/cmd/planner/delete.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/scylladb/argus/cli/internal/cmdctx"
 	"github.com/scylladb/argus/cli/internal/logging"
+	"github.com/scylladb/argus/cli/internal/models"
 	"github.com/scylladb/argus/cli/internal/services"
 	"github.com/spf13/cobra"
 )
@@ -49,6 +50,22 @@ func runDelete(cmd *cobra.Command, _ []string) error {
 	deleteView := !noDeleteView
 	yes, _ := cmd.Flags().GetBool("yes")
 
+	svc := services.NewPlannerService(client, c)
+
+	plan, err := svc.GetPlan(ctx, planRef)
+	if err != nil {
+		log.Error().Err(err).Str("plan_id", planRef).Msg("failed to fetch plan")
+		return err
+	}
+	summaries, err := svc.BuildPlanSummaries(ctx, models.ReleasePlanList{plan})
+	if err != nil {
+		log.Error().Err(err).Str("plan_id", planRef).Msg("failed to summarize plan")
+		return err
+	}
+	if err := out.Write(summaries[0]); err != nil {
+		return err
+	}
+
 	if !yes {
 		ok, err := confirm(cmd, fmt.Sprintf("Delete plan %q?", planRef))
 		if err != nil {
@@ -60,7 +77,6 @@ func runDelete(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	svc := services.NewPlannerService(client, c)
 	if err := svc.DeletePlan(ctx, planRef, deleteView); err != nil {
 		log.Error().Err(err).Str("plan_id", planRef).Msg("failed to delete plan")
 		return err

--- a/cli/cmd/planner/get.go
+++ b/cli/cmd/planner/get.go
@@ -26,6 +26,8 @@ With --template the plan is emitted as a release-independent, name-based spec
 
 	cmd.Flags().StringP("plan-id", "p", "", "Plan UUID or key (e.g. \"scylla-2026.2#3\") (required)")
 	cmd.Flags().Bool("template", false, "Emit a name-based plan spec suitable for 'create --file'")
+	cmd.Flags().Bool("raw", false, "Emit the raw plan as returned by the API (UUIDs, unresolved)")
+	cmd.MarkFlagsMutuallyExclusive("template", "raw")
 	_ = cmd.MarkFlagRequired("plan-id")
 
 	parent.AddCommand(cmd)
@@ -42,7 +44,8 @@ func runGet(cmd *cobra.Command, _ []string) error {
 
 	planRef, _ := cmd.Flags().GetString("plan-id")
 	asTemplate, _ := cmd.Flags().GetBool("template")
-	log.Debug().Str("plan_id", planRef).Bool("template", asTemplate).Msg("fetching plan")
+	raw, _ := cmd.Flags().GetBool("raw")
+	log.Debug().Str("plan_id", planRef).Bool("template", asTemplate).Bool("raw", raw).Msg("fetching plan")
 
 	svc := services.NewPlannerService(client, c)
 
@@ -62,6 +65,16 @@ func runGet(cmd *cobra.Command, _ []string) error {
 		return out.Write(models.NewKVTabular(tmpl))
 	}
 
+	if raw {
+		log.Info().Str("plan_id", planRef).Msg("plan fetched successfully (raw)")
+		return out.Write(models.NewKVTabular(plan))
+	}
+
 	log.Info().Str("plan_id", planRef).Msg("plan fetched successfully")
-	return out.Write(models.NewKVTabular(plan))
+	resolved, err := svc.BuildResolvedPlan(ctx, plan)
+	if err != nil {
+		log.Error().Err(err).Str("plan_id", planRef).Msg("failed to resolve plan references")
+		return err
+	}
+	return out.Write(resolved)
 }

--- a/cli/cmd/planner/get.go
+++ b/cli/cmd/planner/get.go
@@ -18,16 +18,19 @@ human-friendly "releaseName#planNumber" key, e.g.:
   argus planner get --plan-id scylla-2026.2#3
   argus planner get --plan-id 7f3c1e90-...
 
-With --template the plan is emitted as a release-independent, name-based spec
+By default the plan is emitted as a release-independent, name-based template
 (the same schema 'create --file' accepts) so it can be edited and re-created:
-  argus planner get --plan-id scylla-2026.2#3 --template > plan.json`,
+  argus planner get --plan-id scylla-2026.2#3 > plan.json
+
+Use --resolved for a lossless, name-resolved view that keeps the plan's id, key
+and status, or --raw for the unresolved JSON exactly as the backend returns it.`,
 		RunE: runGet,
 	}
 
 	cmd.Flags().StringP("plan-id", "p", "", "Plan UUID or key (e.g. \"scylla-2026.2#3\") (required)")
-	cmd.Flags().Bool("template", false, "Emit a name-based plan spec suitable for 'create --file'")
+	cmd.Flags().Bool("resolved", false, "Emit the full plan with references resolved to names (keeps id/key/status)")
 	cmd.Flags().Bool("raw", false, "Emit the raw plan as returned by the API (UUIDs, unresolved)")
-	cmd.MarkFlagsMutuallyExclusive("template", "raw")
+	cmd.MarkFlagsMutuallyExclusive("resolved", "raw")
 	_ = cmd.MarkFlagRequired("plan-id")
 
 	parent.AddCommand(cmd)
@@ -43,9 +46,9 @@ func runGet(cmd *cobra.Command, _ []string) error {
 	log := logging.For(cmdctx.LoggerFrom(ctx), "planner-get")
 
 	planRef, _ := cmd.Flags().GetString("plan-id")
-	asTemplate, _ := cmd.Flags().GetBool("template")
+	resolved, _ := cmd.Flags().GetBool("resolved")
 	raw, _ := cmd.Flags().GetBool("raw")
-	log.Debug().Str("plan_id", planRef).Bool("template", asTemplate).Bool("raw", raw).Msg("fetching plan")
+	log.Debug().Str("plan_id", planRef).Bool("resolved", resolved).Bool("raw", raw).Msg("fetching plan")
 
 	svc := services.NewPlannerService(client, c)
 
@@ -55,26 +58,26 @@ func runGet(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	if asTemplate {
-		tmpl, err := svc.BuildTemplate(ctx, plan)
-		if err != nil {
-			log.Error().Err(err).Str("plan_id", planRef).Msg("failed to build plan template")
-			return err
-		}
-		log.Info().Str("plan_id", planRef).Msg("plan template built successfully")
-		return out.Write(models.NewKVTabular(tmpl))
-	}
-
 	if raw {
 		log.Info().Str("plan_id", planRef).Msg("plan fetched successfully (raw)")
 		return out.Write(models.NewKVTabular(plan))
 	}
 
-	log.Info().Str("plan_id", planRef).Msg("plan fetched successfully")
-	resolved, err := svc.BuildResolvedPlan(ctx, plan)
+	if resolved {
+		log.Info().Str("plan_id", planRef).Msg("plan fetched successfully (resolved)")
+		rp, err := svc.BuildResolvedPlan(ctx, plan)
+		if err != nil {
+			log.Error().Err(err).Str("plan_id", planRef).Msg("failed to resolve plan references")
+			return err
+		}
+		return out.Write(rp)
+	}
+
+	tmpl, err := svc.BuildTemplate(ctx, plan)
 	if err != nil {
-		log.Error().Err(err).Str("plan_id", planRef).Msg("failed to resolve plan references")
+		log.Error().Err(err).Str("plan_id", planRef).Msg("failed to build plan template")
 		return err
 	}
-	return out.Write(resolved)
+	log.Info().Str("plan_id", planRef).Msg("plan template built successfully")
+	return out.Write(models.NewKVTabular(tmpl))
 }

--- a/cli/cmd/planner/get.go
+++ b/cli/cmd/planner/get.go
@@ -16,11 +16,16 @@ func registerGet(parent *cobra.Command) {
 		Long: `Show a single release plan addressed by its UUID or its
 human-friendly "releaseName#planNumber" key, e.g.:
   argus planner get --plan-id scylla-2026.2#3
-  argus planner get --plan-id 7f3c1e90-...`,
+  argus planner get --plan-id 7f3c1e90-...
+
+With --template the plan is emitted as a release-independent, name-based spec
+(the same schema 'create --file' accepts) so it can be edited and re-created:
+  argus planner get --plan-id scylla-2026.2#3 --template > plan.json`,
 		RunE: runGet,
 	}
 
 	cmd.Flags().StringP("plan-id", "p", "", "Plan UUID or key (e.g. \"scylla-2026.2#3\") (required)")
+	cmd.Flags().Bool("template", false, "Emit a name-based plan spec suitable for 'create --file'")
 	_ = cmd.MarkFlagRequired("plan-id")
 
 	parent.AddCommand(cmd)
@@ -36,7 +41,8 @@ func runGet(cmd *cobra.Command, _ []string) error {
 	log := logging.For(cmdctx.LoggerFrom(ctx), "planner-get")
 
 	planRef, _ := cmd.Flags().GetString("plan-id")
-	log.Debug().Str("plan_id", planRef).Msg("fetching plan")
+	asTemplate, _ := cmd.Flags().GetBool("template")
+	log.Debug().Str("plan_id", planRef).Bool("template", asTemplate).Msg("fetching plan")
 
 	svc := services.NewPlannerService(client, c)
 
@@ -44,6 +50,16 @@ func runGet(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		log.Error().Err(err).Str("plan_id", planRef).Msg("failed to fetch plan")
 		return err
+	}
+
+	if asTemplate {
+		tmpl, err := svc.BuildTemplate(ctx, plan)
+		if err != nil {
+			log.Error().Err(err).Str("plan_id", planRef).Msg("failed to build plan template")
+			return err
+		}
+		log.Info().Str("plan_id", planRef).Msg("plan template built successfully")
+		return out.Write(models.NewKVTabular(tmpl))
 	}
 
 	log.Info().Str("plan_id", planRef).Msg("plan fetched successfully")

--- a/cli/cmd/planner/list.go
+++ b/cli/cmd/planner/list.go
@@ -21,6 +21,7 @@ The release is referenced by its name (not a UUID), e.g.:
 	}
 
 	cmd.Flags().StringP("release", "r", "", "Release name (required)")
+	cmd.Flags().Bool("raw", false, "Emit raw plans as returned by the API (UUIDs, unresolved)")
 	_ = cmd.MarkFlagRequired("release")
 
 	parent.AddCommand(cmd)
@@ -36,7 +37,8 @@ func runList(cmd *cobra.Command, _ []string) error {
 	log := logging.For(cmdctx.LoggerFrom(ctx), "planner-list")
 
 	releaseRef, _ := cmd.Flags().GetString("release")
-	log.Debug().Str("release", releaseRef).Msg("listing plans for release")
+	raw, _ := cmd.Flags().GetBool("raw")
+	log.Debug().Str("release", releaseRef).Bool("raw", raw).Msg("listing plans for release")
 
 	svc := services.NewPlannerService(client, c)
 
@@ -53,5 +55,13 @@ func runList(cmd *cobra.Command, _ []string) error {
 	}
 
 	log.Info().Str("release", releaseRef).Int("count", len(plans)).Msg("plans listed successfully")
-	return out.Write(models.NewTabularSlice(plans))
+	if raw {
+		return out.Write(models.NewTabularSlice(plans))
+	}
+	resolved, err := svc.BuildResolvedPlans(ctx, plans)
+	if err != nil {
+		log.Error().Err(err).Str("release", releaseRef).Msg("failed to resolve plan references")
+		return err
+	}
+	return out.Write(models.ResolvedPlans(resolved))
 }

--- a/cli/cmd/planner/list.go
+++ b/cli/cmd/planner/list.go
@@ -58,10 +58,10 @@ func runList(cmd *cobra.Command, _ []string) error {
 	if raw {
 		return out.Write(models.NewTabularSlice(plans))
 	}
-	resolved, err := svc.BuildResolvedPlans(ctx, plans)
+	resolved, err := svc.BuildPlanSummaries(ctx, plans)
 	if err != nil {
 		log.Error().Err(err).Str("release", releaseRef).Msg("failed to resolve plan references")
 		return err
 	}
-	return out.Write(models.ResolvedPlans(resolved))
+	return out.Write(models.PlanSummaries(resolved))
 }

--- a/cli/cmd/planner/overview.go
+++ b/cli/cmd/planner/overview.go
@@ -1,0 +1,57 @@
+package planner
+
+import (
+	"github.com/scylladb/argus/cli/internal/cmdctx"
+	"github.com/scylladb/argus/cli/internal/logging"
+	"github.com/scylladb/argus/cli/internal/services"
+	"github.com/spf13/cobra"
+)
+
+// registerOverview adds the "overview" sub-command to parent.
+func registerOverview(parent *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "overview",
+		Short: "Overview a release's tests grouped by group",
+		Long: `Show every enabled test in a release as a "group/test: build_system_id"
+overview, useful for discovering the references that 'create'/'update' accept.
+
+The release is referenced by its name (not a UUID), e.g.:
+  argus planner overview --release scylla-2026.2`,
+		RunE: runOverview,
+	}
+
+	cmd.Flags().StringP("release", "r", "", "Release name (required)")
+	_ = cmd.MarkFlagRequired("release")
+
+	parent.AddCommand(cmd)
+}
+
+// runOverview is the RunE handler for "planner overview".
+func runOverview(cmd *cobra.Command, _ []string) error {
+	cmd.SilenceUsage = true
+	ctx := cmd.Context()
+	client := cmdctx.APIClientFrom(ctx)
+	out := cmdctx.OutputterFrom(ctx)
+	c := cmdctx.CacheFrom(ctx)
+	log := logging.For(cmdctx.LoggerFrom(ctx), "planner-overview")
+
+	releaseRef, _ := cmd.Flags().GetString("release")
+	log.Debug().Str("release", releaseRef).Msg("building release overview")
+
+	svc := services.NewPlannerService(client, c)
+
+	releaseID, err := svc.ResolveReleaseID(ctx, releaseRef)
+	if err != nil {
+		log.Error().Err(err).Str("release", releaseRef).Msg("failed to resolve release")
+		return err
+	}
+
+	overview, err := svc.GetReleaseOverview(ctx, releaseID)
+	if err != nil {
+		log.Error().Err(err).Str("release", releaseRef).Msg("failed to build overview")
+		return err
+	}
+
+	log.Info().Str("release", releaseRef).Int("count", len(overview)).Msg("overview built successfully")
+	return out.Write(overview)
+}

--- a/cli/cmd/planner/planner_test.go
+++ b/cli/cmd/planner/planner_test.go
@@ -68,7 +68,7 @@ func TestList_RawFlagRegistered(t *testing.T) {
 func TestDelete_FlagsRegistered(t *testing.T) {
 	t.Parallel()
 	cmd := newSubCmd(t, "delete")
-	assert.NotNil(t, cmd.Flags().Lookup("delete-view"))
+	assert.NotNil(t, cmd.Flags().Lookup("no-delete-view"))
 	assert.NotNil(t, cmd.Flags().Lookup("yes"))
 	planID := cmd.Flags().Lookup("plan-id")
 	require.NotNil(t, planID)
@@ -105,17 +105,13 @@ func TestOverlayFlags_FlagOverFilePrecedence(t *testing.T) {
 	t.Parallel()
 	cmd := newSubCmd(t, "create")
 	require.NoError(t, cmd.Flags().Set("name", "FlagName"))
-	require.NoError(t, cmd.Flags().Set("test", "tier1/b"))
-	require.NoError(t, cmd.Flags().Set("participant", "bob"))
 	require.NoError(t, cmd.Flags().Set("assign", "x=u2"))
 	require.NoError(t, cmd.Flags().Set("assign", "y=u3"))
 
 	tmpl := models.PlanTemplate{
-		Name:         "FileName",
-		Release:      "scylla-2026.2",
-		Tests:        []string{"tier1/a"},
-		Participants: []string{"alice"},
-		Assignments:  map[string]string{"x": "u1"},
+		Name:        "FileName",
+		Release:     "scylla-2026.2",
+		Assignments: map[string]string{"x": "u1"},
 	}
 
 	require.NoError(t, overlayFlags(cmd, &tmpl))
@@ -124,9 +120,6 @@ func TestOverlayFlags_FlagOverFilePrecedence(t *testing.T) {
 	assert.Equal(t, "FlagName", tmpl.Name)
 	// Release is untouched (flag not set).
 	assert.Equal(t, "scylla-2026.2", tmpl.Release)
-	// Collections augment the file collections.
-	assert.Equal(t, []string{"tier1/a", "tier1/b"}, tmpl.Tests)
-	assert.Equal(t, []string{"alice", "bob"}, tmpl.Participants)
 	// Assignment x overridden, y added.
 	assert.Equal(t, map[string]string{"x": "u2", "y": "u3"}, tmpl.Assignments)
 }

--- a/cli/cmd/planner/planner_test.go
+++ b/cli/cmd/planner/planner_test.go
@@ -1,0 +1,121 @@
+package planner
+
+import (
+	"testing"
+
+	"github.com/scylladb/argus/cli/internal/models"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newSubCmd registers the planner sub-commands on a throwaway parent and
+// returns the one named name, mirroring how cmd/planner.go wires them.
+func newSubCmd(t *testing.T, name string) *cobra.Command {
+	t.Helper()
+	parent := &cobra.Command{Use: "planner"}
+	Register(parent)
+	for _, c := range parent.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	require.FailNowf(t, "sub-command not registered", "%q", name)
+	return nil
+}
+
+func TestRegister_WiresAllSubCommands(t *testing.T) {
+	t.Parallel()
+	parent := &cobra.Command{Use: "planner"}
+	Register(parent)
+
+	names := map[string]bool{}
+	for _, c := range parent.Commands() {
+		names[c.Name()] = true
+	}
+	for _, want := range []string{"list", "get", "create", "delete"} {
+		assert.Truef(t, names[want], "expected %q sub-command", want)
+	}
+}
+
+func TestGet_TemplateFlagRegistered(t *testing.T) {
+	t.Parallel()
+	cmd := newSubCmd(t, "get")
+	assert.NotNil(t, cmd.Flags().Lookup("template"))
+}
+
+func TestDelete_FlagsRegistered(t *testing.T) {
+	t.Parallel()
+	cmd := newSubCmd(t, "delete")
+	assert.NotNil(t, cmd.Flags().Lookup("delete-view"))
+	assert.NotNil(t, cmd.Flags().Lookup("yes"))
+	planID := cmd.Flags().Lookup("plan-id")
+	require.NotNil(t, planID)
+	assert.Equal(t, "p", planID.Shorthand)
+}
+
+func TestParseAssignments(t *testing.T) {
+	t.Parallel()
+
+	t.Run("merges over base and supports / in entity", func(t *testing.T) {
+		t.Parallel()
+		base := map[string]string{"tier1/a": "alice", "keep": "carol"}
+		got, err := parseAssignments([]string{"tier1/a=bob", "tier2/b=dave"}, base)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{
+			"tier1/a": "bob",  // flag overrides base
+			"tier2/b": "dave", // new entry
+			"keep":    "carol",
+		}, got)
+		// Base is not mutated.
+		assert.Equal(t, "alice", base["tier1/a"])
+	})
+
+	t.Run("rejects malformed values", func(t *testing.T) {
+		t.Parallel()
+		for _, bad := range []string{"noequals", "=bob", "entity=", "  =  "} {
+			_, err := parseAssignments([]string{bad}, nil)
+			require.Errorf(t, err, "expected error for %q", bad)
+		}
+	})
+}
+
+func TestOverlayFlags_FlagOverFilePrecedence(t *testing.T) {
+	t.Parallel()
+	cmd := newSubCmd(t, "create")
+	require.NoError(t, cmd.Flags().Set("name", "FlagName"))
+	require.NoError(t, cmd.Flags().Set("test", "tier1/b"))
+	require.NoError(t, cmd.Flags().Set("participant", "bob"))
+	require.NoError(t, cmd.Flags().Set("assign", "x=u2"))
+	require.NoError(t, cmd.Flags().Set("assign", "y=u3"))
+
+	tmpl := models.PlanTemplate{
+		Name:         "FileName",
+		Release:      "scylla-2026.2",
+		Tests:        []string{"tier1/a"},
+		Participants: []string{"alice"},
+		Assignments:  map[string]string{"x": "u1"},
+	}
+
+	require.NoError(t, overlayFlags(cmd, &tmpl))
+
+	// Scalar flag overrides the file value.
+	assert.Equal(t, "FlagName", tmpl.Name)
+	// Release is untouched (flag not set).
+	assert.Equal(t, "scylla-2026.2", tmpl.Release)
+	// Collections augment the file collections.
+	assert.Equal(t, []string{"tier1/a", "tier1/b"}, tmpl.Tests)
+	assert.Equal(t, []string{"alice", "bob"}, tmpl.Participants)
+	// Assignment x overridden, y added.
+	assert.Equal(t, map[string]string{"x": "u2", "y": "u3"}, tmpl.Assignments)
+}
+
+func TestOverlayFlags_UnsetScalarsKeepFileValues(t *testing.T) {
+	t.Parallel()
+	cmd := newSubCmd(t, "create")
+
+	tmpl := models.PlanTemplate{Name: "FileName", Owner: "alice"}
+	require.NoError(t, overlayFlags(cmd, &tmpl))
+	assert.Equal(t, "FileName", tmpl.Name)
+	assert.Equal(t, "alice", tmpl.Owner)
+}

--- a/cli/cmd/planner/planner_test.go
+++ b/cli/cmd/planner/planner_test.go
@@ -33,7 +33,7 @@ func TestRegister_WiresAllSubCommands(t *testing.T) {
 	for _, c := range parent.Commands() {
 		names[c.Name()] = true
 	}
-	for _, want := range []string{"list", "get", "create", "delete"} {
+	for _, want := range []string{"list", "get", "create", "update", "delete"} {
 		assert.Truef(t, names[want], "expected %q sub-command", want)
 	}
 }
@@ -140,3 +140,74 @@ func TestOverlayFlags_UnsetScalarsKeepFileValues(t *testing.T) {
 	assert.Equal(t, "FileName", tmpl.Name)
 	assert.Equal(t, "alice", tmpl.Owner)
 }
+
+func TestUpdate_FlagsRegistered(t *testing.T) {
+	t.Parallel()
+	cmd := newSubCmd(t, "update")
+	for _, name := range []string{
+		"name", "description", "owner", "target-version", "completed",
+		"add-test", "remove-test", "add-group", "remove-group",
+		"add-participant", "remove-participant", "assign", "unassign", "file",
+	} {
+		assert.NotNilf(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
+	}
+	planID := cmd.Flags().Lookup("plan-id")
+	require.NotNil(t, planID)
+	assert.Equal(t, "p", planID.Shorthand)
+}
+
+func TestOverlayUpdateFlags_OnlySetScalarsAndAugmentedCollections(t *testing.T) {
+	t.Parallel()
+	cmd := newSubCmd(t, "update")
+	require.NoError(t, cmd.Flags().Set("name", "FlagName"))
+	require.NoError(t, cmd.Flags().Set("completed", "true"))
+	require.NoError(t, cmd.Flags().Set("add-test", "tier1/b"))
+	require.NoError(t, cmd.Flags().Set("remove-group", "tier2"))
+	require.NoError(t, cmd.Flags().Set("add-participant", "bob"))
+	require.NoError(t, cmd.Flags().Set("unassign", "tier1/c"))
+	require.NoError(t, cmd.Flags().Set("assign", "x=u2"))
+
+	// Pre-populate from a file: name is overridden, description is preserved,
+	// and collections are augmented.
+	desc := "from file"
+	spec := models.PlanUpdateSpec{
+		Name:               strPtrT("FileName"),
+		Description:        &desc,
+		TestsAdd:           []string{"tier1/a"},
+		AssigneeMappingSet: map[string]string{"x": "u1"},
+	}
+
+	require.NoError(t, overlayUpdateFlags(cmd, &spec))
+
+	// Scalar flag overrides the file value.
+	require.NotNil(t, spec.Name)
+	assert.Equal(t, "FlagName", *spec.Name)
+	// Unset scalar keeps the file value; untouched scalars stay nil.
+	require.NotNil(t, spec.Description)
+	assert.Equal(t, "from file", *spec.Description)
+	assert.Nil(t, spec.Owner)
+	require.NotNil(t, spec.Completed)
+	assert.True(t, *spec.Completed)
+	// Collections augment the file collections.
+	assert.Equal(t, []string{"tier1/a", "tier1/b"}, spec.TestsAdd)
+	assert.Equal(t, []string{"tier2"}, spec.GroupsRemove)
+	assert.Equal(t, []string{"bob"}, spec.ParticipantsAdd)
+	assert.Equal(t, []string{"tier1/c"}, spec.AssigneeMappingRemove)
+	// Assignment x overridden onto the file's map.
+	assert.Equal(t, map[string]string{"x": "u2"}, spec.AssigneeMappingSet)
+}
+
+func TestOverlayUpdateFlags_NoFlagsLeavesSpecEmpty(t *testing.T) {
+	t.Parallel()
+	cmd := newSubCmd(t, "update")
+
+	var spec models.PlanUpdateSpec
+	require.NoError(t, overlayUpdateFlags(cmd, &spec))
+	assert.Nil(t, spec.Name)
+	assert.Nil(t, spec.Completed)
+	assert.Empty(t, spec.TestsAdd)
+	assert.Empty(t, spec.AssigneeMappingSet)
+}
+
+// strPtrT is a string-pointer helper for table data in this test file.
+func strPtrT(s string) *string { return &s }

--- a/cli/cmd/planner/planner_test.go
+++ b/cli/cmd/planner/planner_test.go
@@ -33,7 +33,7 @@ func TestRegister_WiresAllSubCommands(t *testing.T) {
 	for _, c := range parent.Commands() {
 		names[c.Name()] = true
 	}
-	for _, want := range []string{"list", "get", "create", "update", "delete"} {
+	for _, want := range []string{"list", "get", "create", "update", "delete", "overview"} {
 		assert.Truef(t, names[want], "expected %q sub-command", want)
 	}
 }
@@ -63,6 +63,14 @@ func TestList_RawFlagRegistered(t *testing.T) {
 	t.Parallel()
 	cmd := newSubCmd(t, "list")
 	assert.NotNil(t, cmd.Flags().Lookup("raw"))
+}
+
+func TestOverview_FlagsRegistered(t *testing.T) {
+	t.Parallel()
+	cmd := newSubCmd(t, "overview")
+	release := cmd.Flags().Lookup("release")
+	require.NotNil(t, release)
+	assert.Equal(t, "r", release.Shorthand)
 }
 
 func TestDelete_FlagsRegistered(t *testing.T) {

--- a/cli/cmd/planner/planner_test.go
+++ b/cli/cmd/planner/planner_test.go
@@ -44,6 +44,27 @@ func TestGet_TemplateFlagRegistered(t *testing.T) {
 	assert.NotNil(t, cmd.Flags().Lookup("template"))
 }
 
+func TestGet_RawFlagRegistered(t *testing.T) {
+	t.Parallel()
+	cmd := newSubCmd(t, "get")
+	assert.NotNil(t, cmd.Flags().Lookup("raw"))
+}
+
+func TestGet_TemplateAndRawAreMutuallyExclusive(t *testing.T) {
+	t.Parallel()
+	cmd := newSubCmd(t, "get")
+	require.NoError(t, cmd.ParseFlags([]string{"--template", "--raw"}))
+	err := cmd.ValidateFlagGroups()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "none of the others can be")
+}
+
+func TestList_RawFlagRegistered(t *testing.T) {
+	t.Parallel()
+	cmd := newSubCmd(t, "list")
+	assert.NotNil(t, cmd.Flags().Lookup("raw"))
+}
+
 func TestDelete_FlagsRegistered(t *testing.T) {
 	t.Parallel()
 	cmd := newSubCmd(t, "delete")

--- a/cli/cmd/planner/planner_test.go
+++ b/cli/cmd/planner/planner_test.go
@@ -38,10 +38,10 @@ func TestRegister_WiresAllSubCommands(t *testing.T) {
 	}
 }
 
-func TestGet_TemplateFlagRegistered(t *testing.T) {
+func TestGet_ResolvedFlagRegistered(t *testing.T) {
 	t.Parallel()
 	cmd := newSubCmd(t, "get")
-	assert.NotNil(t, cmd.Flags().Lookup("template"))
+	assert.NotNil(t, cmd.Flags().Lookup("resolved"))
 }
 
 func TestGet_RawFlagRegistered(t *testing.T) {
@@ -50,10 +50,10 @@ func TestGet_RawFlagRegistered(t *testing.T) {
 	assert.NotNil(t, cmd.Flags().Lookup("raw"))
 }
 
-func TestGet_TemplateAndRawAreMutuallyExclusive(t *testing.T) {
+func TestGet_ResolvedAndRawAreMutuallyExclusive(t *testing.T) {
 	t.Parallel()
 	cmd := newSubCmd(t, "get")
-	require.NoError(t, cmd.ParseFlags([]string{"--template", "--raw"}))
+	require.NoError(t, cmd.ParseFlags([]string{"--resolved", "--raw"}))
 	err := cmd.ValidateFlagGroups()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "none of the others can be")

--- a/cli/cmd/planner/planner_test.go
+++ b/cli/cmd/planner/planner_test.go
@@ -140,10 +140,13 @@ func TestUpdate_FlagsRegistered(t *testing.T) {
 	for _, name := range []string{
 		"name", "description", "owner", "target-version", "completed",
 		"add-test", "remove-test", "add-group", "remove-group",
-		"add-participant", "remove-participant", "assign", "unassign", "file",
+		"assign", "unassign", "file",
 	} {
 		assert.NotNilf(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
 	}
+	// Participants are derived from assignments — no manual participant flags.
+	assert.Nil(t, cmd.Flags().Lookup("add-participant"))
+	assert.Nil(t, cmd.Flags().Lookup("remove-participant"))
 	planID := cmd.Flags().Lookup("plan-id")
 	require.NotNil(t, planID)
 	assert.Equal(t, "p", planID.Shorthand)
@@ -156,7 +159,6 @@ func TestOverlayUpdateFlags_OnlySetScalarsAndAugmentedCollections(t *testing.T) 
 	require.NoError(t, cmd.Flags().Set("completed", "true"))
 	require.NoError(t, cmd.Flags().Set("add-test", "tier1/b"))
 	require.NoError(t, cmd.Flags().Set("remove-group", "tier2"))
-	require.NoError(t, cmd.Flags().Set("add-participant", "bob"))
 	require.NoError(t, cmd.Flags().Set("unassign", "tier1/c"))
 	require.NoError(t, cmd.Flags().Set("assign", "x=u2"))
 
@@ -184,7 +186,6 @@ func TestOverlayUpdateFlags_OnlySetScalarsAndAugmentedCollections(t *testing.T) 
 	// Collections augment the file collections.
 	assert.Equal(t, []string{"tier1/a", "tier1/b"}, spec.TestsAdd)
 	assert.Equal(t, []string{"tier2"}, spec.GroupsRemove)
-	assert.Equal(t, []string{"bob"}, spec.ParticipantsAdd)
 	assert.Equal(t, []string{"tier1/c"}, spec.AssigneeMappingRemove)
 	// Assignment x overridden onto the file's map.
 	assert.Equal(t, map[string]string{"x": "u2"}, spec.AssigneeMappingSet)

--- a/cli/cmd/planner/root.go
+++ b/cli/cmd/planner/root.go
@@ -1,17 +1,18 @@
 // Package planner provides the "planner" cobra sub-commands (list, get,
-// create, update, delete) for managing Argus release plans. It is wired into
-// the command tree by the parent cmd package via [Register].
+// create, update, delete, overview) for managing Argus release plans. It is
+// wired into the command tree by the parent cmd package via [Register].
 package planner
 
 import "github.com/spf13/cobra"
 
-// Register adds the planner sub-commands (list, get, create, update, delete) to
-// the given parent command (typically the "planner" command owned by the cmd
-// package).
+// Register adds the planner sub-commands (list, get, create, update, delete,
+// overview) to the given parent command (typically the "planner" command owned
+// by the cmd package).
 func Register(parent *cobra.Command) {
 	registerList(parent)
 	registerGet(parent)
 	registerCreate(parent)
 	registerUpdate(parent)
 	registerDelete(parent)
+	registerOverview(parent)
 }

--- a/cli/cmd/planner/root.go
+++ b/cli/cmd/planner/root.go
@@ -1,13 +1,16 @@
-// Package planner provides the "planner list" and "planner get" cobra
-// sub-commands for managing Argus release plans. It is wired into the command
-// tree by the parent cmd package via [Register].
+// Package planner provides the "planner" cobra sub-commands (list, get,
+// create, delete) for managing Argus release plans. It is wired into the
+// command tree by the parent cmd package via [Register].
 package planner
 
 import "github.com/spf13/cobra"
 
-// Register adds the planner read sub-commands (list, get) to the given parent
-// command (typically the "planner" command owned by the cmd package).
+// Register adds the planner sub-commands (list, get, create, delete) to the
+// given parent command (typically the "planner" command owned by the cmd
+// package).
 func Register(parent *cobra.Command) {
 	registerList(parent)
 	registerGet(parent)
+	registerCreate(parent)
+	registerDelete(parent)
 }

--- a/cli/cmd/planner/root.go
+++ b/cli/cmd/planner/root.go
@@ -1,16 +1,17 @@
 // Package planner provides the "planner" cobra sub-commands (list, get,
-// create, delete) for managing Argus release plans. It is wired into the
-// command tree by the parent cmd package via [Register].
+// create, update, delete) for managing Argus release plans. It is wired into
+// the command tree by the parent cmd package via [Register].
 package planner
 
 import "github.com/spf13/cobra"
 
-// Register adds the planner sub-commands (list, get, create, delete) to the
-// given parent command (typically the "planner" command owned by the cmd
+// Register adds the planner sub-commands (list, get, create, update, delete) to
+// the given parent command (typically the "planner" command owned by the cmd
 // package).
 func Register(parent *cobra.Command) {
 	registerList(parent)
 	registerGet(parent)
 	registerCreate(parent)
+	registerUpdate(parent)
 	registerDelete(parent)
 }

--- a/cli/cmd/planner/update.go
+++ b/cli/cmd/planner/update.go
@@ -1,0 +1,190 @@
+package planner
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/scylladb/argus/cli/internal/cmdctx"
+	"github.com/scylladb/argus/cli/internal/logging"
+	"github.com/scylladb/argus/cli/internal/models"
+	"github.com/scylladb/argus/cli/internal/services"
+	"github.com/spf13/cobra"
+)
+
+// registerUpdate adds the "update" sub-command to parent.
+func registerUpdate(parent *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update a release plan via a computed diff",
+		Long: `Update a release plan, sending only the fields that changed.
+
+The plan is addressed by its UUID or "releaseName#planNumber" key. Changes can
+come from a --file diff (the schema below) and/or from flags; flags override
+matching scalars in the file and augment its collections. Every reference is by
+name (or, for tests, build_system_id) and resolved to a UUID automatically —
+raw UUIDs are not accepted.
+
+  # Rename only (sends just the name scalar):
+  argus planner update --plan-id scylla-2026.2#3 --name "2026.2 Longevity (GA)"
+
+  # Add a test, drop a stored group, (re)assign an entity:
+  argus planner update --plan-id scylla-2026.2#3 \
+    --add-test scylla-2026.2/tier1/longevity-200gb \
+    --remove-group tier2 \
+    --assign scylla-2026.2/tier1/longevity-200gb=bob
+
+  # From a JSON diff file (or stdin with '-'):
+  argus planner update --plan-id scylla-2026.2#3 --file edit.json
+
+Groups passed to --add-group are expanded to their enabled tests (no group is
+stored); a group assignment fans out to each of those tests. Tests referenced
+for add/remove that do not exist in the release are reported and skipped.`,
+		RunE: runUpdate,
+	}
+
+	cmd.Flags().StringP("plan-id", "p", "", "Plan UUID or key (required)")
+	cmd.Flags().StringP("file", "f", "", "Diff spec JSON file (\"-\" for stdin)")
+	cmd.Flags().String("name", "", "New plan name")
+	cmd.Flags().String("description", "", "New description")
+	cmd.Flags().String("owner", "", "New owner username")
+	cmd.Flags().String("target-version", "", "New target version")
+	cmd.Flags().Bool("completed", false, "Mark the plan completed")
+	cmd.Flags().StringArray("add-test", nil, "Add test by build_system_id or group/test (repeatable)")
+	cmd.Flags().StringArray("remove-test", nil, "Remove test by build_system_id or group/test (repeatable)")
+	cmd.Flags().StringArray("add-group", nil, "Add group, expanded to its enabled tests (repeatable)")
+	cmd.Flags().StringArray("remove-group", nil, "Remove a stored group by name (repeatable)")
+	cmd.Flags().StringArray("add-participant", nil, "Add participant username (repeatable)")
+	cmd.Flags().StringArray("remove-participant", nil, "Remove participant username (repeatable)")
+	cmd.Flags().StringArray("assign", nil, "Assignment as entity=username (repeatable)")
+	cmd.Flags().StringArray("unassign", nil, "Remove assignment for entity (repeatable)")
+	_ = cmd.MarkFlagRequired("plan-id")
+
+	parent.AddCommand(cmd)
+}
+
+// runUpdate is the RunE handler for "planner update".
+func runUpdate(cmd *cobra.Command, _ []string) error {
+	cmd.SilenceUsage = true
+	ctx := cmd.Context()
+	client := cmdctx.APIClientFrom(ctx)
+	out := cmdctx.OutputterFrom(ctx)
+	c := cmdctx.CacheFrom(ctx)
+	log := logging.For(cmdctx.LoggerFrom(ctx), "planner-update")
+
+	planRef, _ := cmd.Flags().GetString("plan-id")
+
+	spec, err := loadUpdateSpec(cmd)
+	if err != nil {
+		return err
+	}
+	if err := overlayUpdateFlags(cmd, &spec); err != nil {
+		return err
+	}
+
+	svc := services.NewPlannerService(client, c)
+
+	// Fetch the current plan to obtain its UUID id and release for resolution.
+	plan, err := svc.GetPlan(ctx, planRef)
+	if err != nil {
+		log.Error().Err(err).Str("plan_id", planRef).Msg("failed to fetch plan")
+		return err
+	}
+
+	diff, warnings, err := svc.BuildUpdateRequest(ctx, plan, spec)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to build update diff")
+		return err
+	}
+	for _, w := range warnings {
+		log.Warn().Msg(w)
+	}
+
+	if err := svc.UpdatePlan(ctx, diff); err != nil {
+		log.Error().Err(err).Str("plan_id", planRef).Msg("failed to update plan")
+		return err
+	}
+	log.Info().Str("plan_id", planRef).Msg("plan updated successfully")
+
+	// Re-fetch and show the resolved, updated plan.
+	updated, err := svc.GetPlan(ctx, planRef)
+	if err != nil {
+		log.Error().Err(err).Str("plan_id", planRef).Msg("failed to fetch updated plan")
+		return err
+	}
+	resolved, err := svc.BuildResolvedPlan(ctx, updated)
+	if err != nil {
+		log.Error().Err(err).Str("plan_id", planRef).Msg("failed to resolve updated plan")
+		return err
+	}
+	return out.Write(resolved)
+}
+
+// loadUpdateSpec reads the --file diff spec (path or stdin) into a
+// PlanUpdateSpec. Returns a zero spec when --file is not set.
+func loadUpdateSpec(cmd *cobra.Command) (spec models.PlanUpdateSpec, err error) {
+	path, _ := cmd.Flags().GetString("file")
+	if path == "" {
+		return spec, nil
+	}
+
+	var raw []byte
+	if path == "-" {
+		raw, err = io.ReadAll(bufio.NewReader(os.Stdin))
+	} else {
+		raw, err = os.ReadFile(path)
+	}
+	if err != nil {
+		return spec, fmt.Errorf("reading diff file: %w", err)
+	}
+	if err := json.Unmarshal(raw, &spec); err != nil {
+		return spec, fmt.Errorf("parsing diff file: %w", err)
+	}
+	return spec, nil
+}
+
+// overlayUpdateFlags applies command-line flags onto spec. Scalar flags
+// override the file value only when explicitly set; list/map flags augment the
+// corresponding file collections.
+func overlayUpdateFlags(cmd *cobra.Command, spec *models.PlanUpdateSpec) error {
+	setStr := func(flag string, dst **string) {
+		if cmd.Flags().Changed(flag) {
+			v, _ := cmd.Flags().GetString(flag)
+			*dst = &v
+		}
+	}
+	setStr("name", &spec.Name)
+	setStr("description", &spec.Description)
+	setStr("owner", &spec.Owner)
+	setStr("target-version", &spec.TargetVersion)
+	if cmd.Flags().Changed("completed") {
+		v, _ := cmd.Flags().GetBool("completed")
+		spec.Completed = &v
+	}
+
+	appendArr := func(flag string, dst *[]string) {
+		if cmd.Flags().Changed(flag) {
+			v, _ := cmd.Flags().GetStringArray(flag)
+			*dst = append(*dst, v...)
+		}
+	}
+	appendArr("add-test", &spec.TestsAdd)
+	appendArr("remove-test", &spec.TestsRemove)
+	appendArr("add-group", &spec.GroupsAdd)
+	appendArr("remove-group", &spec.GroupsRemove)
+	appendArr("add-participant", &spec.ParticipantsAdd)
+	appendArr("remove-participant", &spec.ParticipantsRemove)
+	appendArr("unassign", &spec.AssigneeMappingRemove)
+
+	if cmd.Flags().Changed("assign") {
+		assigns, _ := cmd.Flags().GetStringArray("assign")
+		merged, err := parseAssignments(assigns, spec.AssigneeMappingSet)
+		if err != nil {
+			return err
+		}
+		spec.AssigneeMappingSet = merged
+	}
+	return nil
+}

--- a/cli/cmd/planner/update.go
+++ b/cli/cmd/planner/update.go
@@ -39,6 +39,12 @@ raw UUIDs are not accepted.
   # From a JSON diff file (or stdin with '-'):
   argus planner update --plan-id scylla-2026.2#3 --file edit.json
 
+The --file spec accepts add/remove deltas (tests_add, assignee_mapping_set, …)
+and/or the template "assignments" map that 'get'/'create' emit. Template
+assignments are applied as a merge/patch: each listed test/group is added when
+missing and (re)assigned, "$owner" clears an assignee, and tests you do not list
+are left untouched.
+
 Groups passed to --add-group are expanded to their enabled tests (no group is
 stored); a group assignment fans out to each of those tests. Tests referenced
 for add/remove that do not exist in the release are reported and skipped.
@@ -112,18 +118,18 @@ func runUpdate(cmd *cobra.Command, _ []string) error {
 	}
 	log.Info().Str("plan_id", planRef).Msg("plan updated successfully")
 
-	// Re-fetch and show the resolved, updated plan.
+	// Re-fetch and show the updated plan in the same template format as 'get'.
 	updated, err := svc.GetPlan(ctx, planRef)
 	if err != nil {
 		log.Error().Err(err).Str("plan_id", planRef).Msg("failed to fetch updated plan")
 		return err
 	}
-	resolved, err := svc.BuildResolvedPlan(ctx, updated)
+	tmpl, err := svc.BuildTemplate(ctx, updated)
 	if err != nil {
-		log.Error().Err(err).Str("plan_id", planRef).Msg("failed to resolve updated plan")
+		log.Error().Err(err).Str("plan_id", planRef).Msg("failed to build plan template")
 		return err
 	}
-	return out.Write(resolved)
+	return out.Write(models.NewKVTabular(tmpl))
 }
 
 // loadUpdateSpec reads the --file diff spec (path or stdin) into a

--- a/cli/cmd/planner/update.go
+++ b/cli/cmd/planner/update.go
@@ -41,7 +41,13 @@ raw UUIDs are not accepted.
 
 Groups passed to --add-group are expanded to their enabled tests (no group is
 stored); a group assignment fans out to each of those tests. Tests referenced
-for add/remove that do not exist in the release are reported and skipped.`,
+for add/remove that do not exist in the release are reported and skipped.
+
+Participants are not edited directly — they are derived from the assignments,
+so anyone assigned (other than the owner) is a participant. Assigning to $owner
+or using --unassign clears a test's assignee but keeps the test in the plan;
+--remove-test drops the test entirely. A user dropped from their last assigned
+test is removed from participants automatically.`,
 		RunE: runUpdate,
 	}
 
@@ -56,10 +62,8 @@ for add/remove that do not exist in the release are reported and skipped.`,
 	cmd.Flags().StringArray("remove-test", nil, "Remove test by build_system_id or group/test (repeatable)")
 	cmd.Flags().StringArray("add-group", nil, "Add group, expanded to its enabled tests (repeatable)")
 	cmd.Flags().StringArray("remove-group", nil, "Remove a stored group by name (repeatable)")
-	cmd.Flags().StringArray("add-participant", nil, "Add participant username (repeatable)")
-	cmd.Flags().StringArray("remove-participant", nil, "Remove participant username (repeatable)")
-	cmd.Flags().StringArray("assign", nil, "Assignment as entity=username (repeatable)")
-	cmd.Flags().StringArray("unassign", nil, "Remove assignment for entity (repeatable)")
+	cmd.Flags().StringArray("assign", nil, "Assignment as entity=username (use $owner to clear) (repeatable)")
+	cmd.Flags().StringArray("unassign", nil, "Clear assignee for entity, keeping the test (repeatable)")
 	_ = cmd.MarkFlagRequired("plan-id")
 
 	parent.AddCommand(cmd)
@@ -174,8 +178,6 @@ func overlayUpdateFlags(cmd *cobra.Command, spec *models.PlanUpdateSpec) error {
 	appendArr("remove-test", &spec.TestsRemove)
 	appendArr("add-group", &spec.GroupsAdd)
 	appendArr("remove-group", &spec.GroupsRemove)
-	appendArr("add-participant", &spec.ParticipantsAdd)
-	appendArr("remove-participant", &spec.ParticipantsRemove)
 	appendArr("unassign", &spec.AssigneeMappingRemove)
 
 	if cmd.Flags().Changed("assign") {

--- a/cli/cmd/planner/update.go
+++ b/cli/cmd/planner/update.go
@@ -49,11 +49,16 @@ Groups passed to --add-group are expanded to their enabled tests (no group is
 stored); a group assignment fans out to each of those tests. Tests referenced
 for add/remove that do not exist in the release are reported and skipped.
 
+--assign adds the referenced test to the plan when it is not already present
+(membership follows the assignment), so you need not pair it with --add-test; a
+group reference fans out to its enabled tests. Assigning to $owner or using
+--unassign clears a test's assignee but keeps the test in the plan; --remove-test
+drops the test entirely. A reference matching nothing in the release is reported
+and skipped.
+
 Participants are not edited directly — they are derived from the assignments,
-so anyone assigned (other than the owner) is a participant. Assigning to $owner
-or using --unassign clears a test's assignee but keeps the test in the plan;
---remove-test drops the test entirely. A user dropped from their last assigned
-test is removed from participants automatically.`,
+so anyone assigned (other than the owner) is a participant. A user dropped from
+their last assigned test is removed from participants automatically.`,
 		RunE: runUpdate,
 	}
 
@@ -68,7 +73,7 @@ test is removed from participants automatically.`,
 	cmd.Flags().StringArray("remove-test", nil, "Remove test by build_system_id or group/test (repeatable)")
 	cmd.Flags().StringArray("add-group", nil, "Add group, expanded to its enabled tests (repeatable)")
 	cmd.Flags().StringArray("remove-group", nil, "Remove a stored group by name (repeatable)")
-	cmd.Flags().StringArray("assign", nil, "Assignment as entity=username (use $owner to clear) (repeatable)")
+	cmd.Flags().StringArray("assign", nil, "Assignment as entity=username, adding the test if missing (use $owner to clear) (repeatable)")
 	cmd.Flags().StringArray("unassign", nil, "Clear assignee for entity, keeping the test (repeatable)")
 	_ = cmd.MarkFlagRequired("plan-id")
 

--- a/cli/cmd/search.go
+++ b/cli/cmd/search.go
@@ -1,0 +1,9 @@
+package cmd
+
+import (
+	"github.com/scylladb/argus/cli/cmd/search"
+)
+
+func init() {
+	search.Register(rootCmd)
+}

--- a/cli/cmd/search/root.go
+++ b/cli/cmd/search/root.go
@@ -1,0 +1,79 @@
+// Package search provides the top-level "argus search" command — an
+// interactive discovery aid that prints the build_system_id of matching tests
+// and groups so they can be copied as canonical references for the planner
+// commands. It is wired into the command tree by the parent cmd package via
+// [Register].
+//
+// Search is a discovery tool only; it is not the name-resolution path used by
+// the planner commands (that uses the gridview endpoint).
+package search
+
+import (
+	"strings"
+
+	"github.com/scylladb/argus/cli/internal/cmdctx"
+	"github.com/scylladb/argus/cli/internal/logging"
+	"github.com/scylladb/argus/cli/internal/models"
+	"github.com/scylladb/argus/cli/internal/services"
+	"github.com/spf13/cobra"
+)
+
+// Register adds the top-level "search" command to the given parent (rootCmd).
+func Register(parent *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "search <query>",
+		Short: "Search tests, groups, and releases for plan references",
+		Long: `Search Argus for tests, groups, and releases and print their build_system_id,
+which is the canonical, unambiguous way to reference a test in the planner
+commands.
+
+The query combines free text with optional facets, all AND-ed together:
+
+  free text        case-insensitive substring match on the entity's own name
+  type:<value>     exact type: test, group, or release
+  release:<value>  substring match on the related release name
+  group:<value>    substring match on the related group name
+
+Facet values must NOT be quoted and cannot contain spaces. Pass the whole query
+as a single shell-quoted argument, e.g.:
+
+  argus search "release:2026.2 longevity"
+  argus search "type:group release:2026.2"
+  argus search longevity-100gb --release scylla-2026.2
+
+A bare UUID query is treated as a run/entity lookup by the backend.`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: runSearch,
+	}
+
+	cmd.Flags().StringP("release", "r", "", "Scope the search to a release (by name)")
+
+	parent.AddCommand(cmd)
+}
+
+// runSearch is the RunE handler for "search".
+func runSearch(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+	ctx := cmd.Context()
+	client := cmdctx.APIClientFrom(ctx)
+	out := cmdctx.OutputterFrom(ctx)
+	c := cmdctx.CacheFrom(ctx)
+	log := logging.For(cmdctx.LoggerFrom(ctx), "search")
+
+	// Join positional args so an unquoted multi-word query still works; the
+	// backend receives the query verbatim.
+	query := strings.Join(args, " ")
+	releaseRef, _ := cmd.Flags().GetString("release")
+	log.Debug().Str("query", query).Str("release", releaseRef).Msg("searching")
+
+	svc := services.NewPlannerService(client, c)
+
+	hits, err := svc.Search(ctx, query, releaseRef)
+	if err != nil {
+		log.Error().Err(err).Str("query", query).Msg("search failed")
+		return err
+	}
+
+	log.Info().Str("query", query).Int("count", len(hits)).Msg("search completed")
+	return out.Write(models.NewTabularSlice(hits))
+}

--- a/cli/cmd/search/search_test.go
+++ b/cli/cmd/search/search_test.go
@@ -1,0 +1,45 @@
+package search_test
+
+import (
+	"testing"
+
+	"github.com/scylladb/argus/cli/cmd/search"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// findSearchCmd registers the search command on a throwaway parent and returns
+// it, mirroring how cmd/search.go wires it onto rootCmd.
+func findSearchCmd(t *testing.T) *cobra.Command {
+	t.Helper()
+	parent := &cobra.Command{Use: "argus"}
+	search.Register(parent)
+	for _, c := range parent.Commands() {
+		if c.Name() == "search" {
+			return c
+		}
+	}
+	require.FailNow(t, "search command was not registered")
+	return nil
+}
+
+func TestRegister_WiresSearchCommand(t *testing.T) {
+	t.Parallel()
+	cmd := findSearchCmd(t)
+
+	// The release scoping flag is present with its short form.
+	flag := cmd.Flags().Lookup("release")
+	require.NotNil(t, flag)
+	assert.Equal(t, "r", flag.Shorthand)
+}
+
+func TestSearch_RequiresQueryArg(t *testing.T) {
+	t.Parallel()
+	cmd := findSearchCmd(t)
+
+	// Args validator rejects an empty query and accepts one or more terms.
+	require.Error(t, cmd.Args(cmd, []string{}))
+	require.NoError(t, cmd.Args(cmd, []string{"longevity"}))
+	require.NoError(t, cmd.Args(cmd, []string{"type:group", "release:2026.2"}))
+}

--- a/cli/internal/api/routes.go
+++ b/cli/internal/api/routes.go
@@ -62,8 +62,6 @@ const (
 	PlanCreate      = "/api/v1/planning/plan/create"              // POST   – create a plan (CreatePlanRequest)
 	PlanUpdate      = "/api/v1/planning/plan/update"              // POST   – update a plan (PlanDiffRequest)
 	PlanDelete      = "/api/v1/planning/plan/%s/delete"           // DELETE – delete a plan (plan_id); query param deleteView=0|1
-	PlanCopy        = "/api/v1/planning/plan/copy"                // POST   – copy a plan (CopyPlanRequest)
-	PlanCopyCheck   = "/api/v1/planning/plan/%s/copy/check"       // GET    – copy eligibility (plan_id); query param releaseId
 	PlanResolve     = "/api/v1/planning/plan/%s/resolve_entities" // GET  – resolve plan entities (plan_id)
 	PlanningSearch  = "/api/v1/planning/search"                   // GET    – search tests/groups/releases; query params query, releaseId
 	GroupExplode    = "/api/v1/planning/group/%s/explode"         // GET    – explode a group into its tests (group_id)

--- a/cli/internal/models/planner.go
+++ b/cli/internal/models/planner.go
@@ -195,10 +195,10 @@ func (g ReleaseGrid) String() string {
 }
 
 // ---------------------------------------------------------------------------
-// PlanTemplate – editable create-spec (get --template / create --file schema)
+// PlanTemplate – editable create-spec (default get / create --file schema)
 // ---------------------------------------------------------------------------
 // PlanTemplate is the release-independent, human-readable plan spec emitted by
-// `planner get --template` and consumed by `planner create --file`.
+// `planner get` (the default output) and consumed by `planner create --file`.
 //
 // Assignments is the single source of plan membership: it is keyed by a
 // group-qualified "group/test" reference (or a group name, which fans out to
@@ -252,7 +252,7 @@ type PlanUpdateSpec struct {
 // ResolvedPlan is a human-readable view of a [ReleasePlan] with every UUID
 // reference back-resolved to a name: release/owner/participant names, tests and
 // assignment targets as group-qualified "group/test" strings, and groups as
-// names. It is the default (non-`--template`) output of `planner get`/`list`.
+// names. It is the output of `planner get --resolved` and the default `list`.
 //
 // Unlike [PlanTemplate] it retains the plan's identity and status (id, key,
 // completed, timestamps) and never drops entities — a reference that cannot be

--- a/cli/internal/models/planner.go
+++ b/cli/internal/models/planner.go
@@ -233,6 +233,14 @@ const OwnerMarker = "$owner"
 // assignments (assignees minus owner), so the CLI computes the participant
 // deltas. Groups in GroupsAdd are expanded to their enabled tests at resolve
 // time (never sent as groups_add).
+//
+// Assignments accepts the same "assignments" map that the [PlanTemplate] (the
+// default `get`/`create` output) uses, applied as a merge/patch: each keyed
+// test/group reference is ensured to be in the plan (added when missing) and
+// assigned to the given username, or unassigned when the value is "$owner";
+// tests not mentioned are left untouched. It is a convenience for round-tripping
+// an edited template through `update --file`, and is folded into the test-add
+// and assignee deltas at resolve time.
 type PlanUpdateSpec struct {
 	Name          *string `json:"name,omitempty"`
 	Description   *string `json:"description,omitempty"`
@@ -247,6 +255,10 @@ type PlanUpdateSpec struct {
 
 	AssigneeMappingSet    map[string]string `json:"assignee_mapping_set,omitempty"`
 	AssigneeMappingRemove []string          `json:"assignee_mapping_remove,omitempty"`
+
+	// Assignments is the template-style membership+assignment map, merged into
+	// the deltas above (see the type doc). "$owner" clears an assignee.
+	Assignments map[string]string `json:"assignments,omitempty"`
 }
 
 // ResolvedPlan is a human-readable view of a [ReleasePlan] with every UUID

--- a/cli/internal/models/planner.go
+++ b/cli/internal/models/planner.go
@@ -249,8 +249,17 @@ type SearchHit struct {
 	Release       *SearchRef `json:"release"`
 }
 
-// SearchHitList is the response payload for GET /planning/search.
+// SearchHitList is a slice of search hits (the displayed result set after the
+// synthetic "Add all..." row is filtered out).
 type SearchHitList = []SearchHit
+
+// SearchResponse is the response payload for GET /planning/search. The backend
+// wraps the hits in {hits, total}; Total counts the synthetic "Add all..." row
+// too, so it is not used directly for display counts.
+type SearchResponse struct {
+	Hits  []SearchHit `json:"hits"`
+	Total int         `json:"total"`
+}
 
 // Headers implements output.Tabular for SearchHit.
 func (SearchHit) Headers() []string {

--- a/cli/internal/models/planner.go
+++ b/cli/internal/models/planner.go
@@ -109,46 +109,11 @@ type PlanDiffRequest struct {
 	AssigneeMappingRemove []string          `json:"assignee_mapping_remove,omitempty"`
 }
 
-// CopyPlanRequest is the JSON body for POST /planning/plan/copy.
-//
-// It mirrors CopyPlanPayload (planner_service.py): Plan is the source plan
-// (with name/version/description/owner overrides applied), Replacements maps a
-// missing source-entity UUID to a substitute target-entity UUID.
-type CopyPlanRequest struct {
-	Plan              ReleasePlan       `json:"plan"`
-	KeepParticipants  bool              `json:"keepParticipants"`
-	Replacements      map[string]string `json:"replacements"`
-	TargetReleaseID   string            `json:"targetReleaseId"`
-	TargetReleaseName string            `json:"targetReleaseName"`
-}
-
-// ---------------------------------------------------------------------------
-// Copy eligibility check response
-// ---------------------------------------------------------------------------
-
-// CopyCheckResponse is the payload of GET /planning/plan/<id>/copy/check.
-//
-// Status is "passed" or "failed"; Missing lists entities that have no
-// equivalent in the target release (by build_system_id remap).
-type CopyCheckResponse struct {
-	Status          string          `json:"status"`
-	TargetRelease   Release         `json:"targetRelease"`
-	OriginalRelease Release         `json:"originalRelease"`
-	Missing         MissingEntities `json:"missing"`
-}
-
-// MissingEntities groups the missing tests and groups of a copy eligibility check.
-type MissingEntities struct {
-	Tests  []GridEntity `json:"tests"`
-	Groups []GridEntity `json:"groups"`
-}
-
 // ---------------------------------------------------------------------------
 // Release / Gridview – name resolution and group expansion sources
 // ---------------------------------------------------------------------------
 
-// Release mirrors the subset of ArgusRelease returned by /api/v1/releases and
-// the copy-check endpoint.
+// Release mirrors the subset of ArgusRelease returned by /api/v1/releases.
 type Release struct {
 	ID         string `json:"id"`
 	Name       string `json:"name"`

--- a/cli/internal/models/planner.go
+++ b/cli/internal/models/planner.go
@@ -220,6 +220,35 @@ type PlanTemplate struct {
 	Assignments   map[string]string `json:"assignments,omitempty"`
 }
 
+// PlanUpdateSpec is the name-based diff consumed by `planner update`. It is the
+// schema for the `update --file` input and the intermediate that the `update`
+// flags are overlaid onto; [services.PlannerService.BuildUpdateRequest]
+// resolves it into the UUID-based [PlanDiffRequest] sent to the backend.
+//
+// Scalar pointer fields are sent only when set (nil = no change). List/map
+// fields use the same add/remove delta shape as the wire payload, but every
+// value is a human reference: tests as build_system_id or "group/test", groups
+// and participants/owner by name/username, and AssigneeMappingSet keyed by a
+// test/group reference with a username value. Groups in GroupsAdd are expanded
+// to their enabled tests at resolve time (never sent as groups_add).
+type PlanUpdateSpec struct {
+	Name          *string `json:"name,omitempty"`
+	Description   *string `json:"description,omitempty"`
+	Owner         *string `json:"owner,omitempty"`
+	TargetVersion *string `json:"target_version,omitempty"`
+	Completed     *bool   `json:"completed,omitempty"`
+
+	TestsAdd           []string `json:"tests_add,omitempty"`
+	TestsRemove        []string `json:"tests_remove,omitempty"`
+	GroupsAdd          []string `json:"groups_add,omitempty"`
+	GroupsRemove       []string `json:"groups_remove,omitempty"`
+	ParticipantsAdd    []string `json:"participants_add,omitempty"`
+	ParticipantsRemove []string `json:"participants_remove,omitempty"`
+
+	AssigneeMappingSet    map[string]string `json:"assignee_mapping_set,omitempty"`
+	AssigneeMappingRemove []string          `json:"assignee_mapping_remove,omitempty"`
+}
+
 // ResolvedPlan is a human-readable view of a [ReleasePlan] with every UUID
 // reference back-resolved to a name: release/owner/participant names, tests and
 // assignment targets as group-qualified "group/test" strings, and groups as

--- a/cli/internal/models/planner.go
+++ b/cli/internal/models/planner.go
@@ -172,18 +172,24 @@ type GridView struct {
 // PlanTemplate is the release-independent, human-readable plan spec emitted by
 // `planner get --template` and consumed by `planner create --file`.
 //
-// Tests are group-qualified "group/test" strings, Owner/Participants are
-// usernames, and Assignments are keyed by "group/test".
+// Assignments is the single source of plan membership: it is keyed by a
+// group-qualified "group/test" reference (or a group name, which fans out to
+// its enabled tests) and valued by a username. The literal [OwnerMarker]
+// ("$owner") denotes a test that belongs to the plan but is not assigned to a
+// specific participant — it is placed in the plan's tests but left out of the
+// assignee mapping. Owner is a username.
 type PlanTemplate struct {
 	Name          string            `json:"name"`
 	Description   string            `json:"description,omitempty"`
 	Release       string            `json:"release"`
 	TargetVersion string            `json:"target_version,omitempty"`
 	Owner         string            `json:"owner,omitempty"`
-	Participants  []string          `json:"participants,omitempty"`
-	Tests         []string          `json:"tests"`
 	Assignments   map[string]string `json:"assignments,omitempty"`
 }
+
+// OwnerMarker is the sentinel assignment value meaning "include this test in
+// the plan but leave it unassigned (it implicitly belongs to the owner)".
+const OwnerMarker = "$owner"
 
 // PlanUpdateSpec is the name-based diff consumed by `planner update`. It is the
 // schema for the `update --file` input and the intermediate that the `update`
@@ -263,16 +269,53 @@ func (p ResolvedPlan) Rows() [][]string {
 	}}
 }
 
-// ResolvedPlans is a slice of resolved plans rendered as one row per plan in
+// PlanSummary is the per-plan list view. Its JSON fields mirror the text-table
+// columns exactly (test/group/participant references are reported as integer
+// counts), so the `planner list` JSON and `--text` output carry the same data.
+type PlanSummary struct {
+	Key           string `json:"key"`
+	Name          string `json:"name"`
+	Description   string `json:"description"`
+	Release       string `json:"release"`
+	TargetVersion string `json:"target_version"`
+	Owner         string `json:"owner"`
+	Tests         int    `json:"tests"`
+	Groups        int    `json:"groups"`
+	Participants  int    `json:"participants"`
+	LastUpdated   string `json:"last_updated"`
+}
+
+// Headers implements output.Tabular for PlanSummary.
+func (PlanSummary) Headers() []string {
+	return []string{"Key", "Name", "Description", "Release", "Target Version", "Owner", "Tests", "Groups", "Participants", "Last Updated"}
+}
+
+// Rows implements output.Tabular for PlanSummary.
+func (p PlanSummary) Rows() [][]string {
+	return [][]string{{
+		p.Key,
+		p.Name,
+		p.Description,
+		p.Release,
+		p.TargetVersion,
+		p.Owner,
+		strconv.Itoa(p.Tests),
+		strconv.Itoa(p.Groups),
+		strconv.Itoa(p.Participants),
+		p.LastUpdated,
+	}}
+}
+
+// PlanSummaries is a slice of plan summaries rendered as one row per plan in
 // text output, while JSON marshalling emits the full slice. It backs the
 // default `planner list` output.
-type ResolvedPlans []ResolvedPlan
+type PlanSummaries []PlanSummary
 
-// Headers implements output.Tabular for ResolvedPlans.
-func (ResolvedPlans) Headers() []string { return ResolvedPlan{}.Headers() }
+// Headers implements output.Tabular for PlanSummaries.
+func (PlanSummaries) Headers() []string { return PlanSummary{}.Headers() }
 
-// Rows implements output.Tabular for ResolvedPlans.
-func (ps ResolvedPlans) Rows() [][]string {
+// Rows implements output.Tabular for PlanSummaries.
+func (ps PlanSummaries) Rows() [][]string {
 	rows := make([][]string, 0, len(ps))
 	for _, p := range ps {
 		rows = append(rows, p.Rows()[0])

--- a/cli/internal/models/planner.go
+++ b/cli/internal/models/planner.go
@@ -199,9 +199,12 @@ const OwnerMarker = "$owner"
 // Scalar pointer fields are sent only when set (nil = no change). List/map
 // fields use the same add/remove delta shape as the wire payload, but every
 // value is a human reference: tests as build_system_id or "group/test", groups
-// and participants/owner by name/username, and AssigneeMappingSet keyed by a
-// test/group reference with a username value. Groups in GroupsAdd are expanded
-// to their enabled tests at resolve time (never sent as groups_add).
+// by name, and AssigneeMappingSet keyed by a test/group reference with a
+// username value ("$owner" clears the assignee while keeping the test).
+// Participants are not edited directly: they are derived from the resulting
+// assignments (assignees minus owner), so the CLI computes the participant
+// deltas. Groups in GroupsAdd are expanded to their enabled tests at resolve
+// time (never sent as groups_add).
 type PlanUpdateSpec struct {
 	Name          *string `json:"name,omitempty"`
 	Description   *string `json:"description,omitempty"`
@@ -209,12 +212,10 @@ type PlanUpdateSpec struct {
 	TargetVersion *string `json:"target_version,omitempty"`
 	Completed     *bool   `json:"completed,omitempty"`
 
-	TestsAdd           []string `json:"tests_add,omitempty"`
-	TestsRemove        []string `json:"tests_remove,omitempty"`
-	GroupsAdd          []string `json:"groups_add,omitempty"`
-	GroupsRemove       []string `json:"groups_remove,omitempty"`
-	ParticipantsAdd    []string `json:"participants_add,omitempty"`
-	ParticipantsRemove []string `json:"participants_remove,omitempty"`
+	TestsAdd     []string `json:"tests_add,omitempty"`
+	TestsRemove  []string `json:"tests_remove,omitempty"`
+	GroupsAdd    []string `json:"groups_add,omitempty"`
+	GroupsRemove []string `json:"groups_remove,omitempty"`
 
 	AssigneeMappingSet    map[string]string `json:"assignee_mapping_set,omitempty"`
 	AssigneeMappingRemove []string          `json:"assignee_mapping_remove,omitempty"`

--- a/cli/internal/models/planner.go
+++ b/cli/internal/models/planner.go
@@ -1,6 +1,10 @@
 package models
 
-import "strconv"
+import (
+	"sort"
+	"strconv"
+	"strings"
+)
 
 // ---------------------------------------------------------------------------
 // ReleasePlan – mirrors argus.backend.models.plan.ArgusReleasePlan
@@ -164,6 +168,30 @@ type GridView struct {
 	Tests       map[string]GridEntity   `json:"tests"`
 	Groups      map[string]GridEntity   `json:"groups"`
 	TestByGroup map[string][]GridEntity `json:"testByGroup"`
+}
+
+// ReleaseGrid is a release overview: every enabled test keyed by its
+// group-qualified "group/test" reference (the same form `--assign`/`get`/`list`
+// accept) and valued by its build_system_id. JSON output marshals the map
+// directly; text output renders one sorted entry per line as
+// `group/test: build_system_id` via String().
+type ReleaseGrid map[string]string
+
+// String renders the overview one entry per line, sorted by reference.
+func (g ReleaseGrid) String() string {
+	keys := make([]string, 0, len(g))
+	for k := range g {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteString(": ")
+		b.WriteString(g[k])
+		b.WriteByte('\n')
+	}
+	return strings.TrimRight(b.String(), "\n")
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/internal/models/planner.go
+++ b/cli/internal/models/planner.go
@@ -204,7 +204,6 @@ type GridView struct {
 // ---------------------------------------------------------------------------
 // PlanTemplate – editable create-spec (get --template / create --file schema)
 // ---------------------------------------------------------------------------
-
 // PlanTemplate is the release-independent, human-readable plan spec emitted by
 // `planner get --template` and consumed by `planner create --file`.
 //
@@ -219,6 +218,72 @@ type PlanTemplate struct {
 	Participants  []string          `json:"participants,omitempty"`
 	Tests         []string          `json:"tests"`
 	Assignments   map[string]string `json:"assignments,omitempty"`
+}
+
+// ResolvedPlan is a human-readable view of a [ReleasePlan] with every UUID
+// reference back-resolved to a name: release/owner/participant names, tests and
+// assignment targets as group-qualified "group/test" strings, and groups as
+// names. It is the default (non-`--template`) output of `planner get`/`list`.
+//
+// Unlike [PlanTemplate] it retains the plan's identity and status (id, key,
+// completed, timestamps) and never drops entities — a reference that cannot be
+// resolved against the release gridview/users list falls back to its raw UUID
+// rather than being omitted, so the output is lossless.
+type ResolvedPlan struct {
+	ID            string            `json:"id"`
+	Key           string            `json:"key"`
+	Name          string            `json:"name"`
+	Description   string            `json:"description,omitempty"`
+	Release       string            `json:"release"`
+	TargetVersion string            `json:"target_version,omitempty"`
+	Owner         string            `json:"owner"`
+	Participants  []string          `json:"participants,omitempty"`
+	Tests         []string          `json:"tests"`
+	Groups        []string          `json:"groups,omitempty"`
+	Assignments   map[string]string `json:"assignments,omitempty"`
+	Completed     bool              `json:"completed"`
+	ViewID        string            `json:"view_id,omitempty"`
+	CreatedFrom   string            `json:"created_from,omitempty"`
+	CreationTime  string            `json:"creation_time,omitempty"`
+	LastUpdated   string            `json:"last_updated,omitempty"`
+	EndsAt        string            `json:"ends_at,omitempty"`
+}
+
+// Headers implements output.Tabular for ResolvedPlan. Text output is a curated
+// subset of fields; JSON output (via direct marshalling) still carries the full
+// resolved plan.
+func (ResolvedPlan) Headers() []string {
+	return []string{"Key", "Name", "Description", "Release", "Target Version", "Owner", "Last Updated"}
+}
+
+// Rows implements output.Tabular for ResolvedPlan.
+func (p ResolvedPlan) Rows() [][]string {
+	return [][]string{{
+		p.Key,
+		p.Name,
+		p.Description,
+		p.Release,
+		p.TargetVersion,
+		p.Owner,
+		p.LastUpdated,
+	}}
+}
+
+// ResolvedPlans is a slice of resolved plans rendered as one row per plan in
+// text output, while JSON marshalling emits the full slice. It backs the
+// default `planner list` output.
+type ResolvedPlans []ResolvedPlan
+
+// Headers implements output.Tabular for ResolvedPlans.
+func (ResolvedPlans) Headers() []string { return ResolvedPlan{}.Headers() }
+
+// Rows implements output.Tabular for ResolvedPlans.
+func (ps ResolvedPlans) Rows() [][]string {
+	rows := make([][]string, 0, len(ps))
+	for _, p := range ps {
+		rows = append(rows, p.Rows()[0])
+	}
+	return rows
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/internal/models/planner_test.go
+++ b/cli/internal/models/planner_test.go
@@ -235,3 +235,72 @@ func TestCreatePlanRequest_OmitsOptionalEmptyFields(t *testing.T) {
 	assert.NotContains(t, s, `"view_id"`, "empty optional view_id must be omitted")
 	assert.NotContains(t, s, `"created_from"`, "empty optional created_from must be omitted")
 }
+
+func sampleResolvedPlan() models.ResolvedPlan {
+	return models.ResolvedPlan{
+		ID:            "p1",
+		Key:           "scylla-2026.2#3",
+		Name:          "2026.2 Longevity",
+		Description:   "Longevity suite",
+		Release:       "scylla-2026.2",
+		TargetVersion: "2026.2.0~rc3",
+		Owner:         "alice",
+		Participants:  []string{"bob"},
+		Tests:         []string{"Tier 1/longevity-100gb"},
+		Groups:        []string{"tier1"},
+		Assignments:   map[string]string{"Tier 1/longevity-200gb": "bob"},
+		Completed:     true,
+		LastUpdated:   "2026-06-02T11:00:00.000000",
+	}
+}
+
+func TestResolvedPlan_TabularShowsCuratedColumns(t *testing.T) {
+	t.Parallel()
+
+	plan := sampleResolvedPlan()
+	headers := plan.Headers()
+	assert.Equal(t, []string{
+		"Key", "Name", "Description", "Release", "Target Version", "Owner", "Last Updated",
+	}, headers)
+
+	rows := plan.Rows()
+	require.Len(t, rows, 1)
+	assert.Len(t, rows[0], len(headers), "row width must match header count")
+	assert.Equal(t, []string{
+		"scylla-2026.2#3", "2026.2 Longevity", "Longevity suite",
+		"scylla-2026.2", "2026.2.0~rc3", "alice", "2026-06-02T11:00:00.000000",
+	}, rows[0])
+}
+
+func TestResolvedPlan_JSONKeepsFullDetail(t *testing.T) {
+	t.Parallel()
+
+	// Text output is curated, but JSON marshalling still carries every field —
+	// including tests, groups, participants, and assignments.
+	raw, err := json.Marshal(sampleResolvedPlan())
+	require.NoError(t, err)
+	s := string(raw)
+
+	assert.Contains(t, s, `"tests":["Tier 1/longevity-100gb"]`)
+	assert.Contains(t, s, `"groups":["tier1"]`)
+	assert.Contains(t, s, `"participants":["bob"]`)
+	assert.Contains(t, s, `"assignments":{"Tier 1/longevity-200gb":"bob"}`)
+	assert.Contains(t, s, `"id":"p1"`)
+}
+
+func TestResolvedPlans_TabularRowPerPlan(t *testing.T) {
+	t.Parallel()
+
+	plans := models.ResolvedPlans{
+		{Key: "scylla-2026.2#1", Name: "A", Owner: "alice"},
+		{Key: "scylla-2026.2#2", Name: "B", Owner: "bob"},
+	}
+	assert.Equal(t, models.ResolvedPlan{}.Headers(), plans.Headers())
+
+	rows := plans.Rows()
+	require.Len(t, rows, 2)
+	assert.Equal(t, "scylla-2026.2#1", rows[0][0])
+	assert.Equal(t, "alice", rows[0][5])
+	assert.Equal(t, "scylla-2026.2#2", rows[1][0])
+	assert.Equal(t, "bob", rows[1][5])
+}

--- a/cli/internal/models/planner_test.go
+++ b/cli/internal/models/planner_test.go
@@ -319,19 +319,46 @@ func TestResolvedPlan_JSONKeepsFullDetail(t *testing.T) {
 	assert.Contains(t, s, `"id":"p1"`)
 }
 
-func TestResolvedPlans_TabularRowPerPlan(t *testing.T) {
+func TestPlanSummaries_TabularRowPerPlan(t *testing.T) {
 	t.Parallel()
 
-	plans := models.ResolvedPlans{
-		{Key: "scylla-2026.2#1", Name: "A", Owner: "alice"},
+	plans := models.PlanSummaries{
+		{Key: "scylla-2026.2#1", Name: "A", Owner: "alice", Tests: 3, Groups: 1, Participants: 2},
 		{Key: "scylla-2026.2#2", Name: "B", Owner: "bob"},
 	}
-	assert.Equal(t, models.ResolvedPlan{}.Headers(), plans.Headers())
+	assert.Equal(t, models.PlanSummary{}.Headers(), plans.Headers())
 
 	rows := plans.Rows()
 	require.Len(t, rows, 2)
+	assert.Len(t, rows[0], len(plans.Headers()), "row width must match header count")
 	assert.Equal(t, "scylla-2026.2#1", rows[0][0])
 	assert.Equal(t, "alice", rows[0][5])
+	assert.Equal(t, []string{"3", "1", "2"}, rows[0][6:9], "counts rendered as integers")
 	assert.Equal(t, "scylla-2026.2#2", rows[1][0])
 	assert.Equal(t, "bob", rows[1][5])
+}
+
+func TestPlanSummary_JSONMatchesColumns(t *testing.T) {
+	t.Parallel()
+
+	// JSON output must carry exactly the text-table columns, counts as integers.
+	raw, err := json.Marshal(models.PlanSummary{
+		Key: "scylla-2026.2#1", Name: "A", Release: "scylla-2026.2", Owner: "alice",
+		Tests: 3, Groups: 1, Participants: 2,
+	})
+	require.NoError(t, err)
+
+	var fields map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &fields))
+	keys := make([]string, 0, len(fields))
+	for k := range fields {
+		keys = append(keys, k)
+	}
+	assert.ElementsMatch(t, []string{
+		"key", "name", "description", "release", "target_version",
+		"owner", "tests", "groups", "participants", "last_updated",
+	}, keys)
+	assert.JSONEq(t, `3`, string(fields["tests"]))
+	assert.JSONEq(t, `1`, string(fields["groups"]))
+	assert.JSONEq(t, `2`, string(fields["participants"]))
 }

--- a/cli/internal/models/planner_test.go
+++ b/cli/internal/models/planner_test.go
@@ -358,3 +358,20 @@ func TestPlanSummary_JSONMatchesColumns(t *testing.T) {
 	assert.JSONEq(t, `1`, string(fields["groups"]))
 	assert.JSONEq(t, `2`, string(fields["participants"]))
 }
+
+func TestReleaseGrid_StringSortedOnePerLine(t *testing.T) {
+	t.Parallel()
+	grid := models.ReleaseGrid{
+		"tier2/b": "bsid-b",
+		"tier1/a": "bsid-a",
+	}
+	assert.Equal(t, "tier1/a: bsid-a\ntier2/b: bsid-b", grid.String())
+}
+
+func TestReleaseGrid_MarshalsAsPlainMap(t *testing.T) {
+	t.Parallel()
+	grid := models.ReleaseGrid{"tier1/a": "bsid-a"}
+	raw, err := json.Marshal(grid)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"tier1/a":"bsid-a"}`, string(raw))
+}

--- a/cli/internal/models/planner_test.go
+++ b/cli/internal/models/planner_test.go
@@ -183,30 +183,6 @@ func TestPlanUpdateSpec_OmitsUnsetFields(t *testing.T) {
 	}
 }
 
-func TestCopyCheckResponse_JSONRoundTrip(t *testing.T) {
-	t.Parallel()
-
-	const raw = `{
-		"status": "failed",
-		"targetRelease": {"id": "t-1", "name": "scylla-2026.2", "pretty_name": "2026.2", "enabled": true},
-		"originalRelease": {"id": "o-1", "name": "scylla-2026.1", "pretty_name": "2026.1", "enabled": true},
-		"missing": {
-			"tests": [{"id": "x", "name": "longevity-100gb", "build_system_id": "scylla-2026.1/longevity/longevity-100gb", "type": "test", "release": "scylla-2026.1", "enabled": true}],
-			"groups": []
-		}
-	}`
-
-	var resp models.CopyCheckResponse
-	require.NoError(t, json.Unmarshal([]byte(raw), &resp))
-
-	assert.Equal(t, "failed", resp.Status)
-	assert.Equal(t, "scylla-2026.2", resp.TargetRelease.Name)
-	assert.Equal(t, "scylla-2026.1", resp.OriginalRelease.Name)
-	require.Len(t, resp.Missing.Tests, 1)
-	assert.Equal(t, "scylla-2026.1/longevity/longevity-100gb", resp.Missing.Tests[0].BuildSystemID)
-	assert.Empty(t, resp.Missing.Groups)
-}
-
 func TestGridView_JSONRoundTrip(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/models/planner_test.go
+++ b/cli/internal/models/planner_test.go
@@ -137,8 +137,6 @@ func TestPlanUpdateSpec_FileSchemaParses(t *testing.T) {
 		"target_version": "2026.2.0~rc3",
 		"tests_add": ["scylla-2026.2/longevity/longevity-100gb", "tier1/longevity-200gb"],
 		"groups_remove": ["tier2"],
-		"participants_add": ["alice"],
-		"participants_remove": ["bob"],
 		"assignee_mapping_set": {"scylla-2026.2/longevity/longevity-100gb": "alice"},
 		"assignee_mapping_remove": ["tier1/longevity-200gb"]
 	}`
@@ -157,8 +155,6 @@ func TestPlanUpdateSpec_FileSchemaParses(t *testing.T) {
 
 	assert.Equal(t, []string{"scylla-2026.2/longevity/longevity-100gb", "tier1/longevity-200gb"}, spec.TestsAdd)
 	assert.Equal(t, []string{"tier2"}, spec.GroupsRemove)
-	assert.Equal(t, []string{"alice"}, spec.ParticipantsAdd)
-	assert.Equal(t, []string{"bob"}, spec.ParticipantsRemove)
 	assert.Equal(t, map[string]string{"scylla-2026.2/longevity/longevity-100gb": "alice"}, spec.AssigneeMappingSet)
 	assert.Equal(t, []string{"tier1/longevity-200gb"}, spec.AssigneeMappingRemove)
 }

--- a/cli/internal/models/planner_test.go
+++ b/cli/internal/models/planner_test.go
@@ -128,6 +128,61 @@ func TestPlanDiffRequest_ListAndMapDeltas(t *testing.T) {
 	assert.False(t, strings.Contains(s, `"tests_remove"`), "empty tests_remove must be omitted")
 }
 
+func TestPlanUpdateSpec_FileSchemaParses(t *testing.T) {
+	t.Parallel()
+
+	// The --file diff schema uses the wire field names but name-based values.
+	const raw = `{
+		"name": "2026.2 Longevity",
+		"target_version": "2026.2.0~rc3",
+		"tests_add": ["scylla-2026.2/longevity/longevity-100gb", "tier1/longevity-200gb"],
+		"groups_remove": ["tier2"],
+		"participants_add": ["alice"],
+		"participants_remove": ["bob"],
+		"assignee_mapping_set": {"scylla-2026.2/longevity/longevity-100gb": "alice"},
+		"assignee_mapping_remove": ["tier1/longevity-200gb"]
+	}`
+
+	var spec models.PlanUpdateSpec
+	require.NoError(t, json.Unmarshal([]byte(raw), &spec))
+
+	require.NotNil(t, spec.Name)
+	assert.Equal(t, "2026.2 Longevity", *spec.Name)
+	require.NotNil(t, spec.TargetVersion)
+	assert.Equal(t, "2026.2.0~rc3", *spec.TargetVersion)
+	// Unset scalars stay nil so they are never sent as "changes".
+	assert.Nil(t, spec.Description)
+	assert.Nil(t, spec.Owner)
+	assert.Nil(t, spec.Completed)
+
+	assert.Equal(t, []string{"scylla-2026.2/longevity/longevity-100gb", "tier1/longevity-200gb"}, spec.TestsAdd)
+	assert.Equal(t, []string{"tier2"}, spec.GroupsRemove)
+	assert.Equal(t, []string{"alice"}, spec.ParticipantsAdd)
+	assert.Equal(t, []string{"bob"}, spec.ParticipantsRemove)
+	assert.Equal(t, map[string]string{"scylla-2026.2/longevity/longevity-100gb": "alice"}, spec.AssigneeMappingSet)
+	assert.Equal(t, []string{"tier1/longevity-200gb"}, spec.AssigneeMappingRemove)
+}
+
+func TestPlanUpdateSpec_OmitsUnsetFields(t *testing.T) {
+	t.Parallel()
+
+	name := "renamed"
+	spec := models.PlanUpdateSpec{Name: &name}
+	raw, err := json.Marshal(spec)
+	require.NoError(t, err)
+	s := string(raw)
+
+	assert.Contains(t, s, `"name":"renamed"`)
+	for _, key := range []string{
+		"description", "owner", "target_version", "completed",
+		"tests_add", "tests_remove", "groups_add", "groups_remove",
+		"participants_add", "participants_remove",
+		"assignee_mapping_set", "assignee_mapping_remove",
+	} {
+		assert.NotContainsf(t, s, `"`+key+`"`, "unset field %q must be omitted", key)
+	}
+}
+
 func TestCopyCheckResponse_JSONRoundTrip(t *testing.T) {
 	t.Parallel()
 

--- a/cli/internal/services/planner.go
+++ b/cli/internal/services/planner.go
@@ -590,9 +590,14 @@ func (s *PlannerService) resolveAssignmentTargets(ctx context.Context, entityRef
 	if !errors.Is(err, ErrEntityNotFound) {
 		return nil, err
 	}
-	// Not a test — try a group and fan out to its enabled tests.
+	// Not a test — try a group and fan out to its enabled tests. An ambiguous
+	// group name must abort (so the user disambiguates); only a genuine miss is
+	// reported as "not a test or group".
 	ids, gerr := s.ExpandGroup(ctx, releaseID, entityRef)
 	if gerr != nil {
+		if errors.Is(gerr, ErrAmbiguousEntity) {
+			return nil, gerr
+		}
 		return nil, fmt.Errorf("%q is not a test or group in release: %w", entityRef, ErrEntityNotFound)
 	}
 	return ids, nil
@@ -773,25 +778,11 @@ func (s *PlannerService) BuildResolvedPlan(ctx context.Context, plan models.Rele
 	}, nil
 }
 
-// BuildResolvedPlans resolves a slice of plans into their human-readable form.
-// Plans of the same release share the memoised gridview and users list, so a
-// whole release's plan list resolves with at most one fetch of each.
-func (s *PlannerService) BuildResolvedPlans(ctx context.Context, plans models.ReleasePlanList) ([]models.ResolvedPlan, error) {
-	resolved := make([]models.ResolvedPlan, 0, len(plans))
-	for _, p := range plans {
-		rp, err := s.BuildResolvedPlan(ctx, p)
-		if err != nil {
-			return nil, err
-		}
-		resolved = append(resolved, rp)
-	}
-	return resolved, nil
-}
-
 // BuildPlanSummaries resolves a slice of plans into the per-plan list view
 // ([models.PlanSummary]): release/owner names come from the resolved plan,
 // while tests/groups/participants are reported as counts taken from the source
-// plan. Shares the same single-fetch resolution as [BuildResolvedPlans].
+// plan. Plans of the same release share the memoised gridview and users list,
+// so a whole release's plan list resolves with at most one fetch of each.
 func (s *PlannerService) BuildPlanSummaries(ctx context.Context, plans models.ReleasePlanList) ([]models.PlanSummary, error) {
 	summaries := make([]models.PlanSummary, 0, len(plans))
 	for _, p := range plans {
@@ -849,6 +840,10 @@ func (s *PlannerService) UpdatePlan(ctx context.Context, req models.PlanDiffRequ
 //   - AssigneeMappingSet resolves the username value and the entity key (a test,
 //     or a group fanned out to each enabled test); AssigneeMappingRemove resolves
 //     each entity reference (group references fan out) to the UUIDs to drop.
+//   - Assignments (the template-style map) is applied as a merge/patch: each
+//     keyed test/group is added to the plan when missing and (re)assigned, or
+//     unassigned when the value is "$owner". A reference matching nothing is
+//     reported and skipped; tests not mentioned are left untouched.
 func (s *PlannerService) BuildUpdateRequest(ctx context.Context, plan models.ReleasePlan, spec models.PlanUpdateSpec) (models.PlanDiffRequest, []string, error) {
 	releaseID := plan.ReleaseID
 	diff := models.PlanDiffRequest{ID: plan.ID}
@@ -889,9 +884,6 @@ func (s *PlannerService) BuildUpdateRequest(ctx context.Context, plan models.Rel
 		for _, id := range ids {
 			addTests.add(id)
 		}
-	}
-	if len(addTests.items) > 0 {
-		diff.TestsAdd = addTests.items
 	}
 
 	removeTests := newOrderedSet()
@@ -950,7 +942,6 @@ func (s *PlannerService) BuildUpdateRequest(ctx context.Context, plan models.Rel
 			assignSet[id] = userID
 		}
 	}
-	diff.AssigneeMappingSet = assignSet
 
 	// Assignment removal: resolve each entity (group fans out) to its UUIDs.
 	for _, entityRef := range spec.AssigneeMappingRemove {
@@ -961,6 +952,44 @@ func (s *PlannerService) BuildUpdateRequest(ctx context.Context, plan models.Rel
 		for _, id := range ids {
 			assignRemove.add(id)
 		}
+	}
+
+	// Template-style assignments (merge/patch): each keyed test/group is ensured
+	// to be in the plan and (re)assigned, or unassigned on "$owner". A reference
+	// matching nothing is reported and skipped; an ambiguous one aborts.
+	for entityRef, userRef := range spec.Assignments {
+		ids, err := s.resolveAssignmentTargets(ctx, entityRef, releaseID)
+		if err != nil {
+			if errors.Is(err, ErrEntityNotFound) {
+				warnings = append(warnings, fmt.Sprintf("assignment target %q is not in this release — skipped", entityRef))
+				continue
+			}
+			return models.PlanDiffRequest{}, nil, err
+		}
+		for _, id := range ids {
+			addTests.add(id) // membership follows assignment
+		}
+		if userRef == models.OwnerMarker {
+			for _, id := range ids {
+				assignRemove.add(id)
+			}
+			continue
+		}
+		userID, err := s.ResolveUserID(ctx, userRef)
+		if err != nil {
+			return models.PlanDiffRequest{}, nil, fmt.Errorf("assignee %q: %w", userRef, err)
+		}
+		for _, id := range ids {
+			if assignSet == nil {
+				assignSet = map[string]string{}
+			}
+			assignSet[id] = userID
+		}
+	}
+	diff.AssigneeMappingSet = assignSet
+
+	if len(addTests.items) > 0 {
+		diff.TestsAdd = addTests.items
 	}
 	if len(assignRemove.items) > 0 {
 		diff.AssigneeMappingRemove = assignRemove.items
@@ -974,7 +1003,7 @@ func (s *PlannerService) BuildUpdateRequest(ctx context.Context, plan models.Rel
 		ownerID = *diff.Owner
 	}
 	diff.ParticipantsAdd, diff.ParticipantsRemove = participantDeltas(
-		plan, addTests, removeTests, removeGroups, assignSet, assignRemove, ownerID)
+		plan, removeTests, removeGroups, assignSet, assignRemove, ownerID)
 
 	// A plan must keep at least one test; refuse an edit that would empty it.
 	if planLeftEmpty(plan, addTests, removeTests) {
@@ -988,7 +1017,7 @@ func (s *PlannerService) BuildUpdateRequest(ctx context.Context, plan models.Rel
 // equal the resulting assignees minus the owner. assignSet entries are added,
 // assignRemove entries are dropped, and entries on removed tests/groups are
 // dropped too (mirroring the backend's mapping cleanup).
-func participantDeltas(plan models.ReleasePlan, addTests, removeTests, removeGroups *orderedSet, assignSet map[string]string, assignRemove *orderedSet, ownerID string) (add, remove []string) {
+func participantDeltas(plan models.ReleasePlan, removeTests, removeGroups *orderedSet, assignSet map[string]string, assignRemove *orderedSet, ownerID string) (add, remove []string) {
 	removed := map[string]bool{}
 	for _, id := range removeTests.items {
 		removed[id] = true
@@ -1022,11 +1051,6 @@ func participantDeltas(plan models.ReleasePlan, addTests, removeTests, removeGro
 	}
 
 	addSet := newOrderedSet()
-	for _, t := range addTests.items {
-		if user, ok := final[t]; ok && user != ownerID && !current[user] {
-			addSet.add(user)
-		}
-	}
 	for user := range desired {
 		if !current[user] {
 			addSet.add(user)

--- a/cli/internal/services/planner.go
+++ b/cli/internal/services/planner.go
@@ -323,9 +323,10 @@ func (s *PlannerService) GetReleaseOverview(ctx context.Context, releaseID strin
 // ResolveEntityID resolves a test or group reference (by name or
 // build_system_id) to its UUID within a release, using a single gridview fetch.
 //
-// Groups match by name (unique within a release). Tests resolve in priority
-// order: (1) exact build_system_id, (2) group-qualified "group/test",
-// (3) bare name (rejected when ambiguous, with a candidate list).
+// Groups match by name, pretty name, or build_system_id (unique within a
+// release). Tests resolve in priority order: (1) exact build_system_id,
+// (2) group-qualified "group/test", (3) bare name (rejected when ambiguous,
+// with a candidate list).
 func (s *PlannerService) ResolveEntityID(ctx context.Context, ref, releaseID string, kind EntityKind) (string, error) {
 	grid, err := s.GetReleaseStructure(ctx, releaseID)
 	if err != nil {
@@ -365,12 +366,14 @@ func (s *PlannerService) ExpandGroup(ctx context.Context, releaseID, groupRef st
 	return ids, nil
 }
 
-// findGroup locates a group in the gridview by name (then pretty name),
-// case-insensitively.
+// findGroup locates a group in the gridview by name, pretty name, or
+// build_system_id (its fully-qualified "release/group" path), case-insensitively.
 func findGroup(grid models.GridView, ref string) (models.GridEntity, error) {
 	var matches []models.GridEntity
 	for _, g := range grid.Groups {
-		if strings.EqualFold(g.Name, ref) || strings.EqualFold(g.PrettyName, ref) {
+		if strings.EqualFold(g.Name, ref) ||
+			strings.EqualFold(g.PrettyName, ref) ||
+			strings.EqualFold(g.BuildSystemID, ref) {
 			matches = append(matches, g)
 		}
 	}
@@ -397,7 +400,9 @@ func resolveTest(grid models.GridView, ref string) (string, error) {
 	// (2) group-qualified "group/test".
 	if idx := strings.LastIndex(ref, "/"); idx != -1 {
 		groupPart, testName := ref[:idx], ref[idx+1:]
-		if g, err := findGroup(grid, groupPart); err == nil {
+		g, err := findGroup(grid, groupPart)
+		switch {
+		case err == nil:
 			var matches []string
 			for id, t := range grid.Tests {
 				if t.GroupID == g.ID && strings.EqualFold(t.Name, testName) {
@@ -411,6 +416,13 @@ func resolveTest(grid models.GridView, ref string) (string, error) {
 				return "", fmt.Errorf("%w: ambiguous test %q within group %q (%d matches)", ErrAmbiguousEntity, testName, groupPart, len(matches))
 			}
 			return "", fmt.Errorf("%w: no test %q in group %q", ErrEntityNotFound, testName, groupPart)
+		case errors.Is(err, ErrEntityNotFound):
+			// The prefix isn't a known group; fall through to bare-name
+			// resolution (the ref may be a plain name that contains a slash).
+		default:
+			// Ambiguous group prefix (or other error): surface it so callers
+			// abort for disambiguation instead of misreporting "test not found".
+			return "", err
 		}
 	}
 
@@ -516,12 +528,10 @@ func (s *PlannerService) BuildCreateRequest(ctx context.Context, tmpl models.Pla
 
 	// Assignments are the single source of plan membership. Each entry's
 	// targets join the tests list; a specific assignee also enters the
-	// assignee mapping and becomes a participant. "$owner" leaves the test
-	// unassigned (in tests only). Missing entity → warn and omit; bad user
-	// → abort.
+	// assignee mapping. "$owner" leaves the test unassigned (in tests only).
+	// Missing entity → warn and omit; bad user → abort.
 	tests := newOrderedSet()
 	assignments := map[string]string{}
-	participants := newOrderedSet()
 	var missing []string
 	for entityRef, userRef := range tmpl.Assignments {
 		ids, err := s.resolveAssignmentTargets(ctx, entityRef, releaseID)
@@ -549,10 +559,24 @@ func (s *PlannerService) BuildCreateRequest(ctx context.Context, tmpl models.Pla
 			tests.add(id)
 			assignments[id] = userID
 		}
+	}
+
+	// Participants are derived from the settled assignment map (assignees minus
+	// the owner), not accumulated per-entry: when overlapping group/test entries
+	// contend for a test, only the user who actually holds an assignment counts,
+	// so a race loser is never left as a phantom participant. Sorted for a
+	// deterministic payload.
+	participantSet := map[string]bool{}
+	for _, userID := range assignments {
 		if userID != ownerID {
-			participants.add(userID)
+			participantSet[userID] = true
 		}
 	}
+	participants := make([]string, 0, len(participantSet))
+	for userID := range participantSet {
+		participants = append(participants, userID)
+	}
+	sort.Strings(participants)
 
 	// A plan must contain at least one test/group; refuse to create an empty
 	// plan and list what could not be resolved (one per line).
@@ -570,7 +594,7 @@ func (s *PlannerService) BuildCreateRequest(ctx context.Context, tmpl models.Pla
 		Name:          tmpl.Name,
 		Description:   tmpl.Description,
 		Owner:         ownerID,
-		Participants:  nonNilSlice(participants.items),
+		Participants:  nonNilSlice(participants),
 		TargetVersion: tmpl.TargetVersion,
 		ReleaseID:     releaseID,
 		Tests:         nonNilSlice(tests.items),
@@ -836,14 +860,17 @@ func (s *PlannerService) UpdatePlan(ctx context.Context, req models.PlanDiffRequ
 //   - GroupsAdd is always expanded to the group's enabled tests (merged into
 //     tests_add); no groups_add is ever sent. GroupsRemove resolves to a group
 //     UUID and is sent as groups_remove (for groups still stored on the plan).
+//     As with tests, a group name matching nothing warns and is skipped while an
+//     ambiguous name aborts.
 //   - Participants resolve by username.
-//   - AssigneeMappingSet resolves the username value and the entity key (a test,
-//     or a group fanned out to each enabled test); AssigneeMappingRemove resolves
-//     each entity reference (group references fan out) to the UUIDs to drop.
-//   - Assignments (the template-style map) is applied as a merge/patch: each
-//     keyed test/group is added to the plan when missing and (re)assigned, or
-//     unassigned when the value is "$owner". A reference matching nothing is
-//     reported and skipped; tests not mentioned are left untouched.
+//   - AssigneeMappingSet (from --assign) and Assignments (the template-style
+//     map) share merge/patch semantics: each keyed test/group is added to the
+//     plan when missing (membership follows assignment) and (re)assigned, or
+//     unassigned when the value is "$owner". A reference matching nothing in the
+//     release is reported and skipped; an ambiguous one aborts. Groups fan out
+//     to each enabled test. AssigneeMappingRemove (from --unassign) clears an
+//     assignee — resolving each entity reference (groups fan out) — without
+//     adding membership; tests not mentioned are left untouched.
 func (s *PlannerService) BuildUpdateRequest(ctx context.Context, plan models.ReleasePlan, spec models.PlanUpdateSpec) (models.PlanDiffRequest, []string, error) {
 	releaseID := plan.ReleaseID
 	diff := models.PlanDiffRequest{ID: plan.ID}
@@ -876,9 +903,14 @@ func (s *PlannerService) BuildUpdateRequest(ctx context.Context, plan models.Rel
 		addTests.add(id)
 	}
 	// Groups added are always expanded to their enabled tests (no groups_add).
+	// A missing group name warns and is skipped (like tests); ambiguous aborts.
 	for _, g := range spec.GroupsAdd {
 		ids, err := s.ExpandGroup(ctx, releaseID, g)
 		if err != nil {
+			if errors.Is(err, ErrEntityNotFound) {
+				warnings = append(warnings, fmt.Sprintf("group %q to add is not in this release — skipped", g))
+				continue
+			}
 			return models.PlanDiffRequest{}, nil, err
 		}
 		for _, id := range ids {
@@ -903,10 +935,15 @@ func (s *PlannerService) BuildUpdateRequest(ctx context.Context, plan models.Rel
 	}
 
 	// Group removals target groups still stored on the plan (e.g. web-created).
+	// A missing group name warns and is skipped (like tests); ambiguous aborts.
 	removeGroups := newOrderedSet()
 	for _, g := range spec.GroupsRemove {
 		id, err := s.ResolveEntityID(ctx, g, releaseID, KindGroup)
 		if err != nil {
+			if errors.Is(err, ErrEntityNotFound) {
+				warnings = append(warnings, fmt.Sprintf("group %q to remove is not in this release — skipped", g))
+				continue
+			}
 			return models.PlanDiffRequest{}, nil, err
 		}
 		removeGroups.add(id)
@@ -915,35 +952,55 @@ func (s *PlannerService) BuildUpdateRequest(ctx context.Context, plan models.Rel
 		diff.GroupsRemove = removeGroups.items
 	}
 
-	// Assignment set: resolve user, then entity (group fans out to its tests).
-	// A "$owner" value clears the assignee (test stays) by routing the targets
-	// to the removal set instead of the mapping.
+	// Assignment application. The raw --assign / assignee_mapping_set map and the
+	// template-style assignments map share identical merge/patch semantics: each
+	// keyed test/group joins the plan (membership follows assignment) and is
+	// (re)assigned, or is cleared — keeping the test — when the value is "$owner".
+	// Membership is ensured so the backend, which drops mapping entries for tests
+	// not in plan.tests, keeps the assignment instead of silently discarding it.
+	// A reference matching nothing in the release is reported and skipped; an
+	// ambiguous one aborts so the user can disambiguate.
 	var assignSet map[string]string
 	assignRemove := newOrderedSet()
-	for entityRef, userRef := range spec.AssigneeMappingSet {
-		ids, err := s.resolveAssignmentTargets(ctx, entityRef, releaseID)
-		if err != nil {
-			return models.PlanDiffRequest{}, nil, err
-		}
-		if userRef == models.OwnerMarker {
+	applyAssignments := func(m map[string]string) error {
+		for entityRef, userRef := range m {
+			ids, err := s.resolveAssignmentTargets(ctx, entityRef, releaseID)
+			if err != nil {
+				if errors.Is(err, ErrEntityNotFound) {
+					warnings = append(warnings, fmt.Sprintf("assignment target %q is not in this release — skipped", entityRef))
+					continue
+				}
+				return err
+			}
 			for _, id := range ids {
-				assignRemove.add(id)
+				addTests.add(id) // membership follows assignment
 			}
-			continue
-		}
-		userID, err := s.ResolveUserID(ctx, userRef)
-		if err != nil {
-			return models.PlanDiffRequest{}, nil, fmt.Errorf("assignee %q: %w", userRef, err)
-		}
-		for _, id := range ids {
-			if assignSet == nil {
-				assignSet = map[string]string{}
+			if userRef == models.OwnerMarker {
+				for _, id := range ids {
+					assignRemove.add(id)
+				}
+				continue
 			}
-			assignSet[id] = userID
+			userID, err := s.ResolveUserID(ctx, userRef)
+			if err != nil {
+				return fmt.Errorf("assignee %q: %w", userRef, err)
+			}
+			for _, id := range ids {
+				if assignSet == nil {
+					assignSet = map[string]string{}
+				}
+				assignSet[id] = userID
+			}
 		}
+		return nil
+	}
+	if err := applyAssignments(spec.AssigneeMappingSet); err != nil {
+		return models.PlanDiffRequest{}, nil, err
 	}
 
-	// Assignment removal: resolve each entity (group fans out) to its UUIDs.
+	// Assignment removal (--unassign): resolve each entity (group fans out) to
+	// its UUIDs and clear the assignee, keeping the test in the plan. Unlike
+	// --assign this never adds membership — it only clears an existing mapping.
 	for _, entityRef := range spec.AssigneeMappingRemove {
 		ids, err := s.resolveAssignmentTargets(ctx, entityRef, releaseID)
 		if err != nil {
@@ -954,37 +1011,8 @@ func (s *PlannerService) BuildUpdateRequest(ctx context.Context, plan models.Rel
 		}
 	}
 
-	// Template-style assignments (merge/patch): each keyed test/group is ensured
-	// to be in the plan and (re)assigned, or unassigned on "$owner". A reference
-	// matching nothing is reported and skipped; an ambiguous one aborts.
-	for entityRef, userRef := range spec.Assignments {
-		ids, err := s.resolveAssignmentTargets(ctx, entityRef, releaseID)
-		if err != nil {
-			if errors.Is(err, ErrEntityNotFound) {
-				warnings = append(warnings, fmt.Sprintf("assignment target %q is not in this release — skipped", entityRef))
-				continue
-			}
-			return models.PlanDiffRequest{}, nil, err
-		}
-		for _, id := range ids {
-			addTests.add(id) // membership follows assignment
-		}
-		if userRef == models.OwnerMarker {
-			for _, id := range ids {
-				assignRemove.add(id)
-			}
-			continue
-		}
-		userID, err := s.ResolveUserID(ctx, userRef)
-		if err != nil {
-			return models.PlanDiffRequest{}, nil, fmt.Errorf("assignee %q: %w", userRef, err)
-		}
-		for _, id := range ids {
-			if assignSet == nil {
-				assignSet = map[string]string{}
-			}
-			assignSet[id] = userID
-		}
+	if err := applyAssignments(spec.Assignments); err != nil {
+		return models.PlanDiffRequest{}, nil, err
 	}
 	diff.AssigneeMappingSet = assignSet
 
@@ -1005,9 +1033,9 @@ func (s *PlannerService) BuildUpdateRequest(ctx context.Context, plan models.Rel
 	diff.ParticipantsAdd, diff.ParticipantsRemove = participantDeltas(
 		plan, removeTests, removeGroups, assignSet, assignRemove, ownerID)
 
-	// A plan must keep at least one test; refuse an edit that would empty it.
-	if planLeftEmpty(plan, addTests, removeTests) {
-		return models.PlanDiffRequest{}, warnings, fmt.Errorf("update would remove the plan's last test; a plan must include at least one test")
+	// A plan must keep at least one test or group; refuse an edit that empties it.
+	if planLeftEmpty(plan, addTests, removeTests, removeGroups) {
+		return models.PlanDiffRequest{}, warnings, fmt.Errorf("update would remove the plan's last test or group; a plan must include at least one test")
 	}
 
 	return diff, warnings, nil
@@ -1064,11 +1092,14 @@ func participantDeltas(plan models.ReleasePlan, removeTests, removeGroups *order
 	return addSet.items, remove
 }
 
-// planLeftEmpty reports whether applying the test add/remove deltas would empty
-// a plan that currently has tests. A plan that started empty is left alone (it
-// is up to add deltas to populate it).
-func planLeftEmpty(plan models.ReleasePlan, addTests, removeTests *orderedSet) bool {
-	if len(plan.Tests) == 0 {
+// planLeftEmpty reports whether applying the deltas would leave a plan with no
+// membership at all. Membership is tests plus groups: tests shrink via
+// removeTests and grow via addTests, while groups only shrink via removeGroups
+// (the CLI always fans groups out to tests, so no groups are ever added). A
+// plan that started empty of both is left alone — it is up to the add deltas to
+// populate it.
+func planLeftEmpty(plan models.ReleasePlan, addTests, removeTests, removeGroups *orderedSet) bool {
+	if len(plan.Tests) == 0 && len(plan.Groups) == 0 {
 		return false
 	}
 	remaining := map[string]bool{}
@@ -1081,7 +1112,14 @@ func planLeftEmpty(plan models.ReleasePlan, addTests, removeTests *orderedSet) b
 	for _, t := range addTests.items {
 		remaining[t] = true
 	}
-	return len(remaining) == 0
+	groups := map[string]bool{}
+	for _, g := range plan.Groups {
+		groups[g] = true
+	}
+	for _, g := range removeGroups.items {
+		delete(groups, g)
+	}
+	return len(remaining) == 0 && len(groups) == 0
 }
 
 // resolveTestForDiff resolves a single test reference for an add/remove delta.

--- a/cli/internal/services/planner.go
+++ b/cli/internal/services/planner.go
@@ -418,12 +418,22 @@ func resolveTest(grid models.GridView, ref string) (string, error) {
 }
 
 // formatTestCandidates renders ambiguous test matches as an indented list of
-// build_system_id, group, and UUID so the user can pick an unambiguous ref.
+// build_system_id and group so the user can pick an unambiguous reference.
 func formatTestCandidates(matches []models.GridEntity) string {
 	sort.Slice(matches, func(i, j int) bool { return matches[i].BuildSystemID < matches[j].BuildSystemID })
 	var b strings.Builder
 	for _, t := range matches {
-		fmt.Fprintf(&b, "  - %s (group: %s, id: %s)\n", t.BuildSystemID, t.Group, t.ID)
+		fmt.Fprintf(&b, "  - %s (group: %s)\n", t.BuildSystemID, t.Group)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// formatBullets renders refs as an indented one-per-line bullet list for
+// multi-entity error messages.
+func formatBullets(refs []string) string {
+	var b strings.Builder
+	for _, r := range refs {
+		fmt.Fprintf(&b, "  - %s\n", r)
 	}
 	return strings.TrimRight(b.String(), "\n")
 }
@@ -530,13 +540,13 @@ func (s *PlannerService) BuildCreateRequest(ctx context.Context, tmpl models.Pla
 	}
 
 	// A plan must contain at least one test/group; refuse to create an empty
-	// plan and list what could not be resolved.
+	// plan and list what could not be resolved (one per line).
 	if len(tests.items) == 0 {
 		sort.Strings(missing)
 		if len(missing) > 0 {
 			return models.CreatePlanRequest{}, warnings, fmt.Errorf(
-				"no tests resolved in release %q; none of the assigned entities exist there: %s",
-				tmpl.Release, strings.Join(missing, ", "))
+				"no tests resolved in release %q; none of the assigned entities exist there:\n%s",
+				tmpl.Release, formatBullets(missing))
 		}
 		return models.CreatePlanRequest{}, warnings, fmt.Errorf("a plan must include at least one test or group")
 	}

--- a/cli/internal/services/planner.go
+++ b/cli/internal/services/planner.go
@@ -305,6 +305,21 @@ func (s *PlannerService) GetReleaseStructure(ctx context.Context, releaseID stri
 	return gv, nil
 }
 
+// GetReleaseOverview fetches the release gridview and returns a
+// [models.ReleaseGrid] mapping each enabled test's group-qualified "group/test"
+// reference to its build_system_id, for an at-a-glance overview of a release.
+func (s *PlannerService) GetReleaseOverview(ctx context.Context, releaseID string) (models.ReleaseGrid, error) {
+	grid, err := s.GetReleaseStructure(ctx, releaseID)
+	if err != nil {
+		return nil, err
+	}
+	overview := make(models.ReleaseGrid, len(grid.Tests))
+	for _, t := range grid.Tests {
+		overview[t.Group+"/"+t.Name] = t.BuildSystemID
+	}
+	return overview, nil
+}
+
 // ResolveEntityID resolves a test or group reference (by name or
 // build_system_id) to its UUID within a release, using a single gridview fetch.
 //

--- a/cli/internal/services/planner.go
+++ b/cli/internal/services/planner.go
@@ -454,7 +454,7 @@ func formatBullets(refs []string) string {
 }
 
 // ---------------------------------------------------------------------------
-// Create-from-template (BuildCreateRequest) and the get --template transform
+// Create-from-template (BuildCreateRequest) and the get template transform
 // ---------------------------------------------------------------------------
 
 // orderedSet collects strings preserving first-insertion order while skipping
@@ -603,7 +603,7 @@ func (s *PlannerService) resolveAssignmentTargets(ctx context.Context, entityRef
 // source: every test is keyed by its group-qualified "group/test" name and
 // valued by the assignee username, or by [models.OwnerMarker] ("$owner") when
 // the test is in the plan but has no specific assignee. It is the data behind
-// `planner get --template`.
+// the default `planner get` output.
 //
 // Names are back-resolved from the plan's own release gridview and the users
 // list. Tests no longer present in that gridview (e.g. since disabled) cannot
@@ -697,7 +697,8 @@ func (s *PlannerService) releaseNameByID(ctx context.Context, releaseID string) 
 // targets as group-qualified "group/test" strings, and groups as names, while
 // keeping the plan's identity and status fields.
 //
-// It is the data behind the default `planner get`/`list` output. Unlike
+// It is the data behind `planner get --resolved` and the default `list`
+// output. Unlike
 // [PlannerService.BuildTemplate] it is lossless: any reference that cannot be
 // resolved (a user not in the users list, or a test/group not in the release
 // gridview) falls back to its raw UUID rather than being dropped, and an

--- a/cli/internal/services/planner.go
+++ b/cli/internal/services/planner.go
@@ -450,6 +450,16 @@ func (o *orderedSet) add(v string) {
 	o.items = append(o.items, v)
 }
 
+// nonNilSlice returns an empty (non-nil) slice when s is nil, so JSON encodes
+// it as [] rather than null. The backend iterates these lists and rejects a
+// null (TypeError: 'NoneType' object is not iterable).
+func nonNilSlice(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
+}
+
 // BuildCreateRequest turns a name-based [models.PlanTemplate] (plus any extra
 // group references from --group) into a fully UUID-resolved
 // [models.CreatePlanRequest]. Every name is resolved client-side against the
@@ -460,7 +470,7 @@ func (o *orderedSet) add(v string) {
 // key is a group fans out to each of that group's enabled tests. Tests that do
 // not exist in the target release are returned as warnings and omitted; an
 // ambiguous reference instead aborts with an error so the user can disambiguate.
-func (s *PlannerService) BuildCreateRequest(ctx context.Context, tmpl models.PlanTemplate, groupRefs []string) (models.CreatePlanRequest, []string, error) {
+func (s *PlannerService) BuildCreateRequest(ctx context.Context, tmpl models.PlanTemplate) (models.CreatePlanRequest, []string, error) {
 	var warnings []string
 
 	if tmpl.Release == "" {
@@ -479,68 +489,66 @@ func (s *PlannerService) BuildCreateRequest(ctx context.Context, tmpl models.Pla
 		return models.CreatePlanRequest{}, nil, err
 	}
 
-	participants := make([]string, 0, len(tmpl.Participants))
-	for _, p := range tmpl.Participants {
-		id, err := s.ResolveUserID(ctx, p)
-		if err != nil {
-			return models.CreatePlanRequest{}, nil, fmt.Errorf("participant %q: %w", p, err)
-		}
-		participants = append(participants, id)
-	}
-
-	tests := newOrderedSet()
-
-	// Explicit tests: missing in the target release → warn and omit; ambiguous
+	// Assignments are the single source of plan membership. Each entry's
+	// targets join the tests list; a specific assignee also enters the
+	// assignee mapping and becomes a participant. "$owner" leaves the test
+	// unassigned (in tests only). Missing entity → warn and omit; bad user
 	// → abort.
-	for _, ref := range tmpl.Tests {
-		id, err := s.ResolveEntityID(ctx, ref, releaseID, KindTest)
+	tests := newOrderedSet()
+	assignments := map[string]string{}
+	participants := newOrderedSet()
+	var missing []string
+	for entityRef, userRef := range tmpl.Assignments {
+		ids, err := s.resolveAssignmentTargets(ctx, entityRef, releaseID)
 		if err != nil {
 			if errors.Is(err, ErrEntityNotFound) {
-				warnings = append(warnings, fmt.Sprintf("test %q is not in release %q — omitted", ref, tmpl.Release))
+				missing = append(missing, entityRef)
+				warnings = append(warnings, fmt.Sprintf("test %q is not in release %q — omitted", entityRef, tmpl.Release))
 				continue
 			}
 			return models.CreatePlanRequest{}, nil, err
 		}
-		tests.add(id)
-	}
 
-	// Extra groups (--group): always expanded to enabled tests.
-	for _, g := range groupRefs {
-		ids, err := s.ExpandGroup(ctx, releaseID, g)
-		if err != nil {
-			return models.CreatePlanRequest{}, nil, err
+		if userRef == models.OwnerMarker {
+			for _, id := range ids {
+				tests.add(id)
+			}
+			continue
 		}
-		for _, id := range ids {
-			tests.add(id)
-		}
-	}
 
-	// Assignments: resolve the user, then the entity (test, else group → fan
-	// out to each enabled test). Entities also join the tests list.
-	assignments := map[string]string{}
-	for entityRef, userRef := range tmpl.Assignments {
 		userID, err := s.ResolveUserID(ctx, userRef)
 		if err != nil {
 			return models.CreatePlanRequest{}, nil, fmt.Errorf("assignee %q: %w", userRef, err)
 		}
-		ids, err := s.resolveAssignmentTargets(ctx, entityRef, releaseID)
-		if err != nil {
-			return models.CreatePlanRequest{}, nil, err
-		}
 		for _, id := range ids {
-			assignments[id] = userID
 			tests.add(id)
+			assignments[id] = userID
 		}
+		if userID != ownerID {
+			participants.add(userID)
+		}
+	}
+
+	// A plan must contain at least one test/group; refuse to create an empty
+	// plan and list what could not be resolved.
+	if len(tests.items) == 0 {
+		sort.Strings(missing)
+		if len(missing) > 0 {
+			return models.CreatePlanRequest{}, warnings, fmt.Errorf(
+				"no tests resolved in release %q; none of the assigned entities exist there: %s",
+				tmpl.Release, strings.Join(missing, ", "))
+		}
+		return models.CreatePlanRequest{}, warnings, fmt.Errorf("a plan must include at least one test or group")
 	}
 
 	return models.CreatePlanRequest{
 		Name:          tmpl.Name,
 		Description:   tmpl.Description,
 		Owner:         ownerID,
-		Participants:  participants,
+		Participants:  nonNilSlice(participants.items),
 		TargetVersion: tmpl.TargetVersion,
 		ReleaseID:     releaseID,
-		Tests:         tests.items,
+		Tests:         nonNilSlice(tests.items),
 		Groups:        []string{},
 		Assignments:   assignments,
 	}, warnings, nil
@@ -560,15 +568,17 @@ func (s *PlannerService) resolveAssignmentTargets(ctx context.Context, entityRef
 	// Not a test — try a group and fan out to its enabled tests.
 	ids, gerr := s.ExpandGroup(ctx, releaseID, entityRef)
 	if gerr != nil {
-		return nil, fmt.Errorf("assignment target %q is not a test or group in release", entityRef)
+		return nil, fmt.Errorf("%q is not a test or group in release: %w", entityRef, ErrEntityNotFound)
 	}
 	return ids, nil
 }
 
 // BuildTemplate converts a stored plan (UUID-based) into a release-independent,
-// human-readable [models.PlanTemplate]: release/owner/participant names, tests
-// as group-qualified "group/test" strings, and assignments keyed by the same.
-// It is the data behind `planner get --template`.
+// human-readable [models.PlanTemplate]. Assignments is the single membership
+// source: every test is keyed by its group-qualified "group/test" name and
+// valued by the assignee username, or by [models.OwnerMarker] ("$owner") when
+// the test is in the plan but has no specific assignee. It is the data behind
+// `planner get --template`.
 //
 // Names are back-resolved from the plan's own release gridview and the users
 // list. Tests no longer present in that gridview (e.g. since disabled) cannot
@@ -587,21 +597,9 @@ func (s *PlannerService) BuildTemplate(ctx context.Context, plan models.ReleaseP
 		return models.PlanTemplate{}, err
 	}
 
-	participants := make([]string, 0, len(plan.Participants))
-	for _, p := range plan.Participants {
-		if u, ok := users[p]; ok {
-			participants = append(participants, u.Username)
-		}
-	}
+	assignments := map[string]string{}
 
-	tests := make([]string, 0, len(plan.Tests))
-	for _, t := range plan.Tests {
-		if name, ok := entityQualifiedName(grid, t); ok {
-			tests = append(tests, name)
-		}
-	}
-
-	var assignments map[string]string
+	// Assigned tests carry their assignee username.
 	for entityID, userID := range plan.AssigneeMapping {
 		name, ok := entityQualifiedName(grid, entityID)
 		if !ok {
@@ -611,10 +609,18 @@ func (s *PlannerService) BuildTemplate(ctx context.Context, plan models.ReleaseP
 		if !ok {
 			continue
 		}
-		if assignments == nil {
-			assignments = map[string]string{}
-		}
 		assignments[name] = u.Username
+	}
+
+	// Remaining plan tests are unassigned: mark them "$owner".
+	for _, t := range plan.Tests {
+		name, ok := entityQualifiedName(grid, t)
+		if !ok {
+			continue
+		}
+		if _, exists := assignments[name]; !exists {
+			assignments[name] = models.OwnerMarker
+		}
 	}
 
 	tmpl := models.PlanTemplate{
@@ -622,14 +628,10 @@ func (s *PlannerService) BuildTemplate(ctx context.Context, plan models.ReleaseP
 		Description:   plan.Description,
 		Release:       releaseName,
 		TargetVersion: plan.TargetVersion,
-		Tests:         tests,
 		Assignments:   assignments,
 	}
 	if u, ok := users[plan.Owner]; ok {
 		tmpl.Owner = u.Username
-	}
-	if len(participants) > 0 {
-		tmpl.Participants = participants
 	}
 	return tmpl, nil
 }
@@ -758,6 +760,33 @@ func (s *PlannerService) BuildResolvedPlans(ctx context.Context, plans models.Re
 		resolved = append(resolved, rp)
 	}
 	return resolved, nil
+}
+
+// BuildPlanSummaries resolves a slice of plans into the per-plan list view
+// ([models.PlanSummary]): release/owner names come from the resolved plan,
+// while tests/groups/participants are reported as counts taken from the source
+// plan. Shares the same single-fetch resolution as [BuildResolvedPlans].
+func (s *PlannerService) BuildPlanSummaries(ctx context.Context, plans models.ReleasePlanList) ([]models.PlanSummary, error) {
+	summaries := make([]models.PlanSummary, 0, len(plans))
+	for _, p := range plans {
+		rp, err := s.BuildResolvedPlan(ctx, p)
+		if err != nil {
+			return nil, err
+		}
+		summaries = append(summaries, models.PlanSummary{
+			Key:           rp.Key,
+			Name:          rp.Name,
+			Description:   rp.Description,
+			Release:       rp.Release,
+			TargetVersion: rp.TargetVersion,
+			Owner:         rp.Owner,
+			Tests:         len(p.Tests),
+			Groups:        len(p.Groups),
+			Participants:  len(p.Participants),
+			LastUpdated:   rp.LastUpdated,
+		})
+	}
+	return summaries, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/internal/services/planner.go
+++ b/cli/internal/services/planner.go
@@ -759,3 +759,193 @@ func (s *PlannerService) BuildResolvedPlans(ctx context.Context, plans models.Re
 	}
 	return resolved, nil
 }
+
+// ---------------------------------------------------------------------------
+// Plan update (diff-based)
+// ---------------------------------------------------------------------------
+
+// UpdatePlan applies a fully-resolved diff (all references already converted to
+// UUIDs by [PlannerService.BuildUpdateRequest]) to a plan via
+// POST /planning/plan/update. The backend returns a boolean acknowledgement;
+// the caller refetches the plan to display the new state.
+func (s *PlannerService) UpdatePlan(ctx context.Context, req models.PlanDiffRequest) error {
+	r, err := s.client.NewRequest(ctx, "POST", api.PlanUpdate, req)
+	if err != nil {
+		return err
+	}
+	_, err = api.DoJSON[bool](s.client, r)
+	return err
+}
+
+// BuildUpdateRequest turns a name-based [models.PlanUpdateSpec] into the
+// UUID-based [models.PlanDiffRequest] the backend expects, resolving every
+// reference against the plan's own release. Only changed scalars and non-empty
+// deltas are populated, so an unchanged field is never sent.
+//
+// Resolution rules mirror create:
+//   - Scalar owner is a username resolved to a UUID; other scalars pass through.
+//   - Tests in TestsAdd/TestsRemove resolve by build_system_id / "group/test" /
+//     unique bare name. A reference matching nothing is reported as a warning
+//     and omitted; an ambiguous reference aborts so the user can disambiguate.
+//   - GroupsAdd is always expanded to the group's enabled tests (merged into
+//     tests_add); no groups_add is ever sent. GroupsRemove resolves to a group
+//     UUID and is sent as groups_remove (for groups still stored on the plan).
+//   - Participants resolve by username.
+//   - AssigneeMappingSet resolves the username value and the entity key (a test,
+//     or a group fanned out to each enabled test); AssigneeMappingRemove resolves
+//     each entity reference (group references fan out) to the UUIDs to drop.
+func (s *PlannerService) BuildUpdateRequest(ctx context.Context, plan models.ReleasePlan, spec models.PlanUpdateSpec) (models.PlanDiffRequest, []string, error) {
+	releaseID := plan.ReleaseID
+	diff := models.PlanDiffRequest{ID: plan.ID}
+	var warnings []string
+
+	// Scalars — pass through, resolving owner username to a UUID.
+	diff.Name = spec.Name
+	diff.Description = spec.Description
+	diff.TargetVersion = spec.TargetVersion
+	diff.Completed = spec.Completed
+	if spec.Owner != nil {
+		ownerID, err := s.ResolveUserID(ctx, *spec.Owner)
+		if err != nil {
+			return models.PlanDiffRequest{}, nil, fmt.Errorf("owner %q: %w", *spec.Owner, err)
+		}
+		diff.Owner = &ownerID
+	}
+
+	// Test add/remove deltas. Missing → warn-and-omit; ambiguous → abort.
+	addTests := newOrderedSet()
+	for _, ref := range spec.TestsAdd {
+		id, warn, err := s.resolveTestForDiff(ctx, ref, releaseID, "add")
+		if err != nil {
+			return models.PlanDiffRequest{}, nil, err
+		}
+		if warn != "" {
+			warnings = append(warnings, warn)
+			continue
+		}
+		addTests.add(id)
+	}
+	// Groups added are always expanded to their enabled tests (no groups_add).
+	for _, g := range spec.GroupsAdd {
+		ids, err := s.ExpandGroup(ctx, releaseID, g)
+		if err != nil {
+			return models.PlanDiffRequest{}, nil, err
+		}
+		for _, id := range ids {
+			addTests.add(id)
+		}
+	}
+	if len(addTests.items) > 0 {
+		diff.TestsAdd = addTests.items
+	}
+
+	removeTests := newOrderedSet()
+	for _, ref := range spec.TestsRemove {
+		id, warn, err := s.resolveTestForDiff(ctx, ref, releaseID, "remove")
+		if err != nil {
+			return models.PlanDiffRequest{}, nil, err
+		}
+		if warn != "" {
+			warnings = append(warnings, warn)
+			continue
+		}
+		removeTests.add(id)
+	}
+	if len(removeTests.items) > 0 {
+		diff.TestsRemove = removeTests.items
+	}
+
+	// Group removals target groups still stored on the plan (e.g. web-created).
+	removeGroups := newOrderedSet()
+	for _, g := range spec.GroupsRemove {
+		id, err := s.ResolveEntityID(ctx, g, releaseID, KindGroup)
+		if err != nil {
+			return models.PlanDiffRequest{}, nil, err
+		}
+		removeGroups.add(id)
+	}
+	if len(removeGroups.items) > 0 {
+		diff.GroupsRemove = removeGroups.items
+	}
+
+	// Participants resolve by username.
+	addParticipants, err := s.resolveUsers(ctx, spec.ParticipantsAdd)
+	if err != nil {
+		return models.PlanDiffRequest{}, nil, err
+	}
+	diff.ParticipantsAdd = addParticipants
+	removeParticipants, err := s.resolveUsers(ctx, spec.ParticipantsRemove)
+	if err != nil {
+		return models.PlanDiffRequest{}, nil, err
+	}
+	diff.ParticipantsRemove = removeParticipants
+
+	// Assignment set: resolve user, then entity (group fans out to its tests).
+	var assignSet map[string]string
+	for entityRef, userRef := range spec.AssigneeMappingSet {
+		userID, err := s.ResolveUserID(ctx, userRef)
+		if err != nil {
+			return models.PlanDiffRequest{}, nil, fmt.Errorf("assignee %q: %w", userRef, err)
+		}
+		ids, err := s.resolveAssignmentTargets(ctx, entityRef, releaseID)
+		if err != nil {
+			return models.PlanDiffRequest{}, nil, err
+		}
+		for _, id := range ids {
+			if assignSet == nil {
+				assignSet = map[string]string{}
+			}
+			assignSet[id] = userID
+		}
+	}
+	diff.AssigneeMappingSet = assignSet
+
+	// Assignment removal: resolve each entity (group fans out) to its UUIDs.
+	assignRemove := newOrderedSet()
+	for _, entityRef := range spec.AssigneeMappingRemove {
+		ids, err := s.resolveAssignmentTargets(ctx, entityRef, releaseID)
+		if err != nil {
+			return models.PlanDiffRequest{}, nil, err
+		}
+		for _, id := range ids {
+			assignRemove.add(id)
+		}
+	}
+	if len(assignRemove.items) > 0 {
+		diff.AssigneeMappingRemove = assignRemove.items
+	}
+
+	return diff, warnings, nil
+}
+
+// resolveTestForDiff resolves a single test reference for an add/remove delta.
+// A reference matching nothing yields a warning (so the diff still applies the
+// rest); an ambiguous reference returns an error so the user disambiguates.
+// verb ("add"/"remove") is used only in the warning text.
+func (s *PlannerService) resolveTestForDiff(ctx context.Context, ref, releaseID, verb string) (id, warn string, err error) {
+	id, err = s.ResolveEntityID(ctx, ref, releaseID, KindTest)
+	if err == nil {
+		return id, "", nil
+	}
+	if errors.Is(err, ErrEntityNotFound) {
+		return "", fmt.Sprintf("test %q to %s is not in this release — skipped", ref, verb), nil
+	}
+	return "", "", err
+}
+
+// resolveUsers resolves a list of usernames to UUIDs, returning nil for an
+// empty input so the corresponding diff field is omitted.
+func (s *PlannerService) resolveUsers(ctx context.Context, refs []string) ([]string, error) {
+	if len(refs) == 0 {
+		return nil, nil
+	}
+	ids := make([]string, 0, len(refs))
+	for _, r := range refs {
+		id, err := s.ResolveUserID(ctx, r)
+		if err != nil {
+			return nil, fmt.Errorf("participant %q: %w", r, err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}

--- a/cli/internal/services/planner.go
+++ b/cli/internal/services/planner.go
@@ -77,6 +77,48 @@ func (s *PlannerService) GetPlan(ctx context.Context, planRef string) (models.Re
 }
 
 // ---------------------------------------------------------------------------
+// Search (discovery)
+// ---------------------------------------------------------------------------
+
+// Search queries the planning search endpoint for tests/groups/releases
+// matching query, optionally scoped to a release (by name). The query string is
+// passed through verbatim — see the search command help for the facet syntax.
+//
+// The synthetic "Add all..." special row the backend always prepends
+// (type "special") is filtered out before returning. When releaseRef is empty
+// the search spans all releases.
+func (s *PlannerService) Search(ctx context.Context, query, releaseRef string) (models.SearchHitList, error) {
+	params := url.Values{}
+	params.Set("query", query)
+	if releaseRef != "" {
+		releaseID, err := s.ResolveReleaseID(ctx, releaseRef)
+		if err != nil {
+			return nil, err
+		}
+		params.Set("releaseId", releaseID)
+	}
+
+	route := api.PlanningSearch + "?" + params.Encode()
+	req, err := s.client.NewRequest(ctx, "GET", route, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := api.DoJSON[models.SearchResponse](s.client, req)
+	if err != nil {
+		return nil, err
+	}
+
+	hits := make(models.SearchHitList, 0, len(resp.Hits))
+	for _, h := range resp.Hits {
+		if h.Type == "special" {
+			continue
+		}
+		hits = append(hits, h)
+	}
+	return hits, nil
+}
+
+// ---------------------------------------------------------------------------
 // Release resolution
 // ---------------------------------------------------------------------------
 

--- a/cli/internal/services/planner.go
+++ b/cli/internal/services/planner.go
@@ -897,28 +897,25 @@ func (s *PlannerService) BuildUpdateRequest(ctx context.Context, plan models.Rel
 		diff.GroupsRemove = removeGroups.items
 	}
 
-	// Participants resolve by username.
-	addParticipants, err := s.resolveUsers(ctx, spec.ParticipantsAdd)
-	if err != nil {
-		return models.PlanDiffRequest{}, nil, err
-	}
-	diff.ParticipantsAdd = addParticipants
-	removeParticipants, err := s.resolveUsers(ctx, spec.ParticipantsRemove)
-	if err != nil {
-		return models.PlanDiffRequest{}, nil, err
-	}
-	diff.ParticipantsRemove = removeParticipants
-
 	// Assignment set: resolve user, then entity (group fans out to its tests).
+	// A "$owner" value clears the assignee (test stays) by routing the targets
+	// to the removal set instead of the mapping.
 	var assignSet map[string]string
+	assignRemove := newOrderedSet()
 	for entityRef, userRef := range spec.AssigneeMappingSet {
-		userID, err := s.ResolveUserID(ctx, userRef)
-		if err != nil {
-			return models.PlanDiffRequest{}, nil, fmt.Errorf("assignee %q: %w", userRef, err)
-		}
 		ids, err := s.resolveAssignmentTargets(ctx, entityRef, releaseID)
 		if err != nil {
 			return models.PlanDiffRequest{}, nil, err
+		}
+		if userRef == models.OwnerMarker {
+			for _, id := range ids {
+				assignRemove.add(id)
+			}
+			continue
+		}
+		userID, err := s.ResolveUserID(ctx, userRef)
+		if err != nil {
+			return models.PlanDiffRequest{}, nil, fmt.Errorf("assignee %q: %w", userRef, err)
 		}
 		for _, id := range ids {
 			if assignSet == nil {
@@ -930,7 +927,6 @@ func (s *PlannerService) BuildUpdateRequest(ctx context.Context, plan models.Rel
 	diff.AssigneeMappingSet = assignSet
 
 	// Assignment removal: resolve each entity (group fans out) to its UUIDs.
-	assignRemove := newOrderedSet()
 	for _, entityRef := range spec.AssigneeMappingRemove {
 		ids, err := s.resolveAssignmentTargets(ctx, entityRef, releaseID)
 		if err != nil {
@@ -944,7 +940,98 @@ func (s *PlannerService) BuildUpdateRequest(ctx context.Context, plan models.Rel
 		diff.AssigneeMappingRemove = assignRemove.items
 	}
 
+	// Participants are derived from the resulting assignments: anyone assigned
+	// other than the (possibly new) owner is a participant. Compute the final
+	// state and emit only the deltas against the plan's current participants.
+	ownerID := plan.Owner
+	if diff.Owner != nil {
+		ownerID = *diff.Owner
+	}
+	diff.ParticipantsAdd, diff.ParticipantsRemove = participantDeltas(
+		plan, addTests, removeTests, removeGroups, assignSet, assignRemove, ownerID)
+
+	// A plan must keep at least one test; refuse an edit that would empty it.
+	if planLeftEmpty(plan, addTests, removeTests) {
+		return models.PlanDiffRequest{}, warnings, fmt.Errorf("update would remove the plan's last test; a plan must include at least one test")
+	}
+
 	return diff, warnings, nil
+}
+
+// participantDeltas computes participants_add/remove so the stored participants
+// equal the resulting assignees minus the owner. assignSet entries are added,
+// assignRemove entries are dropped, and entries on removed tests/groups are
+// dropped too (mirroring the backend's mapping cleanup).
+func participantDeltas(plan models.ReleasePlan, addTests, removeTests, removeGroups *orderedSet, assignSet map[string]string, assignRemove *orderedSet, ownerID string) (add, remove []string) {
+	removed := map[string]bool{}
+	for _, id := range removeTests.items {
+		removed[id] = true
+	}
+	for _, id := range removeGroups.items {
+		removed[id] = true
+	}
+	for _, id := range assignRemove.items {
+		removed[id] = true
+	}
+
+	final := map[string]string{}
+	for entity, user := range plan.AssigneeMapping {
+		if !removed[entity] {
+			final[entity] = user
+		}
+	}
+	for entity, user := range assignSet {
+		final[entity] = user
+	}
+
+	desired := map[string]bool{}
+	for _, user := range final {
+		if user != ownerID {
+			desired[user] = true
+		}
+	}
+	current := map[string]bool{}
+	for _, p := range plan.Participants {
+		current[p] = true
+	}
+
+	addSet := newOrderedSet()
+	for _, t := range addTests.items {
+		if user, ok := final[t]; ok && user != ownerID && !current[user] {
+			addSet.add(user)
+		}
+	}
+	for user := range desired {
+		if !current[user] {
+			addSet.add(user)
+		}
+	}
+	for _, p := range plan.Participants {
+		if !desired[p] && p != ownerID {
+			remove = append(remove, p)
+		}
+	}
+	return addSet.items, remove
+}
+
+// planLeftEmpty reports whether applying the test add/remove deltas would empty
+// a plan that currently has tests. A plan that started empty is left alone (it
+// is up to add deltas to populate it).
+func planLeftEmpty(plan models.ReleasePlan, addTests, removeTests *orderedSet) bool {
+	if len(plan.Tests) == 0 {
+		return false
+	}
+	remaining := map[string]bool{}
+	for _, t := range plan.Tests {
+		remaining[t] = true
+	}
+	for _, t := range removeTests.items {
+		delete(remaining, t)
+	}
+	for _, t := range addTests.items {
+		remaining[t] = true
+	}
+	return len(remaining) == 0
 }
 
 // resolveTestForDiff resolves a single test reference for an add/remove delta.
@@ -960,21 +1047,4 @@ func (s *PlannerService) resolveTestForDiff(ctx context.Context, ref, releaseID,
 		return "", fmt.Sprintf("test %q to %s is not in this release — skipped", ref, verb), nil
 	}
 	return "", "", err
-}
-
-// resolveUsers resolves a list of usernames to UUIDs, returning nil for an
-// empty input so the corresponding diff field is omitted.
-func (s *PlannerService) resolveUsers(ctx context.Context, refs []string) ([]string, error) {
-	if len(refs) == 0 {
-		return nil, nil
-	}
-	ids := make([]string, 0, len(refs))
-	for _, r := range refs {
-		id, err := s.ResolveUserID(ctx, r)
-		if err != nil {
-			return nil, fmt.Errorf("participant %q: %w", r, err)
-		}
-		ids = append(ids, id)
-	}
-	return ids, nil
 }

--- a/cli/internal/services/planner.go
+++ b/cli/internal/services/planner.go
@@ -660,3 +660,102 @@ func (s *PlannerService) releaseNameByID(ctx context.Context, releaseID string) 
 	}
 	return "", fmt.Errorf("release id %q not found", releaseID)
 }
+
+// ---------------------------------------------------------------------------
+// Resolved plan view (default get/list output)
+// ---------------------------------------------------------------------------
+
+// BuildResolvedPlan turns a stored plan (UUID-based) into a human-readable
+// [models.ResolvedPlan]: release/owner/participant names, tests and assignment
+// targets as group-qualified "group/test" strings, and groups as names, while
+// keeping the plan's identity and status fields.
+//
+// It is the data behind the default `planner get`/`list` output. Unlike
+// [PlannerService.BuildTemplate] it is lossless: any reference that cannot be
+// resolved (a user not in the users list, or a test/group not in the release
+// gridview) falls back to its raw UUID rather than being dropped, and an
+// unknown release id is shown verbatim rather than failing the command.
+func (s *PlannerService) BuildResolvedPlan(ctx context.Context, plan models.ReleasePlan) (models.ResolvedPlan, error) {
+	users, err := s.getUsers(ctx)
+	if err != nil {
+		return models.ResolvedPlan{}, err
+	}
+	grid, err := s.GetReleaseStructure(ctx, plan.ReleaseID)
+	if err != nil {
+		return models.ResolvedPlan{}, err
+	}
+	// A missing release name is non-fatal for a display command — fall back to
+	// the raw id so the rest of the plan still renders.
+	releaseName, err := s.releaseNameByID(ctx, plan.ReleaseID)
+	if err != nil {
+		releaseName = plan.ReleaseID
+	}
+
+	username := func(id string) string {
+		if u, ok := users[id]; ok {
+			return u.Username
+		}
+		return id
+	}
+	entityName := func(id string) string {
+		if name, ok := entityQualifiedName(grid, id); ok {
+			return name
+		}
+		return id
+	}
+
+	participants := make([]string, 0, len(plan.Participants))
+	for _, p := range plan.Participants {
+		participants = append(participants, username(p))
+	}
+	tests := make([]string, 0, len(plan.Tests))
+	for _, t := range plan.Tests {
+		tests = append(tests, entityName(t))
+	}
+	groups := make([]string, 0, len(plan.Groups))
+	for _, g := range plan.Groups {
+		groups = append(groups, entityName(g))
+	}
+	var assignments map[string]string
+	for entityID, userID := range plan.AssigneeMapping {
+		if assignments == nil {
+			assignments = map[string]string{}
+		}
+		assignments[entityName(entityID)] = username(userID)
+	}
+
+	return models.ResolvedPlan{
+		ID:            plan.ID,
+		Key:           plan.Key,
+		Name:          plan.Name,
+		Description:   plan.Description,
+		Release:       releaseName,
+		TargetVersion: plan.TargetVersion,
+		Owner:         username(plan.Owner),
+		Participants:  participants,
+		Tests:         tests,
+		Groups:        groups,
+		Assignments:   assignments,
+		Completed:     plan.Completed,
+		ViewID:        plan.ViewID,
+		CreatedFrom:   plan.CreatedFrom,
+		CreationTime:  plan.CreationTime,
+		LastUpdated:   plan.LastUpdated,
+		EndsAt:        plan.EndsAt,
+	}, nil
+}
+
+// BuildResolvedPlans resolves a slice of plans into their human-readable form.
+// Plans of the same release share the memoised gridview and users list, so a
+// whole release's plan list resolves with at most one fetch of each.
+func (s *PlannerService) BuildResolvedPlans(ctx context.Context, plans models.ReleasePlanList) ([]models.ResolvedPlan, error) {
+	resolved := make([]models.ResolvedPlan, 0, len(plans))
+	for _, p := range plans {
+		rp, err := s.BuildResolvedPlan(ctx, p)
+		if err != nil {
+			return nil, err
+		}
+		resolved = append(resolved, rp)
+	}
+	return resolved, nil
+}

--- a/cli/internal/services/planner.go
+++ b/cli/internal/services/planner.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"sort"
@@ -21,6 +22,18 @@ const (
 	KindTest EntityKind = "test"
 	// KindGroup selects group resolution (group name within the release).
 	KindGroup EntityKind = "group"
+)
+
+// Resolution sentinel errors. They let callers distinguish a reference that
+// matched nothing (safe to warn-and-omit on create) from one that matched
+// several candidates (must abort so the user disambiguates).
+var (
+	// ErrEntityNotFound is returned (wrapped) when a test/group reference
+	// matches no entity in the release.
+	ErrEntityNotFound = errors.New("entity not found in release")
+	// ErrAmbiguousEntity is returned (wrapped) when a reference matches more
+	// than one entity and cannot be resolved safely.
+	ErrAmbiguousEntity = errors.New("ambiguous entity reference")
 )
 
 // PlannerService encapsulates release-plan reads and the client-side name
@@ -116,6 +129,43 @@ func (s *PlannerService) Search(ctx context.Context, query, releaseRef string) (
 		hits = append(hits, h)
 	}
 	return hits, nil
+}
+
+// ---------------------------------------------------------------------------
+// Plan writes
+// ---------------------------------------------------------------------------
+
+// CreatePlan creates a release plan from a fully-resolved request (all
+// references already converted to UUIDs by [PlannerService.BuildCreateRequest])
+// and returns the created plan, including its server-assigned id and key.
+func (s *PlannerService) CreatePlan(ctx context.Context, req models.CreatePlanRequest) (models.ReleasePlan, error) {
+	r, err := s.client.NewRequest(ctx, "POST", api.PlanCreate, req)
+	if err != nil {
+		return models.ReleasePlan{}, err
+	}
+	return api.DoJSON[models.ReleasePlan](s.client, r)
+}
+
+// DeletePlan deletes the plan addressed by UUID id or "releaseName#planNumber"
+// key. When deleteView is true the plan's associated view is deleted too;
+// otherwise the view is detached and kept.
+func (s *PlannerService) DeletePlan(ctx context.Context, planRef string, deleteView bool) error {
+	// Plan keys contain '#'; escape so the ref survives URL parsing.
+	route := fmt.Sprintf(api.PlanDelete, url.PathEscape(planRef))
+	params := url.Values{}
+	if deleteView {
+		params.Set("deleteView", "1")
+	} else {
+		params.Set("deleteView", "0")
+	}
+	route += "?" + params.Encode()
+
+	req, err := s.client.NewRequest(ctx, "DELETE", route, nil)
+	if err != nil {
+		return err
+	}
+	_, err = api.DoJSON[bool](s.client, req)
+	return err
 }
 
 // ---------------------------------------------------------------------------
@@ -313,9 +363,9 @@ func findGroup(grid models.GridView, ref string) (models.GridEntity, error) {
 	case 1:
 		return matches[0], nil
 	case 0:
-		return models.GridEntity{}, fmt.Errorf("no group named %q in this release", ref)
+		return models.GridEntity{}, fmt.Errorf("%w: no group named %q in this release", ErrEntityNotFound, ref)
 	default:
-		return models.GridEntity{}, fmt.Errorf("ambiguous group name %q (%d matches)", ref, len(matches))
+		return models.GridEntity{}, fmt.Errorf("%w: ambiguous group name %q (%d matches)", ErrAmbiguousEntity, ref, len(matches))
 	}
 }
 
@@ -343,9 +393,9 @@ func resolveTest(grid models.GridView, ref string) (string, error) {
 				return matches[0], nil
 			}
 			if len(matches) > 1 {
-				return "", fmt.Errorf("ambiguous test %q within group %q (%d matches)", testName, groupPart, len(matches))
+				return "", fmt.Errorf("%w: ambiguous test %q within group %q (%d matches)", ErrAmbiguousEntity, testName, groupPart, len(matches))
 			}
-			return "", fmt.Errorf("no test %q in group %q", testName, groupPart)
+			return "", fmt.Errorf("%w: no test %q in group %q", ErrEntityNotFound, testName, groupPart)
 		}
 	}
 
@@ -360,10 +410,10 @@ func resolveTest(grid models.GridView, ref string) (string, error) {
 	case 1:
 		return matches[0].ID, nil
 	case 0:
-		return "", fmt.Errorf("no test %q in this release (use build_system_id or group/test)", ref)
+		return "", fmt.Errorf("%w: no test %q in this release (use build_system_id or group/test)", ErrEntityNotFound, ref)
 	default:
-		return "", fmt.Errorf("ambiguous test %q (%d matches): use build_system_id or group/test\n%s",
-			ref, len(matches), formatTestCandidates(matches))
+		return "", fmt.Errorf("%w: ambiguous test %q (%d matches): use build_system_id or group/test\n%s",
+			ErrAmbiguousEntity, ref, len(matches), formatTestCandidates(matches))
 	}
 }
 
@@ -376,4 +426,237 @@ func formatTestCandidates(matches []models.GridEntity) string {
 		fmt.Fprintf(&b, "  - %s (group: %s, id: %s)\n", t.BuildSystemID, t.Group, t.ID)
 	}
 	return strings.TrimRight(b.String(), "\n")
+}
+
+// ---------------------------------------------------------------------------
+// Create-from-template (BuildCreateRequest) and the get --template transform
+// ---------------------------------------------------------------------------
+
+// orderedSet collects strings preserving first-insertion order while skipping
+// duplicates — used to merge tests from multiple sources (explicit tests,
+// expanded groups, assignment fan-out) deterministically.
+type orderedSet struct {
+	seen  map[string]struct{}
+	items []string
+}
+
+func newOrderedSet() *orderedSet { return &orderedSet{seen: map[string]struct{}{}} }
+
+func (o *orderedSet) add(v string) {
+	if _, ok := o.seen[v]; ok {
+		return
+	}
+	o.seen[v] = struct{}{}
+	o.items = append(o.items, v)
+}
+
+// BuildCreateRequest turns a name-based [models.PlanTemplate] (plus any extra
+// group references from --group) into a fully UUID-resolved
+// [models.CreatePlanRequest]. Every name is resolved client-side against the
+// target release; only UUIDs are placed in the request.
+//
+// Groups are always expanded to their enabled member tests and merged into the
+// tests list (the request's groups field is left empty). An assignment whose
+// key is a group fans out to each of that group's enabled tests. Tests that do
+// not exist in the target release are returned as warnings and omitted; an
+// ambiguous reference instead aborts with an error so the user can disambiguate.
+func (s *PlannerService) BuildCreateRequest(ctx context.Context, tmpl models.PlanTemplate, groupRefs []string) (models.CreatePlanRequest, []string, error) {
+	var warnings []string
+
+	if tmpl.Release == "" {
+		return models.CreatePlanRequest{}, nil, fmt.Errorf("a release is required (set 'release' in the file or pass --release)")
+	}
+	releaseID, err := s.ResolveReleaseID(ctx, tmpl.Release)
+	if err != nil {
+		return models.CreatePlanRequest{}, nil, err
+	}
+
+	if tmpl.Owner == "" {
+		return models.CreatePlanRequest{}, nil, fmt.Errorf("an owner is required (set 'owner' in the file or pass --owner)")
+	}
+	ownerID, err := s.ResolveUserID(ctx, tmpl.Owner)
+	if err != nil {
+		return models.CreatePlanRequest{}, nil, err
+	}
+
+	participants := make([]string, 0, len(tmpl.Participants))
+	for _, p := range tmpl.Participants {
+		id, err := s.ResolveUserID(ctx, p)
+		if err != nil {
+			return models.CreatePlanRequest{}, nil, fmt.Errorf("participant %q: %w", p, err)
+		}
+		participants = append(participants, id)
+	}
+
+	tests := newOrderedSet()
+
+	// Explicit tests: missing in the target release → warn and omit; ambiguous
+	// → abort.
+	for _, ref := range tmpl.Tests {
+		id, err := s.ResolveEntityID(ctx, ref, releaseID, KindTest)
+		if err != nil {
+			if errors.Is(err, ErrEntityNotFound) {
+				warnings = append(warnings, fmt.Sprintf("test %q is not in release %q — omitted", ref, tmpl.Release))
+				continue
+			}
+			return models.CreatePlanRequest{}, nil, err
+		}
+		tests.add(id)
+	}
+
+	// Extra groups (--group): always expanded to enabled tests.
+	for _, g := range groupRefs {
+		ids, err := s.ExpandGroup(ctx, releaseID, g)
+		if err != nil {
+			return models.CreatePlanRequest{}, nil, err
+		}
+		for _, id := range ids {
+			tests.add(id)
+		}
+	}
+
+	// Assignments: resolve the user, then the entity (test, else group → fan
+	// out to each enabled test). Entities also join the tests list.
+	assignments := map[string]string{}
+	for entityRef, userRef := range tmpl.Assignments {
+		userID, err := s.ResolveUserID(ctx, userRef)
+		if err != nil {
+			return models.CreatePlanRequest{}, nil, fmt.Errorf("assignee %q: %w", userRef, err)
+		}
+		ids, err := s.resolveAssignmentTargets(ctx, entityRef, releaseID)
+		if err != nil {
+			return models.CreatePlanRequest{}, nil, err
+		}
+		for _, id := range ids {
+			assignments[id] = userID
+			tests.add(id)
+		}
+	}
+
+	return models.CreatePlanRequest{
+		Name:          tmpl.Name,
+		Description:   tmpl.Description,
+		Owner:         ownerID,
+		Participants:  participants,
+		TargetVersion: tmpl.TargetVersion,
+		ReleaseID:     releaseID,
+		Tests:         tests.items,
+		Groups:        []string{},
+		Assignments:   assignments,
+	}, warnings, nil
+}
+
+// resolveAssignmentTargets resolves an assignment entity reference to the test
+// UUIDs it applies to: a test reference yields itself; a group reference fans
+// out to its enabled tests.
+func (s *PlannerService) resolveAssignmentTargets(ctx context.Context, entityRef, releaseID string) ([]string, error) {
+	id, err := s.ResolveEntityID(ctx, entityRef, releaseID, KindTest)
+	if err == nil {
+		return []string{id}, nil
+	}
+	if !errors.Is(err, ErrEntityNotFound) {
+		return nil, err
+	}
+	// Not a test — try a group and fan out to its enabled tests.
+	ids, gerr := s.ExpandGroup(ctx, releaseID, entityRef)
+	if gerr != nil {
+		return nil, fmt.Errorf("assignment target %q is not a test or group in release", entityRef)
+	}
+	return ids, nil
+}
+
+// BuildTemplate converts a stored plan (UUID-based) into a release-independent,
+// human-readable [models.PlanTemplate]: release/owner/participant names, tests
+// as group-qualified "group/test" strings, and assignments keyed by the same.
+// It is the data behind `planner get --template`.
+//
+// Names are back-resolved from the plan's own release gridview and the users
+// list. Tests no longer present in that gridview (e.g. since disabled) cannot
+// be named and are skipped.
+func (s *PlannerService) BuildTemplate(ctx context.Context, plan models.ReleasePlan) (models.PlanTemplate, error) {
+	releaseName, err := s.releaseNameByID(ctx, plan.ReleaseID)
+	if err != nil {
+		return models.PlanTemplate{}, err
+	}
+	users, err := s.getUsers(ctx)
+	if err != nil {
+		return models.PlanTemplate{}, err
+	}
+	grid, err := s.GetReleaseStructure(ctx, plan.ReleaseID)
+	if err != nil {
+		return models.PlanTemplate{}, err
+	}
+
+	participants := make([]string, 0, len(plan.Participants))
+	for _, p := range plan.Participants {
+		if u, ok := users[p]; ok {
+			participants = append(participants, u.Username)
+		}
+	}
+
+	tests := make([]string, 0, len(plan.Tests))
+	for _, t := range plan.Tests {
+		if name, ok := entityQualifiedName(grid, t); ok {
+			tests = append(tests, name)
+		}
+	}
+
+	var assignments map[string]string
+	for entityID, userID := range plan.AssigneeMapping {
+		name, ok := entityQualifiedName(grid, entityID)
+		if !ok {
+			continue
+		}
+		u, ok := users[userID]
+		if !ok {
+			continue
+		}
+		if assignments == nil {
+			assignments = map[string]string{}
+		}
+		assignments[name] = u.Username
+	}
+
+	tmpl := models.PlanTemplate{
+		Name:          plan.Name,
+		Description:   plan.Description,
+		Release:       releaseName,
+		TargetVersion: plan.TargetVersion,
+		Tests:         tests,
+		Assignments:   assignments,
+	}
+	if u, ok := users[plan.Owner]; ok {
+		tmpl.Owner = u.Username
+	}
+	if len(participants) > 0 {
+		tmpl.Participants = participants
+	}
+	return tmpl, nil
+}
+
+// entityQualifiedName returns the "group/test" name for a test UUID, or the
+// group name for a group UUID, found in the gridview. ok is false when the id
+// is in neither map.
+func entityQualifiedName(grid models.GridView, id string) (string, bool) {
+	if t, ok := grid.Tests[id]; ok {
+		return t.Group + "/" + t.Name, true
+	}
+	if g, ok := grid.Groups[id]; ok {
+		return g.Name, true
+	}
+	return "", false
+}
+
+// releaseNameByID returns the name of the release with the given UUID.
+func (s *PlannerService) releaseNameByID(ctx context.Context, releaseID string) (string, error) {
+	releases, err := s.getReleases(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, r := range releases {
+		if r.ID == releaseID {
+			return r.Name, nil
+		}
+	}
+	return "", fmt.Errorf("release id %q not found", releaseID)
 }

--- a/cli/internal/services/planner_test.go
+++ b/cli/internal/services/planner_test.go
@@ -962,25 +962,77 @@ func TestPlannerService_BuildUpdateRequest_RemoveGroup(t *testing.T) {
 	assert.Nil(t, diff.TestsAdd)
 }
 
-func TestPlannerService_BuildUpdateRequest_ParticipantsResolve(t *testing.T) {
+func TestPlannerService_BuildUpdateRequest_AssignAddsParticipant(t *testing.T) {
 	t.Parallel()
 	svc := newPlannerSvc(t, resolveMux(t))
 
-	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1"}
+	// alice owns the plan; assigning bob to a test makes him a participant.
+	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1", Owner: "u1", Tests: []string{"t1"}}
 	diff, _, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
-		ParticipantsAdd:    []string{"alice"},
-		ParticipantsRemove: []string{"bob"},
+		AssigneeMappingSet: map[string]string{"tier1/longevity-200gb": "bob"},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, []string{"u1"}, diff.ParticipantsAdd)
+	assert.Equal(t, map[string]string{"t2": "u2"}, diff.AssigneeMappingSet)
+	assert.Equal(t, []string{"u2"}, diff.ParticipantsAdd)
+	assert.Empty(t, diff.ParticipantsRemove)
+}
+
+func TestPlannerService_BuildUpdateRequest_UnassignDropsParticipant(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	// bob's only assignment (t2) cleared via $owner → dropped from participants.
+	plan := models.ReleasePlan{
+		ID: "p1", ReleaseID: "rel-1", Owner: "u1",
+		Tests: []string{"t2"}, Participants: []string{"u2"},
+		AssigneeMapping: map[string]string{"t2": "u2"},
+	}
+	diff, _, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
+		AssigneeMappingSet: map[string]string{"tier1/longevity-200gb": "$owner"},
+	})
+	require.NoError(t, err)
+	// $owner clears the assignee (test stays) and removes bob as participant.
+	assert.Nil(t, diff.AssigneeMappingSet)
+	assert.Equal(t, []string{"t2"}, diff.AssigneeMappingRemove)
+	assert.Empty(t, diff.ParticipantsAdd)
 	assert.Equal(t, []string{"u2"}, diff.ParticipantsRemove)
+}
+
+func TestPlannerService_BuildUpdateRequest_RemoveLastTestDropsParticipant(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	// bob keeps another assigned test, so removing one keeps him a participant.
+	plan := models.ReleasePlan{
+		ID: "p1", ReleaseID: "rel-1", Owner: "u1",
+		Tests: []string{"t1", "t2"}, Participants: []string{"u2"},
+		AssigneeMapping: map[string]string{"t1": "u2", "t2": "u2"},
+	}
+	diff, _, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
+		TestsRemove: []string{"tier1/longevity-200gb"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"t2"}, diff.TestsRemove)
+	assert.Empty(t, diff.ParticipantsRemove)
+}
+
+func TestPlannerService_BuildUpdateRequest_RejectsEmptyPlan(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1", Tests: []string{"t2"}}
+	_, _, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
+		TestsRemove: []string{"tier1/longevity-200gb"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one test")
 }
 
 func TestPlannerService_BuildUpdateRequest_AssignSetAndRemove(t *testing.T) {
 	t.Parallel()
 	svc := newPlannerSvc(t, resolveMux(t))
 
-	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1"}
+	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1", Tests: []string{"t2", "t3"}}
 	diff, _, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
 		AssigneeMappingSet:    map[string]string{"tier1/longevity-200gb": "alice"},
 		AssigneeMappingRemove: []string{"scylla-2026.2/tier2/longevity-100gb"},
@@ -995,7 +1047,7 @@ func TestPlannerService_BuildUpdateRequest_GroupAssignmentFansOut(t *testing.T) 
 	t.Parallel()
 	svc := newPlannerSvc(t, resolveMux(t))
 
-	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1"}
+	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1", Tests: []string{"t1", "t2"}}
 	diff, _, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
 		AssigneeMappingSet: map[string]string{"tier1": "bob"},
 	})

--- a/cli/internal/services/planner_test.go
+++ b/cli/internal/services/planner_test.go
@@ -663,3 +663,101 @@ func TestPlannerService_ExpandGroup_ByDisplayName(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"t1", "t2"}, ids)
 }
+
+// --------------------------------------------------------------------------
+// Resolved plan view (default get / list output)
+// --------------------------------------------------------------------------
+
+func TestPlannerService_BuildResolvedPlan_ResolvesNames(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	plan := models.ReleasePlan{
+		ID:              "p1",
+		Key:             "scylla-2026.2#1",
+		Name:            "GA",
+		Description:     "ga plan",
+		ReleaseID:       "rel-1",
+		Owner:           "u1",
+		Participants:    []string{"u2"},
+		TargetVersion:   "2026.2.0",
+		Tests:           []string{"t1", "t3"},
+		Groups:          []string{"g1"},
+		AssigneeMapping: map[string]string{"t2": "u2"},
+		Completed:       true,
+	}
+
+	rp, err := svc.BuildResolvedPlan(context.Background(), plan)
+	require.NoError(t, err)
+
+	assert.Equal(t, "scylla-2026.2#1", rp.Key)
+	assert.Equal(t, "scylla-2026.2", rp.Release)
+	assert.Equal(t, "alice", rp.Owner)
+	assert.Equal(t, []string{"bob"}, rp.Participants)
+	assert.Equal(t, []string{"Tier 1/longevity-100gb", "Tier 2/longevity-100gb"}, rp.Tests)
+	assert.Equal(t, []string{"tier1"}, rp.Groups)
+	assert.Equal(t, map[string]string{"Tier 1/longevity-200gb": "bob"}, rp.Assignments)
+	// Identity/status fields are retained (unlike a template).
+	assert.Equal(t, "p1", rp.ID)
+	assert.True(t, rp.Completed)
+}
+
+func TestPlannerService_BuildResolvedPlan_UnknownRefsFallBackToUUID(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	plan := models.ReleasePlan{
+		ID:              "p2",
+		ReleaseID:       "rel-1",
+		Owner:           "u-missing",            // not in users
+		Tests:           []string{"t1", "gone"}, // "gone" not in gridview
+		AssigneeMapping: map[string]string{"gone": "u-missing"},
+	}
+
+	rp, err := svc.BuildResolvedPlan(context.Background(), plan)
+	require.NoError(t, err)
+	// Unknown references are kept verbatim (lossless), not dropped.
+	assert.Equal(t, "u-missing", rp.Owner)
+	assert.Equal(t, []string{"Tier 1/longevity-100gb", "gone"}, rp.Tests)
+	assert.Equal(t, map[string]string{"gone": "u-missing"}, rp.Assignments)
+}
+
+func TestPlannerService_BuildResolvedPlan_UnknownReleaseFallsBack(t *testing.T) {
+	t.Parallel()
+	// gridview for the plan's release is served, but the releases list does not
+	// contain it — the release name falls back to the raw id without failing.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/releases", func(w http.ResponseWriter, r *http.Request) {
+		jsonOK(t, w, []models.Release{{ID: "other", Name: "scylla-2026.1"}})
+	})
+	mux.HandleFunc("/api/v1/users", func(w http.ResponseWriter, r *http.Request) {
+		jsonOK(t, w, models.UsersMap{"u1": {ID: "u1", Username: "alice"}})
+	})
+	mux.HandleFunc("/api/v1/planning/release/rel-1/gridview", func(w http.ResponseWriter, r *http.Request) {
+		jsonOK(t, w, gridviewFixture())
+	})
+	svc := newPlannerSvc(t, mux)
+
+	rp, err := svc.BuildResolvedPlan(context.Background(),
+		models.ReleasePlan{ReleaseID: "rel-1", Owner: "u1"})
+	require.NoError(t, err)
+	assert.Equal(t, "rel-1", rp.Release)
+	assert.Equal(t, "alice", rp.Owner)
+}
+
+func TestPlannerService_BuildResolvedPlans_List(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	plans := models.ReleasePlanList{
+		{Key: "scylla-2026.2#1", ReleaseID: "rel-1", Owner: "u1", Tests: []string{"t1"}},
+		{Key: "scylla-2026.2#2", ReleaseID: "rel-1", Owner: "u2", Tests: []string{"t2"}},
+	}
+
+	resolved, err := svc.BuildResolvedPlans(context.Background(), plans)
+	require.NoError(t, err)
+	require.Len(t, resolved, 2)
+	assert.Equal(t, "alice", resolved[0].Owner)
+	assert.Equal(t, "bob", resolved[1].Owner)
+	assert.Equal(t, []string{"Tier 1/longevity-100gb"}, resolved[0].Tests)
+}

--- a/cli/internal/services/planner_test.go
+++ b/cli/internal/services/planner_test.go
@@ -272,6 +272,21 @@ func TestPlannerService_ExpandGroup_EnabledOnly(t *testing.T) {
 	assert.Equal(t, []string{"t1", "t2"}, ids)
 }
 
+func TestPlannerService_GetReleaseOverview(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, gridviewMux(t, nil))
+
+	overview, err := svc.GetReleaseOverview(context.Background(), "rel-1")
+	require.NoError(t, err)
+	// Every test is keyed by group/test and valued by its build_system_id.
+	assert.Equal(t, models.ReleaseGrid{
+		"Tier 1/longevity-100gb":    "scylla-2026.2/tier1/longevity-100gb",
+		"Tier 1/longevity-200gb":    "scylla-2026.2/tier1/longevity-200gb",
+		"Tier 1/longevity-disabled": "scylla-2026.2/tier1/longevity-disabled",
+		"Tier 2/longevity-100gb":    "scylla-2026.2/tier2/longevity-100gb",
+	}, overview)
+}
+
 func TestPlannerService_Resolution_SingleGridviewFetch(t *testing.T) {
 	t.Parallel()
 	var calls int32

--- a/cli/internal/services/planner_test.go
+++ b/cli/internal/services/planner_test.go
@@ -287,3 +287,100 @@ func TestPlannerService_Resolution_SingleGridviewFetch(t *testing.T) {
 
 	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "gridview should be fetched once")
 }
+
+// --------------------------------------------------------------------------
+// Search
+// --------------------------------------------------------------------------
+
+// searchFixture is a search response with the synthetic "Add all..." special
+// row first (as the backend always prepends it), followed by real hits.
+func searchFixture() models.SearchResponse {
+	return models.SearchResponse{
+		Total: 3,
+		Hits: []models.SearchHit{
+			{ID: "db6f33b2-660b-4639-ba7f-79725ef96616", Name: "Add all...", Type: "special"},
+			{ID: "t1", Name: "longevity-100gb", Type: "test",
+				BuildSystemID: "scylla-2026.2/tier1/longevity-100gb", Enabled: true,
+				Group: &models.SearchRef{ID: "g1", Name: "tier1"}},
+			{ID: "g1", Name: "tier1", Type: "group", BuildSystemID: "scylla-2026.2/tier1"},
+		},
+	}
+}
+
+func TestPlannerService_Search_FiltersSpecialRow(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/planning/search", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		jsonOK(t, w, searchFixture())
+	})
+	svc := newPlannerSvc(t, mux)
+
+	hits, err := svc.Search(context.Background(), "longevity", "")
+	require.NoError(t, err)
+	// The "special" Add-all row is dropped; only the real test and group remain.
+	require.Len(t, hits, 2)
+	for _, h := range hits {
+		assert.NotEqual(t, "special", h.Type)
+	}
+	assert.Equal(t, "t1", hits[0].ID)
+	assert.Equal(t, "g1", hits[1].ID)
+}
+
+func TestPlannerService_Search_QueryPassthroughNoRelease(t *testing.T) {
+	t.Parallel()
+	var gotQuery string
+	var hasReleaseID bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/planning/search", func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query().Get("query")
+		_, hasReleaseID = r.URL.Query()["releaseId"]
+		jsonOK(t, w, searchFixture())
+	})
+	svc := newPlannerSvc(t, mux)
+
+	// Free text + facets are passed through verbatim; no releaseId when unscoped.
+	_, err := svc.Search(context.Background(), "type:group release:2026.2", "")
+	require.NoError(t, err)
+	assert.Equal(t, "type:group release:2026.2", gotQuery)
+	assert.False(t, hasReleaseID, "releaseId must be absent when no release is given")
+}
+
+func TestPlannerService_Search_ScopesByRelease(t *testing.T) {
+	t.Parallel()
+	var gotReleaseID string
+	mux := releasesMux(t, nil)
+	mux.HandleFunc("/api/v1/planning/search", func(w http.ResponseWriter, r *http.Request) {
+		gotReleaseID = r.URL.Query().Get("releaseId")
+		jsonOK(t, w, searchFixture())
+	})
+	svc := newPlannerSvc(t, mux)
+
+	// The --release name resolves to its UUID and is sent as releaseId.
+	_, err := svc.Search(context.Background(), "longevity", "scylla-2026.2")
+	require.NoError(t, err)
+	assert.Equal(t, "rel-1", gotReleaseID)
+}
+
+func TestPlannerService_Search_UnknownReleaseErrors(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, releasesMux(t, nil))
+
+	_, err := svc.Search(context.Background(), "longevity", "scylla-9999")
+	require.Error(t, err)
+}
+
+func TestPlannerService_Search_BackendError(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/planning/search", func(w http.ResponseWriter, r *http.Request) {
+		jsonErr(t, w, "search failed")
+	})
+	svc := newPlannerSvc(t, mux)
+
+	_, err := svc.Search(context.Background(), "longevity", "")
+	require.Error(t, err)
+	var apiErr *api.APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, "search failed", apiErr.Body.Message)
+}

--- a/cli/internal/services/planner_test.go
+++ b/cli/internal/services/planner_test.go
@@ -384,3 +384,282 @@ func TestPlannerService_Search_BackendError(t *testing.T) {
 	require.True(t, errors.As(err, &apiErr))
 	assert.Equal(t, "search failed", apiErr.Body.Message)
 }
+
+// --------------------------------------------------------------------------
+// Create / Delete (Phase 4)
+// --------------------------------------------------------------------------
+
+// resolveMux serves the releases, users, and gridview endpoints so name-based
+// references in a template resolve to UUIDs.
+func resolveMux(t *testing.T) *http.ServeMux {
+	t.Helper()
+	mux := releasesMux(t, nil)
+	mux.HandleFunc("/api/v1/users", func(w http.ResponseWriter, r *http.Request) {
+		jsonOK(t, w, models.UsersMap{
+			"u1": {ID: "u1", Username: "alice"},
+			"u2": {ID: "u2", Username: "bob"},
+		})
+	})
+	mux.HandleFunc("/api/v1/planning/release/rel-1/gridview", func(w http.ResponseWriter, r *http.Request) {
+		jsonOK(t, w, gridviewFixture())
+	})
+	return mux
+}
+
+func TestPlannerService_BuildCreateRequest_ResolvesAndExpands(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	tmpl := models.PlanTemplate{
+		Name:          "2026.2 Longevity",
+		Release:       "scylla-2026.2",
+		Owner:         "alice",
+		Participants:  []string{"bob"},
+		TargetVersion: "2026.2.0",
+		Tests:         []string{"tier1/longevity-200gb"},
+		Assignments:   map[string]string{"tier2/longevity-100gb": "bob"},
+	}
+
+	req, warnings, err := svc.BuildCreateRequest(context.Background(), tmpl, []string{"tier1"})
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+
+	assert.Equal(t, "rel-1", req.ReleaseID)
+	assert.Equal(t, "u1", req.Owner)
+	assert.Equal(t, []string{"u2"}, req.Participants)
+	// Explicit t2, then group tier1 expands to t1+t2 (t2 deduped), then the
+	// assignment target t3 — first-insertion order preserved.
+	assert.Equal(t, []string{"t2", "t1", "t3"}, req.Tests)
+	assert.Equal(t, map[string]string{"t3": "u2"}, req.Assignments)
+	// Collections must serialise as [] / {}, never null (backend requires keys).
+	assert.NotNil(t, req.Groups)
+	assert.Empty(t, req.Groups)
+}
+
+func TestPlannerService_BuildCreateRequest_GroupAssignmentFansOut(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	tmpl := models.PlanTemplate{
+		Name:        "fanout",
+		Release:     "scylla-2026.2",
+		Owner:       "alice",
+		Tests:       []string{},
+		Assignments: map[string]string{"tier1": "bob"},
+	}
+
+	req, warnings, err := svc.BuildCreateRequest(context.Background(), tmpl, nil)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+	// A group assignment fans out to each enabled member test (t1, t2).
+	assert.Equal(t, map[string]string{"t1": "u2", "t2": "u2"}, req.Assignments)
+	assert.ElementsMatch(t, []string{"t1", "t2"}, req.Tests)
+}
+
+func TestPlannerService_BuildCreateRequest_MissingTestWarnsAndOmits(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	tmpl := models.PlanTemplate{
+		Name:    "p",
+		Release: "scylla-2026.2",
+		Owner:   "alice",
+		Tests:   []string{"tier1/longevity-200gb", "tier1/does-not-exist"},
+	}
+
+	req, warnings, err := svc.BuildCreateRequest(context.Background(), tmpl, nil)
+	require.NoError(t, err)
+	// Missing test is omitted (plan still created) and reported as a warning.
+	assert.Equal(t, []string{"t2"}, req.Tests)
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "does-not-exist")
+}
+
+func TestPlannerService_BuildCreateRequest_AmbiguousAborts(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	tmpl := models.PlanTemplate{
+		Name:    "p",
+		Release: "scylla-2026.2",
+		Owner:   "alice",
+		Tests:   []string{"longevity-100gb"}, // present in both tier1 and tier2
+	}
+
+	_, _, err := svc.BuildCreateRequest(context.Background(), tmpl, nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, services.ErrAmbiguousEntity))
+}
+
+func TestPlannerService_BuildCreateRequest_RequiresReleaseAndOwner(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	_, _, err := svc.BuildCreateRequest(context.Background(),
+		models.PlanTemplate{Name: "p", Owner: "alice"}, nil)
+	require.Error(t, err)
+
+	_, _, err = svc.BuildCreateRequest(context.Background(),
+		models.PlanTemplate{Name: "p", Release: "scylla-2026.2"}, nil)
+	require.Error(t, err)
+}
+
+func TestPlannerService_CreatePlan_PostsAndReturns(t *testing.T) {
+	t.Parallel()
+	var gotBody models.CreatePlanRequest
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/planning/plan/create", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
+		jsonOK(t, w, models.ReleasePlan{ID: "p9", Key: "scylla-2026.2#9", Name: gotBody.Name})
+	})
+	svc := newPlannerSvc(t, mux)
+
+	plan, err := svc.CreatePlan(context.Background(), models.CreatePlanRequest{
+		Name: "GA", ReleaseID: "rel-1", Owner: "u1",
+		Tests: []string{"t1"}, Groups: []string{}, Assignments: map[string]string{},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "p9", plan.ID)
+	assert.Equal(t, "GA", gotBody.Name)
+}
+
+func TestPlannerService_CreatePlan_DuplicateError(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/planning/plan/create", func(w http.ResponseWriter, r *http.Request) {
+		jsonErr(t, w, "Plan with this name and version already exists")
+	})
+	svc := newPlannerSvc(t, mux)
+
+	_, err := svc.CreatePlan(context.Background(), models.CreatePlanRequest{Name: "dup"})
+	require.Error(t, err)
+	var apiErr *api.APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Contains(t, apiErr.Body.Message, "already exists")
+}
+
+func TestPlannerService_DeletePlan_EscapesKeyAndSendsDeleteView(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		deleteView bool
+		want       string
+	}{
+		{"keep view", false, "0"},
+		{"delete view", true, "1"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var gotEscaped, gotDeleteView, gotMethod string
+			mux := http.NewServeMux()
+			mux.HandleFunc("/api/v1/planning/plan/scylla-2026.2#3/delete", func(w http.ResponseWriter, r *http.Request) {
+				gotMethod = r.Method
+				gotEscaped = r.URL.EscapedPath()
+				gotDeleteView = r.URL.Query().Get("deleteView")
+				jsonOK(t, w, true)
+			})
+			svc := newPlannerSvc(t, mux)
+
+			err := svc.DeletePlan(context.Background(), "scylla-2026.2#3", tc.deleteView)
+			require.NoError(t, err)
+			assert.Equal(t, "DELETE", gotMethod)
+			// The '#' in the key is percent-escaped so it is not parsed as a fragment.
+			assert.Contains(t, gotEscaped, "%23")
+			assert.Equal(t, tc.want, gotDeleteView)
+		})
+	}
+}
+
+// --------------------------------------------------------------------------
+// BuildTemplate (get --template)
+// --------------------------------------------------------------------------
+
+func TestPlannerService_BuildTemplate_BackResolvesNames(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	plan := models.ReleasePlan{
+		Name:            "2026.2 Longevity",
+		Description:     "ga plan",
+		ReleaseID:       "rel-1",
+		Owner:           "u1",
+		Participants:    []string{"u2"},
+		TargetVersion:   "2026.2.0",
+		Tests:           []string{"t1", "t2"},
+		AssigneeMapping: map[string]string{"t3": "u2"},
+	}
+
+	tmpl, err := svc.BuildTemplate(context.Background(), plan)
+	require.NoError(t, err)
+
+	assert.Equal(t, "scylla-2026.2", tmpl.Release)
+	assert.Equal(t, "alice", tmpl.Owner)
+	assert.Equal(t, []string{"bob"}, tmpl.Participants)
+	assert.Equal(t, []string{"Tier 1/longevity-100gb", "Tier 1/longevity-200gb"}, tmpl.Tests)
+	assert.Equal(t, map[string]string{"Tier 2/longevity-100gb": "bob"}, tmpl.Assignments)
+}
+
+func TestPlannerService_BuildTemplate_SkipsUnknownTests(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	plan := models.ReleasePlan{
+		Name:      "p",
+		ReleaseID: "rel-1",
+		Owner:     "u1",
+		Tests:     []string{"t1", "gone"}, // "gone" is not in the gridview
+	}
+
+	tmpl, err := svc.BuildTemplate(context.Background(), plan)
+	require.NoError(t, err)
+	// Tests no longer present in the gridview cannot be named and are skipped.
+	assert.Equal(t, []string{"Tier 1/longevity-100gb"}, tmpl.Tests)
+}
+
+// TestPlannerService_TemplateRoundTrip locks the get --template -> create path:
+// BuildTemplate emits the group portion as the *display* (pretty) name, so
+// BuildCreateRequest must map that display name back to the same group ID (and
+// thus the same test UUIDs) when it builds the create payload.
+func TestPlannerService_TemplateRoundTrip_DisplayNameMapsToGroupID(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+	ctx := context.Background()
+
+	plan := models.ReleasePlan{
+		Name:            "GA",
+		ReleaseID:       "rel-1",
+		Owner:           "u1",
+		Tests:           []string{"t1", "t2"},          // tier1 (pretty "Tier 1")
+		AssigneeMapping: map[string]string{"t3": "u2"}, // tier2 (pretty "Tier 2")
+	}
+
+	tmpl, err := svc.BuildTemplate(ctx, plan)
+	require.NoError(t, err)
+	// Sanity: the emitted refs use the group's display name, not its raw name.
+	assert.Equal(t, []string{"Tier 1/longevity-100gb", "Tier 1/longevity-200gb"}, tmpl.Tests)
+	require.Contains(t, tmpl.Assignments, "Tier 2/longevity-100gb")
+
+	// Feeding the template straight back must resolve the display names to the
+	// original group/test UUIDs.
+	req, warnings, err := svc.BuildCreateRequest(ctx, tmpl, nil)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+	assert.ElementsMatch(t, []string{"t1", "t2", "t3"}, req.Tests)
+	assert.Equal(t, map[string]string{"t3": "u2"}, req.Assignments)
+	// Group names are never sent to the backend; they expand to test UUIDs.
+	assert.Empty(t, req.Groups)
+}
+
+func TestPlannerService_ExpandGroup_ByDisplayName(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, gridviewMux(t, nil))
+
+	// The group's display (pretty) name resolves to the same enabled tests as
+	// its raw name.
+	ids, err := svc.ExpandGroup(context.Background(), "rel-1", "Tier 1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"t1", "t2"}, ids)
+}

--- a/cli/internal/services/planner_test.go
+++ b/cli/internal/services/planner_test.go
@@ -818,23 +818,6 @@ func TestPlannerService_BuildResolvedPlan_UnknownReleaseFallsBack(t *testing.T) 
 	assert.Equal(t, "alice", rp.Owner)
 }
 
-func TestPlannerService_BuildResolvedPlans_List(t *testing.T) {
-	t.Parallel()
-	svc := newPlannerSvc(t, resolveMux(t))
-
-	plans := models.ReleasePlanList{
-		{Key: "scylla-2026.2#1", ReleaseID: "rel-1", Owner: "u1", Tests: []string{"t1"}},
-		{Key: "scylla-2026.2#2", ReleaseID: "rel-1", Owner: "u2", Tests: []string{"t2"}},
-	}
-
-	resolved, err := svc.BuildResolvedPlans(context.Background(), plans)
-	require.NoError(t, err)
-	require.Len(t, resolved, 2)
-	assert.Equal(t, "alice", resolved[0].Owner)
-	assert.Equal(t, "bob", resolved[1].Owner)
-	assert.Equal(t, []string{"Tier 1/longevity-100gb"}, resolved[0].Tests)
-}
-
 func TestPlannerService_BuildPlanSummaries_CountsAndNames(t *testing.T) {
 	t.Parallel()
 	svc := newPlannerSvc(t, resolveMux(t))
@@ -1069,6 +1052,129 @@ func TestPlannerService_BuildUpdateRequest_GroupAssignmentFansOut(t *testing.T) 
 	require.NoError(t, err)
 	// A group assignment fans out to each enabled member test.
 	assert.Equal(t, map[string]string{"t1": "u2", "t2": "u2"}, diff.AssigneeMappingSet)
+}
+
+func TestPlannerService_BuildUpdateRequest_AssignmentsMergeReassigns(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	// A template-style "assignments" file reassigns an existing test: t2 is
+	// ensured present (already in the plan) and assigned to bob, who becomes a
+	// participant. Tests not mentioned are left untouched.
+	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1", Owner: "u1", Tests: []string{"t2"}}
+	diff, warnings, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
+		Assignments: map[string]string{"tier1/longevity-200gb": "bob"},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+	assert.Equal(t, map[string]string{"t2": "u2"}, diff.AssigneeMappingSet)
+	assert.Equal(t, []string{"t2"}, diff.TestsAdd)
+	assert.Equal(t, []string{"u2"}, diff.ParticipantsAdd)
+	assert.Empty(t, diff.ParticipantsRemove)
+}
+
+func TestPlannerService_BuildUpdateRequest_AssignmentsAddsNewTest(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	// A test named in "assignments" but not yet in the plan is added (membership
+	// follows assignment) and assigned.
+	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1", Owner: "u1", Tests: []string{"t1"}}
+	diff, _, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
+		Assignments: map[string]string{"tier2/longevity-100gb": "bob"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"t3"}, diff.TestsAdd)
+	assert.Equal(t, map[string]string{"t3": "u2"}, diff.AssigneeMappingSet)
+	assert.Equal(t, []string{"u2"}, diff.ParticipantsAdd)
+}
+
+func TestPlannerService_BuildUpdateRequest_AssignmentsOwnerMarkerClears(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	// $owner in a template "assignments" clears the assignee (test stays) and
+	// drops the now-unassigned user from participants.
+	plan := models.ReleasePlan{
+		ID: "p1", ReleaseID: "rel-1", Owner: "u1",
+		Tests: []string{"t2"}, Participants: []string{"u2"},
+		AssigneeMapping: map[string]string{"t2": "u2"},
+	}
+	diff, _, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
+		Assignments: map[string]string{"tier1/longevity-200gb": "$owner"},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, diff.AssigneeMappingSet)
+	assert.Equal(t, []string{"t2"}, diff.AssigneeMappingRemove)
+	assert.Equal(t, []string{"u2"}, diff.ParticipantsRemove)
+}
+
+func TestPlannerService_BuildUpdateRequest_AssignmentsMissingWarns(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	// A reference matching nothing is reported and skipped, not fatal.
+	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1", Owner: "u1", Tests: []string{"t2"}}
+	diff, warnings, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
+		Assignments: map[string]string{"tier1/does-not-exist": "bob"},
+	})
+	require.NoError(t, err)
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "not in this release")
+	assert.Empty(t, diff.AssigneeMappingSet)
+}
+
+// ambiguousGroupMux returns a resolve mux whose gridview has two groups sharing
+// the pretty-name "Tier", so a group-by-name assignment reference is ambiguous.
+func ambiguousGroupMux(t *testing.T) *http.ServeMux {
+	t.Helper()
+	mux := releasesMux(t, nil)
+	mux.HandleFunc("/api/v1/users", func(w http.ResponseWriter, r *http.Request) {
+		jsonOK(t, w, models.UsersMap{"u2": {ID: "u2", Username: "bob"}})
+	})
+	mux.HandleFunc("/api/v1/planning/release/rel-1/gridview", func(w http.ResponseWriter, r *http.Request) {
+		jsonOK(t, w, models.GridView{
+			Groups: map[string]models.GridEntity{
+				"g1": {ID: "g1", Name: "tier1", PrettyName: "Tier", Type: "group"},
+				"g2": {ID: "g2", Name: "tier2", PrettyName: "Tier", Type: "group"},
+			},
+			Tests: map[string]models.GridEntity{
+				"t1": {ID: "t1", Name: "longevity-a", GroupID: "g1", Group: "Tier",
+					BuildSystemID: "scylla-2026.2/tier1/longevity-a", Enabled: true},
+				"t2": {ID: "t2", Name: "longevity-b", GroupID: "g2", Group: "Tier",
+					BuildSystemID: "scylla-2026.2/tier2/longevity-b", Enabled: true},
+			},
+		})
+	})
+	return mux
+}
+
+func TestPlannerService_BuildUpdateRequest_AmbiguousGroupAssignmentAborts(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, ambiguousGroupMux(t))
+
+	// An assignment to a group name matching two groups must abort with a
+	// disambiguation error, not be silently dropped as "not in release".
+	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1", Owner: "u1", Tests: []string{"t1"}}
+	_, _, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
+		AssigneeMappingSet: map[string]string{"Tier": "bob"},
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, services.ErrAmbiguousEntity)
+}
+
+func TestPlannerService_BuildCreateRequest_AmbiguousGroupAssignmentAborts(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, ambiguousGroupMux(t))
+
+	_, _, err := svc.BuildCreateRequest(context.Background(), models.PlanTemplate{
+		Name:        "p",
+		Release:     "scylla-2026.2",
+		Owner:       "bob",
+		Assignments: map[string]string{"Tier": "bob"},
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, services.ErrAmbiguousEntity)
 }
 
 func TestPlannerService_UpdatePlan_PostsDiff(t *testing.T) {

--- a/cli/internal/services/planner_test.go
+++ b/cli/internal/services/planner_test.go
@@ -51,8 +51,10 @@ func newPlannerSvc(t *testing.T, mux *http.ServeMux) *services.PlannerService {
 func gridviewFixture() models.GridView {
 	return models.GridView{
 		Groups: map[string]models.GridEntity{
-			"g1": {ID: "g1", Name: "tier1", PrettyName: "Tier 1", Type: "group"},
-			"g2": {ID: "g2", Name: "tier2", PrettyName: "Tier 2", Type: "group"},
+			"g1": {ID: "g1", Name: "tier1", PrettyName: "Tier 1", Type: "group",
+				BuildSystemID: "scylla-2026.2/tier1"},
+			"g2": {ID: "g2", Name: "tier2", PrettyName: "Tier 2", Type: "group",
+				BuildSystemID: "scylla-2026.2/tier2"},
 		},
 		Tests: map[string]models.GridEntity{
 			"t1": {ID: "t1", Name: "longevity-100gb", GroupID: "g1", Group: "Tier 1",
@@ -262,6 +264,17 @@ func TestPlannerService_ResolveEntityID_Group(t *testing.T) {
 	assert.Equal(t, "g1", id)
 }
 
+func TestPlannerService_ResolveEntityID_GroupByBuildSystemID(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, gridviewMux(t, nil))
+
+	// A group's fully-qualified build_system_id ("release/group") resolves too.
+	id, err := svc.ResolveEntityID(context.Background(),
+		"scylla-2026.2/tier1", "rel-1", services.KindGroup)
+	require.NoError(t, err)
+	assert.Equal(t, "g1", id)
+}
+
 func TestPlannerService_ExpandGroup_EnabledOnly(t *testing.T) {
 	t.Parallel()
 	svc := newPlannerSvc(t, gridviewMux(t, nil))
@@ -269,6 +282,16 @@ func TestPlannerService_ExpandGroup_EnabledOnly(t *testing.T) {
 	ids, err := svc.ExpandGroup(context.Background(), "rel-1", "tier1")
 	require.NoError(t, err)
 	// t1 + t2 are enabled in tier1; t4 is disabled and must be excluded.
+	assert.Equal(t, []string{"t1", "t2"}, ids)
+}
+
+func TestPlannerService_ExpandGroup_ByBuildSystemID(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, gridviewMux(t, nil))
+
+	// A group referenced by build_system_id fans out to its enabled tests.
+	ids, err := svc.ExpandGroup(context.Background(), "rel-1", "scylla-2026.2/tier1")
+	require.NoError(t, err)
 	assert.Equal(t, []string{"t1", "t2"}, ids)
 }
 
@@ -469,6 +492,76 @@ func TestPlannerService_BuildCreateRequest_GroupAssignmentFansOut(t *testing.T) 
 	// A group assignment fans out to each enabled member test (t1, t2).
 	assert.Equal(t, map[string]string{"t1": "u2", "t2": "u2"}, req.Assignments)
 	assert.ElementsMatch(t, []string{"t1", "t2"}, req.Tests)
+}
+
+func TestPlannerService_BuildCreateRequest_GroupByBuildSystemID(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	// Referencing a group by its fully-qualified build_system_id must resolve
+	// and fan out, not fail with "group not found".
+	tmpl := models.PlanTemplate{
+		Name:        "fanout-bsid",
+		Release:     "scylla-2026.2",
+		Owner:       "alice",
+		Assignments: map[string]string{"scylla-2026.2/tier1": "bob"},
+	}
+
+	req, warnings, err := svc.BuildCreateRequest(context.Background(), tmpl)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+	assert.Equal(t, map[string]string{"t1": "u2", "t2": "u2"}, req.Assignments)
+	assert.ElementsMatch(t, []string{"t1", "t2"}, req.Tests)
+}
+
+// TestPlannerService_BuildCreateRequest_NoPhantomParticipants guards against a
+// race loser being left as a participant. When a group entry and a specific
+// test entry both claim the same test, only one assignee wins the mapping (map
+// iteration order is randomised). Participants must be derived from the settled
+// assignment map, so the loser — who holds no assignment — never appears.
+func TestPlannerService_BuildCreateRequest_NoPhantomParticipants(t *testing.T) {
+	t.Parallel()
+	// Three users so the owner (carol) is distinct from both contenders.
+	mux := releasesMux(t, nil)
+	mux.HandleFunc("/api/v1/users", func(w http.ResponseWriter, r *http.Request) {
+		jsonOK(t, w, models.UsersMap{
+			"u1": {ID: "u1", Username: "alice"},
+			"u2": {ID: "u2", Username: "bob"},
+			"u3": {ID: "u3", Username: "carol"},
+		})
+	})
+	mux.HandleFunc("/api/v1/planning/release/rel-1/gridview", func(w http.ResponseWriter, r *http.Request) {
+		jsonOK(t, w, gridviewFixture())
+	})
+	svc := newPlannerSvc(t, mux)
+
+	tmpl := models.PlanTemplate{
+		Name:    "phantom",
+		Release: "scylla-2026.2",
+		Owner:   "carol",
+		Assignments: map[string]string{
+			"tier1":                 "bob",   // fans out to t1, t2
+			"tier1/longevity-200gb": "alice", // contends for t2
+		},
+	}
+
+	// Map iteration order is randomised per range, so repeat to exercise both
+	// orderings and catch a phantom regardless of which entry settles t2.
+	for i := 0; i < 50; i++ {
+		req, warnings, err := svc.BuildCreateRequest(context.Background(), tmpl)
+		require.NoError(t, err)
+		assert.Empty(t, warnings)
+
+		// Every participant must hold at least one assignment in the plan.
+		holders := map[string]bool{}
+		for _, userID := range req.Assignments {
+			holders[userID] = true
+		}
+		for _, p := range req.Participants {
+			assert.Contains(t, holders, p, "participant %q holds no assignment (phantom)", p)
+			assert.NotEqual(t, "u3", p, "owner must not be listed as a participant")
+		}
+	}
 }
 
 func TestPlannerService_BuildCreateRequest_OwnerMarkerLeavesUnassigned(t *testing.T) {
@@ -960,6 +1053,39 @@ func TestPlannerService_BuildUpdateRequest_RemoveGroup(t *testing.T) {
 	assert.Nil(t, diff.TestsAdd)
 }
 
+func TestPlannerService_BuildUpdateRequest_MissingGroupAddWarns(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	// A misspelled --add-group name warns and is skipped, so other deltas in the
+	// same update still apply (rather than aborting the whole call).
+	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1", Tests: []string{"t1"}}
+	diff, warnings, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
+		GroupsAdd: []string{"tierX"},
+		TestsAdd:  []string{"tier2/longevity-100gb"},
+	})
+	require.NoError(t, err)
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "not in this release")
+	// The valid test add is preserved.
+	assert.Equal(t, []string{"t3"}, diff.TestsAdd)
+}
+
+func TestPlannerService_BuildUpdateRequest_MissingGroupRemoveWarns(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	// A misspelled --remove-group name warns and is skipped, not fatal.
+	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1", Tests: []string{"t1"}}
+	diff, warnings, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
+		GroupsRemove: []string{"tierX"},
+	})
+	require.NoError(t, err)
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "not in this release")
+	assert.Nil(t, diff.GroupsRemove)
+}
+
 func TestPlannerService_BuildUpdateRequest_AssignAddsParticipant(t *testing.T) {
 	t.Parallel()
 	svc := newPlannerSvc(t, resolveMux(t))
@@ -971,6 +1097,9 @@ func TestPlannerService_BuildUpdateRequest_AssignAddsParticipant(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"t2": "u2"}, diff.AssigneeMappingSet)
+	// The assigned test is not yet in the plan, so membership follows the
+	// assignment — without tests_add the backend would drop the mapping.
+	assert.Equal(t, []string{"t2"}, diff.TestsAdd)
 	assert.Equal(t, []string{"u2"}, diff.ParticipantsAdd)
 	assert.Empty(t, diff.ParticipantsRemove)
 }
@@ -1024,6 +1153,36 @@ func TestPlannerService_BuildUpdateRequest_RejectsEmptyPlan(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "at least one test")
+}
+
+func TestPlannerService_BuildUpdateRequest_RejectsEmptyPlanViaGroupRemoval(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	// A web-created plan can hold its membership as groups (no explicit tests).
+	// Removing its last group empties it and must be refused. (Group removal
+	// does not cascade to plan.tests server-side, so only a group-held plan can
+	// be emptied this way.)
+	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1", Groups: []string{"g1"}}
+	_, _, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
+		GroupsRemove: []string{"tier1"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one test")
+}
+
+func TestPlannerService_BuildUpdateRequest_RemoveLastTestKeepsGroup(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	// Removing the last explicit test is allowed while a group remains: the
+	// plan still has membership, so the guard must not fire.
+	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1", Tests: []string{"t2"}, Groups: []string{"g2"}}
+	diff, _, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
+		TestsRemove: []string{"tier1/longevity-200gb"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"t2"}, diff.TestsRemove)
 }
 
 func TestPlannerService_BuildUpdateRequest_AssignSetAndRemove(t *testing.T) {
@@ -1124,7 +1283,23 @@ func TestPlannerService_BuildUpdateRequest_AssignmentsMissingWarns(t *testing.T)
 	assert.Empty(t, diff.AssigneeMappingSet)
 }
 
-// ambiguousGroupMux returns a resolve mux whose gridview has two groups sharing
+func TestPlannerService_BuildUpdateRequest_AssignMissingWarns(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	// --assign (AssigneeMappingSet) to a name matching nothing in the release is
+	// reported and skipped, not fatal — mirroring template assignments.
+	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1", Owner: "u1", Tests: []string{"t2"}}
+	diff, warnings, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
+		AssigneeMappingSet: map[string]string{"tier1/does-not-exist": "bob"},
+	})
+	require.NoError(t, err)
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "not in this release")
+	assert.Empty(t, diff.AssigneeMappingSet)
+	assert.Nil(t, diff.TestsAdd)
+}
+
 // the pretty-name "Tier", so a group-by-name assignment reference is ambiguous.
 func ambiguousGroupMux(t *testing.T) *http.ServeMux {
 	t.Helper()
@@ -1175,6 +1350,22 @@ func TestPlannerService_BuildCreateRequest_AmbiguousGroupAssignmentAborts(t *tes
 	})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, services.ErrAmbiguousEntity)
+}
+
+// TestPlannerService_ResolveEntityID_AmbiguousGroupPrefixSurfaces guards the
+// group-qualified resolution path: when the "group/" prefix of a group-qualified
+// test ref matches two groups, resolution must surface ErrAmbiguousEntity for
+// disambiguation rather than falling through to bare-name matching and
+// misreporting the test as simply not found.
+func TestPlannerService_ResolveEntityID_AmbiguousGroupPrefixSurfaces(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, ambiguousGroupMux(t))
+
+	_, err := svc.ResolveEntityID(context.Background(),
+		"Tier/longevity-a", "rel-1", services.KindTest)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, services.ErrAmbiguousEntity)
+	assert.NotErrorIs(t, err, services.ErrEntityNotFound)
 }
 
 func TestPlannerService_UpdatePlan_PostsDiff(t *testing.T) {

--- a/cli/internal/services/planner_test.go
+++ b/cli/internal/services/planner_test.go
@@ -761,3 +761,201 @@ func TestPlannerService_BuildResolvedPlans_List(t *testing.T) {
 	assert.Equal(t, "bob", resolved[1].Owner)
 	assert.Equal(t, []string{"Tier 1/longevity-100gb"}, resolved[0].Tests)
 }
+
+// --------------------------------------------------------------------------
+// Update (diff-based, Phase 5)
+// --------------------------------------------------------------------------
+
+func strPtr(s string) *string { return &s }
+
+func TestPlannerService_BuildUpdateRequest_ScalarOnly(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1"}
+	diff, warnings, err := svc.BuildUpdateRequest(context.Background(), plan,
+		models.PlanUpdateSpec{Name: strPtr("renamed")})
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+
+	assert.Equal(t, "p1", diff.ID)
+	require.NotNil(t, diff.Name)
+	assert.Equal(t, "renamed", *diff.Name)
+	// A scalar-only edit must not produce any list/map deltas.
+	assert.Nil(t, diff.TestsAdd)
+	assert.Nil(t, diff.TestsRemove)
+	assert.Nil(t, diff.GroupsAdd)
+	assert.Nil(t, diff.GroupsRemove)
+	assert.Nil(t, diff.ParticipantsAdd)
+	assert.Nil(t, diff.AssigneeMappingSet)
+	assert.Nil(t, diff.AssigneeMappingRemove)
+
+	// The marshalled body carries only id + name.
+	raw, err := json.Marshal(diff)
+	require.NoError(t, err)
+	s := string(raw)
+	assert.Contains(t, s, `"name":"renamed"`)
+	assert.NotContains(t, s, "tests_add")
+	assert.NotContains(t, s, "assignee_mapping")
+}
+
+func TestPlannerService_BuildUpdateRequest_ResolvesOwner(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1"}
+	diff, _, err := svc.BuildUpdateRequest(context.Background(), plan,
+		models.PlanUpdateSpec{Owner: strPtr("alice")})
+	require.NoError(t, err)
+	require.NotNil(t, diff.Owner)
+	assert.Equal(t, "u1", *diff.Owner)
+}
+
+func TestPlannerService_BuildUpdateRequest_TestAddRemove(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1"}
+	diff, warnings, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
+		TestsAdd:    []string{"tier1/longevity-200gb"},
+		TestsRemove: []string{"scylla-2026.2/tier2/longevity-100gb"},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+	assert.Equal(t, []string{"t2"}, diff.TestsAdd)
+	assert.Equal(t, []string{"t3"}, diff.TestsRemove)
+	// Unrelated fields stay empty.
+	assert.Nil(t, diff.GroupsRemove)
+	assert.Nil(t, diff.ParticipantsAdd)
+}
+
+func TestPlannerService_BuildUpdateRequest_MissingTestWarns(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1"}
+	diff, warnings, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
+		TestsAdd: []string{"tier1/longevity-200gb", "tier1/does-not-exist"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"t2"}, diff.TestsAdd)
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "does-not-exist")
+}
+
+func TestPlannerService_BuildUpdateRequest_AmbiguousTestAborts(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1"}
+	_, _, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
+		TestsAdd: []string{"longevity-100gb"}, // present in tier1 and tier2
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, services.ErrAmbiguousEntity))
+}
+
+func TestPlannerService_BuildUpdateRequest_AddGroupExpands(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1"}
+	diff, _, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
+		GroupsAdd: []string{"tier1"},
+	})
+	require.NoError(t, err)
+	// tier1 expands to its enabled tests; no groups_add is ever sent.
+	assert.Equal(t, []string{"t1", "t2"}, diff.TestsAdd)
+	assert.Nil(t, diff.GroupsAdd)
+}
+
+func TestPlannerService_BuildUpdateRequest_RemoveGroup(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1"}
+	diff, _, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
+		GroupsRemove: []string{"tier2"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"g2"}, diff.GroupsRemove)
+	assert.Nil(t, diff.TestsAdd)
+}
+
+func TestPlannerService_BuildUpdateRequest_ParticipantsResolve(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1"}
+	diff, _, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
+		ParticipantsAdd:    []string{"alice"},
+		ParticipantsRemove: []string{"bob"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"u1"}, diff.ParticipantsAdd)
+	assert.Equal(t, []string{"u2"}, diff.ParticipantsRemove)
+}
+
+func TestPlannerService_BuildUpdateRequest_AssignSetAndRemove(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1"}
+	diff, _, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
+		AssigneeMappingSet:    map[string]string{"tier1/longevity-200gb": "alice"},
+		AssigneeMappingRemove: []string{"scylla-2026.2/tier2/longevity-100gb"},
+	})
+	require.NoError(t, err)
+	// Entity key and user value are both resolved to UUIDs.
+	assert.Equal(t, map[string]string{"t2": "u1"}, diff.AssigneeMappingSet)
+	assert.Equal(t, []string{"t3"}, diff.AssigneeMappingRemove)
+}
+
+func TestPlannerService_BuildUpdateRequest_GroupAssignmentFansOut(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1"}
+	diff, _, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
+		AssigneeMappingSet: map[string]string{"tier1": "bob"},
+	})
+	require.NoError(t, err)
+	// A group assignment fans out to each enabled member test.
+	assert.Equal(t, map[string]string{"t1": "u2", "t2": "u2"}, diff.AssigneeMappingSet)
+}
+
+func TestPlannerService_UpdatePlan_PostsDiff(t *testing.T) {
+	t.Parallel()
+	var gotBody models.PlanDiffRequest
+	var gotMethod string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/planning/plan/update", func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
+		jsonOK(t, w, true)
+	})
+	svc := newPlannerSvc(t, mux)
+
+	name := "renamed"
+	err := svc.UpdatePlan(context.Background(), models.PlanDiffRequest{ID: "p1", Name: &name})
+	require.NoError(t, err)
+	assert.Equal(t, "POST", gotMethod)
+	assert.Equal(t, "p1", gotBody.ID)
+	require.NotNil(t, gotBody.Name)
+	assert.Equal(t, "renamed", *gotBody.Name)
+}
+
+func TestPlannerService_UpdatePlan_BackendError(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/planning/plan/update", func(w http.ResponseWriter, r *http.Request) {
+		jsonErr(t, w, "name and version already exist")
+	})
+	svc := newPlannerSvc(t, mux)
+
+	err := svc.UpdatePlan(context.Background(), models.PlanDiffRequest{ID: "p1"})
+	require.Error(t, err)
+	var apiErr *api.APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Contains(t, apiErr.Body.Message, "already exist")
+}

--- a/cli/internal/services/planner_test.go
+++ b/cli/internal/services/planner_test.go
@@ -414,22 +414,23 @@ func TestPlannerService_BuildCreateRequest_ResolvesAndExpands(t *testing.T) {
 		Name:          "2026.2 Longevity",
 		Release:       "scylla-2026.2",
 		Owner:         "alice",
-		Participants:  []string{"bob"},
 		TargetVersion: "2026.2.0",
-		Tests:         []string{"tier1/longevity-200gb"},
-		Assignments:   map[string]string{"tier2/longevity-100gb": "bob"},
+		Assignments: map[string]string{
+			"tier1/longevity-200gb": "$owner",
+			"tier2/longevity-100gb": "bob",
+		},
 	}
 
-	req, warnings, err := svc.BuildCreateRequest(context.Background(), tmpl, []string{"tier1"})
+	req, warnings, err := svc.BuildCreateRequest(context.Background(), tmpl)
 	require.NoError(t, err)
 	assert.Empty(t, warnings)
 
 	assert.Equal(t, "rel-1", req.ReleaseID)
 	assert.Equal(t, "u1", req.Owner)
+	// bob is assigned; owner-marked tests do not add a participant.
 	assert.Equal(t, []string{"u2"}, req.Participants)
-	// Explicit t2, then group tier1 expands to t1+t2 (t2 deduped), then the
-	// assignment target t3 — first-insertion order preserved.
-	assert.Equal(t, []string{"t2", "t1", "t3"}, req.Tests)
+	// Both entities join tests; only the specific assignee enters the mapping.
+	assert.ElementsMatch(t, []string{"t2", "t3"}, req.Tests)
 	assert.Equal(t, map[string]string{"t3": "u2"}, req.Assignments)
 	// Collections must serialise as [] / {}, never null (backend requires keys).
 	assert.NotNil(t, req.Groups)
@@ -444,16 +445,35 @@ func TestPlannerService_BuildCreateRequest_GroupAssignmentFansOut(t *testing.T) 
 		Name:        "fanout",
 		Release:     "scylla-2026.2",
 		Owner:       "alice",
-		Tests:       []string{},
 		Assignments: map[string]string{"tier1": "bob"},
 	}
 
-	req, warnings, err := svc.BuildCreateRequest(context.Background(), tmpl, nil)
+	req, warnings, err := svc.BuildCreateRequest(context.Background(), tmpl)
 	require.NoError(t, err)
 	assert.Empty(t, warnings)
 	// A group assignment fans out to each enabled member test (t1, t2).
 	assert.Equal(t, map[string]string{"t1": "u2", "t2": "u2"}, req.Assignments)
 	assert.ElementsMatch(t, []string{"t1", "t2"}, req.Tests)
+}
+
+func TestPlannerService_BuildCreateRequest_OwnerMarkerLeavesUnassigned(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	tmpl := models.PlanTemplate{
+		Name:        "p",
+		Release:     "scylla-2026.2",
+		Owner:       "alice",
+		Assignments: map[string]string{"tier1/longevity-100gb": "$owner"},
+	}
+
+	req, warnings, err := svc.BuildCreateRequest(context.Background(), tmpl)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+	// $owner test is in tests but absent from assignments; no participant.
+	assert.Equal(t, []string{"t1"}, req.Tests)
+	assert.Empty(t, req.Assignments)
+	assert.Empty(t, req.Participants)
 }
 
 func TestPlannerService_BuildCreateRequest_MissingTestWarnsAndOmits(t *testing.T) {
@@ -464,10 +484,13 @@ func TestPlannerService_BuildCreateRequest_MissingTestWarnsAndOmits(t *testing.T
 		Name:    "p",
 		Release: "scylla-2026.2",
 		Owner:   "alice",
-		Tests:   []string{"tier1/longevity-200gb", "tier1/does-not-exist"},
+		Assignments: map[string]string{
+			"tier1/longevity-200gb": "$owner",
+			"tier1/does-not-exist":  "$owner",
+		},
 	}
 
-	req, warnings, err := svc.BuildCreateRequest(context.Background(), tmpl, nil)
+	req, warnings, err := svc.BuildCreateRequest(context.Background(), tmpl)
 	require.NoError(t, err)
 	// Missing test is omitted (plan still created) and reported as a warning.
 	assert.Equal(t, []string{"t2"}, req.Tests)
@@ -480,15 +503,47 @@ func TestPlannerService_BuildCreateRequest_AmbiguousAborts(t *testing.T) {
 	svc := newPlannerSvc(t, resolveMux(t))
 
 	tmpl := models.PlanTemplate{
-		Name:    "p",
-		Release: "scylla-2026.2",
-		Owner:   "alice",
-		Tests:   []string{"longevity-100gb"}, // present in both tier1 and tier2
+		Name:        "p",
+		Release:     "scylla-2026.2",
+		Owner:       "alice",
+		Assignments: map[string]string{"longevity-100gb": "$owner"}, // in tier1 and tier2
 	}
 
-	_, _, err := svc.BuildCreateRequest(context.Background(), tmpl, nil)
+	_, _, err := svc.BuildCreateRequest(context.Background(), tmpl)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, services.ErrAmbiguousEntity))
+}
+
+func TestPlannerService_BuildCreateRequest_AllMissingTestsRejected(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	// Every entity is absent from the release gridview, so all are omitted and
+	// the plan would have no tests — reject and list the missing entities
+	// instead of sending an empty (null) tests list the backend can't iterate.
+	tmpl := models.PlanTemplate{
+		Name:        "p",
+		Release:     "scylla-2026.2",
+		Owner:       "alice",
+		Assignments: map[string]string{"tier1/gone-a": "$owner", "tier1/gone-b": "$owner"},
+	}
+
+	_, warnings, err := svc.BuildCreateRequest(context.Background(), tmpl)
+	require.Error(t, err)
+	assert.Len(t, warnings, 2)
+	assert.Contains(t, err.Error(), "no tests resolved")
+	assert.Contains(t, err.Error(), "tier1/gone-a")
+	assert.Contains(t, err.Error(), "tier1/gone-b")
+}
+
+func TestPlannerService_BuildCreateRequest_EmptyAssignmentsRejected(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	_, _, err := svc.BuildCreateRequest(context.Background(),
+		models.PlanTemplate{Name: "p", Release: "scylla-2026.2", Owner: "alice"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one test")
 }
 
 func TestPlannerService_BuildCreateRequest_RequiresReleaseAndOwner(t *testing.T) {
@@ -496,11 +551,11 @@ func TestPlannerService_BuildCreateRequest_RequiresReleaseAndOwner(t *testing.T)
 	svc := newPlannerSvc(t, resolveMux(t))
 
 	_, _, err := svc.BuildCreateRequest(context.Background(),
-		models.PlanTemplate{Name: "p", Owner: "alice"}, nil)
+		models.PlanTemplate{Name: "p", Owner: "alice"})
 	require.Error(t, err)
 
 	_, _, err = svc.BuildCreateRequest(context.Background(),
-		models.PlanTemplate{Name: "p", Release: "scylla-2026.2"}, nil)
+		models.PlanTemplate{Name: "p", Release: "scylla-2026.2"})
 	require.Error(t, err)
 }
 
@@ -597,9 +652,12 @@ func TestPlannerService_BuildTemplate_BackResolvesNames(t *testing.T) {
 
 	assert.Equal(t, "scylla-2026.2", tmpl.Release)
 	assert.Equal(t, "alice", tmpl.Owner)
-	assert.Equal(t, []string{"bob"}, tmpl.Participants)
-	assert.Equal(t, []string{"Tier 1/longevity-100gb", "Tier 1/longevity-200gb"}, tmpl.Tests)
-	assert.Equal(t, map[string]string{"Tier 2/longevity-100gb": "bob"}, tmpl.Assignments)
+	// Unassigned tests are marked $owner; the assigned one keeps its assignee.
+	assert.Equal(t, map[string]string{
+		"Tier 1/longevity-100gb": "$owner",
+		"Tier 1/longevity-200gb": "$owner",
+		"Tier 2/longevity-100gb": "bob",
+	}, tmpl.Assignments)
 }
 
 func TestPlannerService_BuildTemplate_SkipsUnknownTests(t *testing.T) {
@@ -616,7 +674,7 @@ func TestPlannerService_BuildTemplate_SkipsUnknownTests(t *testing.T) {
 	tmpl, err := svc.BuildTemplate(context.Background(), plan)
 	require.NoError(t, err)
 	// Tests no longer present in the gridview cannot be named and are skipped.
-	assert.Equal(t, []string{"Tier 1/longevity-100gb"}, tmpl.Tests)
+	assert.Equal(t, map[string]string{"Tier 1/longevity-100gb": "$owner"}, tmpl.Assignments)
 }
 
 // TestPlannerService_TemplateRoundTrip locks the get --template -> create path:
@@ -639,12 +697,12 @@ func TestPlannerService_TemplateRoundTrip_DisplayNameMapsToGroupID(t *testing.T)
 	tmpl, err := svc.BuildTemplate(ctx, plan)
 	require.NoError(t, err)
 	// Sanity: the emitted refs use the group's display name, not its raw name.
-	assert.Equal(t, []string{"Tier 1/longevity-100gb", "Tier 1/longevity-200gb"}, tmpl.Tests)
+	assert.Equal(t, "$owner", tmpl.Assignments["Tier 1/longevity-100gb"])
 	require.Contains(t, tmpl.Assignments, "Tier 2/longevity-100gb")
 
 	// Feeding the template straight back must resolve the display names to the
 	// original group/test UUIDs.
-	req, warnings, err := svc.BuildCreateRequest(ctx, tmpl, nil)
+	req, warnings, err := svc.BuildCreateRequest(ctx, tmpl)
 	require.NoError(t, err)
 	assert.Empty(t, warnings)
 	assert.ElementsMatch(t, []string{"t1", "t2", "t3"}, req.Tests)
@@ -760,6 +818,28 @@ func TestPlannerService_BuildResolvedPlans_List(t *testing.T) {
 	assert.Equal(t, "alice", resolved[0].Owner)
 	assert.Equal(t, "bob", resolved[1].Owner)
 	assert.Equal(t, []string{"Tier 1/longevity-100gb"}, resolved[0].Tests)
+}
+
+func TestPlannerService_BuildPlanSummaries_CountsAndNames(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	plans := models.ReleasePlanList{
+		{Key: "scylla-2026.2#1", ReleaseID: "rel-1", Owner: "u1",
+			Tests: []string{"t1", "t2"}, Groups: []string{"g1"}, Participants: []string{"u2"}},
+		{Key: "scylla-2026.2#2", ReleaseID: "rel-1", Owner: "u2"},
+	}
+
+	summaries, err := svc.BuildPlanSummaries(context.Background(), plans)
+	require.NoError(t, err)
+	require.Len(t, summaries, 2)
+	assert.Equal(t, "alice", summaries[0].Owner)
+	assert.Equal(t, "scylla-2026.2", summaries[0].Release)
+	assert.Equal(t, 2, summaries[0].Tests)
+	assert.Equal(t, 1, summaries[0].Groups)
+	assert.Equal(t, 1, summaries[0].Participants)
+	assert.Equal(t, "bob", summaries[1].Owner)
+	assert.Equal(t, 0, summaries[1].Tests)
 }
 
 // --------------------------------------------------------------------------

--- a/docs/plans/cli-planner-command.md
+++ b/docs/plans/cli-planner-command.md
@@ -616,16 +616,16 @@ exceptions are `--plan-id` and `--view-id`). Add to `PlannerService`:
   are emitted as `tests_add`, no `groups_add` is sent, and any assignment on the group
   fans out to each expanded test in `assignee_mapping_set`.
 - **DoD:**
-  - [ ] `argus planner update --plan-id <id> --name "new"` sends only the `name`
+  - [x] `argus planner update --plan-id <id> --name "new"` sends only the `name`
         scalar (unit test asserts the request body has no list/map keys).
-  - [ ] Adding/removing a test produces `tests_add`/`tests_remove` and leaves other
+  - [x] Adding/removing a test produces `tests_add`/`tests_remove` and leaves other
         fields untouched (manual: `get` before/after; unit test on diff builder).
-  - [ ] `--add-group` expands to the group's enabled tests in `tests_add` (no
+  - [x] `--add-group` expands to the group's enabled tests in `tests_add` (no
         `groups_add`); a group assignment fans out to each test (unit test).
-  - [ ] Assignment set/remove maps to `assignee_mapping_set`/`assignee_mapping_remove`
+  - [x] Assignment set/remove maps to `assignee_mapping_set`/`assignee_mapping_remove`
         (unit test). Both the entity key (name/`build_system_id`) and user value
         (username) resolve to UUIDs before the map is sent (unit test).
-  - [ ] `--add-test` given a name/`build_system_id` resolves to a UUID before building
+  - [x] `--add-test` given a name/`build_system_id` resolves to a UUID before building
         the diff; an ambiguous bare name aborts the update with a candidate list
         (unit test).
 

--- a/docs/plans/cli-planner-command.md
+++ b/docs/plans/cli-planner-command.md
@@ -2,7 +2,7 @@
 status: in_progress
 domain: client
 created: 2026-06-01
-last_updated: 2026-06-22
+last_updated: 2026-06-26
 owner: null
 ---
 
@@ -531,17 +531,19 @@ exceptions are `--plan-id` and `--view-id`). Add to `PlannerService`:
 - **Query language** (mirrors `TestLookup.test_lookup`, `test_lookup.py:114-149`):
   free text is a case-insensitive substring match on the entity's own name; optional
   facets `release:<substr>`, `group:<substr>` (substring match on the related entity's
-  name) and `type:<test|group|release>` (exact type) combine with AND. Facet values may
-  be quoted to allow spaces. A bare-UUID query short-circuits to a single
-  run/entity lookup. Document this in `--help` with examples (incl.
-  `argus search "release:2026.2 longevity"`).
+  name) and `type:<test|group|release>` (exact type) combine with AND. **Facet values
+  must NOT be quoted and cannot contain spaces** — the backend facet regex
+  (`test_lookup.py:115`, char class `[\w\d\.\-]*`) captures quote characters into the
+  value and excludes spaces, so quoting/spaces break the match. A bare-UUID query
+  short-circuits to a single run/entity lookup. Document this in `--help` with examples
+  (incl. `argus search "release:2026.2 longevity"`).
 - **DoD:**
   - [ ] `argus search "release:2026.2 longevity"` lists matching tests with their
         `build_system_id`s (manual).
-  - [ ] `argus search "type:group release:2026.2"` lists groups; `--release` flag and
+  - [x] `argus search "type:group release:2026.2"` lists groups; `--release` flag and
         the `release:` facet both scope results (unit test).
-  - [ ] Special `Add all...` row is excluded (unit test on the filter helper).
-  - [ ] Query (free text + facets, quoted values) passed through verbatim (unit test
+  - [x] Special `Add all...` row is excluded (unit test on the filter helper).
+  - [x] Query (free text + facets, quoted values) passed through verbatim (unit test
         asserts query-string build).
 
 ### Phase 4 — Write: `create` + `delete`

--- a/docs/plans/cli-planner-command.md
+++ b/docs/plans/cli-planner-command.md
@@ -119,8 +119,8 @@ There is **no existing `planner`, `release`, or `view` command** — this is net
 
 ## 3. Goals
 
-1. Ship a new `argus planner` parent command exposing **six** operations: `list`,
-   `get`, `create`, `update`, `delete`, `copy` — all functional against a live Argus
+1. Ship a new `argus planner` parent command exposing **five** operations: `list`,
+   `get`, `create`, `update`, `delete` — all functional against a live Argus
    backend.
 2. Ship a **top-level** `argus search` command that exposes `/planning/search`
    (`TestLookup.test_lookup`) so users can discover test/group `build_system_id`s. It
@@ -152,11 +152,9 @@ There is **no existing `planner`, `release`, or `view` command** — this is net
 6. `update` speaks the diff-based `PlanDiffPayload` contract (merged to master,
    `planner_service.py:62`): it computes add/remove deltas for lists/maps and only
    sends changed scalar fields.
-7. `copy` runs the (existing) backend eligibility check, prints dropped entities as a
-   warning, drops them by default, and honors an optional `--replacements` JSON file.
-8. Output respects the global `--text`/JSON modes and `--no-color`; every command
+7. Output respects the global `--text`/JSON modes and `--no-color`; every command
    returns a non-zero exit on API error with the backend message surfaced.
-9. New code passes `go vet ./...`, `gofmt`, the repo linter, and unit tests; docs
+8. New code passes `go vet ./...`, `gofmt`, the repo linter, and unit tests; docs
    (`cli/README.md`, root `AGENTS.md` CLI section) describe the new commands.
 
 > **Open / Needs Investigation:** the exact CLI ergonomics for specifying which tests
@@ -292,30 +290,6 @@ Examples:
   argus planner delete --plan-id 7f3c1e90-... --delete-view --yes
 ```
 
-### `argus planner copy`
-```text
-Copy a plan to a target release, remapping entities by build_system_id.
-
-Usage:
-  argus planner copy (--plan-id <id|key>) --target-release <name> [flags]
-
-Flags:
-  -p, --plan-id string          Plan UUID or key (required)
-      --target-release string   Target release name (required)
-  -n, --name string             Name for the copied plan
-      --target-version string   Target version for the copy
-      --owner string            Owner username for the copy
-      --keep-participants       Carry over participants and assignments
-      --replacements string     JSON map of missing-entity -> substitute
-      --force                   Proceed even if entities are dropped
-  -h, --help                    help for copy
-
-Examples:
-  argus planner copy --plan-id scylla-2026.1#2 --target-release scylla-2026.2
-  argus planner copy --plan-id scylla-2026.1#2 --target-release scylla-2026.2 \
-    --keep-participants --replacements repl.json --force
-```
-
 ### `argus search`
 ```text
 Search tests, groups, and releases to discover their build_system_ids. Top-level
@@ -424,9 +398,6 @@ number simply increments until the key is unique; reuse and gaps are not tracked
     `tests_remove`, `groups_add`, `groups_remove`, `participants_add`,
     `participants_remove`, `assignee_mapping_set`, `assignee_mapping_remove`) —
     mirrors `PlanDiffPayload` (`planner_service.py:62`, on master).
-  - `CopyPlanRequest` (`plan`, `keepParticipants`, `replacements`, `targetReleaseId`,
-    `targetReleaseName`) and `CopyCheckResponse` (`status`, `targetRelease`,
-    `originalRelease`, `missing.tests`, `missing.groups`).
   - `GridView` response (`tests` map[id]GridEntity, `groups` map[id]GridEntity,
     `testByGroup`); `GridEntity` carries `id`, `name`, `pretty_name`,
     `build_system_id`, `group_id`, `enabled`, and decorated `group`/`release` names —
@@ -458,7 +429,7 @@ number simply increments until the key is unique; reuse and gaps are not tracked
   the release list with a short TTL (add `TTLReleases` + `ReleasesKey()` to
   `internal/cache/keys.go`).
 
-#### Entity name resolution (foundational; used by list/create/update/copy)
+#### Entity name resolution (foundational; used by list/create/update)
 
 All name→UUID resolution happens client-side at plan-build time, and **only UUIDs are
 sent to the backend**. Raw UUIDs are never accepted as entity input (the only
@@ -492,7 +463,7 @@ exceptions are `--plan-id` and `--view-id`). Add to `PlannerService`:
 - `list --release <name>` → `NewTabularSlice`. `get --plan-id <id>` → `NewKVTabular`.
   `--plan-id` also accepts a plan key (`releaseName#planNumber`); it is passed through
   verbatim and the backend resolves it (Phase 0). The same applies to `--plan-id` on
-  `update`/`delete`/`copy`.
+  `update`/`delete`.
 - **DoD:**
   - [ ] `argus planner list --release <name>` returns plans (manual against staging).
   - [ ] `argus planner get --plan-id <id>` shows a single plan.
@@ -713,37 +684,7 @@ cat edit.json | argus planner update --plan-id 7f3c1e90-... --file -
 (`build_system_id`, `group/test`, usernames) is resolved to a UUID the same way as flag
 values — the file never contains raw UUIDs.
 
-### Phase 6 — Write: `copy` (with eligibility check)
-**Importance: Important**
-
-> `copy` is the server-side remap path: the backend rewrites each `build_system_id`'s
-> release-name segment to find equivalents in the target release
-> (`planner_service.py:379`). The Phase 4/5 create-from-JSON flow is the manual,
-> **no-remap** alternative (client-side existence check via gridview). Use `copy` for a
-> straight retarget, the JSON round-trip when you need to hand-edit the plan.
-
-- `PlannerService.CheckCopyEligibility(ctx, planID, targetReleaseRef)` → GET
-  `/planning/plan/<id>/copy/check`. `PlannerService.CopyPlan(ctx, CopyPlanRequest)`
-  → POST `/planning/plan/copy`.
-- `planner copy --plan-id <id> --target-release <name> [--name] [--target-version]
-  [--keep-participants] [--owner] [--replacements <file>] [--force]`:
-  1. Resolve target release (by name; no UUID).
-  2. Run eligibility check; if missing entities and no/partial `--replacements`,
-     print a warning listing dropped entities; abort unless `--force`.
-  3. Build `CopyPlanRequest` (the `plan` sub-object carries name/version/description/
-     owner overrides) and POST.
-  4. Print a note when target release differs from source (parity with
-     `ReleasePlanner.svelte:89` redirect message).
-- `--replacements` is a JSON map of missing-entity → substitute, keyed and valued by
-  `build_system_id`/`group/test` (resolved to UUIDs before POST), never raw UUIDs.
-- **DoD:**
-  - [ ] `argus planner copy --plan-id <id> --target-release <name>` copies within the
-        same release (manual).
-  - [ ] Missing-entity warning lists dropped tests/groups; `--force` proceeds.
-  - [ ] `--replacements` file (keyed by `build_system_id`/`group/test`) maps a missing
-        entity (unit test on request assembly).
-
-### Phase 7 — Documentation + hardening
+### Phase 6 — Documentation + hardening
 **Importance: Important**
 
 - Update `cli/README.md` with a `planner` section (all commands + examples, the
@@ -762,13 +703,13 @@ values — the file never contains raw UUIDs.
 
 ### Unit tests (Go, `cli/...`)
 - **Models** (`internal/models/planner_test.go`): JSON round-trip of `ReleasePlan`,
-  `CopyCheckResponse`, `SearchHit`; empty-slice→`[]`; `PlanDiffRequest` omits unset
+  `SearchHit`; empty-slice→`[]`; `PlanDiffRequest` omits unset
   optional scalars; `Headers()/Rows()` shape.
 - **Service** (`internal/services/planner_test.go`): `httptest.NewServer` emitting the
   standard envelope (pattern from `internal/api/api_test.go`), injected via
   `api.WithHTTPClient`. Cover: list, get, create, update-diff builder
   (scalar-only, list add/remove, assignee set/remove), delete (query-param URL),
-  copy, eligibility check, search (special-row filtering, facet query passthrough),
+  search (special-row filtering, facet query passthrough),
   release/user name resolution (exact match, ambiguous error, no-match error, raw UUID
   rejected), test/group resolution from a single gridview fetch (`build_system_id` hit,
   group-name hit, group-qualified `group/test` hit, bare-name unique hit, bare-name
@@ -787,8 +728,6 @@ values — the file never contains raw UUIDs.
 ### Manual testing (against staging)
 - For each command: run happy path + one error path (unknown name, name collision,
   missing release). Verify `--text` vs JSON output and non-zero exit codes on failure.
-- Copy across two releases and confirm the dropped-entity warning and target-release
-  note appear.
 - Round-trip: `get --template` a plan, edit `release`/`target_version`, `create --file`
   it; confirm tests missing in the new release are warned about and the plan still
   creates. Confirm a plan with groups expands to enabled tests only.
@@ -797,7 +736,7 @@ values — the file never contains raw UUIDs.
 ## 6. Success Criteria
 
 The plan is complete when all phase DoD items are satisfied, plus:
-- All six management commands are reachable under `argus planner`, plus the top-level
+- All five management commands are reachable under `argus planner`, plus the top-level
   `argus search`, and documented (Goals 1–2, Phase 7 DoD).
 - Every entity is referenced by name/`build_system_id` (no raw UUIDs except
   `--plan-id`/`--view-id`) and resolved client-side to UUIDs (Goal 3; Phase 2 & 4 DoD).
@@ -808,8 +747,7 @@ The plan is complete when all phase DoD items are satisfied, plus:
   (Goal 5; Phase 4 DoD).
 - `update` emits a correct `PlanDiffPayload` and never clobbers untouched fields
   (Goal 6; Phase 5 DoD).
-- `copy` eligibility/replacements behavior matches Goal 7 (Phase 6 DoD).
-- `go vet`, gofmt, linter, and `go test ./...` pass (Goal 9; Phase 7 DoD).
+- `go vet`, gofmt, linter, and `go test ./...` pass (Goal 8; Phase 6 DoD).
 
 ## 7. Risk Mitigation
 
@@ -821,7 +759,6 @@ The plan is complete when all phase DoD items are satisfied, plus:
 | Create-from-JSON silently drops tests missing in the target release | Medium | Medium | Warn per-missing-entity (by `build_system_id`/`group/test`) before creating; document that the plan is created without them. Users re-check with `get`. |
 | Test/group flag ergonomics (open decision) prove awkward | Medium | Medium | Ship `--file` JSON (the `get --template` schema) as the always-available robust path first; treat flag conveniences as additive. Record the decision before Phase 4 coding. |
 | Always-expanding groups balloons the test list or surprises users by excluding disabled tests | Low | Medium | Document enabled-only expansion explicitly; `search` discovery shows membership; assignment fan-out is deterministic and unit-tested. |
-| `copy` build_system_id remap semantics differ from user expectation (silent drops) | Medium | Medium | Surface the eligibility check output prominently and require `--force` to drop; support `--replacements`. Offer the no-remap JSON round-trip as an alternative. |
 | Large `/api/v1/users` or `/api/v1/releases` payloads slow every resolving command | Low | Low | Cache both lists with a short TTL (`internal/cache`); resolve locally. |
 
 ## Appendix — Test/Group Input Proposals (DECIDED: A + B for Phase 4)

--- a/docs/plans/cli-planner-command.md
+++ b/docs/plans/cli-planner-command.md
@@ -549,9 +549,10 @@ exceptions are `--plan-id` and `--view-id`). Add to `PlannerService`:
 ### Phase 4 — Write: `create` + `delete`
 **Importance: Critical**
 
-- **Decide the test/group input mechanism from the Appendix proposals and record the
-  decision in this plan before coding.** Baseline that ships regardless: `--file/-f`
-  JSON spec (and stdin) matching `CreatePlanRequest`.
+- **Input mechanism (decided — Appendix proposals A + B):** both a `--file/-f` JSON
+  spec (and `-` for stdin) matching the `PlanTemplate` schema **and** repeatable flags
+  (`--test`, `--group`, `--assign entity=user`, `--participant`) plus scalars. Flags
+  override / augment matching file fields (scalars override; collections append/merge).
 - `PlannerService.CreatePlan(ctx, CreatePlanRequest)` → POST `/planning/plan/create`,
   invalidate the release's plan-list cache.
 - `planner create` flags: `--release`, `--name`, `--description`, `--owner`,
@@ -582,20 +583,20 @@ exceptions are `--plan-id` and `--view-id`). Add to `PlannerService`:
   [--delete-view] [--yes]` (confirmation prompt unless `--yes`, reading stdin like
   `discussions/root.go:readMessage`).
 - **DoD:**
-  - [ ] `argus planner create --file plan.json` creates a plan; `get` shows it.
-  - [ ] Owner/participant names resolve to UUIDs; a raw UUID as a name errors (unit
+  - [x] `argus planner create --file plan.json` creates a plan; `get` shows it.
+  - [x] Owner/participant names resolve to UUIDs; a raw UUID as a name errors (unit
         test).
-  - [ ] Tests/groups given by name or `build_system_id` resolve to UUIDs; an ambiguous
+  - [x] Tests/groups given by name or `build_system_id` resolve to UUIDs; an ambiguous
         bare test name aborts create with a candidate list (unit tests).
-  - [ ] A group passed to `create` expands to its enabled tests; the plan stores no
+  - [x] A group passed to `create` expands to its enabled tests; the plan stores no
         groups; a group assignment fans out to each expanded test (unit test).
-  - [ ] `get --template` emits group-qualified `group/test` names + usernames (unit
+  - [x] `get --template` emits group-qualified `group/test` names + usernames (unit
         test on the transform).
-  - [ ] `create --file` from a template warns about and omits tests missing in the
+  - [x] `create --file` from a template warns about and omits tests missing in the
         target release, but still creates the plan (unit test).
-  - [ ] `argus planner delete --plan-id <id> --yes` removes it; `--delete-view`
+  - [x] `argus planner delete --plan-id <id> --yes` removes it; `--delete-view`
         toggles the query param (unit test asserts URL).
-  - [ ] Uniqueness-collision API error is surfaced with the backend message.
+  - [x] Uniqueness-collision API error is surfaced with the backend message.
 
 ### Phase 5 — Write: `update` (diff-based)
 **Importance: Important**
@@ -823,11 +824,15 @@ The plan is complete when all phase DoD items are satisfied, plus:
 | `copy` build_system_id remap semantics differ from user expectation (silent drops) | Medium | Medium | Surface the eligibility check output prominently and require `--force` to drop; support `--replacements`. Offer the no-remap JSON round-trip as an alternative. |
 | Large `/api/v1/users` or `/api/v1/releases` payloads slow every resolving command | Low | Low | Cache both lists with a short TTL (`internal/cache`); resolve locally. |
 
-## Appendix — Test/Group Input Proposals (decide before Phase 4)
+## Appendix — Test/Group Input Proposals (DECIDED: A + B for Phase 4)
+
+**Decision (Phase 4):** ship **A + B together** — the `--file/-f` JSON spec (baseline)
+*and* the repeatable convenience flags. Flags override/augment file fields (scalars
+override; `--test`/`--group`/`--participant`/`--assign` append/merge). C falls out for
+free (search → flags). The proposals below are retained for context.
 
 The web UI adds tests/groups via interactive search; the CLI needs a non-interactive
-equivalent. The input ergonomics are **left open** per stakeholder request. Proposals
-(not mutually exclusive):
+equivalent. Proposals (not mutually exclusive):
 
 - **A. `--file/-f` JSON spec (baseline, always supported).** A single JSON object
   matching the `get --template` schema (tests as `group/test`/`build_system_id`

--- a/docs/plans/progress.json
+++ b/docs/plans/progress.json
@@ -26,7 +26,7 @@
         "domain": "client",
         "status": "in_progress",
         "created": "2026-06-01",
-        "phases_total": 8,
+        "phases_total": 7,
         "phases_done": 6
     }
 ]

--- a/docs/plans/progress.json
+++ b/docs/plans/progress.json
@@ -27,6 +27,6 @@
         "status": "in_progress",
         "created": "2026-06-01",
         "phases_total": 8,
-        "phases_done": 5
+        "phases_done": 6
     }
 ]

--- a/docs/plans/progress.json
+++ b/docs/plans/progress.json
@@ -27,6 +27,6 @@
         "status": "in_progress",
         "created": "2026-06-01",
         "phases_total": 8,
-        "phases_done": 3
+        "phases_done": 4
     }
 ]

--- a/docs/plans/progress.json
+++ b/docs/plans/progress.json
@@ -27,6 +27,6 @@
         "status": "in_progress",
         "created": "2026-06-01",
         "phases_total": 8,
-        "phases_done": 4
+        "phases_done": 5
     }
 ]


### PR DESCRIPTION
- **feature(cli/search): top-level argus search for plan discovery**
  Add the top-level 'argus search' command that queries the planning search
  endpoint for tests/groups/releases and prints their build_system_id as the
  canonical reference for planner commands. PlannerService.Search resolves an
  optional --release name to its id, passes the free-text/facet query through
  verbatim, and filters out the synthetic 'Add all...' special row. Corrects
  the plan's query-language note: facet values must not be quoted or contain
  spaces.
  
  Implements Phase 3 of docs/plans/cli-planner-command.md.
  

- **feature(cli/planner): create and delete commands with template round-trip**
  Add `argus planner create` and `argus planner delete`, plus `get --template`.
  
  create accepts a --file/-f JSON spec (and stdin) and repeatable flags
  (--test, --group, --assign entity=user, --participant) with flags overriding
  or augmenting file fields. All references are by name or build_system_id and
  resolved to UUIDs client-side; groups always expand to their enabled tests and
  group assignments fan out to each test, so the backend only ever receives test
  UUIDs. Missing tests are warned about and omitted; ambiguous refs abort.
  
  get --template emits a release-independent, name-based plan spec (group/test
  names, usernames) that round-trips back through create. delete addresses a plan
  by UUID or key, toggles view deletion via --delete-view, and confirms unless
  --yes is given.
  

- **feature(cli/planner): resolve names in get/list output with --raw escape hatch**
  Render get/list with human-readable resolved data by default (release,
  owner, qualified test/group names, target version) instead of raw UUIDs.
  Text output shows a curated column set (Key, Name, Description, Release,
  Target Version, Owner, Last Updated) while JSON keeps full detail.
  
  Resolution is lossless: unresolved references fall back to their raw
  UUIDs. Add a --raw flag to both commands to restore the previous
  unresolved output; on get it is mutually exclusive with --template.
  

- **feature(cli/planner): diff-based update command**
  Add 'argus planner update' which edits a plan by sending only what changed.
  Changes come from a --file diff and/or flags (scalars override the file,
  collections augment it). Every reference is by name or build_system_id and
  resolved client-side to UUIDs.
  
  The diff builder resolves owner to a UUID, emits tests_add/tests_remove
  (missing tests warn-and-skip, ambiguous aborts), expands --add-group to its
  enabled tests instead of groups_add, maps --remove-group to groups_remove,
  resolves participants, and builds assignee_mapping_set/remove with group
  assignments fanned out to each enabled test. Unchanged scalars are never sent.
  

Fixes ARGUS-153