### PR TITLE
fix(argusAI): scope SCT-event dedup to the run partition

### DIFF
--- a/argus/backend/tests/sct_events/test_event_embedding_integration.py
+++ b/argus/backend/tests/sct_events/test_event_embedding_integration.py
@@ -5,7 +5,7 @@ These tests verify the complete flow from event creation to embedding storage.
 """
 
 from dataclasses import asdict
-from datetime import datetime, UTC
+from datetime import datetime, timedelta, UTC
 from uuid import uuid4
 
 from argus.backend.models.argus_ai import SCTErrorEventEmbedding, SCTCriticalEventEmbedding
@@ -258,6 +258,82 @@ def test_event_to_embedding_flow_should_process_multiple_events_into_separate_ta
     # Step 7: Verify all unprocessed events were removed for THIS test run
     remaining_unprocessed = list(SCTUnprocessedEvent.filter(run_id=run_req.run_id).all())
     assert len(remaining_unprocessed) == 0, "All unprocessed events should be removed"
+
+
+def test_dedup_marks_same_run_twin_despite_large_other_run_population(
+    client_service: ClientService,
+    sct_service: SCTService,
+    testrun_service: TestRunService,
+    fake_test: ArgusTest,
+    embedding_processor: EventSimilarityProcessorV2,
+    monkeypatch,
+):
+    """Regression (ARGUS-171): a same-run near-identical ERROR event is marked as a duplicate even when
+    the embedding table holds a large population of unrelated other-run events.
+
+    The old candidate fetch used a global ``ORDER BY embedding ANN OF ? LIMIT 1000``; once the table
+    grew past 1000 rows the current run's own twin was crowded out of the top-1000 by other runs and
+    never matched. The fix reads the run's partition directly (``WHERE run_id = ?``), so the twin is
+    always found regardless of total table size. This test exercises the real partition read against a
+    real ScyllaDB with >1000 other-run embeddings present.
+    """
+    processor = embedding_processor
+
+    # Deterministic embedding so two identical messages collapse to the same 384-dim vector.
+    query_vector = [1.0] + [0.0] * 383
+    monkeypatch.setattr(processor, "embedding_model", lambda texts: [list(query_vector) for _ in texts])
+
+    # Seed a large population of OTHER-run embeddings (> the old ANN LIMIT of 1000) identical to the
+    # query vector — the exact condition that used to crowd out the same-run twin.
+    keyspace = SCTErrorEventEmbedding.__keyspace__
+    insert = processor.db.session.prepare(
+        f"INSERT INTO {keyspace}.{SCTErrorEventEmbedding.__table_name__} (run_id, ts, embedding) VALUES (?, ?, ?)"
+    )
+    base_ts = datetime.now(tz=UTC)
+    for i in range(1100):
+        processor.db.session.execute(insert, (uuid4(), base_ts + timedelta(microseconds=i), list(query_vector)))
+
+    # Create a run and submit two near-identical ERROR events (same message → same embedding).
+    run_type, run_req = get_fake_test_run(fake_test)
+    client_service.submit_run(run_type, asdict(run_req))
+    message = "NoHostAvailable Unable to complete the operation ConnectionShutdown Bad file descriptor"
+    first_ts = datetime.now(tz=UTC).timestamp()
+    for offset in (0, 1):
+        sct_service.submit_event(
+            str(run_req.run_id),
+            {
+                "message": message,
+                "run_id": run_req.run_id,
+                "severity": SCTEventSeverity.ERROR.value,
+                "ts": first_ts + offset,
+                "event_type": "DatabaseEvent",
+            },
+        )
+
+    # Process until this run's unprocessed events are drained.
+    max_attempts = 20
+    for _ in range(max_attempts):
+        processor._process_batch(batch_size=100)
+        remaining = list(
+            SCTUnprocessedEvent.filter(run_id=run_req.run_id, severity=SCTEventSeverity.ERROR.value).all()
+        )
+        if len(remaining) == 0:
+            break
+    else:
+        raise AssertionError(f"Failed to process this test's events after {max_attempts} attempts")
+
+    # Exactly one event is canonical; the other points to it via duplicate_id (order-independent).
+    events = list(SCTEvent.filter(run_id=run_req.run_id, severity=SCTEventSeverity.ERROR.value).all())
+    assert len(events) == 2, "Both ERROR events should exist in SCTEvent"
+    canonical = [e for e in events if e.duplicate_id is None]
+    duplicates = [e for e in events if e.duplicate_id is not None]
+    assert len(canonical) == 1, "Exactly one event should remain canonical"
+    assert len(duplicates) == 1, "The near-identical twin should be marked as a duplicate"
+    assert duplicates[0].duplicate_id == canonical[0].event_id, "duplicate_id must point at the canonical event"
+
+    # Only the canonical event is embedded for this run; the duplicate is not stored.
+    run_embeddings = list(SCTErrorEventEmbedding.filter(run_id=run_req.run_id).all())
+    assert len(run_embeddings) == 1, "Only one embedding should be stored for the run (duplicate skipped)"
 
 
 def test_event_to_embedding_flow_should_handle_processing_errors_gracefully(

--- a/argusAI/event_similarity_processor_v2.py
+++ b/argusAI/event_similarity_processor_v2.py
@@ -7,14 +7,18 @@ This module processes SCT events by:
 3. Generating embeddings using BGE-Small-EN model
 4. Storing embeddings in separate tables (sct_error_event_embedding or sct_critical_event_embedding)
 5. Removing processed events from unprocessed queue
+
+Deduplication is scoped to a single run: an event's embedding is compared only
+against the embeddings already stored for the same ``run_id``. Because ``run_id``
+is the partition key of both embedding tables, this is a single-partition read,
+so exact cosine over the partition is cheap and correct regardless of the total
+table size.
 """
 
