### PR TITLE
fix(planner): clear assignee_mapping entries on remove

### DIFF
--- a/argus/backend/service/planner_service.py
+++ b/argus/backend/service/planner_service.py
@@ -258,7 +258,7 @@ class PlanningService:
         # Apply assignee_mapping diff (remove first, then set)
         current_mapping = dict(plan.assignee_mapping or {})
         for key in plan_request.assignee_mapping_remove:
-            current_mapping.pop(key, None)
+            current_mapping.pop(UUID(key), None)
         mapping = {UUID(k): UUID(v) for k, v in plan_request.assignee_mapping_set.items()}
         for key, value in mapping.items():
             current_mapping[key] = value


### PR DESCRIPTION
The update_plan diff normalizes string references to UUID everywhere
except the assignee_mapping_remove loop, which popped raw string keys
against a Map(UUID, UUID) whose keys are UUID objects. The pop never
matched, so $owner / assignee_mapping_remove silently left assignees
untouched. Wrap the key in UUID() like the other diff sections.
