### PR TITLE
cli/jenkins service commands

### DIFF
--- a/argus/backend/controller/api.py
+++ b/argus/backend/controller/api.py
@@ -7,7 +7,8 @@ from flask import (
     current_app,
     g,
     redirect,
-    request, Response
+    request, Response,
+    url_for,
 )
 from flask.json import jsonify
 from argus.backend.error_handlers import handle_api_exception
@@ -44,6 +45,24 @@ def app_version():
         "status": "ok",
         "response": {
             "commit_id": argus_version
+        }
+    })
+
+
+@bp.route("/test/<path:build_id>/<int:build_number>")
+@api_login_required
+def get_run_by_build(build_id: str, build_number: int):
+    # JSON sibling of main.get_run_by_build: resolve a run from its
+    # build_system_id + Jenkins build number and return its id and Argus URL.
+    run = TestRunService().get_run_by_build_number(build_id, build_number)
+    if not run:
+        raise Exception(f"Run not found for {build_id} #{build_number}")
+    return jsonify({
+        "status": "ok",
+        "response": {
+            "run_id": str(run.id),
+            "plugin_name": run._plugin_name,
+            "url": url_for("main.get_run_by_plugin", plugin_name=run._plugin_name, run_id=run.id, _external=True),
         }
     })
 

--- a/argus/backend/controller/main.py
+++ b/argus/backend/controller/main.py
@@ -58,6 +58,21 @@ def get_run_by_plugin(plugin_name: str, run_id: UUID | str, tab: str):
     return render_template("run_view_by_plugin.html.j2", run=run, tab=tab)
 
 
+@bp.route("/test/<path:build_id>/<int:build_number>", defaults={"tab": "details"})
+@bp.route("/test/<path:build_id>/<int:build_number>/<string:tab>")
+@login_required
+def get_run_by_build(build_id: str, build_number: int, tab: str):
+    # Resolve a run from its build_system_id + Jenkins build number. This gives
+    # a stable, clickable link that can be produced the moment a build starts —
+    # even during the brief window before its run_id exists — and resolves once
+    # the run has been reported to Argus.
+    run = TestRunService().get_run_by_build_number(build_id, build_number)
+    if not run:
+        flash(f"Run {build_id} #{build_number} not found.", "error")
+        return redirect(url_for("main.error", type=404))
+    return render_template("run_view_by_plugin.html.j2", run=run, tab=tab)
+
+
 @bp.route("/")
 def home():
     return redirect(url_for("main.run_dashboard"))

--- a/argus/backend/controller/testrun_api.py
+++ b/argus/backend/controller/testrun_api.py
@@ -438,11 +438,20 @@ def build_jenkins_job():
 
     result = service.build_job(build_id=payload["buildId"], params=payload["parameters"])
 
+    response = {
+        "queueItem": result
+    }
+    # The CLI opts in via includeBuildNumber to receive the guessed next build
+    # number, so it can print a stable Argus run link without waiting for the
+    # build to leave the queue. Omitted (not fatal) when it can't be resolved.
+    if payload.get("includeBuildNumber"):
+        next_build_number = service.next_build_number(build_id=payload["buildId"])
+        if next_build_number > 0:
+            response["nextBuildNumber"] = next_build_number
+
     return {
         "status": "ok",
-        "response": {
-            "queueItem": result
-        }
+        "response": response
     }
 
 

--- a/argus/backend/service/jenkins_service.py
+++ b/argus/backend/service/jenkins_service.py
@@ -145,6 +145,18 @@ class JenkinsService:
         except jenkins.JenkinsException:
             raise JenkinsServiceError("Job doesn't exist", build_id)
 
+    def next_build_number(self, build_id: str) -> int:
+        """Best-effort guess of the build number Jenkins will assign to the next
+        build of ``build_id``. Used to hand out a stable Argus run link right
+        after triggering, before the build leaves the queue. Returns ``-1`` when
+        the number can't be determined (the trigger itself already succeeded, so
+        this must never be fatal)."""
+        try:
+            job_info = self._jenkins.get_job_info(name=build_id)
+            return job_info.get("nextBuildNumber", -1)
+        except jenkins.JenkinsException:
+            return -1
+
     def get_releases_for_clone(self, test_id: str):
         test_id = UUID(test_id)
         # TODO: Filtering based on origin location / user preferences

--- a/argus/backend/service/testrun.py
+++ b/argus/backend/service/testrun.py
@@ -75,6 +75,25 @@ class TestRunService:
             except plugin.model.DoesNotExist:
                 return None
 
+    def get_run_by_build_number(self, build_id: str, build_number: int) -> PluginModelBase | None:
+        """Resolve a run from its build_system_id and Jenkins build number.
+
+        build_id is the partition key of the plugin run table, so filtering by
+        build_number stays within a single small partition (ALLOW FILTERING).
+        Returns None when the test, its plugin, or a matching run is not found
+        (e.g. during the brief window after a build starts but before its run
+        has been reported to Argus).
+        """
+        try:
+            test: ArgusTest = ArgusTest.get(build_system_id=build_id)
+        except ArgusTest.DoesNotExist:
+            return None
+        plugin = self.get_plugin(plugin_name=test.plugin_name)
+        if not plugin:
+            return None
+        runs = list(plugin.model.filter(build_id=build_id, build_number=build_number).allow_filtering().all())
+        return runs[0] if runs else None
+
     def get_test_type_for_run(self, run_id: str) -> str:
         for name, plugin in AVAILABLE_PLUGINS.items():
             try:

--- a/argus/backend/tests/jenkins_service/test_jenkins_service.py
+++ b/argus/backend/tests/jenkins_service/test_jenkins_service.py
@@ -1,5 +1,7 @@
 import xml.etree.ElementTree as ET
 
+import jenkins
+
 from argus.backend.service.jenkins_service import JenkinsService
 
 
@@ -114,3 +116,41 @@ def test_regular_choice_param_defaults_to_first():
     _apply(params, {"region": ["us-east-1", "eu-west-1"]})
     assert params[0]["value"] == "us-east-1"
     assert params[0]["choices"] == ["us-east-1", "eu-west-1"]
+
+
+class _FakeJenkins:
+    """Minimal stand-in for the python-jenkins client so next_build_number can
+    be tested without a real Jenkins connection."""
+
+    def __init__(self, job_info=None, error=None):
+        self._job_info = job_info or {}
+        self._error = error
+
+    def get_job_info(self, name):  # noqa: ARG002 - signature parity
+        if self._error is not None:
+            raise self._error
+        return self._job_info
+
+
+def _service_with(fake):
+    # Bypass __init__ (which opens a real Jenkins connection) and inject the fake.
+    service = object.__new__(JenkinsService)
+    service._jenkins = fake
+    return service
+
+
+def test_next_build_number_returns_next():
+    service = _service_with(_FakeJenkins(job_info={"nextBuildNumber": 43}))
+    assert service.next_build_number("scylla-2026.2/longevity/longevity-100gb") == 43
+
+
+def test_next_build_number_missing_is_minus_one():
+    # A job Jenkins reports without nextBuildNumber yields the sentinel -1.
+    service = _service_with(_FakeJenkins(job_info={}))
+    assert service.next_build_number("scylla-2026.2/longevity/longevity-100gb") == -1
+
+
+def test_next_build_number_jenkins_error_is_non_fatal():
+    # A Jenkins error must not propagate: the trigger already succeeded.
+    service = _service_with(_FakeJenkins(error=jenkins.JenkinsException("boom")))
+    assert service.next_build_number("scylla-2026.2/longevity/longevity-100gb") == -1

--- a/argus/backend/tests/testrun_api/test_run_by_build.py
+++ b/argus/backend/tests/testrun_api/test_run_by_build.py
@@ -1,0 +1,67 @@
+import json
+from uuid import uuid4
+
+import pytest
+from flask.testing import FlaskClient
+
+from argus.backend.models.web import ArgusTest
+
+API_PREFIX = "/api/v1"
+
+
+def _submit_run(flask_client: FlaskClient, fake_test: ArgusTest, *, run_id: str | None = None, build_number: int = 1) -> str:
+    """Submit a single SCT run against `fake_test` and return its run_id."""
+    run_id = run_id or str(uuid4())
+    payload = {
+        "run_id": run_id,
+        "job_name": fake_test.build_system_id,
+        "job_url": f"http://ci.example.com/job/{build_number}",
+        "started_by": "test_user",
+        "commit_id": "deadbeef",
+        "origin_url": "http://example.com/repo.git",
+        "branch_name": "main",
+        "sct_config": {"cluster_backend": "aws"},
+        "schema_version": "v8",
+    }
+    resp = flask_client.post(
+        f"{API_PREFIX}/client/testrun/scylla-cluster-tests/submit",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json["status"] == "ok"
+    return run_id
+
+
+@pytest.mark.docker_required
+def test_get_run_by_build_resolves_run(flask_client: FlaskClient, fake_test: ArgusTest) -> None:
+    """The build_id + build_number pair resolves to the submitted run."""
+    run_id = _submit_run(flask_client, fake_test, build_number=77)
+
+    resp = flask_client.get(f"{API_PREFIX}/test/{fake_test.build_system_id}/77")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json["status"] == "ok"
+    body = resp.json["response"]
+    assert body["run_id"] == run_id
+    assert body["plugin_name"] == "scylla-cluster-tests"
+    # The Argus URL points at the canonical run view for this plugin/run.
+    assert body["url"].endswith(f"/tests/scylla-cluster-tests/{run_id}")
+
+
+@pytest.mark.docker_required
+def test_get_run_by_build_unknown_build_number_errors(flask_client: FlaskClient, fake_test: ArgusTest) -> None:
+    """A build number with no matching run yields an error response."""
+    _submit_run(flask_client, fake_test, build_number=1)
+
+    resp = flask_client.get(f"{API_PREFIX}/test/{fake_test.build_system_id}/999999")
+
+    assert resp.json["status"] != "ok"
+
+
+@pytest.mark.docker_required
+def test_get_run_by_build_unknown_build_id_errors(flask_client: FlaskClient) -> None:
+    """An unknown build_id yields an error response rather than resolving."""
+    resp = flask_client.get(f"{API_PREFIX}/test/does-not-exist-{uuid4()}/1")
+
+    assert resp.json["status"] != "ok"

--- a/cli/cmd/test.go
+++ b/cli/cmd/test.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/scylladb/argus/cli/cmd/test"
+	"github.com/spf13/cobra"
+)
+
+// testCmd is the parent command for Jenkins-backed test execution.
+var testCmd = &cobra.Command{
+	Use:   "test",
+	Short: "Execute Jenkins tests and inspect their parameters",
+	Long: `Inspect a test's Jenkins parameters and trigger builds.
+
+Tests are addressed by their build_system_id (the Jenkins job path, e.g.
+"scylla-2026.2/longevity/longevity-100gb"). Runs are attributed to the
+authenticated user automatically.`,
+}
+
+func init() {
+	test.Register(testCmd)
+	rootCmd.AddCommand(testCmd)
+}

--- a/cli/cmd/test/address.go
+++ b/cli/cmd/test/address.go
@@ -1,0 +1,44 @@
+package test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/scylladb/argus/cli/internal/api"
+	"github.com/scylladb/argus/cli/internal/cache"
+	"github.com/scylladb/argus/cli/internal/services"
+	"github.com/spf13/cobra"
+)
+
+// addFlags registers the shared test-addressing flags on cmd: either an
+// explicit --build-id, or a --release + --test pair resolved against the
+// release's gridview. The two modes are mutually exclusive; --release and
+// --test must be supplied together.
+func addAddressingFlags(cmd *cobra.Command) {
+	cmd.Flags().StringP("build-id", "b", "", "Test build_system_id (Jenkins job path)")
+	cmd.Flags().StringP("release", "r", "", "Release name to resolve --test against (e.g. scylla-2026.2)")
+	cmd.Flags().StringP("test", "t", "", "Test reference within --release (build_system_id, group/test, or name)")
+	cmd.MarkFlagsMutuallyExclusive("build-id", "test")
+	cmd.MarkFlagsMutuallyExclusive("build-id", "release")
+	cmd.MarkFlagsRequiredTogether("release", "test")
+}
+
+// resolveBuildID determines the target test's build_system_id from the
+// addressing flags. --build-id is returned verbatim (no network call); a
+// --release + --test pair is resolved to a build_system_id via the planner
+// gridview. Exactly one addressing mode must be supplied.
+func resolveBuildID(ctx context.Context, cmd *cobra.Command, client *api.Client, c *cache.Cache) (string, error) {
+	buildID, _ := cmd.Flags().GetString("build-id")
+	release, _ := cmd.Flags().GetString("release")
+	test, _ := cmd.Flags().GetString("test")
+
+	if buildID != "" {
+		return buildID, nil
+	}
+	if release == "" || test == "" {
+		return "", fmt.Errorf("a test must be addressed with either --build-id or --release together with --test")
+	}
+
+	svc := services.NewPlannerService(client, c)
+	return svc.ResolveTestBuildID(ctx, release, test)
+}

