### PR TITLE
feature(cli/results): add cross-test generic results catalog and search

### DIFF
--- a/argus/backend/controller/results_api.py
+++ b/argus/backend/controller/results_api.py
@@ -1,0 +1,53 @@
+from datetime import datetime, timezone
+
+from flask import Blueprint, jsonify, request
+
+from argus.backend.error_handlers import handle_api_exception
+from argus.backend.service.results_service import ResultsService
+from argus.backend.service.user import api_login_required
+
+bp = Blueprint("results_api", __name__, url_prefix="/api/results")
+bp.register_error_handler(Exception, handle_api_exception)
+
+
+@bp.route("/catalog", methods=["GET"])
+@api_login_required
+def results_catalog():
+    """Cross-test catalog of every generic result table name, with per-name
+    test count and column metadata."""
+    service = ResultsService()
+    catalog = service.get_generic_result_catalog()
+
+    return jsonify({
+        "status": "ok",
+        "response": catalog,
+    })
+
+
+@bp.route("/search", methods=["GET"])
+@api_login_required
+def results_search():
+    """Cross-test flattened cell dump over generic result tables, filtered by
+    table name substring, status, and a sut_timestamp range."""
+    name = request.args.get("name")
+    statuses = request.args.getlist("status[]")
+    before = request.args.get("before")
+    after = request.args.get("after")
+    limit = int(request.args.get("limit", 500))
+
+    before_dt = datetime.fromtimestamp(int(before), tz=timezone.utc) if before else None
+    after_dt = datetime.fromtimestamp(int(after), tz=timezone.utc) if after else None
+
+    service = ResultsService()
+    result = service.search_generic_results(
+        name=name,
+        statuses=statuses or None,
+        before=before_dt,
+        after=after_dt,
+        limit=limit,
+    )
+
+    return jsonify({
+        "status": "ok",
+        "response": result,
+    })

--- a/argus/backend/service/results_service.py
+++ b/argus/backend/service/results_service.py
@@ -13,8 +13,13 @@ from argus.backend.db import ScyllaCluster
 from argus.backend.models.result import ArgusGenericResultMetadata, ArgusGenericResultData, ArgusBestResultData, ColumnMetadata, ArgusGraphView
 from argus.backend.plugins.sct.udt import PackageVersion
 from argus.backend.service.testrun import TestRunService
+from argus.backend.util.common import chunk, matches_substring
 
 LOGGER = logging.getLogger(__name__)
+
+# Number of (test_id, name) partitions to fan out to concurrently in
+# ResultsService.search_generic_results via execute_async.
+GENERIC_RESULTS_FANOUT_CHUNK_SIZE = 100
 
 type RunId = str
 type ReleasesMap = dict[str, list[RunId]]
@@ -428,12 +433,18 @@ class ResultsService:
         tables_meta = self.cluster.session.execute(query=query, parameters=(test_id,))
         return [ArgusGenericResultMetadata(**table) for table in tables_meta]
 
-    def _get_tables_data(self, test_id: UUID, table_name: str, ignored_runs: list[RunId],
-                         start_date: datetime | None = None, end_date: datetime | None = None) -> list[ArgusGenericResultData]:
+    @staticmethod
+    def _build_generic_result_data_query(test_id: UUID, table_name: str, start_date: datetime | None = None,
+                                          end_date: datetime | None = None) -> tuple[str, list]:
+        """Build the "cell dump" query/parameters for a single (test_id, name) partition.
+
+        Shared by [_get_tables_data] (single-test callers) and
+        [ResultsService.search_generic_results] (cross-test scatter-gather), so the
+        sut_timestamp range/ALLOW FILTERING logic lives in exactly one place.
+        """
         query_fields = ["run_id", "column", "row", "value", "status", "sut_timestamp"]
         raw_query = (f"SELECT {','.join(query_fields)}"
                      f" FROM generic_result_data_v1 WHERE test_id = ? AND name = ?")
-
         parameters = [test_id, table_name]
 
         if start_date:
@@ -445,9 +456,103 @@ class ResultsService:
 
         if start_date or end_date:
             raw_query += " ALLOW FILTERING"