-from collections import namedtuple
 import logging
 import time
 from pathlib import Path
 from threading import Event
-from typing import Literal
 from uuid import UUID
 from datetime import datetime
 
@@ -31,9 +35,8 @@ from argusAI.utils.event_message_sanitizer import MessageSanitizer
 LOGGER = logging.getLogger(__name__)
 SLEEP_INTERVAL = 1  # Sleep for 1 second between processing cycles
 
-SimilarEvent = namedtuple("SimilarEvent", ["run_id", "ts", "embedding", "added_ts"])
-Severity = Literal["ERROR", "CRITICAL"]
-RunIdStr = str
+# Maximum cosine distance for two embeddings to be considered duplicates.
+DUPLICATE_DISTANCE_THRESHOLD = 0.05
 
 
 class BgeSmallEnEmbeddingModel(ONNXMiniLM_L6_V2):
@@ -71,8 +74,6 @@ class EventSimilarityProcessorV2:
         self.db = ScyllaConnection()
         self.processed_count = 0
         self.error_count = 0
-        self.cache_clear_timer = 3600
-        self.similar_event_cache: dict[tuple[RunIdStr, Severity], list[SimilarEvent]] = {}
         self.keyspace = (
             SCTCriticalEventEmbedding.__keyspace__
             or SCTErrorEventEmbedding.__keyspace__
@@ -80,83 +81,45 @@ class EventSimilarityProcessorV2:
         )
         LOGGER.info("EventSimilarityProcessorV2 initialized")
 
-    def _clear_stale_cache(self):
-        def cmp_ts(ts: datetime | float):
-            match ts:
-                case float():
-                    return ts + self.cache_clear_timer > time.time()
-                case datetime():
-                    return ts.timestamp() + self.cache_clear_timer > time.time()
-
-        for key in list(self.similar_event_cache.keys()):
-            full_cache = [event for event in self.similar_event_cache[key] if cmp_ts(getattr(event, "added_ts", 0.0))]
-            if len(full_cache) == 0:
-                self.similar_event_cache.pop(key)
-
-    @staticmethod
-    def is_stale(cache: SimilarEvent, rows: list[SimilarEvent]):
-        for row in rows:
-            if cache.run_id == row.run_id and cache.ts.timestamp() == row.ts.timestamp():
-                return True
-        return False
-
-    def _get_potential_duplicate_rows(self, embedding: list[float], table_name: str) -> list[SimilarEvent]:
-        query = f"""
-                SELECT run_id, ts, embedding
-                FROM {self.keyspace}.{table_name}
-                ORDER BY embedding ANN OF ?
-                LIMIT ?
-            """
+    def _get_potential_duplicate_rows(self, run_id: UUID, table_name: str) -> list:
+        """Read every embedding already stored for ``run_id`` (single-partition read)."""
+        query = f"SELECT ts, embedding FROM {self.keyspace}.{table_name} WHERE run_id = ?"
         bound_statement = self.db.session.prepare(query)