--- a/cli/cmd/test/checkqueue.go
+++ b/cli/cmd/test/checkqueue.go
@@ -1,0 +1,144 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/scylladb/argus/cli/internal/cmdctx"
+	"github.com/scylladb/argus/cli/internal/logging"
+	"github.com/scylladb/argus/cli/internal/models"
+	"github.com/scylladb/argus/cli/internal/services"
+	"github.com/spf13/cobra"
+)
+
+// registerCheckQueue adds the "check-queue" sub-command to parent.
+func registerCheckQueue(parent *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "check-queue",
+		Short: "Query the status of Jenkins queue items",
+		Long: `Report the current state of one or more Jenkins queue items: whether
+each has been scheduled onto an executor (with its build URL) or is still waiting
+in the queue (with the reason why).
+
+Queue items are supplied with repeatable --item flags and/or a --file containing
+the JSON emitted by 'test execute' — either {"queueItem": 123} or
+{"queueItem": [123, 456]}. Use "-" to read that JSON from standard input:
+
+  argus test check-queue --item 123 --item 456
+  argus test check-queue --file queued.json
+  argus test execute --build-id scylla-2026.2/longevity/longevity-100gb \
+    | argus test check-queue --file -
+
+This is a one-shot snapshot; it does not wait for pending items to start.`,
+		RunE: runCheckQueue,
+	}
+
+	cmd.Flags().IntSlice("item", nil, "Queue item to query (repeatable; also accepts a comma-separated list)")
+	cmd.Flags().StringP("file", "f", "", "JSON {\"queueItem\": N|[...]} with queue items (\"-\" for stdin)")
+
+	parent.AddCommand(cmd)
+}
+
+// runCheckQueue is the RunE handler for "test check-queue".
+func runCheckQueue(cmd *cobra.Command, _ []string) error {
+	cmd.SilenceUsage = true
+	ctx := cmd.Context()
+	client := cmdctx.APIClientFrom(ctx)
+	out := cmdctx.OutputterFrom(ctx)
+	c := cmdctx.CacheFrom(ctx)
+	log := logging.For(cmdctx.LoggerFrom(ctx), "test-check-queue")
+
+	items, err := collectQueueItems(cmd)
+	if err != nil {
+		return err
+	}
+	log.Debug().Int("count", len(items)).Msg("querying queue items")
+
+	svc := services.NewTestExecutionService(client, c)
+
+	// Query each item independently; a per-item failure is recorded in its row
+	// and never aborts the batch.
+	results := make(models.QueueStatuses, 0, len(items))
+	for _, item := range items {
+		row := models.QueueStatus{QueueItem: item}
+		info, err := svc.QueueInfo(ctx, item)
+		switch {
+		case err != nil:
+			log.Error().Err(err).Int("queue_item", item).Msg("failed to fetch queue info")
+			row.Status = "error: " + err.Error()
+		case info.Scheduled():
+			row.Status = "started"
+			row.URL = info.URL
+			row.Number = info.Number
+		default:
+			row.Status = "pending"
+			row.Why = info.Why
+		}
+		results = append(results, row)
+	}
+
+	return out.Write(results)
+}
+
+// collectQueueItems gathers the queue items to query from the repeatable --item
+// flag and the optional --file JSON, then de-duplicates and sorts them
+// ascending for deterministic output. At least one source must be supplied.
+func collectQueueItems(cmd *cobra.Command) ([]int, error) {
+	flagItems, _ := cmd.Flags().GetIntSlice("item")
+
+	var fileItems []int
+	if path, _ := cmd.Flags().GetString("file"); path != "" {
+		raw, err := readFileOrStdin(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading queue items file: %w", err)
+		}
+		fileItems, err = parseQueueItems(raw)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if len(flagItems) == 0 && len(fileItems) == 0 {
+		return nil, fmt.Errorf("provide queue items with --item or --file")
+	}
+
+	seen := make(map[int]struct{}, len(flagItems)+len(fileItems))
+	items := make([]int, 0, len(flagItems)+len(fileItems))
+	for _, group := range [][]int{flagItems, fileItems} {
+		for _, item := range group {
+			if _, ok := seen[item]; ok {
+				continue
+			}
+			seen[item] = struct{}{}
+			items = append(items, item)
+		}
+	}
+	sort.Ints(items)
+	return items, nil
+}
+
+// parseQueueItems parses the {"queueItem": N | [...]} JSON produced by
+// 'test execute' into a list of queue items. The queueItem value may be a
+// single number or an array of numbers; a missing key yields no items.
+func parseQueueItems(raw []byte) ([]int, error) {
+	var envelope struct {
+		QueueItem json.RawMessage `json:"queueItem"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return nil, fmt.Errorf("parsing queue items (expected {\"queueItem\": N|[...]}): %w", err)
+	}
+	if len(envelope.QueueItem) == 0 {
+		return nil, nil
+	}
+
+	var list []int
+	if err := json.Unmarshal(envelope.QueueItem, &list); err == nil {
+		return list, nil
+	}
+	var single int
+	if err := json.Unmarshal(envelope.QueueItem, &single); err != nil {
+		return nil, fmt.Errorf("parsing queueItem (expected a number or array of numbers): %w", err)
+	}
+	return []int{single}, nil
+}

--- a/cli/cmd/test/checkqueue_test.go
+++ b/cli/cmd/test/checkqueue_test.go
@@ -1,0 +1,79 @@
+package test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseQueueItems_Scalar(t *testing.T) {
+	got, err := parseQueueItems([]byte(`{"queueItem": 5}`))
+	require.NoError(t, err)
+	assert.Equal(t, []int{5}, got)
+}
+
+func TestParseQueueItems_Array(t *testing.T) {
+	got, err := parseQueueItems([]byte(`{"queueItem": [5, 6, 7]}`))
+	require.NoError(t, err)
+	assert.Equal(t, []int{5, 6, 7}, got)
+}
+
+func TestParseQueueItems_MissingKey(t *testing.T) {
+	// A payload without queueItem yields no items rather than an error.
+	got, err := parseQueueItems([]byte(`{"other": 1}`))
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestParseQueueItems_Invalid(t *testing.T) {
+	for _, bad := range []string{`not-json`, `{"queueItem": "five"}`, `{"queueItem": {}}`} {
+		_, err := parseQueueItems([]byte(bad))
+		require.Error(t, err, "input %q should be rejected", bad)
+	}
+}
+
+// newCheckQueueCmd builds a command carrying just the check-queue flags so
+// collectQueueItems can be unit-tested in isolation.
+func newCheckQueueCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "check-queue"}
+	cmd.Flags().IntSlice("item", nil, "")
+	cmd.Flags().String("file", "", "")
+	return cmd
+}
+
+func TestCollectQueueItems_FlagsOnly(t *testing.T) {
+	cmd := newCheckQueueCmd()
+	require.NoError(t, cmd.Flags().Set("item", "3"))
+	require.NoError(t, cmd.Flags().Set("item", "1"))
+
+	got, err := collectQueueItems(cmd)
+	require.NoError(t, err)
+	// De-duplicated and sorted ascending.
+	assert.Equal(t, []int{1, 3}, got)
+}
+
+func TestCollectQueueItems_MergeFileAndFlagsDedup(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "queued.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"queueItem": [3, 9]}`), 0o600))
+
+	cmd := newCheckQueueCmd()
+	require.NoError(t, cmd.Flags().Set("item", "3"))
+	require.NoError(t, cmd.Flags().Set("item", "5"))
+	require.NoError(t, cmd.Flags().Set("file", path))
+
+	got, err := collectQueueItems(cmd)
+	require.NoError(t, err)
+	// Union of {3,5} and {3,9}, de-duplicated and sorted.
+	assert.Equal(t, []int{3, 5, 9}, got)
+}
+
+func TestCollectQueueItems_NoSource(t *testing.T) {
+	_, err := collectQueueItems(newCheckQueueCmd())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--item or --file")
+}

--- a/cli/cmd/test/execute.go
+++ b/cli/cmd/test/execute.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -163,8 +164,15 @@ func runExecuteSingle(cmd *cobra.Command, _ []string) error {
 		log.Error().Err(err).Int("queue_item", queueItem).Msg("failed while waiting for build to start")
 		return err
 	}
-	log.Info().Str("build_id", buildID).Str("url", info.URL).Msg("build started")
-	return out.Write(models.NewKVTabular(info))
+	cfg := cmdctx.ConfigFrom(ctx)
+	result := models.StartedBuild{
+		BuildID:     buildID,
+		JenkinsURL:  info.URL,
+		BuildNumber: info.Number,
+		ArgusURL:    argusRunURL(cfg.URL, buildID, info.Number),
+	}
+	log.Info().Str("build_id", buildID).Str("url", info.URL).Str("argus_url", result.ArgusURL).Msg("build started")
+	return out.Write(models.NewKVTabular(result))
 }
 
 // runExecutePlan is the RunE handler for the plan fan-out mode of "test execute"
@@ -251,7 +259,8 @@ func runExecutePlan(cmd *cobra.Command) error {
 
 	if wait {
 		timeout, _ := cmd.Flags().GetDuration("wait-timeout")
-		waitAllBuilds(ctx, svc, results, timeout, log)
+		cfg := cmdctx.ConfigFrom(ctx)
+		waitAllBuilds(ctx, svc, results, cfg.URL, timeout, log)
 	}
 
 	return out.Write(results)
@@ -262,7 +271,9 @@ func runExecutePlan(cmd *cobra.Command) error {
 // batch-wide deadline (timeout) bounds the whole wait; when it elapses the
 // shared context is cancelled and any still-pending builds are marked timed out.
 // results is mutated in place — each goroutine writes only its own index.
-func waitAllBuilds(ctx context.Context, svc *services.TestExecutionService, results models.TriggeredBuilds, timeout time.Duration, log zerolog.Logger) {
+// argusBase is the Argus base URL used to derive each row's Argus run link once
+// its build number is known.
+func waitAllBuilds(ctx context.Context, svc *services.TestExecutionService, results models.TriggeredBuilds, argusBase string, timeout time.Duration, log zerolog.Logger) {
 	waitCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -284,6 +295,7 @@ func waitAllBuilds(ctx context.Context, svc *services.TestExecutionService, resu
 				return
 			}
 			results[i].URL = info.URL
+			results[i].ArgusURL = argusRunURL(argusBase, results[i].BuildSystemID, info.Number)
 			results[i].Status = "started"
 		}(i)
 	}
@@ -309,6 +321,16 @@ func loadParamsFile(cmd *cobra.Command) (map[string]any, error) {
 		return nil, fmt.Errorf("parsing params file (expected a {name: value} object): %w", err)
 	}
 	return params, nil
+}
+
+// argusRunURL builds the stable Argus run link for a build from the configured
+// Argus base URL, the test's build_system_id, and its Jenkins build number.
+// It returns "" when the build number is not yet known (number == 0).
+func argusRunURL(base, buildID string, number int) string {
+	if number == 0 {
+		return ""
+	}
+	return strings.TrimRight(base, "/") + "/test/" + buildID + "/" + strconv.Itoa(number)
 }
 
 // readFileOrStdin returns the contents of the file at path, or of standard

--- a/cli/cmd/test/execute.go
+++ b/cli/cmd/test/execute.go
@@ -299,13 +299,7 @@ func loadParamsFile(cmd *cobra.Command) (map[string]any, error) {
 		return nil, nil
 	}
 
-	var raw []byte
-	var err error
-	if path == "-" {
-		raw, err = io.ReadAll(bufio.NewReader(os.Stdin))
-	} else {
-		raw, err = os.ReadFile(path)
-	}
+	raw, err := readFileOrStdin(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading params file: %w", err)
 	}
@@ -315,6 +309,15 @@ func loadParamsFile(cmd *cobra.Command) (map[string]any, error) {
 		return nil, fmt.Errorf("parsing params file (expected a {name: value} object): %w", err)
 	}
 	return params, nil
+}
+
+// readFileOrStdin returns the contents of the file at path, or of standard
+// input when path is "-".
+func readFileOrStdin(path string) ([]byte, error) {
+	if path == "-" {
+		return io.ReadAll(bufio.NewReader(os.Stdin))
+	}
+	return os.ReadFile(path)
 }
 
 // parseParams parses repeatable "name=value" flag values into a parameter map.

--- a/cli/cmd/test/execute.go
+++ b/cli/cmd/test/execute.go
@@ -1,0 +1,170 @@
+package test
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/scylladb/argus/cli/internal/cmdctx"
+	"github.com/scylladb/argus/cli/internal/logging"
+	"github.com/scylladb/argus/cli/internal/models"
+	"github.com/scylladb/argus/cli/internal/services"
+	"github.com/spf13/cobra"
+)
+
+// registerExecute adds the "execute" sub-command to parent.
+func registerExecute(parent *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "execute",
+		Short: "Trigger a Jenkins test build",
+		Long: `Trigger a build of a test, addressed by its build_system_id (the Jenkins
+job path). Parameters are resolved with the cascade defaults < --file < --param:
+the job's current default parameters are the base, a --file JSON map overrides
+them, and repeatable --param name=value flags override both.
+
+  # Rebuild with the job's current defaults:
+  argus test execute --build-id scylla-2026.2/longevity/longevity-100gb
+
+  # Override a couple of values on top of the defaults:
+  argus test execute --build-id scylla-2026.2/longevity/longevity-100gb \
+    --param backend=aws --param region=eu-west-1
+
+  # Start from an edited params file, then tweak one value:
+  argus test execute --build-id scylla-2026.2/longevity/longevity-100gb \
+    --file params.json --param scylla_version=2026.2
+
+Use --dry-run to print the merged parameters without triggering a build, and
+--wait to block until the build leaves the queue and report its URL. If the job
+has no builds and no default definitions, the defaults are simply empty and only
+your --file/--param values are sent.`,
+		RunE: runExecute,
+	}
+
+	cmd.Flags().StringP("build-id", "b", "", "Test build_system_id (Jenkins job path) (required)")
+	cmd.Flags().Int("build-number", 0, "Seed default parameters from this build number (default: last build)")
+	cmd.Flags().StringP("file", "f", "", "JSON file with a {name: value} parameter map (\"-\" for stdin)")
+	cmd.Flags().StringArray("param", nil, "Parameter override as name=value (repeatable)")
+	cmd.Flags().Bool("dry-run", false, "Print the merged parameters and exit without triggering a build")
+	cmd.Flags().Bool("wait", false, "Wait for the build to start and report its URL")
+	cmd.Flags().Duration("wait-timeout", 5*time.Minute, "Maximum time to wait when --wait is set")
+	_ = cmd.MarkFlagRequired("build-id")
+
+	parent.AddCommand(cmd)
+}
+
+// runExecute is the RunE handler for "test execute".
+func runExecute(cmd *cobra.Command, _ []string) error {
+	cmd.SilenceUsage = true
+	ctx := cmd.Context()
+	client := cmdctx.APIClientFrom(ctx)
+	out := cmdctx.OutputterFrom(ctx)
+	c := cmdctx.CacheFrom(ctx)
+	log := logging.For(cmdctx.LoggerFrom(ctx), "test-execute")
+
+	buildID, _ := cmd.Flags().GetString("build-id")
+	buildNumber := buildNumberFlag(cmd)
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	wait, _ := cmd.Flags().GetBool("wait")
+
+	fileParams, err := loadParamsFile(cmd)
+	if err != nil {
+		return err
+	}
+	rawFlags, _ := cmd.Flags().GetStringArray("param")
+	flagParams, err := parseParams(rawFlags)
+	if err != nil {
+		return err
+	}
+
+	svc := services.NewTestExecutionService(client, c)
+
+	// Fetch defaults; a job with no builds/defaults is not fatal here — proceed
+	// with empty defaults so --file/--param can still launch it.
+	defaults, err := svc.FetchParams(ctx, buildID, buildNumber)
+	if err != nil {
+		if errors.Is(err, services.ErrNoBuildsAvailable) {
+			log.Warn().Str("build_id", buildID).Msg("no builds available; sending empty defaults plus --file/--param values")
+			defaults = nil
+		} else {
+			log.Error().Err(err).Str("build_id", buildID).Msg("failed to fetch default parameters")
+			return err
+		}
+	}
+
+	merged := services.MergeParams(defaults, fileParams, flagParams)
+
+	if dryRun {
+		log.Info().Str("build_id", buildID).Int("count", len(merged)).Msg("dry run: not triggering build")
+		return out.Write(models.NewKVTabular(merged))
+	}
+
+	queueItem, err := svc.TriggerBuild(ctx, buildID, merged)
+	if err != nil {
+		log.Error().Err(err).Str("build_id", buildID).Msg("failed to trigger build")
+		return err
+	}
+	log.Info().Str("build_id", buildID).Int("queue_item", queueItem).Msg("build triggered successfully")
+
+	if !wait {
+		return out.Write(models.NewKVTabular(models.JenkinsBuildResponse{QueueItem: queueItem}))
+	}
+
+	timeout, _ := cmd.Flags().GetDuration("wait-timeout")
+	info, err := svc.WaitForBuild(ctx, queueItem, timeout, 0)
+	if err != nil {
+		log.Error().Err(err).Int("queue_item", queueItem).Msg("failed while waiting for build to start")
+		return err
+	}
+	log.Info().Str("build_id", buildID).Str("url", info.URL).Msg("build started")
+	return out.Write(models.NewKVTabular(info))
+}
+
+// loadParamsFile reads the --file parameter map (path or stdin) into a
+// {name: value} map. Returns nil when --file is not set.
+func loadParamsFile(cmd *cobra.Command) (map[string]any, error) {
+	path, _ := cmd.Flags().GetString("file")
+	if path == "" {
+		return nil, nil
+	}
+
+	var raw []byte
+	var err error
+	if path == "-" {
+		raw, err = io.ReadAll(bufio.NewReader(os.Stdin))
+	} else {
+		raw, err = os.ReadFile(path)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading params file: %w", err)
+	}
+
+	var params map[string]any
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return nil, fmt.Errorf("parsing params file (expected a {name: value} object): %w", err)
+	}
+	return params, nil
+}
+
+// parseParams parses repeatable "name=value" flag values into a parameter map.
+// The first "=" separates the name from the value; the value may be empty and
+// may itself contain "=".
+func parseParams(raw []string) (map[string]any, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]any, len(raw))
+	for _, p := range raw {
+		name, value, ok := strings.Cut(p, "=")
+		name = strings.TrimSpace(name)
+		if !ok || name == "" {
+			return nil, fmt.Errorf("invalid --param %q: expected name=value", p)
+		}
+		out[name] = value
+	}
+	return out, nil
+}