+        return raw_query, parameters
+
+    def _get_tables_data(self, test_id: UUID, table_name: str, ignored_runs: list[RunId],
+                         start_date: datetime | None = None, end_date: datetime | None = None) -> list[ArgusGenericResultData]:
+        raw_query, parameters = self._build_generic_result_data_query(test_id, table_name, start_date, end_date)
         query = self.cluster.prepare(raw_query)
         data = self.cluster.session.execute(query=query, parameters=tuple(parameters))
         return [ArgusGenericResultData(**cell) for cell in data if cell["run_id"] not in ignored_runs]
+
+    def get_generic_result_catalog(self) -> list[dict]:
+        """Cross-test catalog of every generic result table name.
+
+        Scans the small generic_result_metadata_v1 table (partitioned by test_id
+        only) in full and groups rows by table name, since there is no other way
+        to discover "which tables exist across all tests" short of a name-keyed
+        index table (out of scope for v1 per the design doc).
+        """
+        raw_query = "SELECT test_id, name, columns_meta FROM generic_result_metadata_v1"
+        query = self.cluster.prepare(raw_query)
+        rows = self.cluster.session.execute(query=query)
+
+        catalog: dict[str, dict] = {}
+        for row in rows:
+            entry = catalog.setdefault(row["name"], {"test_ids": set(), "columns": {}})
+            entry["test_ids"].add(row["test_id"])
+            for col in (row["columns_meta"] or []):
+                entry["columns"].setdefault(col.name, {
+                    "name": col.name,
+                    "unit": col.unit,
+                    "type": col.type,
+                    "higher_is_better": col.higher_is_better,
+                })
+
+        return [
+            {
+                "name": name,
+                "test_count": len(entry["test_ids"]),
+                "columns": list(entry["columns"].values()),
+            }
+            for name, entry in sorted(catalog.items())
+        ]
+
+    def search_generic_results(self, name: str | None = None, statuses: list[str] | None = None,
+                                before: datetime | None = None, after: datetime | None = None,
+                                limit: int = 500) -> dict:
+        """Cross-test "cell dump" search over generic_result_data_v1.
+
+        Mirrors the scatter-gather pattern used by PytestViewService.result_filter:
+        enumerate partitions with a scan, then fan out chunked async queries per
+        partition, then merge/sort/limit app-side. generic_result_data_v1 has a
+        composite partition key (test_id, name), so the fan-out keys on
+        (test_id, name) pairs rather than on test_id alone.
+        """
+        raw_query = "SELECT test_id, name FROM generic_result_metadata_v1"
+        query = self.cluster.prepare(raw_query)
+        pairs = [(row["test_id"], row["name"]) for row in self.cluster.session.execute(query=query)]
+
+        if name:
+            pairs = [pair for pair in pairs if matches_substring(pair[1], name)]
+
+        cells: list[dict] = []
+        for partition_chunk in chunk(pairs, GENERIC_RESULTS_FANOUT_CHUNK_SIZE):
+            futures = []
+            for test_id, table_name in partition_chunk:
+                raw_data_query, parameters = self._build_generic_result_data_query(
+                    test_id, table_name, start_date=after, end_date=before)
+                prepared = self.cluster.prepare(raw_data_query)
+                futures.append((test_id, table_name, self.cluster.session.execute_async(
+                    prepared, parameters=tuple(parameters), execution_profile="read_fast")))
+
+            for test_id, table_name, future in futures:
+                try:
+                    ignored_runs = self._get_runs_details(test_id).ignored
+                except Exception:  # pylint: disable=broad-except
+                    # Orphaned/malformed test data shouldn't fail the whole
+                    # cross-test search; fall back to not filtering this pair.
+                    LOGGER.warning("Failed to resolve ignored runs for test_id=%s", test_id, exc_info=True)
+                    ignored_runs = []
+                for cell in future.result():
+                    if cell["run_id"] in ignored_runs:
+                        continue
+                    cells.append({
+                        "test_id": str(test_id),
+                        "table": table_name,
+                        "run_id": str(cell["run_id"]),
+                        "column": cell["column"],
+                        "row": cell["row"],
+                        "value": cell["value"],
+                        "status": cell["status"],
+                        "sut_timestamp": cell["sut_timestamp"],
+                    })
+
+        if statuses:
+            cells = [cell for cell in cells if cell["status"] in statuses]
+
+        cells.sort(key=lambda cell: cell["sut_timestamp"] or datetime.min, reverse=True)
+        return {"total": len(cells), "cells": cells[:limit]}
 
     def get_table_metadata(self, test_id: UUID, table_name: str) -> ArgusGenericResultMetadata:
         raw_query = ("SELECT * FROM generic_result_metadata_v1 WHERE test_id = ? AND name = ?")