-        result_rows = list(self.db.session.execute(bound_statement, parameters=[embedding, 1000]))
+        return list(self.db.session.execute(bound_statement, parameters=[run_id]))
 
-        return result_rows
-
-    def _merge_cache(
-        self, run_id: str, severity: str, result_rows: list[SimilarEvent]
-    ) -> tuple[list[SimilarEvent], list[SimilarEvent]]:
-        # Remove stale entries from cache if they exist in VS set
-        cached_events = self.similar_event_cache.get((run_id, severity), [])
-        new_cache = [cached for cached in cached_events if not self.is_stale(cached, result_rows)]
-        self.similar_event_cache[(run_id, severity)] = new_cache
-        rows = [*new_cache, *result_rows]
-
-        return rows, new_cache
-
-    def _mark_event_is_duplicate(self, run_id: str, ts: datetime, severity: str, embedding: list[float]) -> bool:
+    def _mark_event_is_duplicate(self, run_id: UUID, ts: datetime, severity: str, embedding: list[float]) -> bool:
         try:
             table_name = (
                 SCTErrorEventEmbedding.__table_name__
                 if severity == "ERROR"
                 else SCTCriticalEventEmbedding.__table_name__
             )
-            rows, _ = self._merge_cache(run_id, severity, self._get_potential_duplicate_rows(embedding, table_name))
-            if len(rows) > 0:
-                dupe_embeddings = [
-                    (row, cosine(array(row.embedding, dtype=float), array(embedding, dtype=float)))
-                    for row in rows
-                    if row.run_id == run_id
-                ]
-                if len(dupe_embeddings) == 0:
-                    return False
-                dupe_embedding = next((row for row, distance in dupe_embeddings if -0.05 < distance < 0.05), None)
-                if not dupe_embedding:
-                    return False
-                q = f"SELECT event_id FROM {SCTEvent.__table_name__} WHERE run_id = ? AND severity = ? AND ts = ?"
-                bound_q = self.db.session.prepare(q)
-                dupe = self.db.session.execute(
-                    bound_q, parameters=(dupe_embedding.run_id, severity, dupe_embedding.ts)
-                ).one()
-                dupe_id = dupe.event_id
-                self._clear_unprocessed_event(SCTUnprocessedEvent.__table_name__, run_id, severity, ts)
-                update_query = f"UPDATE {SCTEvent.__table_name__} SET duplicate_id = ? WHERE run_id = ? AND severity = ? AND ts = ?"
-                self.db.execute(update_query, (dupe_id, run_id, severity, ts))
-                return True
+            query_vector = array(embedding, dtype=float)
+            dupe = next(
+                (
+                    row
+                    for row in self._get_potential_duplicate_rows(run_id, table_name)
+                    if row.ts != ts  # never match the event against its own stored embedding
+                    and cosine(array(row.embedding, dtype=float), query_vector) < DUPLICATE_DISTANCE_THRESHOLD
+                ),
+                None,
+            )
+            if not dupe:
+                return False
+            q = f"SELECT event_id FROM {SCTEvent.__table_name__} WHERE run_id = ? AND severity = ? AND ts = ?"
+            bound_q = self.db.session.prepare(q)
+            dupe_event = self.db.session.execute(bound_q, parameters=(run_id, severity, dupe.ts)).one()
+            if dupe_event is None:
+                return False
+            self._clear_unprocessed_event(SCTUnprocessedEvent.__table_name__, run_id, severity, ts)
+            update_query = (
+                f"UPDATE {SCTEvent.__table_name__} SET duplicate_id = ? WHERE run_id = ? AND severity = ? AND ts = ?"
+            )
+            self.db.execute(update_query, (dupe_event.event_id, run_id, severity, ts))
+            return True
         except Exception as e:
             LOGGER.error(f"Duplicate search error: {e}", exc_info=True)
             raise
-
-        return False
 
     def _clear_unprocessed_event(self, table_name: str, run_id: str, severity: str, ts: datetime):
         delete_query = f"DELETE FROM {table_name} WHERE run_id = ? AND severity = ? AND ts = ?"
