### PR TITLE
backend/planner labels

### DIFF
--- a/argus/backend/models/plan.py
+++ b/argus/backend/models/plan.py
@@ -23,6 +23,9 @@ class ArgusReleasePlan(Model):
     last_updated = columns.DateTime(default=lambda: datetime.datetime.now(tz=datetime.UTC))
     ends_at = columns.DateTime()
     key = columns.Text()
+    # JSON-serialized per-entity options keyed by test/group UUID, e.g.
+    # {"<test-or-group-uuid>": {"labels": ["label-a", "label-b"]}}
+    options = columns.Text()
 
     def __eq__(self, other):
         if isinstance(other, ArgusReleasePlan):

--- a/argus/backend/service/planner_service.py
+++ b/argus/backend/service/planner_service.py
@@ -22,6 +22,15 @@ from argus.backend.util.common import chunk
 LOGGER = logging.getLogger(__name__)
 
 
+class EntityOptions(TypedDict, total=False):
+    """Per-entity options attached to a plan, keyed by test/group UUID."""
+    labels: list[str]
+
+
+# Mapping of entity UUID (test or group) -> its options
+PlanOptions = dict[str, EntityOptions]
+
+
 @dataclass(frozen=True, init=True, repr=True, kw_only=True)
 class CreatePlanPayload:
     name: str
@@ -33,7 +42,7 @@ class CreatePlanPayload:
     tests: list[str]
     groups: list[str]
     assignments: dict[str, str]
-    options: dict[str, Any] = field(default_factory=dict)
+    options: PlanOptions = field(default_factory=dict)
     view_id: Optional[str] = None
     created_from: Optional[str] = None
 
@@ -57,7 +66,7 @@ class TempPlanPayload:
     last_updated: str
     ends_at: str
     created_from: Optional[str]
-    options: dict[str, Any] = None
+    options: PlanOptions = None
     view_id: Optional[str] = None
 
 
@@ -83,7 +92,7 @@ class PlanDiffPayload:
     assignee_mapping_set: dict[str, str] = field(default_factory=dict)
     assignee_mapping_remove: list[str] = field(default_factory=list)
     # Dict diff for per-entity options (keyed by test/group UUID)
-    options_set: dict[str, Any] = field(default_factory=dict)
+    options_set: PlanOptions = field(default_factory=dict)
     options_remove: list[str] = field(default_factory=list)
 
 

--- a/argus/backend/service/planner_service.py
+++ b/argus/backend/service/planner_service.py
@@ -33,6 +33,7 @@ class CreatePlanPayload:
     tests: list[str]
     groups: list[str]
     assignments: dict[str, str]
+    options: dict[str, Any] = field(default_factory=dict)
     view_id: Optional[str] = None
     created_from: Optional[str] = None
 
@@ -56,6 +57,7 @@ class TempPlanPayload:
     last_updated: str
     ends_at: str
     created_from: Optional[str]
+    options: dict[str, Any] = None
     view_id: Optional[str] = None
 
 
@@ -80,6 +82,9 @@ class PlanDiffPayload:
     # Dict diff for assignee_mapping
     assignee_mapping_set: dict[str, str] = field(default_factory=dict)
     assignee_mapping_remove: list[str] = field(default_factory=list)
+    # Dict diff for per-entity options (keyed by test/group UUID)
+    options_set: dict[str, Any] = field(default_factory=dict)
+    options_remove: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True, init=True, repr=True, kw_only=True)
@@ -180,6 +185,7 @@ class PlanningService:
                                  for entity_id, user_id in plan_request.assignments.items()}
         plan.groups = plan_request.groups
         plan.tests = plan_request.tests
+        plan.options = json.dumps(plan_request.options or {})
         if plan_request.created_from:
             plan.created_from = plan_request.created_from
         if not plan_request.view_id:
@@ -266,6 +272,15 @@ class PlanningService:
         all_entity_ids = set(str(eid) for eid in plan.tests + plan.groups)
         current_mapping = {k: v for k, v in current_mapping.items() if str(k) in all_entity_ids}
         plan.assignee_mapping = current_mapping
+
+        # Apply options diff (remove first, then set), then prune to current entities
+        current_options = json.loads(plan.options) if plan.options else {}
+        for key in plan_request.options_remove:
+            current_options.pop(key, None)
+        for key, value in plan_request.options_set.items():
+            current_options[key] = value
+        current_options = {k: v for k, v in current_options.items() if str(k) in all_entity_ids}
+        plan.options = json.dumps(current_options)
 
         plan.last_updated = datetime.datetime.now(tz=datetime.UTC)
 
@@ -431,6 +446,8 @@ class PlanningService:
         new_tests = []
         new_groups = []
         new_assignee_mapping = {}
+        original_options = json.loads(original_plan.options) if original_plan.options else {}
+        new_options = {}
 
         for test in original_tests:
             original_assignee = original_plan.assignee_mapping.get(test.id)
@@ -443,6 +460,9 @@ class PlanningService:
                 new_tests.append(new_test_id)
                 if original_assignee and payload.keepParticipants:
                     new_assignee_mapping[new_test_id] = original_assignee
+                test_options = original_options.get(str(test.id))
+                if test_options:
+                    new_options[str(new_test_id)] = test_options
 
         for group in original_groups:
             original_assignee = original_plan.assignee_mapping.get(group.id)
@@ -455,6 +475,9 @@ class PlanningService:
                 new_groups.append(new_group_id)
                 if original_assignee and payload.keepParticipants:
                     new_assignee_mapping[new_group_id] = original_assignee
+                group_options = original_options.get(str(group.id))
+                if group_options:
+                    new_options[str(new_group_id)] = group_options
 
         new_plan = ArgusReleasePlan()
         new_plan.release_id = target_release.id
@@ -466,6 +489,7 @@ class PlanningService:
         new_plan.assignee_mapping = new_assignee_mapping
         new_plan.tests = new_tests
         new_plan.groups = new_groups
+        new_plan.options = json.dumps(new_options)
         new_plan.target_version = payload.plan.target_version
         view = self.create_view_for_plan(new_plan)
         new_plan.view_id = view.id