--- a/argus/backend/service/views_widgets/pytest.py
+++ b/argus/backend/service/views_widgets/pytest.py
@@ -16,7 +16,7 @@ from argus.backend.db import ScyllaCluster
 from argus.backend.models.pytest import PytestResultTable, PytestUserField
 from argus.backend.models.web import ArgusTest, ArgusUserView
 from argus.backend.plugins.generic.plugin import PluginInfo as GenericPluginInfo
-from argus.backend.util.common import chunk
+from argus.backend.util.common import chunk, matches_substring
 from argus.common.enums import PytestStatus
 
 LOGGER = logging.getLogger(__name__)
@@ -121,8 +121,7 @@ class PytestViewService:
 
         if test:
             LOGGER.warning(test)
-            unique_tests = [
-                t for t in unique_tests if re.search(re.escape(test), t)]
+            unique_tests = [t for t in unique_tests if matches_substring(t, test)]
 
         limit = int(request.args.get("limit", 500))
         before = request.args.get("before")

--- a/argus/backend/tests/results_service/test_cross_test_results.py
+++ b/argus/backend/tests/results_service/test_cross_test_results.py
@@ -1,0 +1,188 @@
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+
+from argus.backend.models.result import ArgusGenericResultData, ArgusGenericResultMetadata, ColumnMetadata
+from argus.backend.plugins.sct.testrun import SCTTestRun
+from argus.backend.service.results_service import ResultsService
+
+
+@pytest.fixture
+def two_tests_same_table_name(argus_db):
+    """Two distinct tests, both reporting a table with the same (per-invocation
+    unique) name, plus a third test with a differently-named table, to
+    exercise cross-test catalog/search without knowing any test_id up front.
+
+    The table name is randomized per invocation because the underlying
+    keyspace is shared (session-scoped) across every test in this file, and
+    catalog/search scan the whole table with no test_id restriction.
+    """
+    test_id_a = uuid4()
+    test_id_b = uuid4()
+    test_id_c = uuid4()
+    table_name = f"Latency-{uuid4()}"
+    other_table_name = f"Throughput-{uuid4()}"
+
+    ArgusGenericResultMetadata(
+        test_id=test_id_a,
+        name=table_name,
+        columns_meta=[
+            ColumnMetadata(name="p99", unit="ms", type="FLOAT", higher_is_better=False),
+        ],
+        rows_meta=["run1"],
+        validation_rules={},
+    ).save()
+    ArgusGenericResultMetadata(
+        test_id=test_id_b,
+        name=table_name,
+        columns_meta=[
+            ColumnMetadata(name="p99", unit="ms", type="FLOAT", higher_is_better=False),
+            ColumnMetadata(name="p999", unit="ms", type="FLOAT", higher_is_better=False),
+        ],
+        rows_meta=["run1"],
+        validation_rules={},
+    ).save()
+    ArgusGenericResultMetadata(
+        test_id=test_id_c,
+        name=other_table_name,
+        columns_meta=[
+            ColumnMetadata(name="ops", unit="op/s", type="FLOAT", higher_is_better=True),
+        ],
+        rows_meta=["run1"],
+        validation_rules={},
+    ).save()
+
+    now = datetime.now(UTC)
+    ArgusGenericResultData(
+        test_id=test_id_a, name=table_name, run_id=uuid4(), column="p99", row="run1",
+        sut_timestamp=now - timedelta(days=5), value=10.0, status="UNSET",
+    ).save()
+    ArgusGenericResultData(
+        test_id=test_id_b, name=table_name, run_id=uuid4(), column="p99", row="run1",
+        sut_timestamp=now - timedelta(days=1), value=20.0, status="ERROR",
+    ).save()
+    ArgusGenericResultData(
+        test_id=test_id_c, name=other_table_name, run_id=uuid4(), column="ops", row="run1",
+        sut_timestamp=now - timedelta(days=10), value=1000.0, status="UNSET",
+    ).save()
+
+    return test_id_a, test_id_b, test_id_c, table_name, other_table_name
+
+
+def test_catalog_groups_same_named_table_across_tests(two_tests_same_table_name):
+    _, _, _, table_name, other_table_name = two_tests_same_table_name
+    service = ResultsService()
+    catalog = service.get_generic_result_catalog()
+
+    by_name = {entry["name"]: entry for entry in catalog}
+    assert by_name[table_name]["test_count"] == 2
+    column_names = {col["name"] for col in by_name[table_name]["columns"]}
+    assert column_names == {"p99", "p999"}
+    assert by_name[other_table_name]["test_count"] == 1
+
+
+def test_search_returns_cells_across_tests_without_a_test_id(two_tests_same_table_name):
+    test_id_a, test_id_b, _, table_name, _ = two_tests_same_table_name
+    service = ResultsService()
+    result = service.search_generic_results(name=table_name)
+
+    assert result["total"] == 2
+    cells = result["cells"]
+    assert len(cells) == 2
+    test_ids = {cell["test_id"] for cell in cells}
+    assert test_ids == {str(test_id_a), str(test_id_b)}
+    assert all(cell["table"] == table_name for cell in cells)
+
+
+def test_search_filters_by_status(two_tests_same_table_name):
+    _, _, _, table_name, _ = two_tests_same_table_name
+    service = ResultsService()
+    result = service.search_generic_results(name=table_name, statuses=["ERROR"])
+
+    assert result["total"] == 1
+    assert result["cells"][0]["status"] == "ERROR"
+
+
+def test_search_respects_limit_but_reports_true_total(two_tests_same_table_name):
+    _, _, _, table_name, _ = two_tests_same_table_name
+    service = ResultsService()
+    result = service.search_generic_results(name=table_name, limit=1)
+
+    assert result["total"] == 2
+    assert len(result["cells"]) == 1
+
+
+def test_search_filters_by_date_range(two_tests_same_table_name):
+    _, test_id_b, _, table_name, _ = two_tests_same_table_name
+    service = ResultsService()
+    now = datetime.now(UTC)
+    result = service.search_generic_results(name=table_name, after=now - timedelta(days=2))
+
+    assert result["total"] == 1
+    assert result["cells"][0]["test_id"] == str(test_id_b)
+
+
+def test_search_excludes_cells_from_ignored_runs(fake_test):
+    table_name = f"IgnoredRunsTable-{uuid4()}"
+    ignored_run_id = uuid4()
+    kept_run_id = uuid4()
+    start_time = datetime.now(UTC)
+
+    ArgusGenericResultMetadata(
+        test_id=fake_test.id,
+        name=table_name,
+        columns_meta=[ColumnMetadata(name="col1", unit="ms", type="FLOAT", higher_is_better=False)],
+        rows_meta=["row1"],
+        validation_rules={},
+    ).save()
+
+    SCTTestRun(
+        id=ignored_run_id, build_id="build1", test_id=fake_test.id, test_method="method1",
+        investigation_status="ignored", packages=[], start_time=start_time,
+    ).save()
+    SCTTestRun(
+        id=kept_run_id, build_id="build1", test_id=fake_test.id, test_method="method1",
+        investigation_status="", packages=[], start_time=start_time + timedelta(milliseconds=1),
+    ).save()
+
+    ArgusGenericResultData(
+        test_id=fake_test.id, name=table_name, run_id=ignored_run_id, column="col1", row="row1",
+        sut_timestamp=start_time, value=1.0, status="UNSET",
+    ).save()
+    ArgusGenericResultData(
+        test_id=fake_test.id, name=table_name, run_id=kept_run_id, column="col1", row="row1",
+        sut_timestamp=start_time, value=2.0, status="UNSET",
+    ).save()
+
+    service = ResultsService()
+    result = service.search_generic_results(name=table_name)
+
+    assert result["total"] == 1
+    assert result["cells"][0]["run_id"] == str(kept_run_id)
+
+
+def test_search_sorts_cells_with_missing_sut_timestamp_without_crashing(fake_test):
+    table_name = f"NullTimestampTable-{uuid4()}"
+
+    ArgusGenericResultMetadata(
+        test_id=fake_test.id,
+        name=table_name,
+        columns_meta=[ColumnMetadata(name="col1", unit="ms", type="FLOAT", higher_is_better=False)],
+        rows_meta=["row1"],
+        validation_rules={},
+    ).save()
+
+    ArgusGenericResultData(
+        test_id=fake_test.id, name=table_name, run_id=uuid4(), column="col1", row="row1",
+        sut_timestamp=None, value=1.0, status="UNSET",
+    ).save()
+    ArgusGenericResultData(
+        test_id=fake_test.id, name=table_name, run_id=uuid4(), column="col1", row="row1",
+        sut_timestamp=datetime.now(UTC), value=2.0, status="UNSET",
+    ).save()
+
+    service = ResultsService()
+    result = service.search_generic_results(name=table_name)
+
+    assert result["total"] == 2