@@ -167,13 +130,9 @@ class EventSimilarityProcessorV2:
         Main processing loop that continuously reads and processes unprocessed events.
         """
         LOGGER.info("Starting event processing loop")
-        next_clear_ts = time.time() + self.cache_clear_timer
         while not self.stop_event.is_set():
             try:
                 batch_processed = self._process_batch()
-                if time.time() > next_clear_ts:
-                    self._clear_stale_cache()
-                    next_clear_ts = time.time() + self.cache_clear_timer
                 if batch_processed == 0:
                     # No events to process, sleep before next iteration
                     time.sleep(SLEEP_INTERVAL)
@@ -227,7 +186,6 @@ class EventSimilarityProcessorV2:
                     f"DELETE FROM {SCTUnprocessedEvent.__table_name__} WHERE run_id = ? AND severity = ? AND ts = ?"
                 )
                 self.db.execute(delete_query, (event_row.run_id, event_row.severity, event_row.ts))
-        self._clear_stale_cache()
         return processed_in_batch
 
     def _process_single_event(self, run_id: UUID, severity: str, ts: datetime) -> None:
@@ -297,12 +255,6 @@ class EventSimilarityProcessorV2:
             insert_query = f"INSERT INTO {self.keyspace}.{table_name} (run_id, ts, embedding) VALUES (?, ?, ?)"
             self.db.execute(insert_query, (run_id, ts, embedding))
             LOGGER.debug(f"Stored embedding in {table_name} for event: run_id={run_id}, ts={ts}")
-            # cache event until it is visible in VS
-            cache = self.similar_event_cache.get((run_id, severity))
-            if not cache:
-                cache: list[SimilarEvent] = []
-            cache.append(SimilarEvent(run_id, ts, embedding, time.time()))
-            self.similar_event_cache[(run_id, severity)] = cache
         except Exception as e:
             LOGGER.error(f"Failed to store embedding for event (run_id={run_id}): {e}", exc_info=True)
             raise

--- a/argusAI/tests/test_event_similarity_processor_v2.py
+++ b/argusAI/tests/test_event_similarity_processor_v2.py
@@ -10,7 +10,7 @@ Test coverage:
 """
 
 import logging
-import time
+from collections import namedtuple
 from datetime import datetime
 from threading import Event
 from unittest.mock import Mock, MagicMock, patch
@@ -20,10 +20,13 @@ import pytest
 
 from argus.backend.models.argus_ai import SCTErrorEventEmbedding, SCTCriticalEventEmbedding
 from argus.backend.plugins.sct.testrun import SCTUnprocessedEvent
-from argusAI.event_similarity_processor_v2 import EventSimilarityProcessorV2, BgeSmallEnEmbeddingModel, SimilarEvent
+from argusAI.event_similarity_processor_v2 import EventSimilarityProcessorV2, BgeSmallEnEmbeddingModel
 
 
 LOGGER = logging.getLogger(__name__)
+
+# Lightweight stand-in for a row returned by the embedding-table partition read.
+EmbeddingRow = namedtuple("EmbeddingRow", ["run_id", "ts", "embedding"])
 
 
 class TestBgeSmallEnEmbeddingModel:
@@ -561,35 +564,33 @@ class TestDeduplication:
 
         assert result is False
 
-    def test_mark_event_is_duplicate_should_return_false_when_similar_embedding_belongs_to_different_run(
-        self, processor
-    ):
-        """Should return False when near-identical embedding exists but belongs to a different run."""
+    def test_get_potential_duplicate_rows_should_query_current_run_partition_only(self, processor):
+        """Regression (ARGUS-171): candidate fetch must be a per-run partition read, not a global ANN.
+
+        A global ``ORDER BY embedding ANN OF ? LIMIT N`` lets other runs' near-identical events
+        crowd the current run's own twins out of the top-N, so same-run duplicates are missed once
+        the table grows past N rows. The fix scopes the read to ``WHERE run_id = ?``.
+        """
         run_id = uuid4()
-        other_run_id = uuid4()
-        ts = datetime.now()
-        # Identical unit vectors — cosine distance would be ~0
-        embedding = [1.0] + [0.0] * 383
+        processor.db.session.execute.return_value = []
 