--- a/cli/cmd/test/execute.go
+++ b/cli/cmd/test/execute.go
@@ -22,13 +22,19 @@ func registerExecute(parent *cobra.Command) {
 	cmd := &cobra.Command{
 		Use:   "execute",
 		Short: "Trigger a Jenkins test build",
-		Long: `Trigger a build of a test, addressed by its build_system_id (the Jenkins
-job path). Parameters are resolved with the cascade defaults < --file < --param:
-the job's current default parameters are the base, a --file JSON map overrides
-them, and repeatable --param name=value flags override both.
+		Long: `Trigger a build of a test. Parameters are resolved with the cascade
+defaults < --file < --param: the job's current default parameters are the base,
+a --file JSON map overrides them, and repeatable --param name=value flags
+override both.
 
-  # Rebuild with the job's current defaults:
+The test is addressed either by its build_system_id directly, or by a release
+name plus a test reference resolved against that release's gridview:
+
+  # Rebuild with the job's current defaults (by build_system_id):
   argus test execute --build-id scylla-2026.2/longevity/longevity-100gb
+
+  # Same test addressed by release + name:
+  argus test execute --release scylla-2026.2 --test longevity/longevity-100gb
 
   # Override a couple of values on top of the defaults:
   argus test execute --build-id scylla-2026.2/longevity/longevity-100gb \
@@ -45,14 +51,13 @@ your --file/--param values are sent.`,
 		RunE: runExecute,
 	}
 
-	cmd.Flags().StringP("build-id", "b", "", "Test build_system_id (Jenkins job path) (required)")
+	addAddressingFlags(cmd)
 	cmd.Flags().Int("build-number", 0, "Seed default parameters from this build number (default: last build)")
 	cmd.Flags().StringP("file", "f", "", "JSON file with a {name: value} parameter map (\"-\" for stdin)")
 	cmd.Flags().StringArray("param", nil, "Parameter override as name=value (repeatable)")
 	cmd.Flags().Bool("dry-run", false, "Print the merged parameters and exit without triggering a build")
 	cmd.Flags().Bool("wait", false, "Wait for the build to start and report its URL")
 	cmd.Flags().Duration("wait-timeout", 5*time.Minute, "Maximum time to wait when --wait is set")
-	_ = cmd.MarkFlagRequired("build-id")
 
 	parent.AddCommand(cmd)
 }
@@ -66,7 +71,10 @@ func runExecute(cmd *cobra.Command, _ []string) error {
 	c := cmdctx.CacheFrom(ctx)
 	log := logging.For(cmdctx.LoggerFrom(ctx), "test-execute")
 
-	buildID, _ := cmd.Flags().GetString("build-id")
+	buildID, err := resolveBuildID(ctx, cmd, client, c)
+	if err != nil {
+		return err
+	}
 	buildNumber := buildNumberFlag(cmd)
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	wait, _ := cmd.Flags().GetBool("wait")

--- a/cli/cmd/test/execute.go
+++ b/cli/cmd/test/execute.go
@@ -147,7 +147,7 @@ func runExecuteSingle(cmd *cobra.Command, _ []string) error {
 		return out.Write(models.NewKVTabular(merged))
 	}
 
-	queueItem, err := svc.TriggerBuild(ctx, buildID, merged)
+	queueItem, nextBuildNumber, err := svc.TriggerBuildWithNumber(ctx, buildID, merged)
 	if err != nil {
 		log.Error().Err(err).Str("build_id", buildID).Msg("failed to trigger build")
 		return err
@@ -155,7 +155,15 @@ func runExecuteSingle(cmd *cobra.Command, _ []string) error {
 	log.Info().Str("build_id", buildID).Int("queue_item", queueItem).Msg("build triggered successfully")
 
 	if !wait {
-		return out.Write(models.NewKVTabular(models.JenkinsBuildResponse{QueueItem: queueItem}))
+		cfg := cmdctx.ConfigFrom(ctx)
+		result := models.ExecutedBuild{
+			BuildID:     buildID,
+			QueueItem:   queueItem,
+			BuildNumber: nextBuildNumber,
+			ArgusURL:    argusRunURL(cfg.URL, buildID, nextBuildNumber),
+		}
+		log.Info().Str("build_id", buildID).Int("build_number", nextBuildNumber).Str("argus_url", result.ArgusURL).Msg("build queued")
+		return out.Write(models.NewKVTabular(result))
 	}
 
 	timeout, _ := cmd.Flags().GetDuration("wait-timeout")

--- a/cli/cmd/test/execute.go
+++ b/cli/cmd/test/execute.go
@@ -2,14 +2,17 @@ package test
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/scylladb/argus/cli/internal/cmdctx"
 	"github.com/scylladb/argus/cli/internal/logging"
 	"github.com/scylladb/argus/cli/internal/models"
@@ -47,11 +50,24 @@ name plus a test reference resolved against that release's gridview:
 Use --dry-run to print the merged parameters without triggering a build, and
 --wait to block until the build leaves the queue and report its URL. If the job
 has no builds and no default definitions, the defaults are simply empty and only
-your --file/--param values are sent.`,
+your --file/--param values are sent.
+
+Alternatively, fan out across a plan's labelled tests with --plan-id and one or
+more --label flags: every plan test carrying any of the labels is triggered (use
+--match-all to require all labels). --param overrides apply to every build;
+--wait then blocks until all builds start (or --wait-timeout elapses), waiting in
+parallel:
+
+  argus test execute --plan-id scylla-2026.2#3 --label smoke --label nightly
+  argus test execute --plan-id scylla-2026.2#3 --label smoke --dry-run
+  argus test execute --plan-id scylla-2026.2#3 --label smoke --label perf --match-all --wait`,
 		RunE: runExecute,
 	}
 
 	addAddressingFlags(cmd)
+	cmd.Flags().StringP("plan-id", "p", "", "Plan UUID or key to fan out across (with --label)")
+	cmd.Flags().StringArray("label", nil, "Select plan tests carrying this label (repeatable; requires --plan-id)")
+	cmd.Flags().Bool("match-all", false, "Require plan tests to carry all --label values instead of any")
 	cmd.Flags().Int("build-number", 0, "Seed default parameters from this build number (default: last build)")
 	cmd.Flags().StringP("file", "f", "", "JSON file with a {name: value} parameter map (\"-\" for stdin)")
 	cmd.Flags().StringArray("param", nil, "Parameter override as name=value (repeatable)")
@@ -59,11 +75,30 @@ your --file/--param values are sent.`,
 	cmd.Flags().Bool("wait", false, "Wait for the build to start and report its URL")
 	cmd.Flags().Duration("wait-timeout", 5*time.Minute, "Maximum time to wait when --wait is set")
 
+	// Plan fan-out is its own addressing mode: --plan-id/--label go together and
+	// are mutually exclusive with the single-test selectors.
+	cmd.MarkFlagsRequiredTogether("plan-id", "label")
+	cmd.MarkFlagsMutuallyExclusive("build-id", "plan-id")
+	cmd.MarkFlagsMutuallyExclusive("release", "plan-id")
+	cmd.MarkFlagsMutuallyExclusive("test", "plan-id")
+	cmd.MarkFlagsMutuallyExclusive("build-id", "label")
+	cmd.MarkFlagsMutuallyExclusive("release", "label")
+	cmd.MarkFlagsMutuallyExclusive("test", "label")
+
 	parent.AddCommand(cmd)
 }
 
-// runExecute is the RunE handler for "test execute".
-func runExecute(cmd *cobra.Command, _ []string) error {
+// runExecute dispatches to the single-test or plan fan-out path based on whether
+// --plan-id was supplied.
+func runExecute(cmd *cobra.Command, args []string) error {
+	if planID, _ := cmd.Flags().GetString("plan-id"); planID != "" {
+		return runExecutePlan(cmd)
+	}
+	return runExecuteSingle(cmd, args)
+}
+
+// runExecuteSingle is the RunE handler for a single-test "test execute".
+func runExecuteSingle(cmd *cobra.Command, _ []string) error {
 	cmd.SilenceUsage = true
 	ctx := cmd.Context()
 	client := cmdctx.APIClientFrom(ctx)
@@ -130,6 +165,130 @@ func runExecute(cmd *cobra.Command, _ []string) error {
 	}
 	log.Info().Str("build_id", buildID).Str("url", info.URL).Msg("build started")
 	return out.Write(models.NewKVTabular(info))
+}
+
+// runExecutePlan is the RunE handler for the plan fan-out mode of "test execute"
+// (--plan-id with --label): it resolves the plan's labelled tests and triggers a
+// build for each, optionally waiting for all of them in parallel.
+func runExecutePlan(cmd *cobra.Command) error {
+	cmd.SilenceUsage = true
+
+	// --file and --build-number are per-test and make no sense across a fan-out;
+	// reject them up front (before any dependencies are touched).
+	if path, _ := cmd.Flags().GetString("file"); path != "" {
+		return fmt.Errorf("--file is not supported with --plan-id (each test has its own parameters)")
+	}
+	if cmd.Flags().Changed("build-number") {
+		return fmt.Errorf("--build-number is not supported with --plan-id (each test is a distinct job)")
+	}
+
+	ctx := cmd.Context()
+	client := cmdctx.APIClientFrom(ctx)
+	out := cmdctx.OutputterFrom(ctx)
+	c := cmdctx.CacheFrom(ctx)
+	log := logging.For(cmdctx.LoggerFrom(ctx), "test-execute-plan")
+
+	planID, _ := cmd.Flags().GetString("plan-id")
+	labels, _ := cmd.Flags().GetStringArray("label")
+	matchAll, _ := cmd.Flags().GetBool("match-all")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	wait, _ := cmd.Flags().GetBool("wait")
+
+	rawFlags, _ := cmd.Flags().GetStringArray("param")
+	flagParams, err := parseParams(rawFlags)
+	if err != nil {
+		return err
+	}
+
+	planner := services.NewPlannerService(client, c)
+	targets, err := planner.ResolveLabeledTests(ctx, planID, labels, matchAll)
+	if err != nil {
+		log.Error().Err(err).Str("plan_id", planID).Msg("failed to resolve labelled tests")
+		return err
+	}
+	log.Info().Str("plan_id", planID).Int("count", len(targets)).Bool("match_all", matchAll).Msg("resolved labelled tests")
+
+	if dryRun {
+		overview := make(models.ReleaseGrid, len(targets))
+		for _, t := range targets {
+			overview[t.Ref] = t.BuildSystemID
+		}
+		log.Info().Str("plan_id", planID).Int("count", len(targets)).Msg("dry run: not triggering builds")
+		return out.Write(overview)
+	}
+
+	svc := services.NewTestExecutionService(client, c)
+
+	// Trigger sequentially so queue assignment is deterministic; a per-test
+	// failure is recorded and the batch continues.
+	results := make(models.TriggeredBuilds, len(targets))
+	for i, t := range targets {
+		results[i] = models.TriggeredBuild{Test: t.Ref, BuildSystemID: t.BuildSystemID}
+
+		defaults, err := svc.FetchParams(ctx, t.BuildSystemID, nil)
+		if err != nil {
+			if errors.Is(err, services.ErrNoBuildsAvailable) {
+				log.Warn().Str("build_id", t.BuildSystemID).Msg("no builds available; sending only --param values")
+				defaults = nil
+			} else {
+				log.Error().Err(err).Str("build_id", t.BuildSystemID).Msg("failed to fetch default parameters")
+				results[i].Status = "error: " + err.Error()
+				continue
+			}
+		}
+
+		merged := services.MergeParams(defaults, nil, flagParams)
+		queueItem, err := svc.TriggerBuild(ctx, t.BuildSystemID, merged)
+		if err != nil {
+			log.Error().Err(err).Str("build_id", t.BuildSystemID).Msg("failed to trigger build")
+			results[i].Status = "error: " + err.Error()
+			continue
+		}
+		results[i].QueueItem = queueItem
+		results[i].Status = "queued"
+		log.Info().Str("build_id", t.BuildSystemID).Int("queue_item", queueItem).Msg("build triggered")
+	}
+
+	if wait {
+		timeout, _ := cmd.Flags().GetDuration("wait-timeout")
+		waitAllBuilds(ctx, svc, results, timeout, log)
+	}
+
+	return out.Write(results)
+}
+
+// waitAllBuilds waits, in parallel, for every successfully-queued build in
+// results to leave the queue and receive an executable URL. A single
+// batch-wide deadline (timeout) bounds the whole wait; when it elapses the
+// shared context is cancelled and any still-pending builds are marked timed out.
+// results is mutated in place — each goroutine writes only its own index.
+func waitAllBuilds(ctx context.Context, svc *services.TestExecutionService, results models.TriggeredBuilds, timeout time.Duration, log zerolog.Logger) {
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	for i := range results {
+		if results[i].QueueItem == 0 {
+			continue // skipped or failed to trigger — nothing to wait for.
+		}
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			info, err := svc.WaitForBuild(waitCtx, results[i].QueueItem, timeout, 0)
+			if err != nil {
+				if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+					results[i].Status = "timed out"
+				} else {
+					results[i].Status = "error: " + err.Error()
+				}
+				return
+			}
+			results[i].URL = info.URL
+			results[i].Status = "started"
+		}(i)
+	}
+	wg.Wait()
+	log.Info().Int("count", len(results)).Msg("finished waiting for builds")
 }
 
 // loadParamsFile reads the --file parameter map (path or stdin) into a

--- a/cli/cmd/test/params.go
+++ b/cli/cmd/test/params.go
@@ -15,9 +15,13 @@ func registerParams(parent *cobra.Command) {
 	cmd := &cobra.Command{
 		Use:   "params",
 		Short: "Show a Jenkins job's parameters",
-		Long: `Fetch the parameter set for a test, addressed by its build_system_id
-(the Jenkins job path). By default the last build's values are used, falling
-back to the job's default parameter definitions.
+		Long: `Fetch the parameter set for a test. By default the last build's
+values are used, falling back to the job's default parameter definitions.
+
+The test is addressed either by its build_system_id directly, or by a release
+name plus a test reference resolved against that release's gridview:
+  argus test params --build-id scylla-2026.2/longevity/longevity-100gb
+  argus test params --release scylla-2026.2 --test longevity/longevity-100gb
 
 By default only a {name: value} map is emitted, which can be redirected to a
 file and fed straight into 'test execute --file':
@@ -29,10 +33,9 @@ job has no builds and no default definitions, this command fails; use
 		RunE: runParams,
 	}
 
-	cmd.Flags().StringP("build-id", "b", "", "Test build_system_id (Jenkins job path) (required)")
+	addAddressingFlags(cmd)
 	cmd.Flags().Int("build-number", 0, "Seed parameters from this build number (default: last build)")
 	cmd.Flags().Bool("full", false, "Show full parameter details (description, choices) instead of a values map")
-	_ = cmd.MarkFlagRequired("build-id")
 
 	parent.AddCommand(cmd)
 }
@@ -46,7 +49,10 @@ func runParams(cmd *cobra.Command, _ []string) error {
 	c := cmdctx.CacheFrom(ctx)
 	log := logging.For(cmdctx.LoggerFrom(ctx), "test-params")
 
-	buildID, _ := cmd.Flags().GetString("build-id")
+	buildID, err := resolveBuildID(ctx, cmd, client, c)
+	if err != nil {
+		return err
+	}
 	buildNumber := buildNumberFlag(cmd)
 	full, _ := cmd.Flags().GetBool("full")
 	log.Debug().Str("build_id", buildID).Bool("full", full).Msg("fetching job parameters")

--- a/cli/cmd/test/params.go
+++ b/cli/cmd/test/params.go
@@ -1,0 +1,87 @@
+package test
+
+import (
+	"errors"
+
+	"github.com/scylladb/argus/cli/internal/cmdctx"
+	"github.com/scylladb/argus/cli/internal/logging"
+	"github.com/scylladb/argus/cli/internal/models"
+	"github.com/scylladb/argus/cli/internal/services"
+	"github.com/spf13/cobra"
+)
+
+// registerParams adds the "params" sub-command to parent.
+func registerParams(parent *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "params",
+		Short: "Show a Jenkins job's parameters",
+		Long: `Fetch the parameter set for a test, addressed by its build_system_id
+(the Jenkins job path). By default the last build's values are used, falling
+back to the job's default parameter definitions.
+
+By default only a {name: value} map is emitted, which can be redirected to a
+file and fed straight into 'test execute --file':
+  argus test params --build-id scylla-2026.2/longevity/longevity-100gb > params.json
+
+Use --full to also see each parameter's description and allowed choices. If the
+job has no builds and no default definitions, this command fails; use
+'test execute' with --file/--param to launch it anyway.`,
+		RunE: runParams,
+	}
+
+	cmd.Flags().StringP("build-id", "b", "", "Test build_system_id (Jenkins job path) (required)")
+	cmd.Flags().Int("build-number", 0, "Seed parameters from this build number (default: last build)")
+	cmd.Flags().Bool("full", false, "Show full parameter details (description, choices) instead of a values map")
+	_ = cmd.MarkFlagRequired("build-id")
+
+	parent.AddCommand(cmd)
+}
+
+// runParams is the RunE handler for "test params".
+func runParams(cmd *cobra.Command, _ []string) error {
+	cmd.SilenceUsage = true
+	ctx := cmd.Context()
+	client := cmdctx.APIClientFrom(ctx)
+	out := cmdctx.OutputterFrom(ctx)
+	c := cmdctx.CacheFrom(ctx)
+	log := logging.For(cmdctx.LoggerFrom(ctx), "test-params")
+
+	buildID, _ := cmd.Flags().GetString("build-id")
+	buildNumber := buildNumberFlag(cmd)
+	full, _ := cmd.Flags().GetBool("full")
+	log.Debug().Str("build_id", buildID).Bool("full", full).Msg("fetching job parameters")
+
+	svc := services.NewTestExecutionService(client, c)
+
+	params, err := svc.FetchParams(ctx, buildID, buildNumber)
+	if err != nil {
+		if errors.Is(err, services.ErrNoBuildsAvailable) {
+			log.Error().Str("build_id", buildID).Msg("no builds available; job default parameters unavailable")
+		} else {
+			log.Error().Err(err).Str("build_id", buildID).Msg("failed to fetch job parameters")
+		}
+		return err
+	}
+
+	log.Info().Str("build_id", buildID).Int("count", len(params)).Msg("job parameters fetched successfully")
+
+	if full {
+		return out.Write(models.NewParamsTable(params))
+	}
+
+	values := make(map[string]any, len(params))
+	for _, p := range params {
+		values[p.Name] = p.Value
+	}
+	return out.Write(models.NewKVTabular(values))
+}
+
+// buildNumberFlag returns a pointer to the --build-number value, or nil when the
+// flag was not set (so the backend seeds from the last build).
+func buildNumberFlag(cmd *cobra.Command) *int {
+	if !cmd.Flags().Changed("build-number") {
+		return nil
+	}
+	n, _ := cmd.Flags().GetInt("build-number")
+	return &n
+}

--- a/cli/cmd/test/root.go
+++ b/cli/cmd/test/root.go
@@ -1,0 +1,13 @@
+// Package test provides the "test" cobra sub-commands (params, execute) for
+// inspecting a Jenkins job's parameters and triggering test runs through Argus.
+// It is wired into the command tree by the parent cmd package via [Register].
+package test
+
+import "github.com/spf13/cobra"
+
+// Register adds the test sub-commands (params, execute) to the given parent
+// command (typically the "test" command owned by the cmd package).
+func Register(parent *cobra.Command) {
+	registerParams(parent)
+	registerExecute(parent)
+}

--- a/cli/cmd/test/root.go
+++ b/cli/cmd/test/root.go
@@ -1,13 +1,15 @@
-// Package test provides the "test" cobra sub-commands (params, execute) for
-// inspecting a Jenkins job's parameters and triggering test runs through Argus.
-// It is wired into the command tree by the parent cmd package via [Register].
+// Package test provides the "test" cobra sub-commands (params, execute,
+// check-queue) for inspecting a Jenkins job's parameters, triggering test runs,
+// and querying queue status through Argus. It is wired into the command tree by
+// the parent cmd package via [Register].
 package test
 
 import "github.com/spf13/cobra"
 
-// Register adds the test sub-commands (params, execute) to the given parent
-// command (typically the "test" command owned by the cmd package).
+// Register adds the test sub-commands (params, execute, check-queue) to the
+// given parent command (typically the "test" command owned by the cmd package).
 func Register(parent *cobra.Command) {
 	registerParams(parent)
 	registerExecute(parent)
+	registerCheckQueue(parent)
 }

--- a/cli/cmd/test/test_test.go
+++ b/cli/cmd/test/test_test.go
@@ -178,3 +178,14 @@ func TestExecute_BuildIDExclusiveWithPlanID(t *testing.T) {
 	err := cmd.ValidateFlagGroups()
 	require.Error(t, err)
 }
+
+func TestArgusRunURL(t *testing.T) {
+	// build_system_id contains slashes and the base has a trailing slash.
+	got := argusRunURL("https://argus.scylladb.com/", "scylla-2026.2/longevity/longevity-100gb", 42)
+	assert.Equal(t, "https://argus.scylladb.com/test/scylla-2026.2/longevity/longevity-100gb/42", got)
+}
+
+func TestArgusRunURL_NoBuildNumber(t *testing.T) {
+	// Build number not yet known → no link.
+	assert.Empty(t, argusRunURL("https://argus.scylladb.com", "scylla-2026.2/longevity/longevity-100gb", 0))
+}

--- a/cli/cmd/test/test_test.go
+++ b/cli/cmd/test/test_test.go
@@ -120,3 +120,61 @@ func TestResolveBuildID_ReleaseWithoutTest(t *testing.T) {
 	_, err := resolveBuildID(context.Background(), cmd, nil, nil)
 	require.Error(t, err)
 }
+
+// executeCmd returns the fully-registered "execute" command so its flag groups
+// and plan-mode validation can be exercised.
+func executeCmd() *cobra.Command {
+	parent := &cobra.Command{Use: "test"}
+	registerExecute(parent)
+	for _, c := range parent.Commands() {
+		if c.Name() == "execute" {
+			return c
+		}
+	}
+	return nil
+}
+
+func TestExecute_PlanRejectsFile(t *testing.T) {
+	cmd := executeCmd()
+	require.NoError(t, cmd.Flags().Set("plan-id", "scylla-2026.2#1"))
+	require.NoError(t, cmd.Flags().Set("label", "smoke"))
+	require.NoError(t, cmd.Flags().Set("file", "params.json"))
+
+	// The plan path rejects --file before touching any dependencies.
+	cmd.SetContext(context.Background())
+	err := runExecutePlan(cmd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--file is not supported")
+}
+
+func TestExecute_PlanRejectsBuildNumber(t *testing.T) {
+	cmd := executeCmd()
+	require.NoError(t, cmd.Flags().Set("plan-id", "scylla-2026.2#1"))
+	require.NoError(t, cmd.Flags().Set("label", "smoke"))
+	require.NoError(t, cmd.Flags().Set("build-number", "7"))
+
+	cmd.SetContext(context.Background())
+	err := runExecutePlan(cmd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--build-number is not supported")
+}
+
+func TestExecute_PlanIDRequiresLabel(t *testing.T) {
+	cmd := executeCmd()
+	require.NoError(t, cmd.Flags().Set("plan-id", "scylla-2026.2#1"))
+
+	// Cobra's required-together group fires during flag-group validation.
+	err := cmd.ValidateFlagGroups()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "label")
+}
+
+func TestExecute_BuildIDExclusiveWithPlanID(t *testing.T) {
+	cmd := executeCmd()
+	require.NoError(t, cmd.Flags().Set("build-id", "scylla-2026.2/longevity/longevity-100gb"))
+	require.NoError(t, cmd.Flags().Set("plan-id", "scylla-2026.2#1"))
+	require.NoError(t, cmd.Flags().Set("label", "smoke"))
+
+	err := cmd.ValidateFlagGroups()
+	require.Error(t, err)
+}

--- a/cli/cmd/test/test_test.go
+++ b/cli/cmd/test/test_test.go
@@ -1,0 +1,88 @@
+package test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseParams(t *testing.T) {
+	got, err := parseParams([]string{"backend=aws", "region=eu-west-1"})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"backend": "aws", "region": "eu-west-1"}, got)
+}
+
+func TestParseParams_EmptyValueAndEquals(t *testing.T) {
+	// Empty value is allowed; the first "=" splits, so values may contain "=".
+	got, err := parseParams([]string{"empty=", "expr=a=b"})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"empty": "", "expr": "a=b"}, got)
+}
+
+func TestParseParams_Invalid(t *testing.T) {
+	for _, bad := range []string{"noequals", "=value", "  =x"} {
+		_, err := parseParams([]string{bad})
+		require.Error(t, err, "input %q should be rejected", bad)
+	}
+}
+
+func TestParseParams_Nil(t *testing.T) {
+	got, err := parseParams(nil)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+// newExecuteCmd builds a minimal command carrying just the flags loadParamsFile
+// and buildNumberFlag read, so the helpers can be unit-tested in isolation.
+func newExecuteCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "execute"}
+	cmd.Flags().String("file", "", "")
+	cmd.Flags().Int("build-number", 0, "")
+	return cmd
+}
+
+func TestLoadParamsFile_Unset(t *testing.T) {
+	got, err := loadParamsFile(newExecuteCmd())
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestLoadParamsFile_ReadsMap(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "params.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"backend":"aws","test_duration":"600"}`), 0o600))
+
+	cmd := newExecuteCmd()
+	require.NoError(t, cmd.Flags().Set("file", path))
+
+	got, err := loadParamsFile(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"backend": "aws", "test_duration": "600"}, got)
+}
+
+func TestLoadParamsFile_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.json")
+	require.NoError(t, os.WriteFile(path, []byte(`not-json`), 0o600))
+
+	cmd := newExecuteCmd()
+	require.NoError(t, cmd.Flags().Set("file", path))
+
+	_, err := loadParamsFile(cmd)
+	require.Error(t, err)
+}
+
+func TestBuildNumberFlag(t *testing.T) {
+	// Unset → nil (backend seeds from last build).
+	assert.Nil(t, buildNumberFlag(newExecuteCmd()))
+
+	cmd := newExecuteCmd()
+	require.NoError(t, cmd.Flags().Set("build-number", "42"))
+	n := buildNumberFlag(cmd)
+	require.NotNil(t, n)
+	assert.Equal(t, 42, *n)
+}