--- a/argus/backend/tests/planner_api/test_planner_options.py
+++ b/argus/backend/tests/planner_api/test_planner_options.py
@@ -1,0 +1,180 @@
+"""
+Standalone tests for per-entity ``options`` on ``ArgusReleasePlan``.
+
+Covers the JSON-text ``options`` column threaded through the planner service:
+- ``create_plan`` persists options and they round-trip from the DB.
+- ``update_plan`` applies ``options_set`` / ``options_remove`` diffs.
+- options are pruned when their test/group leaves the plan.
+- options are keyed by both test and group UUIDs.
+- ``copy_plan`` remaps options onto the copied entities.
+"""
+import json
+import time
+import uuid
+
+import pytest
+from flask import g
+
+from argus.backend.models.plan import ArgusReleasePlan
+from argus.backend.service.planner_service import (
+    CopyPlanPayload,
+    PlanningService,
+    TempPlanPayload,
+)
+
+
+@pytest.fixture
+def planning_service():
+    return PlanningService()
+
+
+def _create_payload(release, tests=None, groups=None, options=None):
+    suffix = uuid.uuid4().hex[:8]
+    return {
+        "name": f"options_plan_{suffix}",
+        "description": "options test plan",
+        "owner": str(g.user.id),
+        "participants": [],
+        "target_version": f"1.0.0-{suffix}",
+        "release_id": str(release.id),
+        "tests": [str(t) for t in (tests or [])],
+        "groups": [str(gid) for gid in (groups or [])],
+        "assignments": {},
+        "options": options or {},
+    }
+
+
+@pytest.mark.docker_required
+def test_create_plan_persists_options(planning_service, release, fake_test):
+    labels = {str(fake_test.id): {"labels": ["alpha", "beta"]}}
+    plan = planning_service.create_plan(
+        _create_payload(release, tests=[fake_test.id], options=labels))
+
+    stored = ArgusReleasePlan.get(id=plan.id)
+    assert json.loads(stored.options) == labels
+
+
+@pytest.mark.docker_required
+def test_create_plan_defaults_to_empty_options(planning_service, release, fake_test):
+    plan = planning_service.create_plan(_create_payload(release, tests=[fake_test.id]))
+
+    stored = ArgusReleasePlan.get(id=plan.id)
+    assert json.loads(stored.options) == {}
+
+
+@pytest.mark.docker_required
+def test_update_plan_sets_and_removes_options(planning_service, release, fake_test, group):
+    plan = planning_service.create_plan(
+        _create_payload(release, tests=[fake_test.id], groups=[group.id]))
+
+    # Set options for both a test and a group (collision-free shared keyspace).
+    planning_service.update_plan({
+        "id": str(plan.id),
+        "options_set": {
+            str(fake_test.id): {"labels": ["needs-triage"]},
+            str(group.id): {"labels": ["group-wide"]},
+        },
+    })
+    stored = ArgusReleasePlan.get(id=plan.id)
+    assert json.loads(stored.options) == {
+        str(fake_test.id): {"labels": ["needs-triage"]},
+        str(group.id): {"labels": ["group-wide"]},
+    }
+
+    # Remove the test's options; the group's options remain untouched.
+    planning_service.update_plan({
+        "id": str(plan.id),
+        "options_remove": [str(fake_test.id)],
+    })
+    stored = ArgusReleasePlan.get(id=plan.id)
+    assert json.loads(stored.options) == {str(group.id): {"labels": ["group-wide"]}}
+
+
+@pytest.mark.docker_required
+def test_update_plan_prunes_options_for_removed_entities(planning_service, release, fake_test, group):
+    plan = planning_service.create_plan(
+        _create_payload(
+            release,
+            tests=[fake_test.id],
+            groups=[group.id],
+            options={
+                str(fake_test.id): {"labels": ["t"]},
+                str(group.id): {"labels": ["g"]},
+            },
+        ))
+
+    # Dropping the test from the plan prunes its options entry.
+    planning_service.update_plan({
+        "id": str(plan.id),
+        "tests_remove": [str(fake_test.id)],
+    })
+    stored = ArgusReleasePlan.get(id=plan.id)
+    assert json.loads(stored.options) == {str(group.id): {"labels": ["g"]}}
+
+    # Dropping the group prunes the remaining entry.
+    planning_service.update_plan({
+        "id": str(plan.id),
+        "groups_remove": [str(group.id)],
+    })
+    stored = ArgusReleasePlan.get(id=plan.id)
+    assert json.loads(stored.options) == {}
+
+
+@pytest.mark.docker_required
+def test_copy_plan_remaps_options(planning_service, release_manager_service):
+    ns = time.time_ns()
+    # Source release/group/test with build ids that embed the release name, so
+    # copy_plan can remap them onto the target release by substring replacement.
+    src_release = release_manager_service.create_release(f"opt_src_{ns}", f"opt_src_{ns}", False)
+    src_group = release_manager_service.create_group(
+        f"g_{ns}", f"g_{ns}", build_system_id=f"{src_release.name}/g", release_id=str(src_release.id))
+    src_test = release_manager_service.create_test(
+        f"t_{ns}", f"t_{ns}", f"{src_release.name}/g/t", f"{src_release.name}/g/t",
+        group_id=str(src_group.id), release_id=str(src_release.id),
+        plugin_name="scylla-cluster-tests")
+
+    source_options = {str(src_test.id): {"labels": ["carry-me"]}}
+    plan = planning_service.create_plan(
+        _create_payload(src_release, tests=[src_test.id], options=source_options))
+
+    target_release = release_manager_service.create_release(f"opt_dst_{ns}", f"opt_dst_{ns}", False)
+    target_group = release_manager_service.create_group(
+        src_group.name, src_group.pretty_name,
+        build_system_id=src_group.build_system_id.replace(src_release.name, target_release.name, 1),
+        release_id=str(target_release.id))
+    target_test = release_manager_service.create_test(
+        src_test.name, src_test.pretty_name,
+        src_test.build_system_id.replace(src_release.name, target_release.name, 1),
+        src_test.build_system_url,
+        group_id=str(target_group.id), release_id=str(target_release.id),
+        plugin_name=src_test.plugin_name)
+
+    temp_plan = TempPlanPayload(
+        id=str(plan.id),
+        name=f"copied_{ns}",
+        completed=False,
+        description="copied plan",
+        owner=str(g.user.id),
+        key=plan.key,
+        participants=[],
+        target_version=f"2.0.0-{ns}",
+        assignee_mapping={},
+        release_id=str(target_release.id),
+        tests=[str(src_test.id)],
+        groups=[],
+        creation_time="",
+        last_updated="",
+        ends_at="",
+        created_from=None,
+    )
+    payload = CopyPlanPayload(
+        plan=temp_plan,
+        keepParticipants=False,
+        replacements={},
+        targetReleaseId=str(target_release.id),
+        targetReleaseName=target_release.name,
+    )
+    new_plan = planning_service.copy_plan(payload)
+
+    stored = ArgusReleasePlan.get(id=new_plan.id)
+    assert json.loads(stored.options) == {str(target_test.id): {"labels": ["carry-me"]}}