-        # DB returns a row with the same embedding but for a different run
-        other_run_row = SimilarEvent(run_id=other_run_id, ts=datetime.now(), embedding=embedding, added_ts=time.time())
-        processor.db.session.execute.return_value = [other_run_row]
+        processor._get_potential_duplicate_rows(run_id, SCTErrorEventEmbedding.__table_name__)
 
-        result = processor._mark_event_is_duplicate(run_id, ts, "ERROR", embedding)
-
-        assert result is False
+        prepared_query = " ".join(processor.db.session.prepare.call_args[0][0].split())
+        assert "WHERE run_id = ?" in prepared_query, "candidate fetch must be scoped to the run partition"
+        assert "ANN" not in prepared_query, "candidate fetch must not use a global ANN search"
+        # run_id is the only bound parameter — no LIMIT that could truncate the partition.
+        assert processor.db.session.execute.call_args.kwargs["parameters"] == [run_id]
 
     def test_mark_event_is_duplicate_should_return_false_when_cosine_distance_too_large(self, processor):
         """Should return False when the closest embedding exceeds the similarity threshold."""
         run_id = uuid4()
         ts = datetime.now()
-        # Two orthogonal unit vectors — cosine distance = 1.0, well outside (-0.1, 0.1)
+        # Two orthogonal unit vectors — cosine distance = 1.0, well outside (-0.05, 0.05)
         embedding = [1.0] + [0.0] * 383
         different_embedding = [0.0, 1.0] + [0.0] * 382
 
-        existing_row = SimilarEvent(
-            run_id=run_id, ts=datetime.now(), embedding=different_embedding, added_ts=time.time()
-        )
+        existing_row = EmbeddingRow(run_id=run_id, ts=datetime.now(), embedding=different_embedding)
         processor.db.session.execute.return_value = [existing_row]
 
         result = processor._mark_event_is_duplicate(run_id, ts, "ERROR", embedding)
@@ -599,23 +600,24 @@ class TestDeduplication:
     def test_mark_event_is_duplicate_should_return_true_for_near_identical_embedding(self, processor):
         """Should return True and write duplicate_id when a near-identical embedding exists in the same run."""
         run_id = uuid4()
-        ts = datetime.now()
-        ts_existing = datetime.now()
+        # Distinct timestamps: the canonical event was stored earlier than the one being processed.
+        ts = datetime(2026, 1, 1, 12, 0, 0)
+        ts_existing = datetime(2026, 1, 1, 11, 0, 0)
         existing_event_id = uuid4()
-        # Same unit vector — cosine distance = 0, clearly within (-0.1, 0.1)
+        # Same unit vector — cosine distance = 0, clearly within (-0.05, 0.05)
         embedding = [1.0] + [0.0] * 383
 
-        existing_row = SimilarEvent(run_id=run_id, ts=ts_existing, embedding=embedding, added_ts=time.time())
+        existing_row = EmbeddingRow(run_id=run_id, ts=ts_existing, embedding=embedding)
 
-        # First session.execute call: ANN query → returns [existing_row]
+        # First session.execute call: partition read → returns [existing_row]
         # Second session.execute call: SELECT event_id → returns a mock dupe
         mock_dupe = Mock(event_id=existing_event_id)
-        ann_result_exhausted = False
+        partition_read_done = False
 
         def session_execute_side_effect(*args, **kwargs):
-            nonlocal ann_result_exhausted
-            if not ann_result_exhausted:
-                ann_result_exhausted = True
+            nonlocal partition_read_done
+            if not partition_read_done:
+                partition_read_done = True
                 return [existing_row]
             return Mock(one=Mock(return_value=mock_dupe))
 
@@ -633,6 +635,56 @@ class TestDeduplication:
         update_calls = [call for call in processor.db.execute.call_args_list if "UPDATE" in call[0][0]]
         assert len(update_calls) == 1
         assert update_calls[0][0][1][0] == existing_event_id