--- a/cli/cmd/test/test_test.go
+++ b/cli/cmd/test/test_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -85,4 +86,37 @@ func TestBuildNumberFlag(t *testing.T) {
 	n := buildNumberFlag(cmd)
 	require.NotNil(t, n)
 	assert.Equal(t, 42, *n)
+}
+
+// newAddressedCmd builds a command carrying the shared addressing flags so
+// resolveBuildID's flag handling can be unit-tested in isolation.
+func newAddressedCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "execute"}
+	addAddressingFlags(cmd)
+	return cmd
+}
+
+func TestResolveBuildID_ExplicitBuildID(t *testing.T) {
+	cmd := newAddressedCmd()
+	require.NoError(t, cmd.Flags().Set("build-id", "scylla-2026.2/longevity/longevity-100gb"))
+
+	// --build-id is returned verbatim without any client/cache access.
+	got, err := resolveBuildID(context.Background(), cmd, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "scylla-2026.2/longevity/longevity-100gb", got)
+}
+
+func TestResolveBuildID_NoModeSupplied(t *testing.T) {
+	// Neither --build-id nor --release/--test → error before any resolution.
+	_, err := resolveBuildID(context.Background(), newAddressedCmd(), nil, nil)
+	require.Error(t, err)
+}
+
+func TestResolveBuildID_ReleaseWithoutTest(t *testing.T) {
+	cmd := newAddressedCmd()
+	require.NoError(t, cmd.Flags().Set("release", "scylla-2026.2"))
+
+	// --release without --test is incomplete and must not attempt resolution.
+	_, err := resolveBuildID(context.Background(), cmd, nil, nil)
+	require.Error(t, err)
 }

