### PR TITLE
feature(deploy): rotate and compress argus logs weekly

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,11 @@ WARNING: `start_argus.sh` assumes pyenv is installed into `~/.pyenv`
 sudo systemctl daemon-reload
 sudo systemctl enable --now argus.service
 ```
+
+`uwsgi.ini` logs to `/var/log/argus/argus.log`; make sure that directory exists and is writable by the `argus` user, then install log rotation by copying `docs/config/argus.logrotate` to `/etc/logrotate.d/argus`:
+
+```bash
+sudo mkdir -p /var/log/argus
+sudo chown argus:argus /var/log/argus
+sudo cp docs/config/argus.logrotate /etc/logrotate.d/argus
+```

--- a/docs/config/argus.logrotate
+++ b/docs/config/argus.logrotate
@@ -1,0 +1,9 @@
+/var/log/argus/argus.log {
+    daily
+    rotate 7
+    compress
+    delaycompress
+    missingok
+    notifempty
+    copytruncate
+}

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -4,6 +4,7 @@ env = PROMETHEUS_MULTIPROC_DIR=/tmp/promdb-argus-metrics
 lazy-apps = true
 enable-threads = true
 socket = /var/lib/argus/argus.sock
+logto = /var/log/argus/argus.log
 umask = 0007
 wsgi-file = argus_backend.py
 callable = argus_app


### PR DESCRIPTION
## Summary
- uwsgi previously logged only to journald, which was retaining prod logs for just 1 day
- `uwsgi.ini` now logs to `/var/log/argus/argus.log`
- Added `docs/config/argus.logrotate` (daily rotation, keep 7, compressed) alongside the existing `argus.service`/`argus.nginx.conf` deploy docs
- README updated with the steps to create the log directory and install the logrotate config on a new machine

## Test plan
- [ ] Deploy to a test host, confirm uwsgi writes to `/var/log/argus/argus.log`
- [ ] Run `logrotate -d /etc/logrotate.d/argus` to verify the config parses and rotation/compression rules apply as expected