+
+    def test_mark_event_is_duplicate_should_not_match_event_against_itself(self, processor):
+        """On a reprocess the partition read returns the event's own stored embedding; it must not
+        be treated as its own duplicate (same run_id and same ts)."""
+        run_id = uuid4()
+        ts = datetime.now()
+        embedding = [1.0] + [0.0] * 383
+
+        # The only row in the partition is this exact event (same ts) — identical embedding.
+        own_row = EmbeddingRow(run_id=run_id, ts=ts, embedding=embedding)
+        processor.db.session.execute.return_value = [own_row]
+
+        assert processor._mark_event_is_duplicate(run_id, ts, "ERROR", embedding) is False
+        assert not [call for call in processor.db.execute.call_args_list if "UPDATE" in call[0][0]]
+
+    def test_mark_event_is_duplicate_should_find_twin_among_many_same_run_events(self, processor):
+        """The whole run partition is scanned, so a twin is found even amid many non-matching same-run rows.
+
+        This is the crowd-out scenario from ARGUS-171 reduced to a unit test: the matching row is the
+        last one in a large partition. A top-N ANN could drop it; an exhaustive partition scan cannot.
+        """
+        run_id = uuid4()
+        # Distinct timestamps: the twin was stored earlier than the event being processed.
+        ts = datetime(2026, 1, 1, 12, 0, 0)
+        twin_ts = datetime(2026, 1, 1, 11, 0, 0)
+        twin_event_id = uuid4()
+        embedding = [1.0] + [0.0] * 383
+
+        # 1500 unrelated same-run rows (orthogonal) followed by the near-identical twin.
+        noise = [
+            EmbeddingRow(run_id=run_id, ts=datetime(2025, 1, 1, 0, 0, i % 60), embedding=[0.0, 1.0] + [0.0] * 382)
+            for i in range(1500)
+        ]
+        twin = EmbeddingRow(run_id=run_id, ts=twin_ts, embedding=embedding)
+
+        mock_dupe = Mock(event_id=twin_event_id)
+        partition_read_done = False
+
+        def session_execute_side_effect(*args, **kwargs):
+            nonlocal partition_read_done
+            if not partition_read_done:
+                partition_read_done = True
+                return [*noise, twin]
+            return Mock(one=Mock(return_value=mock_dupe))
+
+        processor.db.session.execute.side_effect = session_execute_side_effect
+
+        assert processor._mark_event_is_duplicate(run_id, ts, "ERROR", embedding) is True
+        update_calls = [call for call in processor.db.execute.call_args_list if "UPDATE" in call[0][0]]
+        assert update_calls[0][0][1][0] == twin_event_id
 
     def test_process_single_event_should_skip_insert_and_delete_when_duplicate_detected(self, processor):
         """_process_single_event should return early without INSERT or final DELETE when a duplicate is found."""
@@ -669,169 +721,3 @@ class TestDeduplication:
 
         with pytest.raises(RuntimeError, match="ScyllaDB timeout"):
             processor._mark_event_is_duplicate(run_id, ts, "ERROR", embedding)