--- a/argus/backend/tests/results_service/test_results_api.py
+++ b/argus/backend/tests/results_service/test_results_api.py
@@ -1,0 +1,82 @@
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+
+from argus.backend.models.result import ArgusGenericResultData, ArgusGenericResultMetadata, ColumnMetadata
+
+
+@pytest.fixture
+def cross_test_table(argus_db):
+    """Two tests reporting the same (per-invocation unique) table name.
+
+    The name is randomized because the underlying keyspace is session-scoped
+    and shared across every test in this file, and catalog/search scan the
+    whole table with no test_id restriction.
+    """
+    test_id_a = uuid4()
+    test_id_b = uuid4()
+    table_name = f"ApiCrossTestTable-{uuid4()}"
+
+    ArgusGenericResultMetadata(
+        test_id=test_id_a,
+        name=table_name,
+        columns_meta=[ColumnMetadata(name="col1", unit="ms", type="FLOAT", higher_is_better=False)],
+        rows_meta=["row1"],
+        validation_rules={},
+    ).save()
+    ArgusGenericResultMetadata(
+        test_id=test_id_b,
+        name=table_name,
+        columns_meta=[ColumnMetadata(name="col1", unit="ms", type="FLOAT", higher_is_better=False)],
+        rows_meta=["row1"],
+        validation_rules={},
+    ).save()
+
+    now = datetime.now(UTC)
+    ArgusGenericResultData(
+        test_id=test_id_a, name=table_name, run_id=uuid4(), column="col1", row="row1",
+        sut_timestamp=now - timedelta(days=1), value=1.0, status="UNSET",
+    ).save()
+    ArgusGenericResultData(
+        test_id=test_id_b, name=table_name, run_id=uuid4(), column="col1", row="row1",
+        sut_timestamp=now, value=2.0, status="UNSET",
+    ).save()
+
+    return test_id_a, test_id_b, table_name
+
+
+def test_results_catalog_endpoint_returns_names_across_tests(cross_test_table, flask_client):
+    _, _, table_name = cross_test_table
+    response = flask_client.get("/api/results/catalog")
+
+    assert response.status_code == 200, response.text
+    assert response.json["status"] == "ok"
+    by_name = {entry["name"]: entry for entry in response.json["response"]}
+    assert by_name[table_name]["test_count"] == 2
+    assert by_name[table_name]["columns"][0]["name"] == "col1"
+
+
+def test_results_search_endpoint_returns_cells_across_tests(cross_test_table, flask_client):
+    test_id_a, test_id_b, table_name = cross_test_table
+    response = flask_client.get(f"/api/results/search?name={table_name}&limit=10")
+
+    assert response.status_code == 200, response.text
+    assert response.json["status"] == "ok"
+    cells = response.json["response"]["cells"]
+    assert response.json["response"]["total"] == 2
+    assert {cell["test_id"] for cell in cells} == {str(test_id_a), str(test_id_b)}
+
+
+def test_results_search_endpoint_filters_by_status(cross_test_table, flask_client):
+    _, _, table_name = cross_test_table
+    response = flask_client.get(
+        f"/api/results/search?name={table_name}&status[]=UNSET&limit=1")
+
+    assert response.status_code == 200, response.text
+    # "total" reflects the full matching set (2 UNSET cells), not just the
+    # page returned once --limit truncates it down to 1.
+    assert response.json["response"]["total"] == 2
+    cells = response.json["response"]["cells"]
+    assert len(cells) == 1
+    assert cells[0]["status"] == "UNSET"