--- a/cli/internal/api/routes.go
+++ b/cli/internal/api/routes.go
@@ -67,6 +67,11 @@ const (
 	GroupExplode    = "/api/v1/planning/group/%s/explode"         // GET    – explode a group into its tests (group_id)
 	Gridview        = "/api/v1/planning/release/%s/gridview"      // GET    – release structure (enabled tests + groups) (release_id)
 
+	// Jenkins test-execution routes (testrun_api blueprint)
+	JenkinsParams    = "/api/v1/jenkins/params"     // POST – fetch a job's params (body {buildId, buildNumber}); buildId is build_system_id
+	JenkinsBuild     = "/api/v1/jenkins/build"      // POST – trigger a build (body {buildId, parameters}); returns {queueItem}
+	JenkinsQueueInfo = "/api/v1/jenkins/queue_info" // GET  – queue/build info (query param queueItem)
+
 	// Name-resolution routes
 	Releases = "/api/v1/releases" // GET – enabled releases (id/name); query param all=1 for every release
 	Users    = "/api/v1/users"    // GET – users keyed by id with username/full_name/email

--- a/cli/internal/models/queuestatus_test.go
+++ b/cli/internal/models/queuestatus_test.go
@@ -1,0 +1,44 @@
+package models_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/scylladb/argus/cli/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueueStatuses_Rows(t *testing.T) {
+	statuses := models.QueueStatuses{
+		{QueueItem: 10, Status: "started", URL: "https://ci/job/42/", Number: 42},
+		{QueueItem: 11, Status: "pending", Why: "Waiting for next available executor"},
+	}
+
+	assert.Equal(t, []string{"Queue Item", "Status", "URL", "Number", "Why"}, statuses.Headers())
+	assert.Equal(t, [][]string{
+		{"10", "started", "https://ci/job/42/", "42", ""},
+		{"11", "pending", "", "", "Waiting for next available executor"},
+	}, statuses.Rows())
+}
+
+func TestQueueStatuses_MarshalJSON(t *testing.T) {
+	statuses := models.QueueStatuses{
+		{QueueItem: 10, Status: "started", URL: "https://ci/job/42/", Number: 42},
+		{QueueItem: 11, Status: "pending", Why: "queued"},
+	}
+
+	raw, err := json.Marshal(statuses)
+	require.NoError(t, err)
+
+	var back []map[string]any
+	require.NoError(t, json.Unmarshal(raw, &back))
+	require.Len(t, back, 2)
+	assert.Equal(t, float64(10), back[0]["queue_item"])
+	assert.Equal(t, "started", back[0]["status"])
+	// Zero-valued optional fields are omitted for the pending row.
+	_, hasURL := back[1]["url"]
+	assert.False(t, hasURL)
+	_, hasNumber := back[1]["number"]
+	assert.False(t, hasNumber)
+}

--- a/cli/internal/models/testexec.go
+++ b/cli/internal/models/testexec.go
@@ -36,15 +36,22 @@ type JenkinsParamsResponse struct {
 
 // JenkinsBuildRequest is the request body for POST /api/v1/jenkins/build. The
 // backend adds the reserved requested_by_user parameter from the authenticated
-// user automatically, so it must not be included here.
+// user automatically, so it must not be included here. IncludeBuildNumber opts
+// in to receiving the guessed next build number in the response (an extra
+// Jenkins lookup on the backend), used to derive an Argus link without waiting.
 type JenkinsBuildRequest struct {
-	BuildID    string         `json:"buildId"`
-	Parameters map[string]any `json:"parameters"`
+	BuildID            string         `json:"buildId"`
+	Parameters         map[string]any `json:"parameters"`
+	IncludeBuildNumber bool           `json:"includeBuildNumber,omitempty"`
 }
 
 // JenkinsBuildResponse is the response payload for POST /api/v1/jenkins/build.
+// NextBuildNumber is the backend's best-effort guess of the build number the
+// triggered build will receive; it is present only when the request set
+// IncludeBuildNumber and the backend could resolve it.
 type JenkinsBuildResponse struct {
-	QueueItem int `json:"queueItem"`
+	QueueItem       int `json:"queueItem"`
+	NextBuildNumber int `json:"nextBuildNumber,omitempty"`
 }
 
 // JenkinsQueueInfo is the response payload for GET /api/v1/jenkins/queue_info.
@@ -166,6 +173,18 @@ func (b TriggeredBuilds) Rows() [][]string {
 type StartedBuild struct {
 	BuildID     string `json:"build_id"`
 	JenkinsURL  string `json:"jenkins_url,omitempty"`
+	BuildNumber int    `json:"build_number,omitempty"`
+	ArgusURL    string `json:"argus_url,omitempty"`
+}
+
+// ExecutedBuild is the result of a single 'test execute' without --wait: the
+// triggered job, its Jenkins queue item, and — when the backend could guess the
+// next build number — the guessed build number and the stable Argus run URL
+// derived from it. The number is a best-effort guess made at trigger time, so
+// BuildNumber/ArgusURL are omitted when it isn't known.
+type ExecutedBuild struct {
+	BuildID     string `json:"build_id"`
+	QueueItem   int    `json:"queue_item"`
 	BuildNumber int    `json:"build_number,omitempty"`
 	ArgusURL    string `json:"argus_url,omitempty"`
 }

--- a/cli/internal/models/testexec.go
+++ b/cli/internal/models/testexec.go
@@ -1,0 +1,119 @@
+package models
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// ---------------------------------------------------------------------------
+// Jenkins test-execution payloads
+// ---------------------------------------------------------------------------
+
+// JenkinsParameter is a single Jenkins job parameter as returned by
+// POST /api/v1/jenkins/params. Value is untyped because Jenkins parameter
+// values may be strings, booleans, or numbers. Choices (when present) enumerate
+// the allowed values for a choice parameter.
+type JenkinsParameter struct {
+	Name        string   `json:"name"`
+	Value       any      `json:"value"`
+	Description string   `json:"description,omitempty"`
+	Choices     []string `json:"choices,omitempty"`
+}
+
+// JenkinsParamsRequest is the request body for POST /api/v1/jenkins/params.
+// BuildNumber is a pointer so that a nil value is encoded as JSON null, which
+// the backend interprets as "seed from the last build (or job defaults)".
+type JenkinsParamsRequest struct {
+	BuildID     string `json:"buildId"`
+	BuildNumber *int   `json:"buildNumber"`
+}
+
+// JenkinsParamsResponse is the response payload for POST /api/v1/jenkins/params.
+type JenkinsParamsResponse struct {
+	Parameters []JenkinsParameter `json:"parameters"`
+}
+
+// JenkinsBuildRequest is the request body for POST /api/v1/jenkins/build. The
+// backend adds the reserved requested_by_user parameter from the authenticated
+// user automatically, so it must not be included here.
+type JenkinsBuildRequest struct {
+	BuildID    string         `json:"buildId"`
+	Parameters map[string]any `json:"parameters"`
+}
+
+// JenkinsBuildResponse is the response payload for POST /api/v1/jenkins/build.
+type JenkinsBuildResponse struct {
+	QueueItem int `json:"queueItem"`
+}
+
+// JenkinsQueueInfo is the response payload for GET /api/v1/jenkins/queue_info.
+// It is a union: once the queued item has been scheduled onto an executor, URL
+// (and Number) are populated; while the item is still waiting, Why /
+// InQueueSince / TaskURL describe the pending state.
+type JenkinsQueueInfo struct {
+	URL          string `json:"url,omitempty"`
+	Number       int    `json:"number,omitempty"`
+	Why          string `json:"why,omitempty"`
+	InQueueSince int64  `json:"inQueueSince,omitempty"`
+	TaskURL      string `json:"taskUrl,omitempty"`
+}
+
+// Scheduled reports whether the queued item has been assigned a build (i.e. it
+// has an executable URL) rather than still waiting in the queue.
+func (q JenkinsQueueInfo) Scheduled() bool { return q.URL != "" }
+
+// ---------------------------------------------------------------------------
+// Rich (--full) parameter table
+// ---------------------------------------------------------------------------
+
+// ParamsTable adapts a Jenkins parameter list to output.Tabular for the
+// `test params --full` view: a multi-column table of name / value / description
+// / choices. It implements json.Marshaler so JSON output emits the underlying
+// []JenkinsParameter (with the real choices array), not the flattened rows.
+type ParamsTable struct{ params []JenkinsParameter }
+
+// NewParamsTable wraps a parameter list for --full rendering.
+func NewParamsTable(params []JenkinsParameter) *ParamsTable {
+	return &ParamsTable{params: params}
+}
+
+// Headers implements output.Tabular.
+func (*ParamsTable) Headers() []string {
+	return []string{"Name", "Value", "Description", "Choices"}
+}
+
+// Rows implements output.Tabular.
+func (p *ParamsTable) Rows() [][]string {
+	rows := make([][]string, 0, len(p.params))
+	for _, param := range p.params {
+		rows = append(rows, []string{
+			param.Name,
+			paramValueString(param.Value),
+			param.Description,
+			strings.Join(param.Choices, ", "),
+		})
+	}
+	return rows
+}
+
+// MarshalJSON implements json.Marshaler so the JSON outputter serialises the
+// wrapped parameter list directly, not the ParamsTable wrapper.
+func (p *ParamsTable) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.params)
+}
+
+// paramValueString renders a parameter value (which may be a string, bool, or
+// number) as a single table cell.
+func paramValueString(v any) string {
+	if v == nil {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}

--- a/cli/internal/models/testexec.go
+++ b/cli/internal/models/testexec.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
 )
 
@@ -116,4 +117,43 @@ func paramValueString(v any) string {
 		return ""
 	}
 	return string(b)
+}
+
+// ---------------------------------------------------------------------------
+// Fan-out (label-based) execution results
+// ---------------------------------------------------------------------------
+
+// TriggeredBuild is one row of a fan-out execution result: the test reference
+// and its build_system_id, the Jenkins queue item the build was scheduled as,
+// its resolved URL (populated only when --wait is used and the build started),
+// and a human-readable status.
+type TriggeredBuild struct {
+	Test          string `json:"test"`
+	BuildSystemID string `json:"build_system_id"`
+	QueueItem     int    `json:"queue_item,omitempty"`
+	URL           string `json:"url,omitempty"`
+	Status        string `json:"status"`
+}
+
+// TriggeredBuilds is a fan-out execution result set. It implements
+// output.Tabular for text rendering while JSON output marshals the slice
+// directly.
+type TriggeredBuilds []TriggeredBuild
+
+// Headers implements output.Tabular.
+func (TriggeredBuilds) Headers() []string {
+	return []string{"Test", "Build System ID", "Queue Item", "URL", "Status"}
+}
+
+// Rows implements output.Tabular.
+func (b TriggeredBuilds) Rows() [][]string {
+	rows := make([][]string, 0, len(b))
+	for _, r := range b {
+		queue := ""
+		if r.QueueItem != 0 {
+			queue = strconv.Itoa(r.QueueItem)
+		}
+		rows = append(rows, []string{r.Test, r.BuildSystemID, queue, r.URL, r.Status})
+	}
+	return rows
 }

--- a/cli/internal/models/testexec.go
+++ b/cli/internal/models/testexec.go
@@ -157,3 +157,41 @@ func (b TriggeredBuilds) Rows() [][]string {
 	}
 	return rows
 }
+
+// ---------------------------------------------------------------------------
+// Queue status snapshot (check-queue)
+// ---------------------------------------------------------------------------
+
+// QueueStatus is one row of a `test check-queue` result: the queried Jenkins
+// queue item and its current state. A scheduled item carries URL/Number; an
+// item still waiting carries Why. Status is a human-readable summary
+// ("started", "pending", or "error: ...").
+type QueueStatus struct {
+	QueueItem int    `json:"queue_item"`
+	Status    string `json:"status"`
+	URL       string `json:"url,omitempty"`
+	Number    int    `json:"number,omitempty"`
+	Why       string `json:"why,omitempty"`
+}
+
+// QueueStatuses is a check-queue result set. It implements output.Tabular for
+// text rendering while JSON output marshals the slice directly.
+type QueueStatuses []QueueStatus
+
+// Headers implements output.Tabular.
+func (QueueStatuses) Headers() []string {
+	return []string{"Queue Item", "Status", "URL", "Number", "Why"}
+}
+
+// Rows implements output.Tabular.
+func (s QueueStatuses) Rows() [][]string {
+	rows := make([][]string, 0, len(s))
+	for _, r := range s {
+		number := ""
+		if r.Number != 0 {
+			number = strconv.Itoa(r.Number)
+		}
+		rows = append(rows, []string{strconv.Itoa(r.QueueItem), r.Status, r.URL, number, r.Why})
+	}
+	return rows
+}