-
-
-class TestCaching:
-    """Tests for the embedding cache used to bridge the vector-search indexing lag."""
-
-    @pytest.fixture
-    def processor(self):
-        """Create processor with mocked dependencies."""
-        with (
-            patch("argusAI.event_similarity_processor_v2.ScyllaConnection") as mock_scylla,
-            patch("argusAI.event_similarity_processor_v2.BgeSmallEnEmbeddingModel") as mock_embedding,
-            patch("argusAI.event_similarity_processor_v2.MessageSanitizer") as mock_sanitizer,
-        ):
-            mock_db = MagicMock()
-            mock_scylla.return_value = mock_db
-            mock_embedding.return_value = MagicMock(return_value=[[0.1] * 384])
-            mock_sanitizer.return_value = MagicMock(sanitize=MagicMock(return_value="sanitized"))
-            processor = EventSimilarityProcessorV2()
-            return processor
-
-    def test_processed_event_should_be_added_to_cache(self, processor):
-        """A successfully embedded event should appear in similar_event_cache immediately."""
-        run_id = uuid4()
-        severity = "ERROR"
-        ts = datetime.now()
-
-        mock_event = Mock(message="Disk full on node")
-        mock_result = Mock()
-        mock_result.one.return_value = mock_event
-        processor.db.execute.return_value = mock_result
-
-        with patch.object(processor, "_mark_event_is_duplicate", return_value=False):
-            processor._process_single_event(run_id, severity, ts)
-
-        cache_key = (run_id, severity)
-        assert cache_key in processor.similar_event_cache
-        cached = processor.similar_event_cache[cache_key]
-        assert len(cached) == 1
-        assert cached[0].ts == ts
-
-    def test_duplicate_event_should_not_be_added_to_cache(self, processor):
-        """An event identified as a duplicate must not be inserted into the cache."""
-        run_id = uuid4()
-        severity = "ERROR"
-        ts = datetime.now()
-
-        mock_event = Mock(message="Disk full on node")
-        mock_result = Mock()
-        mock_result.one.return_value = mock_event
-        processor.db.execute.return_value = mock_result
-
-        with patch.object(processor, "_mark_event_is_duplicate", return_value=True):
-            processor._process_single_event(run_id, severity, ts)
-
-        assert len(processor.similar_event_cache) == 0
-
-    def test_merge_cache_should_remove_entries_now_visible_in_database(self, processor):
-        """Cache entries that the ANN query now returns (indexed) should be evicted from cache."""
-        run_id = uuid4()
-        severity = "ERROR"
-        ts = datetime.now()
-
-        stale = SimilarEvent(run_id=run_id, ts=ts, embedding=[0.1] * 384, added_ts=time.time())
-        processor.similar_event_cache[(run_id, severity)] = [stale]
-
-        # Database now returns the same event (vector index has caught up)
-        combined_rows, remaining_cache = processor._merge_cache(run_id, severity, [stale])
-
-        # Entry should have been evicted from the in-memory cache
-        assert len(remaining_cache) == 0
-        assert processor.similar_event_cache[(run_id, severity)] == []
-        # But it is still present in the combined view returned to the caller
-        assert stale in combined_rows
-
-    def test_merge_cache_should_keep_entries_not_yet_indexed_by_database(self, processor):
-        """Cache entries absent from the ANN result set should be preserved and included in combined rows."""
-        run_id = uuid4()
-        severity = "ERROR"
-
-        unindexed = SimilarEvent(run_id=run_id, ts=datetime.now(), embedding=[0.2] * 384, added_ts=time.time())
-        processor.similar_event_cache[(run_id, severity)] = [unindexed]
-
-        # DB returns a different event (unindexed is not visible there yet)
-        db_row = SimilarEvent(run_id=run_id, ts=datetime.now(), embedding=[0.5] * 384, added_ts=time.time())
-
-        combined_rows, remaining_cache = processor._merge_cache(run_id, severity, [db_row])
-
-        # Unindexed cache entry should survive in cache and appear in combined rows
-        assert unindexed in remaining_cache
-        assert unindexed in combined_rows
-        assert db_row in combined_rows
-
-    def test_is_stale_should_return_true_when_event_present_in_db_rows(self, processor):
-        """is_stale should identify a cached event that is now returned by the database."""
-        run_id = uuid4()
-        ts = datetime.now()
-        cached = SimilarEvent(run_id=run_id, ts=ts, embedding=[0.1] * 384, added_ts=time.time())
-        db_row = SimilarEvent(run_id=run_id, ts=ts, embedding=[0.1] * 384, added_ts=time.time())
-
-        assert processor.is_stale(cached, [db_row]) is True
-
-    def test_is_stale_should_return_false_when_event_absent_from_db_rows(self, processor):
-        """is_stale should return False when the cached event is not yet returned by the database."""
-        run_id = uuid4()
-        cached = SimilarEvent(run_id=run_id, ts=datetime.now(), embedding=[0.1] * 384, added_ts=time.time())
-        other_row = SimilarEvent(run_id=run_id, ts=datetime.now(), embedding=[0.5] * 384, added_ts=time.time())
-
-        assert processor.is_stale(cached, [other_row]) is False
-
-    def test_clear_stale_cache_should_remove_keys_whose_entries_have_expired_added_ts(self, processor):
-        """Cache entries with an old added_ts (not in the future window) should be purged."""
-        run_id = uuid4()
-        severity = "ERROR"
-
-        # added_ts = 0.0 is far in the past; cmp_ts returns False → full_cache empty → key dropped
-        old_entry = SimilarEvent(run_id=run_id, ts=datetime.now(), embedding=[0.1] * 384, added_ts=0.0)
-        processor.similar_event_cache[(run_id, severity)] = [old_entry]
-
-        processor._clear_stale_cache()
-
-        assert (run_id, severity) not in processor.similar_event_cache
-
-    def test_clear_stale_cache_should_retain_keys_with_future_added_ts(self, processor):
-        """Cache entries whose added_ts lies beyond time.time() + cache_clear_timer should be retained."""
-        run_id = uuid4()
-        severity = "ERROR"
-
-        # added_ts > time.time() + cache_clear_timer so the entry survives
-        future_ts = time.time() + processor.cache_clear_timer + 60
-        fresh_entry = SimilarEvent(run_id=run_id, ts=datetime.now(), embedding=[0.1] * 384, added_ts=future_ts)
-        processor.similar_event_cache[(run_id, severity)] = [fresh_entry]
-
-        processor._clear_stale_cache()
-
-        assert (run_id, severity) in processor.similar_event_cache
-        assert len(processor.similar_event_cache[(run_id, severity)]) == 1
-
-    def test_deduplication_should_use_cache_when_db_has_not_indexed_new_event(self, processor):
-        """An event stored in cache (not yet in DB) should still trigger deduplication for a new identical event."""
-        run_id = uuid4()
-        severity = "ERROR"
-        ts_existing = datetime.now()
-        existing_event_id = uuid4()
-        # Identical unit vectors
-        embedding = [1.0] + [0.0] * 383
-
-        # Pre-populate cache; DB ANN query returns nothing (not yet indexed)
-        cached_event = SimilarEvent(run_id=run_id, ts=ts_existing, embedding=embedding, added_ts=time.time() + 3600)
-        processor.similar_event_cache[(run_id, severity)] = [cached_event]
-
-        mock_dupe = Mock(event_id=existing_event_id)
-        ann_call_done = False
-
-        def session_execute_side_effect(*args, **kwargs):
-            nonlocal ann_call_done
-            if not ann_call_done:
-                ann_call_done = True
-                return []  # ANN search sees nothing yet
-            return Mock(one=Mock(return_value=mock_dupe))
-
-        processor.db.session.execute.side_effect = session_execute_side_effect
-
-        new_ts = datetime.now()
-        result = processor._mark_event_is_duplicate(run_id, new_ts, severity, embedding)
-
-        assert result is True


