### PR TITLE
fix(backend/stats): collapse snapshot invalidation into single partition delete

### DIFF
--- a/argus/backend/models/web.py
+++ b/argus/backend/models/web.py
@@ -437,8 +437,7 @@ def invalidate_release_snapshots(release_id: UUID) -> None:
     is used only for run lifecycle events (submit/finish).
     """
     try:
-        for snapshot in ReleaseStatsSnapshot.filter(release_id=release_id).all():
-            snapshot.delete()
+        ReleaseStatsSnapshot.filter(release_id=release_id).delete()
     except Exception:  # pylint: disable=broad-except
         _SNAPSHOT_LOGGER.warning("Failed to invalidate release snapshots for %s", release_id, exc_info=True)
 


### PR DESCRIPTION
## Problem

`submit_testrun_comment` (and comment edit/delete) could take up to ~4.5s.

Root cause: `invalidate_release_snapshots()` did a read-then-loop delete:

```python
for snapshot in ReleaseStatsSnapshot.filter(release_id=release_id).all():
    snapshot.delete()
```

This reads **every** `ReleaseStatsSnapshot` row for the release — loading full `payload` JSON blobs — then issues **one DELETE per row, serially**. For releases with many filter combinations that is a large read plus N sequential round-trips.

Snapshots are invalidated on every comment mutation because the cached payload embeds per-run `comments` / `hasComments`, so the cost is paid on each post/edit/delete.

## Solution

`release_id` is the partition key — all snapshots for a release live in one partition. Replace the read-then-loop with a single partition-level delete:

```python
ReleaseStatsSnapshot.filter(release_id=release_id).delete()
```

No read, one query, exact same rows removed. Scope unchanged (only that release's snapshots; other releases are separate partitions). Next stats request regenerates the cache as before.