--- a/argus/backend/util/common.py
+++ b/argus/backend/util/common.py
@@ -1,4 +1,5 @@
 import base64
+import re
 from itertools import islice
 import logging
 import os
@@ -29,6 +30,11 @@ def first(iterable, value, key: Callable = None, predicate: Callable = None):
 def chunk(iterable: Iterable[T], slice_size=90) -> list[list[T]]:
     it = iter(iterable)
     return iter(lambda: list(islice(it, slice_size)), [])
+
+
+def matches_substring(text: str, term: str) -> bool:
+    """Case-sensitive substring match, treating term as literal text rather than a regex."""
+    return bool(re.search(re.escape(term), text))
 
 
 def check_scheduled_test(test, group, testname):

--- a/argus_backend.py
+++ b/argus_backend.py
@@ -6,7 +6,7 @@ from prometheus_flask_exporter import NO_PREFIX
 from argus.backend.error_handlers import DBErrorHandler
 from argus.backend.metrics import METRICS
 from argus.backend.template_filters import export_filters
-from argus.backend.controller import admin, api, main
+from argus.backend.controller import admin, api, main, results_api
 from argus.backend.cli import cli_bp
 from argus.backend.util.logsetup import setup_application_logging
 from argus.backend.util.encoders import ArgusJSONProvider