### PR DESCRIPTION
Fixes [ARGUS-171](https://scylladb.atlassian.net/browse/ARGUS-171)

## Problem

`EventSimilarityProcessorV2` failed to mark same-run near-identical ERROR/CRITICAL events as duplicates, so they rendered as separate entries on the sct-events page (their `duplicate_id` was never set).

Candidate retrieval used a **global** ANN over the whole embedding table:

```sql
SELECT run_id, ts, embedding FROM <table> ORDER BY embedding ANN OF ? LIMIT 1000
```

then filtered `row.run_id == run_id` in Python. Once the table held more than 1000 rows across all runs, the 1000 globally-nearest neighbours filled up with *other* runs' events and the current run's own near-identical twins fell outside the top-1000 — the post-filter came back empty and no duplicate was recorded. The in-process cache only half-hid this, so misses looked intermittent (they surfaced after a processor restart, gaps > 1h, or backlogs spanning batches).

## Fix

`run_id` is the **partition key** of both embedding tables, so intra-run dedup is a single-partition problem and needs no global ANN. Replace the ANN with a partition read and exact cosine over the partition:

```sql
SELECT run_id, ts, embedding FROM <table> WHERE run_id = ?
```

- Cheap and 100% correct regardless of total table size.
- Independent of the deployed ScyllaDB vector-search version (avoids the unreliable `WHERE run_id … ORDER BY … ANN` combination).
- Retires the in-memory cache (`similar_event_cache`, `_merge_cache`, `is_stale`, `_clear_stale_cache`) that only existed to bridge the ANN index lag — QUORUM reads/writes make a just-inserted same-run embedding immediately visible to the partition read.
- Adds a `ts` guard so a reprocessed event can't be marked a duplicate of its own stored embedding.

## Testing

- Unit regression test asserting the candidate query is partition-scoped (`WHERE run_id = ?`, no global ANN); verified RED on the old code, GREEN on the new. Plus large-partition and self-match tests.
- Integration test (real ScyllaDB + vector-store) marking a same-run twin as duplicate with 1100 unrelated other-run embeddings present.
- Full unit suite (29) and embedding integration suite (6) pass.

## Follow-up (not in this PR)

Backfill: recent runs whose `duplicate_id` was wrongly left empty (e.g. run `ccacbcbe`) need a one-off re-dedup pass — tracked on the ticket.


[ARGUS-171]: https://scylladb.atlassian.net/browse/ARGUS-171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