--- a/cli/cmd/planner/create.go
+++ b/cli/cmd/planner/create.go
@@ -50,6 +50,7 @@ are reported and omitted, and the plan is created anyway.`,
 	cmd.Flags().String("target-version", "", "Target version")
 	cmd.Flags().String("view-id", "", "Existing view UUID to attach (optional)")
 	cmd.Flags().StringArray("assign", nil, "Assignment as entity=username (use $owner to leave unassigned, repeatable)")
+	cmd.Flags().StringArray("label", nil, "Label as entity=label, added to the entity's options (repeatable)")
 
 	parent.AddCommand(cmd)
 }
@@ -150,24 +151,79 @@ func overlayFlags(cmd *cobra.Command, tmpl *models.PlanTemplate) error {
 		}
 		tmpl.Assignments = merged
 	}
+	if cmd.Flags().Changed("label") {
+		labels, _ := cmd.Flags().GetStringArray("label")
+		merged, err := parseLabels(labels, tmpl.Assignments)
+		if err != nil {
+			return err
+		}
+		tmpl.Assignments = merged
+	}
 	return nil
 }
 
-// parseAssignments parses repeatable "entity=username" flag values, merging
-// them onto base (which may be nil). The entity key may contain "/" but not
-// "=", so the first "=" separates entity from username.
-func parseAssignments(raw []string, base map[string]string) (map[string]string, error) {
-	out := map[string]string{}
-	for k, v := range base {
-		out[k] = v
-	}
+// parseAssignments parses repeatable "entity=username" flag values, merging the
+// assignee onto base (which may be nil), preserving any existing labels. The
+// entity key may contain "/" but not "=", so the first "=" separates entity
+// from username.
+func parseAssignments(raw []string, base map[string]models.AssignmentValue) (map[string]models.AssignmentValue, error) {
+	out := cloneAssignments(base)
 	for _, a := range raw {
 		entity, user, ok := strings.Cut(a, "=")
 		entity, user = strings.TrimSpace(entity), strings.TrimSpace(user)
 		if !ok || entity == "" || user == "" {
 			return nil, fmt.Errorf("invalid --assign %q: expected entity=username", a)
 		}
-		out[entity] = user
+		v := out[entity]
+		v.Assignee = user
+		out[entity] = v
 	}
 	return out, nil
+}
+
+// parseLabels parses repeatable "entity=label" flag values, appending each
+// label to the entity's options on base (which may be nil), preserving any
+// existing assignee. Duplicate labels for an entity are ignored.
+func parseLabels(raw []string, base map[string]models.AssignmentValue) (map[string]models.AssignmentValue, error) {
+	out := cloneAssignments(base)
+	for _, a := range raw {
+		entity, label, ok := strings.Cut(a, "=")
+		entity, label = strings.TrimSpace(entity), strings.TrimSpace(label)
+		if !ok || entity == "" || label == "" {
+			return nil, fmt.Errorf("invalid --label %q: expected entity=label", a)
+		}
+		v := out[entity]
+		if v.Options == nil {
+			v.Options = &models.EntityOptions{}
+		}
+		if !containsString(v.Options.Labels, label) {
+			v.Options.Labels = append(v.Options.Labels, label)
+		}
+		out[entity] = v
+	}
+	return out, nil
+}
+
+// cloneAssignments deep-copies an assignments map (including each entry's
+// options) so flag overlays never mutate the value loaded from --file.
+func cloneAssignments(base map[string]models.AssignmentValue) map[string]models.AssignmentValue {
+	out := make(map[string]models.AssignmentValue, len(base))
+	for k, v := range base {
+		nv := models.AssignmentValue{Assignee: v.Assignee}
+		if v.Options != nil {
+			nv.Options = &models.EntityOptions{Labels: append([]string(nil), v.Options.Labels...)}
+		}
+		out[k] = nv
+	}
+	return out
+}
+
+// containsString reports whether s contains v.
+func containsString(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
 }

--- a/cli/cmd/planner/planner_test.go
+++ b/cli/cmd/planner/planner_test.go
@@ -88,22 +88,72 @@ func TestParseAssignments(t *testing.T) {
 
 	t.Run("merges over base and supports / in entity", func(t *testing.T) {
 		t.Parallel()
-		base := map[string]string{"tier1/a": "alice", "keep": "carol"}
+		base := map[string]models.AssignmentValue{
+			"tier1/a": {Assignee: "alice"},
+			"keep":    {Assignee: "carol"},
+		}
 		got, err := parseAssignments([]string{"tier1/a=bob", "tier2/b=dave"}, base)
 		require.NoError(t, err)
-		assert.Equal(t, map[string]string{
-			"tier1/a": "bob",  // flag overrides base
-			"tier2/b": "dave", // new entry
-			"keep":    "carol",
+		assert.Equal(t, map[string]models.AssignmentValue{
+			"tier1/a": {Assignee: "bob"},  // flag overrides base
+			"tier2/b": {Assignee: "dave"}, // new entry
+			"keep":    {Assignee: "carol"},
 		}, got)
 		// Base is not mutated.
-		assert.Equal(t, "alice", base["tier1/a"])
+		assert.Equal(t, "alice", base["tier1/a"].Assignee)
+	})
+
+	t.Run("preserves existing labels when setting assignee", func(t *testing.T) {
+		t.Parallel()
+		base := map[string]models.AssignmentValue{
+			"tier1/a": {Options: &models.EntityOptions{Labels: []string{"smoke"}}},
+		}
+		got, err := parseAssignments([]string{"tier1/a=bob"}, base)
+		require.NoError(t, err)
+		assert.Equal(t, models.AssignmentValue{
+			Assignee: "bob",
+			Options:  &models.EntityOptions{Labels: []string{"smoke"}},
+		}, got["tier1/a"])
 	})
 
 	t.Run("rejects malformed values", func(t *testing.T) {
 		t.Parallel()
 		for _, bad := range []string{"noequals", "=bob", "entity=", "  =  "} {
 			_, err := parseAssignments([]string{bad}, nil)
+			require.Errorf(t, err, "expected error for %q", bad)
+		}
+	})
+}
+
+func TestParseLabels(t *testing.T) {
+	t.Parallel()
+
+	t.Run("appends labels preserving assignee and dedupes", func(t *testing.T) {
+		t.Parallel()
+		base := map[string]models.AssignmentValue{"tier1/a": {Assignee: "bob"}}
+		got, err := parseLabels([]string{"tier1/a=smoke", "tier1/a=smoke", "tier1/a=blocker"}, base)
+		require.NoError(t, err)
+		assert.Equal(t, models.AssignmentValue{
+			Assignee: "bob",
+			Options:  &models.EntityOptions{Labels: []string{"smoke", "blocker"}},
+		}, got["tier1/a"])
+		// Base is not mutated.
+		assert.Nil(t, base["tier1/a"].Options)
+	})
+
+	t.Run("labels an unassigned entity", func(t *testing.T) {
+		t.Parallel()
+		got, err := parseLabels([]string{"tier1/a=needs-triage"}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, models.AssignmentValue{
+			Options: &models.EntityOptions{Labels: []string{"needs-triage"}},
+		}, got["tier1/a"])
+	})
+
+	t.Run("rejects malformed values", func(t *testing.T) {
+		t.Parallel()
+		for _, bad := range []string{"noequals", "=lbl", "entity=", "  =  "} {
+			_, err := parseLabels([]string{bad}, nil)
 			require.Errorf(t, err, "expected error for %q", bad)
 		}
 	})
@@ -119,7 +169,7 @@ func TestOverlayFlags_FlagOverFilePrecedence(t *testing.T) {
 	tmpl := models.PlanTemplate{
 		Name:        "FileName",
 		Release:     "scylla-2026.2",
-		Assignments: map[string]string{"x": "u1"},
+		Assignments: map[string]models.AssignmentValue{"x": {Assignee: "u1"}},
 	}
 
 	require.NoError(t, overlayFlags(cmd, &tmpl))
@@ -129,7 +179,10 @@ func TestOverlayFlags_FlagOverFilePrecedence(t *testing.T) {
 	// Release is untouched (flag not set).
 	assert.Equal(t, "scylla-2026.2", tmpl.Release)
 	// Assignment x overridden, y added.
-	assert.Equal(t, map[string]string{"x": "u2", "y": "u3"}, tmpl.Assignments)
+	assert.Equal(t, map[string]models.AssignmentValue{
+		"x": {Assignee: "u2"},
+		"y": {Assignee: "u3"},
+	}, tmpl.Assignments)
 }
 
 func TestOverlayFlags_UnsetScalarsKeepFileValues(t *testing.T) {
@@ -148,7 +201,7 @@ func TestUpdate_FlagsRegistered(t *testing.T) {
 	for _, name := range []string{
 		"name", "description", "owner", "target-version", "completed",
 		"add-test", "remove-test", "add-group", "remove-group",
-		"assign", "unassign", "file",
+		"assign", "unassign", "label", "unlabel", "file",
 	} {
 		assert.NotNilf(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
 	}
@@ -169,6 +222,8 @@ func TestOverlayUpdateFlags_OnlySetScalarsAndAugmentedCollections(t *testing.T) 
 	require.NoError(t, cmd.Flags().Set("remove-group", "tier2"))
 	require.NoError(t, cmd.Flags().Set("unassign", "tier1/c"))
 	require.NoError(t, cmd.Flags().Set("assign", "x=u2"))
+	require.NoError(t, cmd.Flags().Set("label", "tier1/a=smoke"))
+	require.NoError(t, cmd.Flags().Set("unlabel", "tier1/d=stale"))
 
 	// Pre-populate from a file: name is overridden, description is preserved,
 	// and collections are augmented.
@@ -178,6 +233,7 @@ func TestOverlayUpdateFlags_OnlySetScalarsAndAugmentedCollections(t *testing.T) 
 		Description:        &desc,
 		TestsAdd:           []string{"tier1/a"},
 		AssigneeMappingSet: map[string]string{"x": "u1"},
+		LabelsAdd:          map[string][]string{"tier1/a": {"blocker"}},
 	}
 
 	require.NoError(t, overlayUpdateFlags(cmd, &spec))
@@ -197,6 +253,9 @@ func TestOverlayUpdateFlags_OnlySetScalarsAndAugmentedCollections(t *testing.T) 
 	assert.Equal(t, []string{"tier1/c"}, spec.AssigneeMappingRemove)
 	// Assignment x overridden onto the file's map.
 	assert.Equal(t, map[string]string{"x": "u2"}, spec.AssigneeMappingSet)
+	// Label deltas augment the file's labels_add and populate labels_remove.
+	assert.Equal(t, map[string][]string{"tier1/a": {"blocker", "smoke"}}, spec.LabelsAdd)
+	assert.Equal(t, map[string][]string{"tier1/d": {"stale"}}, spec.LabelsRemove)
 }
 
 func TestOverlayUpdateFlags_NoFlagsLeavesSpecEmpty(t *testing.T) {

--- a/cli/cmd/planner/update.go
+++ b/cli/cmd/planner/update.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/scylladb/argus/cli/internal/cmdctx"
 	"github.com/scylladb/argus/cli/internal/logging"
@@ -58,7 +59,13 @@ and skipped.
 
 Participants are not edited directly — they are derived from the assignments,
 so anyone assigned (other than the owner) is a participant. A user dropped from
-their last assigned test is removed from participants automatically.`,
+their last assigned test is removed from participants automatically.
+
+Labels are per-entity options: --label entity=label adds a label (adding the
+test to the plan if missing, like --assign), and --unlabel entity=label removes
+one. Label changes merge with the entity's current labels; the "assignments"
+map in --file may also carry per-entity "options": {"labels": [...]}, applied as
+additive label deltas. An entity may carry labels while unassigned.`,
 		RunE: runUpdate,
 	}
 
@@ -75,6 +82,8 @@ their last assigned test is removed from participants automatically.`,
 	cmd.Flags().StringArray("remove-group", nil, "Remove a stored group by name (repeatable)")
 	cmd.Flags().StringArray("assign", nil, "Assignment as entity=username, adding the test if missing (use $owner to clear) (repeatable)")
 	cmd.Flags().StringArray("unassign", nil, "Clear assignee for entity, keeping the test (repeatable)")
+	cmd.Flags().StringArray("label", nil, "Add label as entity=label, adding the test if missing (repeatable)")
+	cmd.Flags().StringArray("unlabel", nil, "Remove label as entity=label from the entity's options (repeatable)")
 	_ = cmd.MarkFlagRequired("plan-id")
 
 	parent.AddCommand(cmd)
@@ -193,11 +202,68 @@ func overlayUpdateFlags(cmd *cobra.Command, spec *models.PlanUpdateSpec) error {
 
 	if cmd.Flags().Changed("assign") {
 		assigns, _ := cmd.Flags().GetStringArray("assign")
-		merged, err := parseAssignments(assigns, spec.AssigneeMappingSet)
+		merged, err := parseAssignStrings(assigns, spec.AssigneeMappingSet)
 		if err != nil {
 			return err
 		}
 		spec.AssigneeMappingSet = merged
 	}
+	if cmd.Flags().Changed("label") {
+		labels, _ := cmd.Flags().GetStringArray("label")
+		merged, err := parseLabelDeltas(labels, spec.LabelsAdd, "--label")
+		if err != nil {
+			return err
+		}
+		spec.LabelsAdd = merged
+	}
+	if cmd.Flags().Changed("unlabel") {
+		labels, _ := cmd.Flags().GetStringArray("unlabel")
+		merged, err := parseLabelDeltas(labels, spec.LabelsRemove, "--unlabel")
+		if err != nil {
+			return err
+		}
+		spec.LabelsRemove = merged
+	}
 	return nil
+}
+
+// parseAssignStrings parses repeatable "entity=username" flag values into a
+// string-valued assignee map, merging onto base (which may be nil). It keeps
+// --assign's original behaviour: it feeds assignee_mapping_set (assignee only,
+// no labels). The first "=" separates entity from username.
+func parseAssignStrings(raw []string, base map[string]string) (map[string]string, error) {
+	out := map[string]string{}
+	for k, v := range base {
+		out[k] = v
+	}
+	for _, a := range raw {
+		entity, user, ok := strings.Cut(a, "=")
+		entity, user = strings.TrimSpace(entity), strings.TrimSpace(user)
+		if !ok || entity == "" || user == "" {
+			return nil, fmt.Errorf("invalid --assign %q: expected entity=username", a)
+		}
+		out[entity] = user
+	}
+	return out, nil
+}
+
+// parseLabelDeltas parses repeatable "entity=label" flag values into a
+// per-entity label list, merging onto base (which may be nil). flagName is used
+// in error text (e.g. "--label"). Duplicate labels for an entity are ignored.
+func parseLabelDeltas(raw []string, base map[string][]string, flagName string) (map[string][]string, error) {
+	out := map[string][]string{}
+	for k, v := range base {
+		out[k] = append([]string(nil), v...)
+	}
+	for _, a := range raw {
+		entity, label, ok := strings.Cut(a, "=")
+		entity, label = strings.TrimSpace(entity), strings.TrimSpace(label)
+		if !ok || entity == "" || label == "" {
+			return nil, fmt.Errorf("invalid %s %q: expected entity=label", flagName, a)
+		}
+		if !containsString(out[entity], label) {
+			out[entity] = append(out[entity], label)
+		}
+	}
+	return out, nil
 }