--- a/cli/internal/models/testexec.go
+++ b/cli/internal/models/testexec.go
@@ -126,12 +126,14 @@ func paramValueString(v any) string {
 // TriggeredBuild is one row of a fan-out execution result: the test reference
 // and its build_system_id, the Jenkins queue item the build was scheduled as,
 // its resolved URL (populated only when --wait is used and the build started),
+// the Argus run URL (also populated on --wait once the build number is known),
 // and a human-readable status.
 type TriggeredBuild struct {
 	Test          string `json:"test"`
 	BuildSystemID string `json:"build_system_id"`
 	QueueItem     int    `json:"queue_item,omitempty"`
 	URL           string `json:"url,omitempty"`
+	ArgusURL      string `json:"argus_url,omitempty"`
 	Status        string `json:"status"`
 }
 
@@ -142,7 +144,7 @@ type TriggeredBuilds []TriggeredBuild
 
 // Headers implements output.Tabular.
 func (TriggeredBuilds) Headers() []string {
-	return []string{"Test", "Build System ID", "Queue Item", "URL", "Status"}
+	return []string{"Test", "Build System ID", "Queue Item", "URL", "Argus URL", "Status"}
 }
 
 // Rows implements output.Tabular.
@@ -153,9 +155,19 @@ func (b TriggeredBuilds) Rows() [][]string {
 		if r.QueueItem != 0 {
 			queue = strconv.Itoa(r.QueueItem)
 		}
-		rows = append(rows, []string{r.Test, r.BuildSystemID, queue, r.URL, r.Status})
+		rows = append(rows, []string{r.Test, r.BuildSystemID, queue, r.URL, r.ArgusURL, r.Status})
 	}
 	return rows
+}
+
+// StartedBuild is the result of a single 'test execute --wait': the triggered
+// job, its Jenkins build URL/number once scheduled, and the stable Argus run
+// URL derived from the build_system_id and build number.
+type StartedBuild struct {
+	BuildID     string `json:"build_id"`
+	JenkinsURL  string `json:"jenkins_url,omitempty"`
+	BuildNumber int    `json:"build_number,omitempty"`
+	ArgusURL    string `json:"argus_url,omitempty"`
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/internal/models/triggeredbuild_test.go
+++ b/cli/internal/models/triggeredbuild_test.go
@@ -1,0 +1,70 @@
+package models_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/scylladb/argus/cli/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTriggeredBuilds_Rows(t *testing.T) {
+	builds := models.TriggeredBuilds{
+		{
+			Test:          "Tier 1/longevity-100gb",
+			BuildSystemID: "scylla-2026.2/longevity/longevity-100gb",
+			QueueItem:     101,
+			URL:           "https://jenkins/job/longevity/42/",
+			ArgusURL:      "https://argus/test/scylla-2026.2/longevity/longevity-100gb/42",
+			Status:        "started",
+		},
+		{Test: "Tier 1/other", BuildSystemID: "scylla-2026.2/other", Status: "error: boom"},
+	}
+
+	assert.Equal(t,
+		[]string{"Test", "Build System ID", "Queue Item", "URL", "Argus URL", "Status"},
+		builds.Headers(),
+	)
+	assert.Equal(t, [][]string{
+		{
+			"Tier 1/longevity-100gb",
+			"scylla-2026.2/longevity/longevity-100gb",
+			"101",
+			"https://jenkins/job/longevity/42/",
+			"https://argus/test/scylla-2026.2/longevity/longevity-100gb/42",
+			"started",
+		},
+		{"Tier 1/other", "scylla-2026.2/other", "", "", "", "error: boom"},
+	}, builds.Rows())
+}
+
+func TestStartedBuild_MarshalJSON(t *testing.T) {
+	b := models.StartedBuild{
+		BuildID:     "scylla-2026.2/longevity/longevity-100gb",
+		JenkinsURL:  "https://jenkins/job/longevity/42/",
+		BuildNumber: 42,
+		ArgusURL:    "https://argus/test/scylla-2026.2/longevity/longevity-100gb/42",
+	}
+	raw, err := json.Marshal(b)
+	require.NoError(t, err)
+
+	var back map[string]any
+	require.NoError(t, json.Unmarshal(raw, &back))
+	assert.Equal(t, "scylla-2026.2/longevity/longevity-100gb", back["build_id"])
+	assert.Equal(t, float64(42), back["build_number"])
+	assert.Equal(t, "https://argus/test/scylla-2026.2/longevity/longevity-100gb/42", back["argus_url"])
+}
+
+func TestStartedBuild_MarshalJSON_OmitsEmpty(t *testing.T) {
+	// Before the build number is known, optional fields are omitted.
+	raw, err := json.Marshal(models.StartedBuild{BuildID: "scylla-2026.2/other"})
+	require.NoError(t, err)
+
+	var back map[string]any
+	require.NoError(t, json.Unmarshal(raw, &back))
+	_, hasNumber := back["build_number"]
+	assert.False(t, hasNumber)
+	_, hasArgus := back["argus_url"]
+	assert.False(t, hasArgus)
+}

--- a/cli/internal/models/triggeredbuild_test.go
+++ b/cli/internal/models/triggeredbuild_test.go
@@ -68,3 +68,49 @@ func TestStartedBuild_MarshalJSON_OmitsEmpty(t *testing.T) {
 	_, hasArgus := back["argus_url"]
 	assert.False(t, hasArgus)
 }
+
+func TestExecutedBuild_MarshalJSON(t *testing.T) {
+	b := models.ExecutedBuild{
+		BuildID:     "scylla-2026.2/longevity/longevity-100gb",
+		QueueItem:   101,
+		BuildNumber: 43,
+		ArgusURL:    "https://argus/test/scylla-2026.2/longevity/longevity-100gb/43",
+	}
+	raw, err := json.Marshal(b)
+	require.NoError(t, err)
+
+	var back map[string]any
+	require.NoError(t, json.Unmarshal(raw, &back))
+	assert.Equal(t, "scylla-2026.2/longevity/longevity-100gb", back["build_id"])
+	assert.Equal(t, float64(101), back["queue_item"])
+	assert.Equal(t, float64(43), back["build_number"])
+	assert.Equal(t, "https://argus/test/scylla-2026.2/longevity/longevity-100gb/43", back["argus_url"])
+}
+
+func TestExecutedBuild_MarshalJSON_OmitsGuessWhenUnknown(t *testing.T) {
+	// The queue item is always present; the guessed number/link are omitted
+	// when the backend couldn't resolve the next build number.
+	raw, err := json.Marshal(models.ExecutedBuild{BuildID: "scylla-2026.2/other", QueueItem: 7})
+	require.NoError(t, err)
+
+	var back map[string]any
+	require.NoError(t, json.Unmarshal(raw, &back))
+	assert.Equal(t, float64(7), back["queue_item"])
+	_, hasNumber := back["build_number"]
+	assert.False(t, hasNumber)
+	_, hasArgus := back["argus_url"]
+	assert.False(t, hasArgus)
+}
+
+func TestJenkinsBuildResponse_DecodesNextBuildNumber(t *testing.T) {
+	var resp models.JenkinsBuildResponse
+	require.NoError(t, json.Unmarshal([]byte(`{"queueItem":101,"nextBuildNumber":43}`), &resp))
+	assert.Equal(t, 101, resp.QueueItem)
+	assert.Equal(t, 43, resp.NextBuildNumber)
+
+	// Absent nextBuildNumber decodes to 0 (guess unavailable).
+	var noGuess models.JenkinsBuildResponse
+	require.NoError(t, json.Unmarshal([]byte(`{"queueItem":5}`), &noGuess))
+	assert.Equal(t, 5, noGuess.QueueItem)
+	assert.Zero(t, noGuess.NextBuildNumber)
+}

--- a/cli/internal/services/planner.go
+++ b/cli/internal/services/planner.go
@@ -371,6 +371,127 @@ func (s *PlannerService) ResolveTestBuildID(ctx context.Context, releaseRef, tes
 	return t.BuildSystemID, nil
 }
 
+// LabeledTest is a plan test selected by label: its group-qualified "group/test"
+// reference, the build_system_id the test-execution endpoints consume, and the
+// labels the underlying plan entity carries (for display).
+type LabeledTest struct {
+	Ref           string
+	BuildSystemID string
+	Labels        []string
+}
+
+// ResolveLabeledTests resolves a plan (by UUID or "releaseName#planNumber" key)
+// and a set of labels to the plan's matching tests. A plan entity matches when
+// its labels intersect the requested set (union), or — when matchAll is set —
+// when it carries every requested label. Matching is case-insensitive.
+//
+// A matching test yields its own build_system_id; a matching group fans out to
+// its enabled member tests. Entities no longer present in the release gridview
+// (e.g. since disabled) are skipped. Results are de-duplicated by
+// build_system_id and sorted by reference. When nothing matches, the error
+// lists the labels actually present in the plan so the caller can correct a typo.
+func (s *PlannerService) ResolveLabeledTests(ctx context.Context, planRef string, labels []string, matchAll bool) ([]LabeledTest, error) {
+	if len(labels) == 0 {
+		return nil, fmt.Errorf("at least one label is required")
+	}
+	plan, err := s.GetPlan(ctx, planRef)
+	if err != nil {
+		return nil, err
+	}
+	options, err := models.ParsePlanOptions(plan.Options)
+	if err != nil {
+		return nil, fmt.Errorf("parsing plan options: %w", err)
+	}
+	grid, err := s.GetReleaseStructure(ctx, plan.ReleaseID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Wanted labels, lower-cased for case-insensitive matching.
+	wanted := make(map[string]struct{}, len(labels))
+	for _, l := range labels {
+		wanted[strings.ToLower(l)] = struct{}{}
+	}
+
+	// Collect every distinct label seen in the plan, so an empty match can steer
+	// the user toward a valid one.
+	available := newOrderedSet()
+
+	results := make([]LabeledTest, 0)
+	seen := map[string]struct{}{} // dedup by build_system_id
+	appendTest := func(t models.GridEntity, entityLabels []string) {
+		if _, dup := seen[t.BuildSystemID]; dup {
+			return
+		}
+		seen[t.BuildSystemID] = struct{}{}
+		results = append(results, LabeledTest{
+			Ref:           t.Group + "/" + t.Name,
+			BuildSystemID: t.BuildSystemID,
+			Labels:        append([]string(nil), entityLabels...),
+		})
+	}
+
+	for entityID, opt := range options {
+		for _, l := range opt.Labels {
+			available.add(l)
+		}
+		if !labelsMatch(opt.Labels, wanted, matchAll) {
+			continue
+		}
+		if t, ok := grid.Tests[entityID]; ok {
+			appendTest(t, opt.Labels)
+			continue
+		}
+		if _, ok := grid.Groups[entityID]; ok {
+			// A labelled group fans out to its enabled member tests. Iterate the
+			// gridview directly by group UUID (ExpandGroup resolves by name).
+			for _, t := range grid.Tests {
+				if t.GroupID == entityID && t.Enabled {
+					appendTest(t, opt.Labels)
+				}
+			}
+		}
+		// Entity absent from the gridview (disabled/removed): skip.
+	}
+
+	if len(results) == 0 {
+		if len(available.items) == 0 {
+			return nil, fmt.Errorf("plan %q has no labelled tests", planRef)
+		}
+		sort.Strings(available.items)
+		return nil, fmt.Errorf("no tests in plan %q match the requested labels; available labels: %s",
+			planRef, strings.Join(available.items, ", "))
+	}
+
+	sort.Slice(results, func(i, j int) bool { return results[i].Ref < results[j].Ref })
+	return results, nil
+}
+
+// labelsMatch reports whether an entity's labels satisfy the wanted set. With
+// matchAll it requires every wanted label to be present (intersection == wanted);
+// otherwise a single overlap suffices (union). Comparison is case-insensitive
+// via the lower-cased wanted set.
+func labelsMatch(entityLabels []string, wanted map[string]struct{}, matchAll bool) bool {
+	if matchAll {
+		have := make(map[string]struct{}, len(entityLabels))
+		for _, l := range entityLabels {
+			have[strings.ToLower(l)] = struct{}{}
+		}
+		for w := range wanted {
+			if _, ok := have[w]; !ok {
+				return false
+			}
+		}
+		return true
+	}
+	for _, l := range entityLabels {
+		if _, ok := wanted[strings.ToLower(l)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 // ExpandGroup resolves a group reference and returns the UUIDs of its enabled
 // member tests, taken from the gridview's enabled-only tests map (deliberately
 // not testByGroup / explode, which include disabled tests). The result is

--- a/cli/internal/services/planner.go
+++ b/cli/internal/services/planner.go
@@ -339,7 +339,36 @@ func (s *PlannerService) ResolveEntityID(ctx context.Context, ref, releaseID str
 		}
 		return g.ID, nil
 	}
-	return resolveTest(grid, ref)
+	t, err := resolveTestEntity(grid, ref)
+	if err != nil {
+		return "", err
+	}
+	return t.ID, nil
+}
+
+// ResolveTestBuildID resolves a release name and a single test reference to the
+// test's build_system_id (the Jenkins job path the test-execution endpoints
+// consume). The test reference uses the same priority as [ResolveEntityID]:
+// exact build_system_id, group-qualified "group/test", then unique bare name.
+//
+// Unlike assignment resolution, a reference that names a group (not a single
+// test) is rejected — a build targets exactly one job — with an
+// [ErrEntityNotFound]-wrapped message. An ambiguous test reference aborts with
+// [ErrAmbiguousEntity] and a candidate list so the user can disambiguate.
+func (s *PlannerService) ResolveTestBuildID(ctx context.Context, releaseRef, testRef string) (string, error) {
+	releaseID, err := s.ResolveReleaseID(ctx, releaseRef)
+	if err != nil {
+		return "", err
+	}
+	grid, err := s.GetReleaseStructure(ctx, releaseID)
+	if err != nil {
+		return "", err
+	}
+	t, err := resolveTestEntity(grid, testRef)
+	if err != nil {
+		return "", err
+	}
+	return t.BuildSystemID, nil
 }
 
 // ExpandGroup resolves a group reference and returns the UUIDs of its enabled
@@ -387,13 +416,14 @@ func findGroup(grid models.GridView, ref string) (models.GridEntity, error) {
 	}
 }
 
-// resolveTest implements the test resolution priority described on
-// [PlannerService.ResolveEntityID].
-func resolveTest(grid models.GridView, ref string) (string, error) {
+// resolveTestEntity implements the test resolution priority described on
+// [PlannerService.ResolveEntityID], returning the matched gridview entity so
+// callers can read either its UUID or its build_system_id.
+func resolveTestEntity(grid models.GridView, ref string) (models.GridEntity, error) {
 	// (1) exact build_system_id — globally unique, never ambiguous.
-	for id, t := range grid.Tests {
+	for _, t := range grid.Tests {
 		if t.BuildSystemID == ref {
-			return id, nil
+			return t, nil
 		}
 	}
 
@@ -403,26 +433,26 @@ func resolveTest(grid models.GridView, ref string) (string, error) {
 		g, err := findGroup(grid, groupPart)
 		switch {
 		case err == nil:
-			var matches []string
-			for id, t := range grid.Tests {
+			var matches []models.GridEntity
+			for _, t := range grid.Tests {
 				if t.GroupID == g.ID && strings.EqualFold(t.Name, testName) {
-					matches = append(matches, id)
+					matches = append(matches, t)
 				}
 			}
 			if len(matches) == 1 {
 				return matches[0], nil
 			}
 			if len(matches) > 1 {
-				return "", fmt.Errorf("%w: ambiguous test %q within group %q (%d matches)", ErrAmbiguousEntity, testName, groupPart, len(matches))
+				return models.GridEntity{}, fmt.Errorf("%w: ambiguous test %q within group %q (%d matches)", ErrAmbiguousEntity, testName, groupPart, len(matches))
 			}
-			return "", fmt.Errorf("%w: no test %q in group %q", ErrEntityNotFound, testName, groupPart)
+			return models.GridEntity{}, fmt.Errorf("%w: no test %q in group %q", ErrEntityNotFound, testName, groupPart)
 		case errors.Is(err, ErrEntityNotFound):
 			// The prefix isn't a known group; fall through to bare-name
 			// resolution (the ref may be a plain name that contains a slash).
 		default:
 			// Ambiguous group prefix (or other error): surface it so callers
 			// abort for disambiguation instead of misreporting "test not found".
-			return "", err
+			return models.GridEntity{}, err
 		}
 	}
 
@@ -435,11 +465,11 @@ func resolveTest(grid models.GridView, ref string) (string, error) {
 	}
 	switch len(matches) {
 	case 1:
-		return matches[0].ID, nil
+		return matches[0], nil
 	case 0:
-		return "", fmt.Errorf("%w: no test %q in this release (use build_system_id or group/test)", ErrEntityNotFound, ref)
+		return models.GridEntity{}, fmt.Errorf("%w: no test %q in this release (use build_system_id or group/test)", ErrEntityNotFound, ref)
 	default:
-		return "", fmt.Errorf("%w: ambiguous test %q (%d matches): use build_system_id or group/test\n%s",
+		return models.GridEntity{}, fmt.Errorf("%w: ambiguous test %q (%d matches): use build_system_id or group/test\n%s",
 			ErrAmbiguousEntity, ref, len(matches), formatTestCandidates(matches))
 	}
 }

--- a/cli/internal/services/planner_test.go
+++ b/cli/internal/services/planner_test.go
@@ -275,6 +275,62 @@ func TestPlannerService_ResolveEntityID_GroupByBuildSystemID(t *testing.T) {
 	assert.Equal(t, "g1", id)
 }
 
+func TestPlannerService_ResolveTestBuildID_GroupQualified(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	bsid, err := svc.ResolveTestBuildID(context.Background(), "scylla-2026.2", "tier1/longevity-100gb")
+	require.NoError(t, err)
+	assert.Equal(t, "scylla-2026.2/tier1/longevity-100gb", bsid)
+}
+
+func TestPlannerService_ResolveTestBuildID_BareUnique(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	// longevity-200gb is unique across groups → resolves by bare name.
+	bsid, err := svc.ResolveTestBuildID(context.Background(), "scylla-2026.2", "longevity-200gb")
+	require.NoError(t, err)
+	assert.Equal(t, "scylla-2026.2/tier1/longevity-200gb", bsid)
+}
+
+func TestPlannerService_ResolveTestBuildID_UnknownRelease(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	_, err := svc.ResolveTestBuildID(context.Background(), "scylla-9999", "longevity-200gb")
+	require.Error(t, err)
+}
+
+func TestPlannerService_ResolveTestBuildID_UnknownTest(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	_, err := svc.ResolveTestBuildID(context.Background(), "scylla-2026.2", "does-not-exist")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, services.ErrEntityNotFound)
+}
+
+func TestPlannerService_ResolveTestBuildID_AmbiguousAborts(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	// longevity-100gb exists in two groups → ambiguous bare name must abort.
+	_, err := svc.ResolveTestBuildID(context.Background(), "scylla-2026.2", "longevity-100gb")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, services.ErrAmbiguousEntity)
+}
+
+func TestPlannerService_ResolveTestBuildID_GroupRejected(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, resolveMux(t))
+
+	// A group reference is not a single test and must be rejected (no fan-out).
+	_, err := svc.ResolveTestBuildID(context.Background(), "scylla-2026.2", "tier1")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, services.ErrEntityNotFound)
+}
+
 func TestPlannerService_ExpandGroup_EnabledOnly(t *testing.T) {
 	t.Parallel()
 	svc := newPlannerSvc(t, gridviewMux(t, nil))

--- a/cli/internal/services/planner_test.go
+++ b/cli/internal/services/planner_test.go
@@ -331,6 +331,110 @@ func TestPlannerService_ResolveTestBuildID_GroupRejected(t *testing.T) {
 	assert.ErrorIs(t, err, services.ErrEntityNotFound)
 }
 
+// labeledPlanMux extends resolveMux (releases + gridview) with a plan-get
+// endpoint whose Options blob attaches labels to plan entities: t1 carries
+// smoke+nightly, t2 carries perf, t3 carries smoke, group g1 carries regression
+// (and fans out to its enabled tests t1+t2), and a stale UUID carries smoke to
+// exercise the "not in gridview" skip.
+func labeledPlanMux(t *testing.T) *http.ServeMux {
+	t.Helper()
+	mux := resolveMux(t)
+	options, err := json.Marshal(map[string]models.EntityOptions{
+		"t1":    {Labels: []string{"smoke", "nightly"}},
+		"t2":    {Labels: []string{"perf"}},
+		"t3":    {Labels: []string{"smoke"}},
+		"g1":    {Labels: []string{"regression"}},
+		"stale": {Labels: []string{"smoke"}},
+	})
+	require.NoError(t, err)
+	mux.HandleFunc("/api/v1/planning/plan/plan-1/get", func(w http.ResponseWriter, r *http.Request) {
+		jsonOK(t, w, models.ReleasePlan{
+			ID:        "plan-1",
+			Key:       "scylla-2026.2#1",
+			ReleaseID: "rel-1",
+			Tests:     []string{"t1", "t2", "t3"},
+			Groups:    []string{"g1"},
+			Options:   string(options),
+		})
+	})
+	return mux
+}
+
+// refs extracts the ordered reference list from a LabeledTest slice.
+func refs(tests []services.LabeledTest) []string {
+	out := make([]string, len(tests))
+	for i, t := range tests {
+		out[i] = t.Ref
+	}
+	return out
+}
+
+func TestPlannerService_ResolveLabeledTests_Union(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, labeledPlanMux(t))
+
+	// "smoke" matches t1 and t3 (sorted by group-qualified ref).
+	got, err := svc.ResolveLabeledTests(context.Background(), "plan-1", []string{"smoke"}, false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Tier 1/longevity-100gb", "Tier 2/longevity-100gb"}, refs(got))
+	assert.Equal(t, "scylla-2026.2/tier1/longevity-100gb", got[0].BuildSystemID)
+}
+
+func TestPlannerService_ResolveLabeledTests_UnionMultiple(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, labeledPlanMux(t))
+
+	// nightly (t1) ∪ perf (t2).
+	got, err := svc.ResolveLabeledTests(context.Background(), "plan-1", []string{"nightly", "perf"}, false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Tier 1/longevity-100gb", "Tier 1/longevity-200gb"}, refs(got))
+}
+
+func TestPlannerService_ResolveLabeledTests_MatchAll(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, labeledPlanMux(t))
+
+	// Only t1 carries both smoke and nightly; t3 (smoke only) is excluded.
+	got, err := svc.ResolveLabeledTests(context.Background(), "plan-1", []string{"smoke", "nightly"}, true)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Tier 1/longevity-100gb"}, refs(got))
+}
+
+func TestPlannerService_ResolveLabeledTests_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, labeledPlanMux(t))
+
+	got, err := svc.ResolveLabeledTests(context.Background(), "plan-1", []string{"SMOKE"}, false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Tier 1/longevity-100gb", "Tier 2/longevity-100gb"}, refs(got))
+}
+
+func TestPlannerService_ResolveLabeledTests_GroupFanoutAndDedup(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, labeledPlanMux(t))
+
+	// regression is on group g1 → fans out to enabled t1+t2; combined with smoke
+	// (t1, t3) the t1 overlap is de-duplicated. Expect t1, t2, t3 once each.
+	got, err := svc.ResolveLabeledTests(context.Background(), "plan-1", []string{"regression", "smoke"}, false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"Tier 1/longevity-100gb",
+		"Tier 1/longevity-200gb",
+		"Tier 2/longevity-100gb",
+	}, refs(got))
+}
+
+func TestPlannerService_ResolveLabeledTests_NoMatchListsLabels(t *testing.T) {
+	t.Parallel()
+	svc := newPlannerSvc(t, labeledPlanMux(t))
+
+	_, err := svc.ResolveLabeledTests(context.Background(), "plan-1", []string{"does-not-exist"}, false)
+	require.Error(t, err)
+	// The error names the labels actually present so the user can correct a typo.
+	assert.Contains(t, err.Error(), "smoke")
+	assert.Contains(t, err.Error(), "regression")
+}
+
 func TestPlannerService_ExpandGroup_EnabledOnly(t *testing.T) {
 	t.Parallel()
 	svc := newPlannerSvc(t, gridviewMux(t, nil))

--- a/cli/internal/services/testexec.go
+++ b/cli/internal/services/testexec.go
@@ -26,7 +26,7 @@ const noBuildsSignal = "#noBuildsAvailable"
 // Default polling behaviour for [TestExecutionService.WaitForBuild].
 const (
 	defaultWaitTimeout  = 5 * time.Minute
-	defaultWaitInterval = 2 * time.Second
+	defaultWaitInterval = 3 * time.Second
 )
 
 // TestExecutionService drives the Jenkins-backed test-execution endpoints:

--- a/cli/internal/services/testexec.go
+++ b/cli/internal/services/testexec.go
@@ -1,0 +1,167 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/scylladb/argus/cli/internal/api"
+	"github.com/scylladb/argus/cli/internal/cache"
+	"github.com/scylladb/argus/cli/internal/models"
+)
+
+// ErrNoBuildsAvailable is returned (wrapped) by [TestExecutionService.FetchParams]
+// when the backend reports that a job has no builds and no default parameter
+// definitions to seed from (the "#noBuildsAvailable" signal). Callers decide
+// whether that is fatal (`test params`) or recoverable (`test execute`, which
+// proceeds with empty defaults supplied by --file/--param).
+var ErrNoBuildsAvailable = errors.New("no builds available for this job")
+
+// noBuildsSignal is the sentinel message the backend's JenkinsService raises
+// when a job has neither historical builds nor default parameter definitions.
+const noBuildsSignal = "#noBuildsAvailable"
+
+// Default polling behaviour for [TestExecutionService.WaitForBuild].
+const (
+	defaultWaitTimeout  = 5 * time.Minute
+	defaultWaitInterval = 2 * time.Second
+)
+
+// TestExecutionService drives the Jenkins-backed test-execution endpoints:
+// fetching a job's parameters, triggering a build, and inspecting the resulting
+// queue item. Tests are addressed by build_system_id (the Jenkins job path);
+// the backend derives the requesting user from the authenticated session.
+type TestExecutionService struct {
+	client *api.Client
+	cache  *cache.Cache
+}
+
+// NewTestExecutionService constructs a [TestExecutionService].
+func NewTestExecutionService(client *api.Client, c *cache.Cache) *TestExecutionService {
+	return &TestExecutionService{client: client, cache: c}
+}
+
+// FetchParams returns the parameter set for the job identified by buildID
+// (a build_system_id). buildNumber selects which historical build's parameters
+// to seed from; nil means "the last build, falling back to job defaults".
+//
+// When the job has no builds and no default definitions, the backend signals
+// "#noBuildsAvailable"; FetchParams maps that to [ErrNoBuildsAvailable] so
+// callers can distinguish it from a genuine failure.
+func (s *TestExecutionService) FetchParams(ctx context.Context, buildID string, buildNumber *int) ([]models.JenkinsParameter, error) {
+	body := models.JenkinsParamsRequest{BuildID: buildID, BuildNumber: buildNumber}
+	req, err := s.client.NewRequest(ctx, "POST", api.JenkinsParams, body)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := api.DoJSON[models.JenkinsParamsResponse](s.client, req)
+	if err != nil {
+		if isNoBuildsError(err) {
+			return nil, fmt.Errorf("%w: %q", ErrNoBuildsAvailable, buildID)
+		}
+		return nil, err
+	}
+	return resp.Parameters, nil
+}
+
+// TriggerBuild schedules a build of the job identified by buildID with the
+// given parameters and returns the Jenkins queue item number.
+func (s *TestExecutionService) TriggerBuild(ctx context.Context, buildID string, params map[string]any) (int, error) {
+	if params == nil {
+		params = map[string]any{}
+	}
+	body := models.JenkinsBuildRequest{BuildID: buildID, Parameters: params}
+	req, err := s.client.NewRequest(ctx, "POST", api.JenkinsBuild, body)
+	if err != nil {
+		return 0, err
+	}
+	resp, err := api.DoJSON[models.JenkinsBuildResponse](s.client, req)
+	if err != nil {
+		return 0, err
+	}
+	return resp.QueueItem, nil
+}
+
+// QueueInfo returns the current state of a Jenkins queue item: either the
+// scheduled build (with URL) or the pending-queue reason.
+func (s *TestExecutionService) QueueInfo(ctx context.Context, queueItem int) (models.JenkinsQueueInfo, error) {
+	params := url.Values{}
+	params.Set("queueItem", fmt.Sprint(queueItem))
+	route := api.JenkinsQueueInfo + "?" + params.Encode()
+	req, err := s.client.NewRequest(ctx, "GET", route, nil)
+	if err != nil {
+		return models.JenkinsQueueInfo{}, err
+	}
+	return api.DoJSON[models.JenkinsQueueInfo](s.client, req)
+}
+
+// WaitForBuild polls QueueInfo until the queue item is scheduled onto an
+// executor (its build URL is known), the timeout elapses, or ctx is cancelled.
+// A zero timeout or interval falls back to the package defaults.
+func (s *TestExecutionService) WaitForBuild(ctx context.Context, queueItem int, timeout, interval time.Duration) (models.JenkinsQueueInfo, error) {
+	if timeout <= 0 {
+		timeout = defaultWaitTimeout
+	}
+	if interval <= 0 {
+		interval = defaultWaitInterval
+	}
+
+	deadline := time.Now().Add(timeout)
+	var last models.JenkinsQueueInfo
+	for {
+		info, err := s.QueueInfo(ctx, queueItem)
+		if err != nil {
+			return last, err
+		}
+		last = info
+		if info.Scheduled() {
+			return info, nil
+		}
+		if time.Now().After(deadline) {
+			return last, fmt.Errorf("timed out after %s waiting for queue item %d to start", timeout, queueItem)
+		}
+
+		select {
+		case <-ctx.Done():
+			return last, ctx.Err()
+		case <-time.After(interval):
+		}
+	}
+}
+
+// MergeParams computes the final parameter map for a build using the cascade
+// defaults < file < flags: it starts from the fetched job defaults, overlays
+// the --file map, then overlays the --param flag map (each level overriding the
+// previous by key). Nil overlays are ignored. The result is always non-nil.
+func MergeParams(defaults []models.JenkinsParameter, file, flags map[string]any) map[string]any {
+	merged := make(map[string]any, len(defaults))
+	for _, p := range defaults {
+		merged[p.Name] = p.Value
+	}
+	for k, v := range file {
+		merged[k] = v
+	}
+	for k, v := range flags {
+		merged[k] = v
+	}
+	return merged
+}
+
+// isNoBuildsError reports whether err carries the backend's "#noBuildsAvailable"
+// signal (surfaced through the APIError envelope).
+func isNoBuildsError(err error) bool {
+	var apiErr *api.APIError
+	if errors.As(err, &apiErr) {
+		if apiErr.Body.Message == noBuildsSignal {
+			return true
+		}
+		for _, arg := range apiErr.Body.Arguments {
+			if arg == noBuildsSignal {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/cli/internal/services/testexec.go
+++ b/cli/internal/services/testexec.go
@@ -69,19 +69,34 @@ func (s *TestExecutionService) FetchParams(ctx context.Context, buildID string, 
 // TriggerBuild schedules a build of the job identified by buildID with the
 // given parameters and returns the Jenkins queue item number.
 func (s *TestExecutionService) TriggerBuild(ctx context.Context, buildID string, params map[string]any) (int, error) {
+	queueItem, _, err := s.triggerBuild(ctx, buildID, params, false)
+	return queueItem, err
+}
+
+// TriggerBuildWithNumber behaves like TriggerBuild but also asks the backend to
+// guess the next build number for the job (an extra Jenkins lookup). The guess
+// is best-effort: it is 0 when the backend couldn't resolve it. Used by the
+// non-wait single execute path to derive an Argus run link at trigger time.
+func (s *TestExecutionService) TriggerBuildWithNumber(ctx context.Context, buildID string, params map[string]any) (queueItem, nextBuildNumber int, err error) {
+	return s.triggerBuild(ctx, buildID, params, true)
+}
+
+// triggerBuild posts to the build endpoint, optionally requesting the guessed
+// next build number.
+func (s *TestExecutionService) triggerBuild(ctx context.Context, buildID string, params map[string]any, includeBuildNumber bool) (int, int, error) {
 	if params == nil {
 		params = map[string]any{}
 	}
-	body := models.JenkinsBuildRequest{BuildID: buildID, Parameters: params}
+	body := models.JenkinsBuildRequest{BuildID: buildID, Parameters: params, IncludeBuildNumber: includeBuildNumber}
 	req, err := s.client.NewRequest(ctx, "POST", api.JenkinsBuild, body)
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 	resp, err := api.DoJSON[models.JenkinsBuildResponse](s.client, req)
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
-	return resp.QueueItem, nil
+	return resp.QueueItem, resp.NextBuildNumber, nil
 }
 
 // QueueInfo returns the current state of a Jenkins queue item: either the

--- a/cli/internal/services/testexec_test.go
+++ b/cli/internal/services/testexec_test.go
@@ -1,0 +1,181 @@
+package services_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/scylladb/argus/cli/internal/api"
+	"github.com/scylladb/argus/cli/internal/cache"
+	"github.com/scylladb/argus/cli/internal/models"
+	"github.com/scylladb/argus/cli/internal/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestExecSvc(t *testing.T, mux *http.ServeMux) *services.TestExecutionService {
+	t.Helper()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	client, err := api.New(srv.URL, api.WithHTTPClient(srv.Client()))
+	require.NoError(t, err)
+	ca := cache.New(t.TempDir(), cache.WithDisabled(true))
+	return services.NewTestExecutionService(client, ca)
+}
+
+func TestMergeParams_Cascade(t *testing.T) {
+	defaults := []models.JenkinsParameter{
+		{Name: "backend", Value: "aws"},
+		{Name: "region", Value: "us-east-1"},
+		{Name: "keep", Value: "always"},
+	}
+	file := map[string]any{"region": "eu-west-1", "extra": "from-file"}
+	flags := map[string]any{"backend": "gce", "extra": "from-flag"}
+
+	merged := services.MergeParams(defaults, file, flags)
+
+	// defaults < file < flags: flags win over file, file wins over defaults,
+	// untouched defaults are preserved.
+	assert.Equal(t, "gce", merged["backend"])      // flag overrides default
+	assert.Equal(t, "eu-west-1", merged["region"]) // file overrides default
+	assert.Equal(t, "always", merged["keep"])      // default preserved
+	assert.Equal(t, "from-flag", merged["extra"])  // flag overrides file
+}
+
+func TestMergeParams_EmptyOverlays(t *testing.T) {
+	defaults := []models.JenkinsParameter{{Name: "a", Value: "1"}}
+	merged := services.MergeParams(defaults, nil, nil)
+	assert.Equal(t, map[string]any{"a": "1"}, merged)
+
+	// No defaults, only overlays.
+	merged = services.MergeParams(nil, map[string]any{"b": "2"}, nil)
+	assert.Equal(t, map[string]any{"b": "2"}, merged)
+}
+
+func TestFetchParams_Success(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/jenkins/params", func(w http.ResponseWriter, r *http.Request) {
+		var body models.JenkinsParamsRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "scylla/longevity", body.BuildID)
+		assert.Nil(t, body.BuildNumber)
+		jsonOK(t, w, models.JenkinsParamsResponse{Parameters: []models.JenkinsParameter{
+			{Name: "backend", Value: "aws", Choices: []string{"aws", "gce"}},
+		}})
+	})
+	svc := newTestExecSvc(t, mux)
+
+	params, err := svc.FetchParams(context.Background(), "scylla/longevity", nil)
+	require.NoError(t, err)
+	require.Len(t, params, 1)
+	assert.Equal(t, "backend", params[0].Name)
+	assert.Equal(t, []string{"aws", "gce"}, params[0].Choices)
+}
+
+func TestFetchParams_BuildNumberSent(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/jenkins/params", func(w http.ResponseWriter, r *http.Request) {
+		var body models.JenkinsParamsRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		require.NotNil(t, body.BuildNumber)
+		assert.Equal(t, 42, *body.BuildNumber)
+		jsonOK(t, w, models.JenkinsParamsResponse{})
+	})
+	svc := newTestExecSvc(t, mux)
+
+	n := 42
+	_, err := svc.FetchParams(context.Background(), "scylla/longevity", &n)
+	require.NoError(t, err)
+}
+
+func TestFetchParams_NoBuildsAvailable(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/jenkins/params", func(w http.ResponseWriter, _ *http.Request) {
+		jsonErr(t, w, "#noBuildsAvailable")
+	})
+	svc := newTestExecSvc(t, mux)
+
+	_, err := svc.FetchParams(context.Background(), "scylla/longevity", nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, services.ErrNoBuildsAvailable))
+}
+
+func TestTriggerBuild(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/jenkins/build", func(w http.ResponseWriter, r *http.Request) {
+		var body models.JenkinsBuildRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "scylla/longevity", body.BuildID)
+		assert.Equal(t, "eu-west-1", body.Parameters["region"])
+		jsonOK(t, w, models.JenkinsBuildResponse{QueueItem: 777})
+	})
+	svc := newTestExecSvc(t, mux)
+
+	item, err := svc.TriggerBuild(context.Background(), "scylla/longevity", map[string]any{"region": "eu-west-1"})
+	require.NoError(t, err)
+	assert.Equal(t, 777, item)
+}
+
+func TestTriggerBuild_NilParams(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/jenkins/build", func(w http.ResponseWriter, r *http.Request) {
+		var body models.JenkinsBuildRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		// nil params must serialise as an empty object, not null.
+		assert.NotNil(t, body.Parameters)
+		jsonOK(t, w, models.JenkinsBuildResponse{QueueItem: 1})
+	})
+	svc := newTestExecSvc(t, mux)
+
+	_, err := svc.TriggerBuild(context.Background(), "scylla/longevity", nil)
+	require.NoError(t, err)
+}
+
+func TestQueueInfo(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/jenkins/queue_info", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "777", r.URL.Query().Get("queueItem"))
+		jsonOK(t, w, models.JenkinsQueueInfo{URL: "https://jenkins/job/x/12/", Number: 12})
+	})
+	svc := newTestExecSvc(t, mux)
+
+	info, err := svc.QueueInfo(context.Background(), 777)
+	require.NoError(t, err)
+	assert.True(t, info.Scheduled())
+	assert.Equal(t, "https://jenkins/job/x/12/", info.URL)
+}
+
+func TestWaitForBuild_PollsUntilScheduled(t *testing.T) {
+	var calls int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/jenkins/queue_info", func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		if calls < 2 {
+			jsonOK(t, w, models.JenkinsQueueInfo{Why: "waiting", TaskURL: "https://jenkins/job/x/"})
+			return
+		}
+		jsonOK(t, w, models.JenkinsQueueInfo{URL: "https://jenkins/job/x/12/", Number: 12})
+	})
+	svc := newTestExecSvc(t, mux)
+
+	info, err := svc.WaitForBuild(context.Background(), 777, time.Second, time.Millisecond)
+	require.NoError(t, err)
+	assert.True(t, info.Scheduled())
+	assert.GreaterOrEqual(t, calls, 2)
+}
+
+func TestWaitForBuild_Timeout(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/jenkins/queue_info", func(w http.ResponseWriter, _ *http.Request) {
+		jsonOK(t, w, models.JenkinsQueueInfo{Why: "waiting"})
+	})
+	svc := newTestExecSvc(t, mux)
+
+	_, err := svc.WaitForBuild(context.Background(), 777, 20*time.Millisecond, time.Millisecond)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timed out")
+}