@@ -121,6 +121,7 @@ def start_server(config=None) -> Flask:
     app.register_blueprint(auth.bp)
     app.register_blueprint(main.bp)
     app.register_blueprint(api.bp)
+    app.register_blueprint(results_api.bp)
     app.register_blueprint(admin.bp)
     app.register_blueprint(cli_bp)
     cache_ssh_tunnel_server_allowed_endpoints(app)

--- a/cli/cmd/results.go
+++ b/cli/cmd/results.go
@@ -1,0 +1,168 @@
+package cmd
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/scylladb/argus/cli/internal/api"
+	"github.com/scylladb/argus/cli/internal/cache"
+	"github.com/scylladb/argus/cli/internal/logging"
+	"github.com/scylladb/argus/cli/internal/models"
+	"github.com/spf13/cobra"
+)
+
+// ---------------------------------------------------------------------------
+// Parent command: results
+// ---------------------------------------------------------------------------
+
+// crossResultsCmd is the top-level "argus results" command. Named distinctly
+// from the existing (unrelated) resultsCmd in testrun.go, which implements
+// "argus run results" (per-run result tables for a single test_id/run_id).
+var crossResultsCmd = &cobra.Command{
+	Use:   "results",
+	Short: "Cross-test queries over generic result tables",
+	Long: `Query Argus generic result tables across every test, without knowing
+any test_id up front.`,
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand: results catalog
+// ---------------------------------------------------------------------------
+
+var resultsCatalogCmd = &cobra.Command{
+	Use:   "catalog",
+	Short: "List every distinct generic result table name system-wide",
+	Long: `Lists every distinct generic result table name across all tests,
+along with how many tests report a table with that name and the (merged)
+column metadata for it.`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		cmd.SilenceUsage = true
+		ctx := cmd.Context()
+		client := APIClientFrom(ctx)
+		out := OutputterFrom(ctx)
+		c := CacheFrom(ctx)
+		log := logging.For(LoggerFrom(ctx), "results-catalog")
+
+		route := api.ResultsCatalog
+		log.Debug().Str("route", route).Msg("fetching results catalog")
+
+		cacheKey := cache.ResultsCatalogKey()
+		if cached, _, err := cache.Get[models.ResultCatalogResponse](c, cacheKey); isCacheable(err) {
+			log.Debug().Msg("results catalog served from cache")
+			return out.Write(cached)
+		}
+
+		req, err := client.NewRequest(ctx, "GET", route, nil)
+		if err != nil {
+			log.Error().Err(err).Str("route", route).Msg("failed to build request")
+			return err
+		}
+
+		result, err := api.DoJSON[models.ResultCatalogResponse](client, req)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to fetch results catalog")
+			return err
+		}
+
+		if cacheErr := cache.Set(c, cacheKey, result, route, cache.TTLResultsCatalog); cacheErr != nil {
+			log.Warn().Err(cacheErr).Msg("failed to cache results catalog")
+		}
+
+		log.Info().Int("tables", len(result)).Msg("results catalog fetched successfully")
+		return out.Write(result)
+	},
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand: results query
+// ---------------------------------------------------------------------------
+
+var resultsQueryCmd = &cobra.Command{
+	Use:   "query",
+	Short: "Query flattened result cells across every test",
+	Long: `Fetch a flattened cell dump (one row per cell: test_id, table, run_id,
+column, row, value, status, sut_timestamp) from generic result tables whose
+name matches a substring, optionally filtered by status and a sut_timestamp
+range, across every test.
+
+All flags are optional. Without any flags the endpoint returns up to 500
+cells across every generic result table.`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		cmd.SilenceUsage = true
+		ctx := cmd.Context()
+		client := APIClientFrom(ctx)
+		out := OutputterFrom(ctx)
+		c := CacheFrom(ctx)
+		log := logging.For(LoggerFrom(ctx), "results-query")
+
+		// Read flags.
+		name, _ := cmd.Flags().GetString("name")
+		limit, _ := cmd.Flags().GetInt("limit")
+		before, _ := cmd.Flags().GetInt64("before")
+		after, _ := cmd.Flags().GetInt64("after")
+		statuses, _ := cmd.Flags().GetStringSlice("status")
+
+		// Build query string.
+		params := url.Values{}
+		if name != "" {
+			params.Set("name", name)
+		}
+		if limit > 0 {
+			params.Set("limit", fmt.Sprint(limit))
+		}
+		if before > 0 {
+			params.Set("before", fmt.Sprint(before))
+		}
+		if after > 0 {
+			params.Set("after", fmt.Sprint(after))
+		}
+		for _, s := range statuses {
+			params.Add("status[]", s)
+		}
+
+		qs := params.Encode()
+		route := api.ResultsSearch
+		if qs != "" {
+			route += "?" + qs
+		}
+
+		log.Debug().Str("route", route).Msg("querying cross-test results")
+
+		cacheKey := cache.ResultsSearchKey(qs)
+		if cached, _, err := cache.Get[models.ResultSearchResponse](c, cacheKey); isCacheable(err) {
+			log.Debug().Msg("results query served from cache")
+			return out.Write(cached)
+		}
+
+		req, err := client.NewRequest(ctx, "GET", route, nil)
+		if err != nil {
+			log.Error().Err(err).Str("route", route).Msg("failed to build request")
+			return err
+		}
+
+		result, err := api.DoJSON[models.ResultSearchResponse](client, req)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to query cross-test results")
+			return err
+		}
+
+		if cacheErr := cache.Set(c, cacheKey, result, route, cache.TTLResultsSearch); cacheErr != nil {
+			log.Warn().Err(cacheErr).Msg("failed to cache results query")
+		}
+
+		log.Info().Int("total", result.Total).Int("cells", len(result.Cells)).Msg("results query fetched successfully")
+		return out.Write(result)
+	},
+}
+
+func init() {
+	resultsQueryCmd.Flags().String("name", "", "Filter table names by substring")
+	resultsQueryCmd.Flags().Int("limit", 500, "Maximum number of cells to return")
+	resultsQueryCmd.Flags().Int64("before", 0, "Only cells with sut_timestamp before this Unix timestamp")
+	resultsQueryCmd.Flags().Int64("after", 0, "Only cells with sut_timestamp after this Unix timestamp")
+	resultsQueryCmd.Flags().StringSlice("status", nil, "Filter by cell status (repeatable)")
+
+	crossResultsCmd.AddCommand(resultsCatalogCmd)
+	crossResultsCmd.AddCommand(resultsQueryCmd)
+	rootCmd.AddCommand(crossResultsCmd)
+}