--- a/cli/internal/models/planner.go
+++ b/cli/internal/models/planner.go
@@ -1,10 +1,76 @@
 package models
 
 import (
+	"encoding/json"
 	"sort"
 	"strconv"
 	"strings"
 )
+
+// ---------------------------------------------------------------------------
+// Per-entity options (labels) and assignment values
+// ---------------------------------------------------------------------------
+
+// EntityOptions is the per-entity option bag attached to a plan entry, keyed by
+// the entity (test or group) it applies to. It mirrors the object stored in the
+// backend plan's `options` column (serialised there as JSON). Currently it only
+// carries free-form labels.
+type EntityOptions struct {
+	Labels []string `json:"labels,omitempty"`
+}
+
+// AssignmentValue is the value of an entry in an assignments map: the assignee
+// username (or [OwnerMarker] for an entity that is in the plan but unassigned)
+// plus optional per-entity [EntityOptions] (labels).
+//
+// On input it accepts either a bare string — the assignee, for backward
+// compatibility with the original string-valued assignments map — or the full
+// object form. It always marshals as an object so emitted templates carry
+// labels; an entity may carry labels while unassigned (assignee "$owner").
+type AssignmentValue struct {
+	Assignee string         `json:"assignee,omitempty"`
+	Options  *EntityOptions `json:"options,omitempty"`
+}
+
+// UnmarshalJSON accepts either a bare assignee string (back-compat) or the full
+// object form.
+func (a *AssignmentValue) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err == nil {
+		a.Assignee = s
+		a.Options = nil
+		return nil
+	}
+	// Alias avoids recursing into this UnmarshalJSON for the object form.
+	type alias AssignmentValue
+	var v alias
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	*a = AssignmentValue(v)
+	return nil
+}
+
+// Labels returns the assignment's labels, or nil when no options are set.
+func (a AssignmentValue) Labels() []string {
+	if a.Options == nil {
+		return nil
+	}
+	return a.Options.Labels
+}
+
+// ParsePlanOptions parses a [ReleasePlan.Options] JSON string into a map keyed
+// by entity UUID. An empty string yields an empty (non-nil) map.
+func ParsePlanOptions(raw string) (map[string]EntityOptions, error) {
+	out := map[string]EntityOptions{}
+	if strings.TrimSpace(raw) == "" {
+		return out, nil
+	}
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
 
 // ---------------------------------------------------------------------------
 // ReleasePlan – mirrors argus.backend.models.plan.ArgusReleasePlan
@@ -28,15 +94,19 @@ type ReleasePlan struct {
 	Participants    []string          `json:"participants"`
 	TargetVersion   string            `json:"target_version"`
 	AssigneeMapping map[string]string `json:"assignee_mapping"`
-	ReleaseID       string            `json:"release_id"`
-	Tests           []string          `json:"tests"`
-	Groups          []string          `json:"groups"`
-	ViewID          string            `json:"view_id"`
-	CreatedFrom     string            `json:"created_from"`
-	Completed       bool              `json:"completed"`
-	CreationTime    string            `json:"creation_time"`
-	LastUpdated     string            `json:"last_updated"`
-	EndsAt          string            `json:"ends_at"`
+	// Options is the per-entity option bag (labels) keyed by entity UUID,
+	// serialised by the backend as a JSON string (ArgusReleasePlan.options is a
+	// Text column). Parse it with [ParsePlanOptions]; empty means no options.
+	Options      string   `json:"options"`
+	ReleaseID    string   `json:"release_id"`
+	Tests        []string `json:"tests"`
+	Groups       []string `json:"groups"`
+	ViewID       string   `json:"view_id"`
+	CreatedFrom  string   `json:"created_from"`
+	Completed    bool     `json:"completed"`
+	CreationTime string   `json:"creation_time"`
+	LastUpdated  string   `json:"last_updated"`
+	EndsAt       string   `json:"ends_at"`
 }
 
 // ReleasePlanList is the response payload for the plans-for-release endpoint.
@@ -79,8 +149,11 @@ type CreatePlanRequest struct {
 	Tests         []string          `json:"tests"`
 	Groups        []string          `json:"groups"`
 	Assignments   map[string]string `json:"assignments"`
-	ViewID        string            `json:"view_id,omitempty"`
-	CreatedFrom   string            `json:"created_from,omitempty"`
+	// Options maps an entity UUID to its per-entity options (labels); it is
+	// serialised server-side into the plan's options column.
+	Options     map[string]EntityOptions `json:"options,omitempty"`
+	ViewID      string                   `json:"view_id,omitempty"`
+	CreatedFrom string                   `json:"created_from,omitempty"`
 }
 
 // PlanDiffRequest is the JSON body for POST /planning/plan/update.
@@ -111,6 +184,13 @@ type PlanDiffRequest struct {
 	// Map diff for assignee_mapping.
 	AssigneeMappingSet    map[string]string `json:"assignee_mapping_set,omitempty"`
 	AssigneeMappingRemove []string          `json:"assignee_mapping_remove,omitempty"`
+
+	// Map diff for per-entity options (labels). The server applies removes
+	// before sets, then prunes to the plan's current entities. OptionsSet
+	// replaces an entity's whole option bag (the CLI merges current + label
+	// deltas before sending); OptionsRemove drops the entity's options entirely.
+	OptionsSet    map[string]EntityOptions `json:"options_set,omitempty"`
+	OptionsRemove []string                 `json:"options_remove,omitempty"`
 }
 
 // ---------------------------------------------------------------------------
@@ -202,17 +282,19 @@ func (g ReleaseGrid) String() string {
 //
 // Assignments is the single source of plan membership: it is keyed by a
 // group-qualified "group/test" reference (or a group name, which fans out to
-// its enabled tests) and valued by a username. The literal [OwnerMarker]
-// ("$owner") denotes a test that belongs to the plan but is not assigned to a
-// specific participant — it is placed in the plan's tests but left out of the
-// assignee mapping. Owner is a username.
+// its enabled tests) and valued by an [AssignmentValue] carrying the assignee
+// username plus optional labels. On input the value may also be a bare
+// username string. The literal [OwnerMarker] ("$owner") as the assignee denotes
+// a test that belongs to the plan but is not assigned to a specific participant
+// — it is placed in the plan's tests but left out of the assignee mapping (it
+// may still carry labels). Owner is a username.
 type PlanTemplate struct {
-	Name          string            `json:"name"`
-	Description   string            `json:"description,omitempty"`
-	Release       string            `json:"release"`
-	TargetVersion string            `json:"target_version,omitempty"`
-	Owner         string            `json:"owner,omitempty"`
-	Assignments   map[string]string `json:"assignments,omitempty"`
+	Name          string                     `json:"name"`
+	Description   string                     `json:"description,omitempty"`
+	Release       string                     `json:"release"`
+	TargetVersion string                     `json:"target_version,omitempty"`
+	Owner         string                     `json:"owner,omitempty"`
+	Assignments   map[string]AssignmentValue `json:"assignments,omitempty"`
 }
 
 // OwnerMarker is the sentinel assignment value meaning "include this test in
@@ -257,8 +339,19 @@ type PlanUpdateSpec struct {
 	AssigneeMappingRemove []string          `json:"assignee_mapping_remove,omitempty"`
 
 	// Assignments is the template-style membership+assignment map, merged into
-	// the deltas above (see the type doc). "$owner" clears an assignee.
-	Assignments map[string]string `json:"assignments,omitempty"`
+	// the deltas above (see the type doc). "$owner" clears an assignee. Its
+	// per-entity labels are applied as additive label deltas (merged with
+	// LabelsAdd) rather than replacing an entity's existing labels.
+	Assignments map[string]AssignmentValue `json:"assignments,omitempty"`
+
+	// LabelsAdd/LabelsRemove are additive per-entity label deltas keyed by a
+	// test/group reference (groups fan out to their enabled tests). They are
+	// merged with the entity's current labels client-side and sent to the
+	// backend as a full options_set/options_remove diff. Adding a label to an
+	// entity not yet in the plan also adds the entity (membership follows
+	// labels, like assignment).
+	LabelsAdd    map[string][]string `json:"labels_add,omitempty"`
+	LabelsRemove map[string][]string `json:"labels_remove,omitempty"`
 }
 
 // ResolvedPlan is a human-readable view of a [ReleasePlan] with every UUID
@@ -271,23 +364,23 @@ type PlanUpdateSpec struct {
 // resolved against the release gridview/users list falls back to its raw UUID
 // rather than being omitted, so the output is lossless.
 type ResolvedPlan struct {
-	ID            string            `json:"id"`
-	Key           string            `json:"key"`
-	Name          string            `json:"name"`
-	Description   string            `json:"description,omitempty"`
-	Release       string            `json:"release"`
-	TargetVersion string            `json:"target_version,omitempty"`
-	Owner         string            `json:"owner"`
-	Participants  []string          `json:"participants,omitempty"`
-	Tests         []string          `json:"tests"`
-	Groups        []string          `json:"groups,omitempty"`
-	Assignments   map[string]string `json:"assignments,omitempty"`
-	Completed     bool              `json:"completed"`
-	ViewID        string            `json:"view_id,omitempty"`
-	CreatedFrom   string            `json:"created_from,omitempty"`
-	CreationTime  string            `json:"creation_time,omitempty"`
-	LastUpdated   string            `json:"last_updated,omitempty"`
-	EndsAt        string            `json:"ends_at,omitempty"`
+	ID            string                     `json:"id"`
+	Key           string                     `json:"key"`
+	Name          string                     `json:"name"`
+	Description   string                     `json:"description,omitempty"`
+	Release       string                     `json:"release"`
+	TargetVersion string                     `json:"target_version,omitempty"`
+	Owner         string                     `json:"owner"`
+	Participants  []string                   `json:"participants,omitempty"`
+	Tests         []string                   `json:"tests"`
+	Groups        []string                   `json:"groups,omitempty"`
+	Assignments   map[string]AssignmentValue `json:"assignments,omitempty"`
+	Completed     bool                       `json:"completed"`
+	ViewID        string                     `json:"view_id,omitempty"`
+	CreatedFrom   string                     `json:"created_from,omitempty"`
+	CreationTime  string                     `json:"creation_time,omitempty"`
+	LastUpdated   string                     `json:"last_updated,omitempty"`
+	EndsAt        string                     `json:"ends_at,omitempty"`
 }
 
 // Headers implements output.Tabular for ResolvedPlan. Text output is a curated

--- a/cli/internal/models/planner_test.go
+++ b/cli/internal/models/planner_test.go
@@ -263,6 +263,77 @@ func TestCreatePlanRequest_OmitsOptionalEmptyFields(t *testing.T) {
 	assert.NotContains(t, s, `"created_from"`, "empty optional created_from must be omitted")
 }
 
+func TestAssignmentValue_UnmarshalAcceptsStringOrObject(t *testing.T) {
+	t.Parallel()
+
+	t.Run("bare string is the assignee (back-compat)", func(t *testing.T) {
+		t.Parallel()
+		var v models.AssignmentValue
+		require.NoError(t, json.Unmarshal([]byte(`"bob"`), &v))
+		assert.Equal(t, models.AssignmentValue{Assignee: "bob"}, v)
+		assert.Nil(t, v.Labels())
+	})
+
+	t.Run("object with assignee and labels", func(t *testing.T) {
+		t.Parallel()
+		var v models.AssignmentValue
+		require.NoError(t, json.Unmarshal([]byte(`{"assignee":"bob","options":{"labels":["a","b"]}}`), &v))
+		assert.Equal(t, "bob", v.Assignee)
+		assert.Equal(t, []string{"a", "b"}, v.Labels())
+	})
+
+	t.Run("object with labels only (unassigned)", func(t *testing.T) {
+		t.Parallel()
+		var v models.AssignmentValue
+		require.NoError(t, json.Unmarshal([]byte(`{"options":{"labels":["x"]}}`), &v))
+		assert.Empty(t, v.Assignee)
+		assert.Equal(t, []string{"x"}, v.Labels())
+	})
+
+	t.Run("always marshals as an object", func(t *testing.T) {
+		t.Parallel()
+		raw, err := json.Marshal(models.AssignmentValue{Assignee: "bob"})
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"assignee":"bob"}`, string(raw))
+	})
+
+	t.Run("round-trips a map keyed by reference", func(t *testing.T) {
+		t.Parallel()
+		var m map[string]models.AssignmentValue
+		require.NoError(t, json.Unmarshal([]byte(`{"g/t1":"bob","g/t2":{"assignee":"$owner","options":{"labels":["l"]}}}`), &m))
+		assert.Equal(t, "bob", m["g/t1"].Assignee)
+		assert.Equal(t, "$owner", m["g/t2"].Assignee)
+		assert.Equal(t, []string{"l"}, m["g/t2"].Labels())
+	})
+}
+
+func TestParsePlanOptions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty string yields an empty map", func(t *testing.T) {
+		t.Parallel()
+		got, err := models.ParsePlanOptions("")
+		require.NoError(t, err)
+		assert.Empty(t, got)
+		assert.NotNil(t, got)
+	})
+
+	t.Run("parses entity-keyed options", func(t *testing.T) {
+		t.Parallel()
+		got, err := models.ParsePlanOptions(`{"uuid-1":{"labels":["a","b"]}}`)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]models.EntityOptions{
+			"uuid-1": {Labels: []string{"a", "b"}},
+		}, got)
+	})
+
+	t.Run("errors on malformed JSON", func(t *testing.T) {
+		t.Parallel()
+		_, err := models.ParsePlanOptions(`{not json`)
+		require.Error(t, err)
+	})
+}
+
 func sampleResolvedPlan() models.ResolvedPlan {
 	return models.ResolvedPlan{
 		ID:            "p1",
@@ -275,7 +346,7 @@ func sampleResolvedPlan() models.ResolvedPlan {
 		Participants:  []string{"bob"},
 		Tests:         []string{"Tier 1/longevity-100gb"},
 		Groups:        []string{"tier1"},
-		Assignments:   map[string]string{"Tier 1/longevity-200gb": "bob"},
+		Assignments:   map[string]models.AssignmentValue{"Tier 1/longevity-200gb": {Assignee: "bob"}},
 		Completed:     true,
 		LastUpdated:   "2026-06-02T11:00:00.000000",
 	}
@@ -311,7 +382,7 @@ func TestResolvedPlan_JSONKeepsFullDetail(t *testing.T) {
 	assert.Contains(t, s, `"tests":["Tier 1/longevity-100gb"]`)
 	assert.Contains(t, s, `"groups":["tier1"]`)
 	assert.Contains(t, s, `"participants":["bob"]`)
-	assert.Contains(t, s, `"assignments":{"Tier 1/longevity-200gb":"bob"}`)
+	assert.Contains(t, s, `"assignments":{"Tier 1/longevity-200gb":{"assignee":"bob"}}`)
 	assert.Contains(t, s, `"id":"p1"`)
 }
 

--- a/cli/internal/services/planner.go
+++ b/cli/internal/services/planner.go
@@ -529,11 +529,13 @@ func (s *PlannerService) BuildCreateRequest(ctx context.Context, tmpl models.Pla
 	// Assignments are the single source of plan membership. Each entry's
 	// targets join the tests list; a specific assignee also enters the
 	// assignee mapping. "$owner" leaves the test unassigned (in tests only).
+	// Labels attach to each resolved entity regardless of assignee.
 	// Missing entity → warn and omit; bad user → abort.
 	tests := newOrderedSet()
 	assignments := map[string]string{}
+	options := map[string]models.EntityOptions{}
 	var missing []string
-	for entityRef, userRef := range tmpl.Assignments {
+	for entityRef, value := range tmpl.Assignments {
 		ids, err := s.resolveAssignmentTargets(ctx, entityRef, releaseID)
 		if err != nil {
 			if errors.Is(err, ErrEntityNotFound) {
@@ -544,19 +546,23 @@ func (s *PlannerService) BuildCreateRequest(ctx context.Context, tmpl models.Pla
 			return models.CreatePlanRequest{}, nil, err
 		}
 
-		if userRef == models.OwnerMarker {
-			for _, id := range ids {
-				tests.add(id)
+		labels := value.Labels()
+		for _, id := range ids {
+			tests.add(id)
+			if len(labels) > 0 {
+				options[id] = models.EntityOptions{Labels: append([]string(nil), labels...)}
 			}
+		}
+
+		if value.Assignee == "" || value.Assignee == models.OwnerMarker {
 			continue
 		}
 
-		userID, err := s.ResolveUserID(ctx, userRef)
+		userID, err := s.ResolveUserID(ctx, value.Assignee)
 		if err != nil {
-			return models.CreatePlanRequest{}, nil, fmt.Errorf("assignee %q: %w", userRef, err)
+			return models.CreatePlanRequest{}, nil, fmt.Errorf("assignee %q: %w", value.Assignee, err)
 		}
 		for _, id := range ids {
-			tests.add(id)
 			assignments[id] = userID
 		}
 	}
@@ -600,6 +606,7 @@ func (s *PlannerService) BuildCreateRequest(ctx context.Context, tmpl models.Pla
 		Tests:         nonNilSlice(tests.items),
 		Groups:        []string{},
 		Assignments:   assignments,
+		Options:       options,
 	}, warnings, nil
 }
 
@@ -650,8 +657,12 @@ func (s *PlannerService) BuildTemplate(ctx context.Context, plan models.ReleaseP
 	if err != nil {
 		return models.PlanTemplate{}, err
 	}
+	planOptions, err := models.ParsePlanOptions(plan.Options)
+	if err != nil {
+		return models.PlanTemplate{}, fmt.Errorf("parsing plan options: %w", err)
+	}
 
-	assignments := map[string]string{}
+	assignments := map[string]models.AssignmentValue{}
 
 	// Assigned tests carry their assignee username.
 	for entityID, userID := range plan.AssigneeMapping {
@@ -663,17 +674,24 @@ func (s *PlannerService) BuildTemplate(ctx context.Context, plan models.ReleaseP
 		if !ok {
 			continue
 		}
-		assignments[name] = u.Username
+		assignments[name] = models.AssignmentValue{
+			Assignee: u.Username,
+			Options:  entityOptions(planOptions, entityID),
+		}
 	}
 
-	// Remaining plan tests are unassigned: mark them "$owner".
+	// Remaining plan tests are unassigned: mark them "$owner" (they may still
+	// carry labels).
 	for _, t := range plan.Tests {
 		name, ok := entityQualifiedName(grid, t)
 		if !ok {
 			continue
 		}
 		if _, exists := assignments[name]; !exists {
-			assignments[name] = models.OwnerMarker
+			assignments[name] = models.AssignmentValue{
+				Assignee: models.OwnerMarker,
+				Options:  entityOptions(planOptions, t),
+			}
 		}
 	}
 
@@ -701,6 +719,17 @@ func entityQualifiedName(grid models.GridView, id string) (string, bool) {
 		return g.Name, true
 	}
 	return "", false
+}
+
+// entityOptions returns a copy of the per-entity options for id, or nil when
+// the entity has no options (so an emitted [models.AssignmentValue] omits the
+// options object entirely).
+func entityOptions(options map[string]models.EntityOptions, id string) *models.EntityOptions {
+	opt, ok := options[id]
+	if !ok || len(opt.Labels) == 0 {
+		return nil
+	}
+	return &models.EntityOptions{Labels: append([]string(nil), opt.Labels...)}
 }
 
 // releaseNameByID returns the name of the release with the given UUID.
@@ -747,6 +776,8 @@ func (s *PlannerService) BuildResolvedPlan(ctx context.Context, plan models.Rele
 	if err != nil {
 		releaseName = plan.ReleaseID
 	}
+	// Options are non-fatal too: a malformed blob simply yields no labels.
+	planOptions, _ := models.ParsePlanOptions(plan.Options)
 
 	username := func(id string) string {
 		if u, ok := users[id]; ok {
@@ -773,12 +804,15 @@ func (s *PlannerService) BuildResolvedPlan(ctx context.Context, plan models.Rele
 	for _, g := range plan.Groups {
 		groups = append(groups, entityName(g))
 	}
-	var assignments map[string]string
+	var assignments map[string]models.AssignmentValue
 	for entityID, userID := range plan.AssigneeMapping {
 		if assignments == nil {
-			assignments = map[string]string{}
+			assignments = map[string]models.AssignmentValue{}
 		}
-		assignments[entityName(entityID)] = username(userID)
+		assignments[entityName(entityID)] = models.AssignmentValue{
+			Assignee: username(userID),
+			Options:  entityOptions(planOptions, entityID),
+		}
 	}
 
 	return models.ResolvedPlan{
@@ -955,15 +989,30 @@ func (s *PlannerService) BuildUpdateRequest(ctx context.Context, plan models.Rel
 	// Assignment application. The raw --assign / assignee_mapping_set map and the
 	// template-style assignments map share identical merge/patch semantics: each
 	// keyed test/group joins the plan (membership follows assignment) and is
-	// (re)assigned, or is cleared — keeping the test — when the value is "$owner".
-	// Membership is ensured so the backend, which drops mapping entries for tests
-	// not in plan.tests, keeps the assignment instead of silently discarding it.
-	// A reference matching nothing in the release is reported and skipped; an
-	// ambiguous one aborts so the user can disambiguate.
+	// (re)assigned, or is cleared — keeping the test — when the assignee is
+	// "$owner". A template assignment value may also carry labels, applied as
+	// additive label deltas (see below). Membership is ensured so the backend,
+	// which drops mapping entries for tests not in plan.tests, keeps the
+	// assignment instead of silently discarding it. A reference matching nothing
+	// in the release is reported and skipped; an ambiguous one aborts so the user
+	// can disambiguate.
 	var assignSet map[string]string
 	assignRemove := newOrderedSet()
-	applyAssignments := func(m map[string]string) error {
-		for entityRef, userRef := range m {
+	// Additive per-entity label deltas keyed by entity UUID, merged with the
+	// entity's current labels below into a full options_set/options_remove diff.
+	labelAdd := map[string]*orderedSet{}
+	labelRemove := map[string]*orderedSet{}
+	addLabel := func(store map[string]*orderedSet, id, label string) {
+		set, ok := store[id]
+		if !ok {
+			set = newOrderedSet()
+			store[id] = set
+		}
+		set.add(label)
+	}
+
+	applyAssignments := func(m map[string]models.AssignmentValue) error {
+		for entityRef, value := range m {
 			ids, err := s.resolveAssignmentTargets(ctx, entityRef, releaseID)
 			if err != nil {
 				if errors.Is(err, ErrEntityNotFound) {
@@ -973,29 +1022,46 @@ func (s *PlannerService) BuildUpdateRequest(ctx context.Context, plan models.Rel
 				return err
 			}
 			for _, id := range ids {
-				addTests.add(id) // membership follows assignment
+				addTests.add(id) // membership follows assignment/labels
 			}
-			if userRef == models.OwnerMarker {
+			for _, label := range value.Labels() {
+				for _, id := range ids {
+					addLabel(labelAdd, id, label)
+				}
+			}
+			switch value.Assignee {
+			case "":
+				// Labels-only entry: no assignee change.
+			case models.OwnerMarker:
 				for _, id := range ids {
 					assignRemove.add(id)
 				}
-				continue
-			}
-			userID, err := s.ResolveUserID(ctx, userRef)
-			if err != nil {
-				return fmt.Errorf("assignee %q: %w", userRef, err)
-			}
-			for _, id := range ids {
-				if assignSet == nil {
-					assignSet = map[string]string{}
+			default:
+				userID, err := s.ResolveUserID(ctx, value.Assignee)
+				if err != nil {
+					return fmt.Errorf("assignee %q: %w", value.Assignee, err)
 				}
-				assignSet[id] = userID
+				for _, id := range ids {
+					if assignSet == nil {
+						assignSet = map[string]string{}
+					}
+					assignSet[id] = userID
+				}
 			}
 		}
 		return nil
 	}
-	if err := applyAssignments(spec.AssigneeMappingSet); err != nil {
-		return models.PlanDiffRequest{}, nil, err
+
+	// --assign feeds the string-valued assignee_mapping_set (assignee only,
+	// unchanged behaviour): adapt it to the shared applier.
+	if len(spec.AssigneeMappingSet) > 0 {
+		converted := make(map[string]models.AssignmentValue, len(spec.AssigneeMappingSet))
+		for ref, user := range spec.AssigneeMappingSet {
+			converted[ref] = models.AssignmentValue{Assignee: user}
+		}
+		if err := applyAssignments(converted); err != nil {
+			return models.PlanDiffRequest{}, nil, err
+		}
 	}
 
 	// Assignment removal (--unassign): resolve each entity (group fans out) to
@@ -1014,7 +1080,51 @@ func (s *PlannerService) BuildUpdateRequest(ctx context.Context, plan models.Rel
 	if err := applyAssignments(spec.Assignments); err != nil {
 		return models.PlanDiffRequest{}, nil, err
 	}
+
+	// --label adds labels (membership follows labels, like --assign); --unlabel
+	// removes them without adding membership. Missing → warn/skip; ambiguous →
+	// abort.
+	for entityRef, labels := range spec.LabelsAdd {
+		ids, err := s.resolveAssignmentTargets(ctx, entityRef, releaseID)
+		if err != nil {
+			if errors.Is(err, ErrEntityNotFound) {
+				warnings = append(warnings, fmt.Sprintf("label target %q is not in this release — skipped", entityRef))
+				continue
+			}
+			return models.PlanDiffRequest{}, nil, err
+		}
+		for _, id := range ids {
+			addTests.add(id) // membership follows labels
+			for _, label := range labels {
+				addLabel(labelAdd, id, label)
+			}
+		}
+	}
+	for entityRef, labels := range spec.LabelsRemove {
+		ids, err := s.resolveAssignmentTargets(ctx, entityRef, releaseID)
+		if err != nil {
+			if errors.Is(err, ErrEntityNotFound) {
+				warnings = append(warnings, fmt.Sprintf("unlabel target %q is not in this release — skipped", entityRef))
+				continue
+			}
+			return models.PlanDiffRequest{}, nil, err
+		}
+		for _, id := range ids {
+			for _, label := range labels {
+				addLabel(labelRemove, id, label)
+			}
+		}
+	}
+
 	diff.AssigneeMappingSet = assignSet
+
+	// Merge label deltas with the plan's current labels into a full per-entity
+	// options diff. An entity whose label set becomes empty is dropped via
+	// options_remove; the backend applies removes before sets and prunes to the
+	// plan's surviving entities.
+	if err := s.applyOptionsDiff(&diff, plan, labelAdd, labelRemove); err != nil {
+		return models.PlanDiffRequest{}, nil, err
+	}
 
 	if len(addTests.items) > 0 {
 		diff.TestsAdd = addTests.items
@@ -1039,6 +1149,74 @@ func (s *PlannerService) BuildUpdateRequest(ctx context.Context, plan models.Rel
 	}
 
 	return diff, warnings, nil
+}
+
+// applyOptionsDiff merges the additive per-entity label deltas (labelAdd,
+// labelRemove, both keyed by entity UUID) with the plan's current labels and
+// populates diff.OptionsSet / diff.OptionsRemove. For each touched entity the
+// final label set is current ∪ adds − removes: a non-empty set is sent as a
+// full options_set (the backend replaces the entity's option bag), while a set
+// that becomes empty is sent as options_remove when the entity currently has
+// options (otherwise it is a no-op and omitted).
+func (s *PlannerService) applyOptionsDiff(diff *models.PlanDiffRequest, plan models.ReleasePlan, labelAdd, labelRemove map[string]*orderedSet) error {
+	if len(labelAdd) == 0 && len(labelRemove) == 0 {
+		return nil
+	}
+	current, err := models.ParsePlanOptions(plan.Options)
+	if err != nil {
+		return fmt.Errorf("parsing plan options: %w", err)
+	}
+
+	touched := map[string]struct{}{}
+	for id := range labelAdd {
+		touched[id] = struct{}{}
+	}
+	for id := range labelRemove {
+		touched[id] = struct{}{}
+	}
+
+	var optionsSet map[string]models.EntityOptions
+	var optionsRemove []string
+	for id := range touched {
+		removeSet := map[string]bool{}
+		if rem, ok := labelRemove[id]; ok {
+			for _, l := range rem.items {
+				removeSet[l] = true
+			}
+		}
+		final := newOrderedSet()
+		for _, l := range current[id].Labels {
+			if !removeSet[l] {
+				final.add(l)
+			}
+		}
+		if add, ok := labelAdd[id]; ok {
+			for _, l := range add.items {
+				if !removeSet[l] {
+					final.add(l)
+				}
+			}
+		}
+
+		if len(final.items) == 0 {
+			// Only emit a removal when the entity actually had options today.
+			if _, had := current[id]; had {
+				optionsRemove = append(optionsRemove, id)
+			}
+			continue
+		}
+		if optionsSet == nil {
+			optionsSet = map[string]models.EntityOptions{}
+		}
+		optionsSet[id] = models.EntityOptions{Labels: final.items}
+	}
+	sort.Strings(optionsRemove)
+
+	diff.OptionsSet = optionsSet
+	if len(optionsRemove) > 0 {
+		diff.OptionsRemove = optionsRemove
+	}
+	return nil
 }
 
 // participantDeltas computes participants_add/remove so the stored participants

--- a/cli/internal/services/planner_test.go
+++ b/cli/internal/services/planner_test.go
@@ -444,6 +444,17 @@ func resolveMux(t *testing.T) *http.ServeMux {
 	return mux
 }
 
+// av wraps a reference→assignee string map into the assignments map that
+// PlanTemplate/PlanUpdateSpec now use (assignee only, no labels), keeping the
+// existing table data terse.
+func av(m map[string]string) map[string]models.AssignmentValue {
+	out := make(map[string]models.AssignmentValue, len(m))
+	for k, v := range m {
+		out[k] = models.AssignmentValue{Assignee: v}
+	}
+	return out
+}
+
 func TestPlannerService_BuildCreateRequest_ResolvesAndExpands(t *testing.T) {
 	t.Parallel()
 	svc := newPlannerSvc(t, resolveMux(t))
@@ -453,10 +464,10 @@ func TestPlannerService_BuildCreateRequest_ResolvesAndExpands(t *testing.T) {
 		Release:       "scylla-2026.2",
 		Owner:         "alice",
 		TargetVersion: "2026.2.0",
-		Assignments: map[string]string{
+		Assignments: av(map[string]string{
 			"tier1/longevity-200gb": "$owner",
 			"tier2/longevity-100gb": "bob",
-		},
+		}),
 	}
 
 	req, warnings, err := svc.BuildCreateRequest(context.Background(), tmpl)
@@ -483,7 +494,7 @@ func TestPlannerService_BuildCreateRequest_GroupAssignmentFansOut(t *testing.T) 
 		Name:        "fanout",
 		Release:     "scylla-2026.2",
 		Owner:       "alice",
-		Assignments: map[string]string{"tier1": "bob"},
+		Assignments: av(map[string]string{"tier1": "bob"}),
 	}
 
 	req, warnings, err := svc.BuildCreateRequest(context.Background(), tmpl)
@@ -504,7 +515,7 @@ func TestPlannerService_BuildCreateRequest_GroupByBuildSystemID(t *testing.T) {
 		Name:        "fanout-bsid",
 		Release:     "scylla-2026.2",
 		Owner:       "alice",
-		Assignments: map[string]string{"scylla-2026.2/tier1": "bob"},
+		Assignments: av(map[string]string{"scylla-2026.2/tier1": "bob"}),
 	}
 
 	req, warnings, err := svc.BuildCreateRequest(context.Background(), tmpl)
@@ -539,10 +550,10 @@ func TestPlannerService_BuildCreateRequest_NoPhantomParticipants(t *testing.T) {
 		Name:    "phantom",
 		Release: "scylla-2026.2",
 		Owner:   "carol",
-		Assignments: map[string]string{
+		Assignments: av(map[string]string{
 			"tier1":                 "bob",   // fans out to t1, t2
 			"tier1/longevity-200gb": "alice", // contends for t2
-		},
+		}),
 	}
 
 	// Map iteration order is randomised per range, so repeat to exercise both
@@ -572,7 +583,7 @@ func TestPlannerService_BuildCreateRequest_OwnerMarkerLeavesUnassigned(t *testin
 		Name:        "p",
 		Release:     "scylla-2026.2",
 		Owner:       "alice",
-		Assignments: map[string]string{"tier1/longevity-100gb": "$owner"},
+		Assignments: av(map[string]string{"tier1/longevity-100gb": "$owner"}),
 	}
 
 	req, warnings, err := svc.BuildCreateRequest(context.Background(), tmpl)
@@ -592,10 +603,10 @@ func TestPlannerService_BuildCreateRequest_MissingTestWarnsAndOmits(t *testing.T
 		Name:    "p",
 		Release: "scylla-2026.2",
 		Owner:   "alice",
-		Assignments: map[string]string{
+		Assignments: av(map[string]string{
 			"tier1/longevity-200gb": "$owner",
 			"tier1/does-not-exist":  "$owner",
-		},
+		}),
 	}
 
 	req, warnings, err := svc.BuildCreateRequest(context.Background(), tmpl)
@@ -614,7 +625,7 @@ func TestPlannerService_BuildCreateRequest_AmbiguousAborts(t *testing.T) {
 		Name:        "p",
 		Release:     "scylla-2026.2",
 		Owner:       "alice",
-		Assignments: map[string]string{"longevity-100gb": "$owner"}, // in tier1 and tier2
+		Assignments: av(map[string]string{"longevity-100gb": "$owner"}), // in tier1 and tier2
 	}
 
 	_, _, err := svc.BuildCreateRequest(context.Background(), tmpl)
@@ -633,7 +644,7 @@ func TestPlannerService_BuildCreateRequest_AllMissingTestsRejected(t *testing.T)
 		Name:        "p",
 		Release:     "scylla-2026.2",
 		Owner:       "alice",
-		Assignments: map[string]string{"tier1/gone-a": "$owner", "tier1/gone-b": "$owner"},
+		Assignments: av(map[string]string{"tier1/gone-a": "$owner", "tier1/gone-b": "$owner"}),
 	}
 
 	_, warnings, err := svc.BuildCreateRequest(context.Background(), tmpl)
@@ -761,11 +772,11 @@ func TestPlannerService_BuildTemplate_BackResolvesNames(t *testing.T) {
 	assert.Equal(t, "scylla-2026.2", tmpl.Release)
 	assert.Equal(t, "alice", tmpl.Owner)
 	// Unassigned tests are marked $owner; the assigned one keeps its assignee.
-	assert.Equal(t, map[string]string{
+	assert.Equal(t, av(map[string]string{
 		"Tier 1/longevity-100gb": "$owner",
 		"Tier 1/longevity-200gb": "$owner",
 		"Tier 2/longevity-100gb": "bob",
-	}, tmpl.Assignments)
+	}), tmpl.Assignments)
 }
 
 func TestPlannerService_BuildTemplate_SkipsUnknownTests(t *testing.T) {
@@ -782,7 +793,7 @@ func TestPlannerService_BuildTemplate_SkipsUnknownTests(t *testing.T) {
 	tmpl, err := svc.BuildTemplate(context.Background(), plan)
 	require.NoError(t, err)
 	// Tests no longer present in the gridview cannot be named and are skipped.
-	assert.Equal(t, map[string]string{"Tier 1/longevity-100gb": "$owner"}, tmpl.Assignments)
+	assert.Equal(t, av(map[string]string{"Tier 1/longevity-100gb": "$owner"}), tmpl.Assignments)
 }
 
 // TestPlannerService_TemplateRoundTrip locks the get --template -> create path:
@@ -805,7 +816,7 @@ func TestPlannerService_TemplateRoundTrip_DisplayNameMapsToGroupID(t *testing.T)
 	tmpl, err := svc.BuildTemplate(ctx, plan)
 	require.NoError(t, err)
 	// Sanity: the emitted refs use the group's display name, not its raw name.
-	assert.Equal(t, "$owner", tmpl.Assignments["Tier 1/longevity-100gb"])
+	assert.Equal(t, "$owner", tmpl.Assignments["Tier 1/longevity-100gb"].Assignee)
 	require.Contains(t, tmpl.Assignments, "Tier 2/longevity-100gb")
 
 	// Feeding the template straight back must resolve the display names to the
@@ -862,7 +873,7 @@ func TestPlannerService_BuildResolvedPlan_ResolvesNames(t *testing.T) {
 	assert.Equal(t, []string{"bob"}, rp.Participants)
 	assert.Equal(t, []string{"Tier 1/longevity-100gb", "Tier 2/longevity-100gb"}, rp.Tests)
 	assert.Equal(t, []string{"tier1"}, rp.Groups)
-	assert.Equal(t, map[string]string{"Tier 1/longevity-200gb": "bob"}, rp.Assignments)
+	assert.Equal(t, av(map[string]string{"Tier 1/longevity-200gb": "bob"}), rp.Assignments)
 	// Identity/status fields are retained (unlike a template).
 	assert.Equal(t, "p1", rp.ID)
 	assert.True(t, rp.Completed)
@@ -885,7 +896,7 @@ func TestPlannerService_BuildResolvedPlan_UnknownRefsFallBackToUUID(t *testing.T
 	// Unknown references are kept verbatim (lossless), not dropped.
 	assert.Equal(t, "u-missing", rp.Owner)
 	assert.Equal(t, []string{"Tier 1/longevity-100gb", "gone"}, rp.Tests)
-	assert.Equal(t, map[string]string{"gone": "u-missing"}, rp.Assignments)
+	assert.Equal(t, av(map[string]string{"gone": "u-missing"}), rp.Assignments)
 }
 
 func TestPlannerService_BuildResolvedPlan_UnknownReleaseFallsBack(t *testing.T) {
@@ -1222,7 +1233,7 @@ func TestPlannerService_BuildUpdateRequest_AssignmentsMergeReassigns(t *testing.
 	// participant. Tests not mentioned are left untouched.
 	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1", Owner: "u1", Tests: []string{"t2"}}
 	diff, warnings, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
-		Assignments: map[string]string{"tier1/longevity-200gb": "bob"},
+		Assignments: av(map[string]string{"tier1/longevity-200gb": "bob"}),
 	})
 	require.NoError(t, err)
 	assert.Empty(t, warnings)
@@ -1240,7 +1251,7 @@ func TestPlannerService_BuildUpdateRequest_AssignmentsAddsNewTest(t *testing.T) 
 	// follows assignment) and assigned.
 	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1", Owner: "u1", Tests: []string{"t1"}}
 	diff, _, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
-		Assignments: map[string]string{"tier2/longevity-100gb": "bob"},
+		Assignments: av(map[string]string{"tier2/longevity-100gb": "bob"}),
 	})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"t3"}, diff.TestsAdd)
@@ -1260,7 +1271,7 @@ func TestPlannerService_BuildUpdateRequest_AssignmentsOwnerMarkerClears(t *testi
 		AssigneeMapping: map[string]string{"t2": "u2"},
 	}
 	diff, _, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
-		Assignments: map[string]string{"tier1/longevity-200gb": "$owner"},
+		Assignments: av(map[string]string{"tier1/longevity-200gb": "$owner"}),
 	})
 	require.NoError(t, err)
 	assert.Nil(t, diff.AssigneeMappingSet)
@@ -1275,7 +1286,7 @@ func TestPlannerService_BuildUpdateRequest_AssignmentsMissingWarns(t *testing.T)
 	// A reference matching nothing is reported and skipped, not fatal.
 	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1", Owner: "u1", Tests: []string{"t2"}}
 	diff, warnings, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
-		Assignments: map[string]string{"tier1/does-not-exist": "bob"},
+		Assignments: av(map[string]string{"tier1/does-not-exist": "bob"}),
 	})
 	require.NoError(t, err)
 	require.Len(t, warnings, 1)
@@ -1346,7 +1357,7 @@ func TestPlannerService_BuildCreateRequest_AmbiguousGroupAssignmentAborts(t *tes
 		Name:        "p",
 		Release:     "scylla-2026.2",
 		Owner:       "bob",
-		Assignments: map[string]string{"Tier": "bob"},
+		Assignments: av(map[string]string{"Tier": "bob"}),
 	})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, services.ErrAmbiguousEntity)
@@ -1402,4 +1413,150 @@ func TestPlannerService_UpdatePlan_BackendError(t *testing.T) {
 	var apiErr *api.APIError
 	require.True(t, errors.As(err, &apiErr))
 	assert.Contains(t, apiErr.Body.Message, "already exist")
+}
+
+// --------------------------------------------------------------------------
+// Per-entity options (labels)
+// --------------------------------------------------------------------------
+
+func TestPlannerService_BuildCreateRequest_EmitsOptions(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	// Labels attach to the resolved entity UUID, including an unassigned test.
+	tmpl := models.PlanTemplate{
+		Name:    "labelled",
+		Release: "scylla-2026.2",
+		Owner:   "alice",
+		Assignments: map[string]models.AssignmentValue{
+			"tier1/longevity-200gb": {Assignee: "bob", Options: &models.EntityOptions{Labels: []string{"blocker"}}},
+			"tier2/longevity-100gb": {Assignee: "$owner", Options: &models.EntityOptions{Labels: []string{"needs-triage"}}},
+		},
+	}
+
+	req, warnings, err := svc.BuildCreateRequest(context.Background(), tmpl)
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+	assert.Equal(t, map[string]models.EntityOptions{
+		"t2": {Labels: []string{"blocker"}},
+		"t3": {Labels: []string{"needs-triage"}},
+	}, req.Options)
+	// The $owner test still carries labels but no assignee.
+	assert.Equal(t, map[string]string{"t2": "u2"}, req.Assignments)
+}
+
+func TestPlannerService_BuildCreateRequest_GroupLabelFansOut(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	// A group entry's labels attach to each enabled member test (t1, t2).
+	tmpl := models.PlanTemplate{
+		Name:    "grouplabel",
+		Release: "scylla-2026.2",
+		Owner:   "alice",
+		Assignments: map[string]models.AssignmentValue{
+			"tier1": {Assignee: "bob", Options: &models.EntityOptions{Labels: []string{"smoke"}}},
+		},
+	}
+
+	req, _, err := svc.BuildCreateRequest(context.Background(), tmpl)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]models.EntityOptions{
+		"t1": {Labels: []string{"smoke"}},
+		"t2": {Labels: []string{"smoke"}},
+	}, req.Options)
+}
+
+func TestPlannerService_BuildTemplate_IncludesLabels(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	// The plan stores options as a JSON string keyed by entity UUID.
+	plan := models.ReleasePlan{
+		ID: "p1", ReleaseID: "rel-1", Owner: "u1",
+		Tests:           []string{"t1", "t2"},
+		AssigneeMapping: map[string]string{"t2": "u2"},
+		Options:         `{"t1":{"labels":["needs-triage"]},"t2":{"labels":["blocker","smoke"]}}`,
+	}
+
+	tmpl, err := svc.BuildTemplate(context.Background(), plan)
+	require.NoError(t, err)
+	// Assigned test carries its labels; unassigned test keeps labels under $owner.
+	assert.Equal(t, models.AssignmentValue{
+		Assignee: "bob",
+		Options:  &models.EntityOptions{Labels: []string{"blocker", "smoke"}},
+	}, tmpl.Assignments["Tier 1/longevity-200gb"])
+	assert.Equal(t, models.AssignmentValue{
+		Assignee: "$owner",
+		Options:  &models.EntityOptions{Labels: []string{"needs-triage"}},
+	}, tmpl.Assignments["Tier 1/longevity-100gb"])
+}
+
+func TestPlannerService_BuildUpdateRequest_LabelAddMergesWithCurrent(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	// t2 already has "blocker"; --label adds "smoke" → merged set is sent.
+	plan := models.ReleasePlan{
+		ID: "p1", ReleaseID: "rel-1", Owner: "u1",
+		Tests:   []string{"t2"},
+		Options: `{"t2":{"labels":["blocker"]}}`,
+	}
+	diff, warnings, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
+		LabelsAdd: map[string][]string{"tier1/longevity-200gb": {"smoke"}},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+	assert.Equal(t, map[string]models.EntityOptions{
+		"t2": {Labels: []string{"blocker", "smoke"}},
+	}, diff.OptionsSet)
+	assert.Nil(t, diff.OptionsRemove)
+}
+
+func TestPlannerService_BuildUpdateRequest_LabelAddAddsMembership(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	// Labelling a test not yet in the plan adds it (membership follows labels).
+	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1", Owner: "u1", Tests: []string{"t1"}}
+	diff, _, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
+		LabelsAdd: map[string][]string{"tier2/longevity-100gb": {"smoke"}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"t3"}, diff.TestsAdd)
+	assert.Equal(t, map[string]models.EntityOptions{"t3": {Labels: []string{"smoke"}}}, diff.OptionsSet)
+}
+
+func TestPlannerService_BuildUpdateRequest_UnlabelRemovesAllEmitsOptionsRemove(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	// Removing the only label clears the entity's option bag via options_remove.
+	plan := models.ReleasePlan{
+		ID: "p1", ReleaseID: "rel-1", Owner: "u1",
+		Tests:   []string{"t2"},
+		Options: `{"t2":{"labels":["blocker"]}}`,
+	}
+	diff, _, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
+		LabelsRemove: map[string][]string{"tier1/longevity-200gb": {"blocker"}},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, diff.OptionsSet)
+	assert.Equal(t, []string{"t2"}, diff.OptionsRemove)
+}
+
+func TestPlannerService_BuildUpdateRequest_FileAssignmentsCarryLabels(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	// The template-style assignments map may carry labels (applied additively).
+	plan := models.ReleasePlan{ID: "p1", ReleaseID: "rel-1", Owner: "u1", Tests: []string{"t2"}}
+	diff, _, err := svc.BuildUpdateRequest(context.Background(), plan, models.PlanUpdateSpec{
+		Assignments: map[string]models.AssignmentValue{
+			"tier1/longevity-200gb": {Assignee: "bob", Options: &models.EntityOptions{Labels: []string{"smoke"}}},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"t2": "u2"}, diff.AssigneeMappingSet)
+	assert.Equal(t, map[string]models.EntityOptions{"t2": {Labels: []string{"smoke"}}}, diff.OptionsSet)
 }


### PR DESCRIPTION
- **feature(service/planner): add per-entity options with labels to release plans**
  Introduce an options object on ArgusReleasePlan stored as serialized JSON
  in a text column, keyed by test or group UUID. Initially carries a labels
  array per entity. Threaded through create/update (diff-based set/remove with
  pruning) and copy (remap onto copied entities).
  

- **feature(cli/planner): wire per-entity labels into planner commands**
  Extend the assignments map value to an object carrying an assignee plus
  per-entity options (labels), while still accepting the bare-string assignee
  form for backward compatibility. Labels flow through get/create/update: they
  are back-resolved in templates, emitted as options on create, and applied as
  merge deltas on update via new --label/--unlabel flags, computing the backend
  options_set/options_remove diff. Labels may attach to unassigned ($owner)
  entities. --assign behaviour is unchanged.
  

Task: ARGUS-183