### PR DESCRIPTION
- **feature(cli/test): add test execute and params commands**
  Add a 'test' command group wiring the Jenkins test-execution endpoints into
  the Go CLI: 'test params' fetches a job's parameter set (values map by
  default, --full for details) and 'test execute' triggers a build with the
  merge cascade defaults < --file < --param, plus --dry-run and --wait.
  

- **feature(cli/test): resolve tests by --release and --test**
  Let `test params` and `test execute` address a test by release name plus a
  test reference, resolved to a build_system_id via the planner gridview, as an
  alternative to the existing --build-id. The two addressing modes are mutually
  exclusive; --release and --test are required together.
  
  Resolution reuses the planner's name-resolution machinery (and its disk cache)
  through a new PlannerService.ResolveTestBuildID, which returns the matched
  test's build_system_id and rejects group references since a build targets a
  single job.
  

- **feature(cli/test): execute plan tests by label**
  Add a third addressing mode to `test execute`: --plan-id with one or
  more --label flags fans out and triggers a Jenkins build for every
  enabled test in the plan carrying the given label(s). Labels match as a
  union by default; --match-all switches to intersection. Matching is
  case-insensitive, labeled groups expand to their member tests, and
  results are deduplicated by build_system_id.
  
  Each build is triggered with its own fetched defaults plus any
  repeatable --param overrides; --file and --build-number are rejected in
  plan mode. --wait waits for all builds in parallel under a single
  batch-wide --wait-timeout, and per-test failures are recorded per row
  without aborting the batch.
  