--- a/cli/internal/api/routes.go
+++ b/cli/internal/api/routes.go
@@ -33,6 +33,10 @@ const (
 	TestRunPytestResults = "/api/v1/run/%s/pytest/results"        // GET  – pytest results for a run (run_id)
 	PytestFilterResults  = "/api/v1/views/widgets/pytest/results" // GET  – filtered pytest results (query params: test, limit, before, after, status[], query, filters[], markers[])
 
+	// Cross-test generic result routes (no /v1, see argus/backend/controller/results_api.py)
+	ResultsCatalog = "/api/results/catalog" // GET – all distinct result table names, with per-name test count and column metadata
+	ResultsSearch  = "/api/results/search"  // GET – flattened cross-test cell dump (query params: name, limit, before, after, status[])
+
 	// Log file routes
 	TestRunLogDownload = "/api/v1/tests/%s/%s/log/%s/download" // GET  – download log file, 302 to S3 (plugin_name, run_id, log_name)
 

--- a/cli/internal/cache/keys.go
+++ b/cli/internal/cache/keys.go
@@ -35,6 +35,14 @@ const (
 	// Shorter than per-run results since filters are dynamic.
 	TTLPytestFilter = 2 * time.Minute
 
+	// TTLResultsCatalog is the TTL for the cross-test generic results catalog.
+	// It changes only as new result tables are introduced, so a longer TTL is fine.
+	TTLResultsCatalog = 10 * time.Minute
+
+	// TTLResultsSearch is the TTL for cross-test generic results search queries.
+	// Shorter than the catalog since filters are dynamic and data is actively written.
+	TTLResultsSearch = 2 * time.Minute
+
 	// TTLVersion is the TTL for the API version response.
 	// The version only changes on a new server deployment.
 	TTLVersion = time.Hour
@@ -177,6 +185,24 @@ func NemesesFilteredKey(runID, before, after string) string {
 func PytestFilterKey(queryString string) string {
 	h := sha256.Sum256([]byte(queryString))
 	return path.Join("pytest-filter", fmt.Sprintf("%x", h[:8]))
+}
+
+// ResultsCatalogKey returns the cache key for the cross-test generic results
+// catalog. The catalog takes no parameters, so this is a fixed key.
+//
+// On disk: cache/results-catalog/
+func ResultsCatalogKey() string {
+	return "results-catalog"
+}
+
+// ResultsSearchKey returns the cache key for a cross-test generic results
+// search query. The queryString is hashed to produce a fixed-length
+// directory name that uniquely identifies the parameter combination.
+//
+// On disk: cache/results-search/{hash}/
+func ResultsSearchKey(queryString string) string {
+	h := sha256.Sum256([]byte(queryString))
+	return path.Join("results-search", fmt.Sprintf("%x", h[:8]))
 }
 
 // PrometheusLogKey returns the cache key for a downloaded monitor-set archive.

--- a/cli/internal/models/results.go
+++ b/cli/internal/models/results.go
@@ -1,0 +1,72 @@
+package models
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ResultCatalogEntry is a single result-table name in the cross-test catalog.
+// Columns are merged (union, first-definition-wins) across every test
+// reporting a table with this name, since the same table name can carry
+// slightly different columns across tests.
+type ResultCatalogEntry struct {
+	Name      string             `json:"name"`
+	TestCount int                `json:"test_count"`
+	Columns   []ResultColumnMeta `json:"columns"`
+}
+
+// ResultCatalogResponse is the response from the results catalog endpoint.
+type ResultCatalogResponse []ResultCatalogEntry
+
+// Headers implements the Tabular interface for ResultCatalogResponse.
+func (ResultCatalogResponse) Headers() []string {
+	return []string{"Name", "Test Count", "Columns"}
+}
+
+// Rows implements the Tabular interface for ResultCatalogResponse.
+func (r ResultCatalogResponse) Rows() [][]string {
+	rows := make([][]string, 0, len(r))
+	for _, entry := range r {
+		colNames := make([]string, 0, len(entry.Columns))
+		for _, col := range entry.Columns {
+			colNames = append(colNames, col.Name)
+		}
+		rows = append(rows, []string{
+			entry.Name,
+			fmt.Sprint(entry.TestCount),
+			strings.Join(colNames, ", "),
+		})
+	}
+	return rows
+}
+
+// GenericResultCell is a single flattened cell from a generic result table,
+// as returned by the cross-test results search endpoint. Every field is
+// scalar, so tabular rendering is delegated to [ReflectTabularSlice] via
+// [NewTabularSlice] instead of a hand-written Headers()/Rows() pair.
+type GenericResultCell struct {
+	TestID       string  `json:"test_id"`
+	Table        string  `json:"table"`
+	RunID        string  `json:"run_id"`
+	Column       string  `json:"column"`
+	Row          string  `json:"row"`
+	Value        float64 `json:"value"`
+	Status       string  `json:"status"`
+	SutTimestamp string  `json:"sut_timestamp"`
+}
+
+// ResultSearchResponse is the response from the cross-test results search endpoint.
+type ResultSearchResponse struct {
+	Total int                 `json:"total"`
+	Cells []GenericResultCell `json:"cells"`
+}
+
+// Headers implements the Tabular interface for ResultSearchResponse.
+func (ResultSearchResponse) Headers() []string {
+	return NewTabularSlice([]GenericResultCell(nil)).Headers()
+}
+
+// Rows implements the Tabular interface for ResultSearchResponse.
+func (r ResultSearchResponse) Rows() [][]string {
+	return NewTabularSlice(r.Cells).Rows()
+}


### PR DESCRIPTION
Adds argus results catalog and argus results query CLI commands backed by new /api/results/catalog and /api/results/search endpoints, enabling cross-test reads over generic result tables without a test_id up front. Uses a scatter-gather scan+fan-out over generic_result_metadata_v1's (test_id, name) pairs, mirroring the existing pytest result_filter pattern, and reuses the ALLOW FILTERING range-query path already used by _get_tables_data.

Closes https://scylladb.atlassian.net/browse/ARGUS-176