- **feature(cli/test): add check-queue command**
  Add `test check-queue` to report the current Jenkins queue/build status
  of one or more queue items. Items are supplied with repeatable --item
  flags and/or a --file (path or "-" for stdin) carrying the JSON emitted
  by `test execute`, accepting either {"queueItem": 123} or
  {"queueItem": [123, 456]}.
  
  Items are merged, de-duplicated, and sorted; each is queried once via the
  existing queue_info endpoint and rendered as one row (JSON array or text
  table) reporting started/pending/error. A per-item failure is recorded
  in its row without aborting the batch. This is a one-shot snapshot with
  no waiting.
  

- **feature(service/testrun): add run lookup by build id and number**
  Add TestRunService.get_run_by_build_number plus HTML and JSON routes to
  resolve a run from its build_system_id and Jenkins build number. This
  yields a stable, clickable Argus link that resolves at click-time even
  before the run reports its id back to Argus.
  

- **feature(cli/test): show Argus run link on --wait**
  Print the Argus run URL for started builds when using --wait, for both
  single execute and plan fan-out. Poll interval is bumped from 2s to 3s.
  

- **feature(service/jenkins): guess next build number on trigger**
  Add JenkinsService.next_build_number and let the build endpoint return it
  on demand (includeBuildNumber), so callers can derive a stable Argus run
  link right after triggering, before the build leaves the queue. Resolving
  the number is best-effort and never fails the trigger.
  

- **feature(cli/test): show guessed Argus run link on non-wait execute**
  A single 'test execute' without --wait now prints the queue item plus the
  guessed build number and Argus run URL, obtained by opting into the
  backend's next-build-number guess. The link resolves at click-time, so a
  rare wrong guess just 404s briefly. Fan-out output is unchanged.
  