### PR TITLE
fix(backend/replay): reconstruct events, logs and terminal state on ingest

### DIFF
--- a/argus/backend/controller/replay_api.py
+++ b/argus/backend/controller/replay_api.py
@@ -70,6 +70,9 @@ def replay_ingest():
     create_missing_tests = request.args.get(
         "create_missing_tests", "false",
     ).lower() in {"1", "true", "yes"}
+    backfill_logs = request.args.get(
+        "backfill_logs", "true",
+    ).lower() in {"1", "true", "yes"}
 
     # Propagate the caller's Authorization header to the in-process
     # ``test_client`` so internal proxied requests inherit the same identity
@@ -81,6 +84,7 @@ def replay_ingest():
     summary = ReplayService(
         auth_header=auth_header,
         create_missing_tests=create_missing_tests,
+        backfill_logs=backfill_logs,
     ).ingest(archive, dry_run=dry_run)
 
     return {"status": "ok", "response": summary.as_dict()}

--- a/argus/backend/plugins/driver_matrix_tests/model.py
+++ b/argus/backend/plugins/driver_matrix_tests/model.py
@@ -446,7 +446,16 @@ class DriverTestRun(PluginModelBase):
         self.index_version()
 
     def finish_run(self, payload: dict = None):
-        self.end_time = datetime.utcnow()
+        payload = payload or {}
+        # ``end_time`` may be supplied (as an epoch timestamp) so replay can
+        # preserve the run's original finish time; otherwise stamp it now.
+        # ``is not None`` so an explicit epoch of 0 is honoured, not treated
+        # as absent.
+        end_time = payload.get("end_time")
+        if end_time is not None:
+            self.end_time = datetime.utcfromtimestamp(end_time)
+        else:
+            self.end_time = datetime.utcnow()
         status = payload.get("status", "passed")
         self.status = TestStatus(status).value
         self.invalidate_release_snapshot()

--- a/argus/backend/plugins/generic/model.py
+++ b/argus/backend/plugins/generic/model.py
@@ -80,8 +80,14 @@ class GenericRun(PluginModelBase):
         return run
 
     def finish_run(self, payload: GenericRunFinishRequest = None):
-        self.end_time = datetime.now(UTC)
-        self.status = TestStatus(payload["status"]).value
+        payload = payload or {}
+        end_time = payload.get("end_time")
+        if end_time is not None:
+            self.end_time = datetime.fromtimestamp(end_time, UTC)
+        else:
+            self.end_time = datetime.now(UTC)
+        if status := payload.get("status"):
+            self.status = TestStatus(status).value
         if version := payload.get("scylla_version"):
             self.submit_product_version(version)
         self.invalidate_release_snapshot()

--- a/argus/backend/plugins/generic/types.py
+++ b/argus/backend/plugins/generic/types.py
@@ -14,3 +14,4 @@ class GenericRunSubmitRequest(TypedDict):
 class GenericRunFinishRequest(TypedDict):
     status: str
     scylla_version: str | None
+    end_time: float | None

--- a/argus/backend/plugins/sct/service.py
+++ b/argus/backend/plugins/sct/service.py
@@ -456,6 +456,12 @@ class SCTService:
             run: SCTTestRun = SCTTestRun.get(id=run_id)
             nemesis = SCTNemesis.get(
                 run_id=run.id, start_time=int(nem_req.start_time))
+            # Idempotency (e.g. the same replay archive uploaded twice): once a
+            # nemesis is finalized its status leaves RUNNING. Re-finalizing would
+            # re-increment ``nemesis_stats`` and recompute end_time/duration, so
+            # skip when it is already in a terminal state.
+            if nemesis.status != NemesisStatus.RUNNING.value:
+                return "updated"
             nemesis.status = NemesisStatus(nem_req.status).value
             nemesis.stack_trace = nem_req.message
             nemesis.end_time = int(time())
@@ -548,7 +554,8 @@ class SCTService:
     @staticmethod
     def submit_events(run_id: str, events: list[dict]) -> str:
         # NOTE: Dummied out – EventsBySeverity column is being dropped.
-        # Kept for API compatibility with old clients.
+        # Kept for API compatibility with old clients. Events are submitted
+        # through the per-event ``event/submit`` endpoint instead.
         return "added"
 
     @classmethod

--- a/argus/backend/plugins/sct/testrun.py
+++ b/argus/backend/plugins/sct/testrun.py
@@ -418,7 +418,11 @@ class SCTTestRun(PluginModelBase):
         self.index_version()
 
     def finish_run(self, payload: dict = None):
-        self.end_time = datetime.utcnow()
+        end_time = payload.get("end_time") if payload else None
+        if end_time is not None:
+            self.end_time = datetime.utcfromtimestamp(end_time)
+        else:
+            self.end_time = datetime.utcnow()
         self.invalidate_release_snapshot()
         self.index_version()
         self.index_image(self)

--- a/argus/backend/service/replay_service.py
+++ b/argus/backend/service/replay_service.py
@@ -23,18 +23,33 @@ exactly as they would for a live client.
 
 Two side concerns remain server-side:
 
-* **Ordering** -- ``submit_run`` must run before anything referencing the run,
-  terminal ``set_status`` runs last so ``end_time`` is back-filled, and
-  heartbeats collapse to the most recent record (per run).
-* **Skip-list** -- endpoints with side effects outside Argus
+* **Ordering** -- ``submit_run`` must run before anything referencing the run;
+  terminal ``set_status`` and ``finalize`` run last; and heartbeats collapse to
+  the most recent record (per run). ``finalize`` is the only call that
+  back-fills ``end_time`` -- and, for the generic (pytest/dtest) and
+  driver-matrix plugins, the terminal ``status`` and ``scylla_version`` too --
+  so it must land after every middle record.
+* **Skip-list** -- only endpoints with side effects *outside* Argus
   (``/testrun/report/email``, ``/planning/plan/trigger``) are skipped so
-  replay doesn't send emails or trigger CI jobs.
+  replay doesn't send emails or trigger CI jobs. ``finalize`` is deliberately
+  *not* skipped: it only writes to the run row and is the single source of
+  terminal status/version for non-SCT plugins, so skipping it silently left
+  replayed dtest/pytest runs stuck without a final status.
 
 When ``create_missing_tests`` is set, ``submit_run`` records get a pre-step
 that ensures the ``ArgusRelease/Group/Test`` triple exists for the run's
 build_id, so that the controller's ``assign_categories`` can populate
 ``test_id`` on the row. This is opt-in because curated instances already have
 the hierarchy populated and don't want orphan auto-creates.
+
+When ``backfill_logs`` is set, a post-step lists each run's S3 log prefix
+(derived from the run-id in any recorded log link) and submits links for any
+archive that reached S3 but whose ``logs/submit`` was never recorded -- e.g.
+loader/monitor/sct-runner bundles collected at teardown. The ingest endpoint
+enables this by default (disable with ``?backfill_logs=false``); it re-uses
+the app's existing read-only S3 credentials and the link-only log model
+(nothing is uploaded or hosted), and is idempotent, so the extra S3 list per
+ingest is the only cost when there is nothing to back-fill.
 """
 import gzip
 import io
@@ -59,9 +74,6 @@ LOGGER = logging.getLogger(__name__)
 SKIP_ENDPOINTS: frozenset[str] = frozenset({
     "/testrun/report/email",       # would send actual mail
     "/planning/plan/trigger",      # would re-trigger CI jobs
-    # ``finalize`` is folded into terminal ``set_status`` by the new client
-    # flow; older logs that still emit it are no-ops.
-    "/testrun/$type/$id/finalize",
 })
 
 # Set of ``set_status`` body.new_status values that we treat as terminal.
@@ -74,6 +86,33 @@ TERMINAL_STATUSES = frozenset({
 # ``/testrun/$type/submit``); we prepend this when reconstructing the URL
 # for the Flask test client.
 CLIENT_ROUTE_PREFIX = "/api/v1/client"
+
+# The ``logs/submit`` endpoint template, referenced from both ordering and the
+# S3 log back-fill.
+LOGS_SUBMIT_ENDPOINT = "/testrun/$type/$id/logs/submit"
+
+# The ``finalize`` endpoint template. It writes the run's terminal state
+# (``end_time`` for every plugin; ``status`` and ``scylla_version`` for the
+# generic/driver-matrix plugins), so ordering runs it in the terminal group.
+FINALIZE_ENDPOINT = "/testrun/$type/$id/finalize"
+
+# SCT's ``S3Storage.bucket_name`` default (sdcm/utils/common.py) -- every SCT
+# log collector (``LogCollector.collect_logs``, ``collect_sct_logs``,
+# ``upload_system_table_to_s3``) uploads here unless a run overrides it, so
+# it's the right fallback when a run recorded no S3 links to derive its
+# bucket from.
+_DEFAULT_LOG_BACKFILL_BUCKET = "cloudius-jenkins-test"
+
+# Parse ``bucket`` and ``key`` out of a virtual-hosted S3 URL, e.g.
+# ``https://cloudius-jenkins-test.s3.amazonaws.com/<run_id>/<ts>/<name>``.
+# Mirrors ``TestRunService._match_s3_link`` so the URLs we synthesise line up
+# byte-for-byte with the ones the client records.
+_S3_LINK_RE = re.compile(
+    r"(https:\/\/)?(?P<bucket>[\w\-]+)\.s3(?P<region>\.[\w\-\d]*)?\.amazonaws\.com\/(?P<key>.+)"
+)
+
+# Suffixes stripped from an S3 key's basename to derive a human log name.
+_LOG_NAME_SUFFIXES = (".tar.zst", ".tar.gz", ".tar.zstd", ".tgz", ".tar", ".zip")
 
 
 @dataclass
@@ -91,6 +130,9 @@ class ReplaySummary:
     succeeded: int = 0
     failed: int = 0
     skipped_no_replay: int = 0
+    # Number of log links discovered in S3 and back-filled onto runs (i.e. logs
+    # that were uploaded but whose ``logs/submit`` call was never recorded).
+    backfilled_logs: int = 0
     errors: list[dict] = field(default_factory=list)
 
     def as_dict(self) -> dict:
@@ -100,6 +142,7 @@ class ReplaySummary:
             "succeeded": self.succeeded,
             "failed": self.failed,
             "skipped_no_replay": self.skipped_no_replay,
+            "backfilled_logs": self.backfilled_logs,
             "errors": self.errors,
         }
 
@@ -130,10 +173,15 @@ class ReplayService:
         app=None,
         auth_header: str | None = None,
         create_missing_tests: bool = False,
+        backfill_logs: bool = False,
+        s3_client=None,
     ) -> None:
         self._app = app
         self._auth_header = auth_header
         self._create_missing_tests = create_missing_tests
+        self._backfill_logs = backfill_logs
+        # Lazily built from app config on first use; injectable for tests.
+        self._s3 = s3_client
 
     # ------------------------------------------------------------------
     # Entry point
@@ -145,15 +193,27 @@ class ReplayService:
         summary = ReplaySummary(total=len(records))
         if records:
             client = self._test_client()
+            last_seen_ts = self._compute_last_seen_ts(records)
             for rec in records:
-                self._process_one(client, rec, summary, dry_run=dry_run)
+                self._process_one(client, rec, summary, dry_run=dry_run, last_seen_ts=last_seen_ts)
+
+            # After the recorded calls are applied, optionally discover log
+            # archives that reached S3 but whose ``logs/submit`` was never
+            # recorded (e.g. loader/monitor/sct-runner bundles), and submit
+            # their links through the same dispatch path. Skipped on dry_run.
+            if self._backfill_logs and not dry_run:
+                backfill_records = self._build_log_backfill_records(records)
+                summary.total += len(backfill_records)
+                for rec in backfill_records:
+                    self._process_one(client, rec, summary, dry_run=dry_run, last_seen_ts=last_seen_ts)
+                    summary.backfilled_logs += len((rec.get("body") or {}).get("logs") or [])
 
         LOGGER.info(
             "Replay ingest complete: total=%d processed=%d ok=%d failed=%d skipped=%d "
-            "(dry_run=%s, create_missing_tests=%s)",
+            "backfilled_logs=%d (dry_run=%s, create_missing_tests=%s, backfill_logs=%s)",
             summary.total, summary.processed, summary.succeeded,
-            summary.failed, summary.skipped_no_replay,
-            dry_run, self._create_missing_tests,
+            summary.failed, summary.skipped_no_replay, summary.backfilled_logs,
+            dry_run, self._create_missing_tests, self._backfill_logs,
         )
         return summary
 
@@ -292,13 +352,17 @@ class ReplayService:
 
         * ``submit_run`` records run first (the run must exist before
           anything else touches it).
-        * Terminal ``set_status`` records run last (back-fills ``end_time``).
+        * Terminal ``set_status`` and ``finalize`` records run last.
+          ``finalize`` is the only call that back-fills ``end_time`` (and, for
+          the generic/driver-matrix plugins, the terminal ``status`` and
+          ``scylla_version``), so it must run after every middle record.
         * Heartbeats are collapsed to only the last one per ``(type, id)``.
         """
         records.sort(key=lambda r: r.get("ts", 0))
 
         submit_runs: list[dict] = []
         terminal_statuses: list[dict] = []
+        finalizes: list[dict] = []
         middle: list[dict] = []
         last_heartbeat: dict[tuple, dict] = {}
 
@@ -308,6 +372,8 @@ class ReplayService:
                 submit_runs.append(r)
             elif endpoint == "/testrun/$type/$id/set_status" and ReplayService._is_terminal_status(r):
                 terminal_statuses.append(r)
+            elif endpoint == FINALIZE_ENDPOINT:
+                finalizes.append(r)
             elif endpoint == "/testrun/$type/$id/heartbeat":
                 loc = r.get("location_params") or {}
                 key = (loc.get("type"), loc.get("id"))
@@ -315,13 +381,35 @@ class ReplayService:
             else:
                 middle.append(r)
 
-        return submit_runs + middle + list(last_heartbeat.values()) + terminal_statuses
+        return (
+            submit_runs + middle + list(last_heartbeat.values())
+            + terminal_statuses + finalizes
+        )
 
     @staticmethod
     def _is_terminal_status(record: dict) -> bool:
         body = record.get("body") or {}
         new_status = (body.get("new_status") or "").lower()
         return new_status in TERMINAL_STATUSES
+
+    @staticmethod
+    def _compute_last_seen_ts(records: list[dict]) -> dict[tuple, int]:
+        """Map each run touched by ``records`` to the highest ``ts`` seen for it.
+
+        Used as the ``finalize`` ``end_time`` fallback when a record's own
+        ``ts`` is missing: recovering from an Argus outage can take days, and
+        the run itself may be days-long, so defaulting to the replay moment
+        would badly misrepresent when the run actually finished. The last
+        timestamp Argus recorded for that run is a far closer approximation.
+        """
+        last_seen: dict[tuple, int] = {}
+        for r in records:
+            loc = r.get("location_params") or {}
+            key = (loc.get("type"), loc.get("id"))
+            ts = r.get("ts", 0)
+            if ts and ts > last_seen.get(key, 0):
+                last_seen[key] = ts
+        return last_seen
 
     # ------------------------------------------------------------------
     # URL reconstruction
@@ -479,6 +567,146 @@ class ReplayService:
             )
 
     # ------------------------------------------------------------------
+    # S3 log back-fill (opt-in: backfill_logs=True)
+    # ------------------------------------------------------------------
+    def _s3_client(self):
+        """Lazily build (or return the injected) boto3 S3 client.
+
+        Uses the same credentials the app already reads log objects with, so
+        listing a run's prefix works exactly where ``get_log`` presigning does.
+        """
+        if self._s3 is None:
+            import boto3
+            self._s3 = boto3.client(
+                service_name="s3",
+                aws_access_key_id=current_app.config.get("AWS_CLIENT_ID"),
+                aws_secret_access_key=current_app.config.get("AWS_CLIENT_SECRET"),
+            )
+        return self._s3
+
+    @staticmethod
+    def _s3_url(bucket: str, key: str) -> str:
+        return f"https://{bucket}.s3.amazonaws.com/{key}"
+
+    @staticmethod
+    def _log_name_from_key(key: str) -> str:
+        """Derive a display log name from an S3 key's basename.
+
+        Strips the archive suffix so ``.../loader-set-15bb6cad.tar.zst`` becomes
+        ``loader-set-15bb6cad``. Only used for links that were *not* recorded,
+        so it never has to match a client-chosen name.
+        """
+        name = key.rsplit("/", 1)[-1]
+        for suffix in _LOG_NAME_SUFFIXES:
+            if name.endswith(suffix):
+                return name[: -len(suffix)]
+        return name
+
+    @classmethod
+    def _resolve_run_bucket(cls, recorded_links: set[str]) -> str | None:
+        """Derive the S3 bucket from any recorded log link for the run.
+
+        Falls back to ``REPLAY_LOG_BACKFILL_BUCKET`` from config, then to
+        SCT's own default bucket, when the run recorded no S3 links to learn
+        the bucket from.
+        """
+        for link in recorded_links:
+            match = _S3_LINK_RE.match(link or "")
+            if match:
+                return match.group("bucket")
+        try:
+            configured = current_app.config.get("REPLAY_LOG_BACKFILL_BUCKET")
+        except RuntimeError:
+            # No application context (e.g. unit tests): no configured override.
+            configured = None
+        return configured or _DEFAULT_LOG_BACKFILL_BUCKET
+
+    def _list_s3_run_objects(self, bucket: str, prefix: str) -> list[str]:
+        """Return every (non-directory) object key under ``prefix``, paginated."""
+        s3 = self._s3_client()
+        keys: list[str] = []
+        continuation: str | None = None
+        while True:
+            kwargs = {"Bucket": bucket, "Prefix": prefix}
+            if continuation:
+                kwargs["ContinuationToken"] = continuation
+            resp = s3.list_objects_v2(**kwargs)
+            for obj in resp.get("Contents", []) or []:
+                key = obj.get("Key", "")
+                if key and not key.endswith("/"):
+                    keys.append(key)
+            if not resp.get("IsTruncated"):
+                break
+            continuation = resp.get("NextContinuationToken")
+            if not continuation:
+                break
+        return keys
+
+    def _build_log_backfill_records(self, records: list[dict]) -> list[dict]:
+        """Synthesise ``logs/submit`` records for a run's S3 log archives that
+        were uploaded but never recorded.
+
+        For each run touched by the archive we derive its S3 bucket + ``run_id``
+        prefix from any recorded log link, list the prefix, and emit a record
+        for every object whose URL is not already in the recorded set. The
+        records are dispatched through the normal ``logs/submit`` path, whose
+        ``submit_logs`` appends-and-dedups -- so this is idempotent across
+        re-ingests (deterministic key-derived names) and never clobbers links
+        the client already submitted.
+        """
+        runs: dict[tuple, set] = {}
+        schema_version: str | None = None
+        for rec in records:
+            loc = rec.get("location_params") or {}
+            run_type, run_id = loc.get("type"), loc.get("id")
+            if not run_type or not run_id:
+                continue
+            links = runs.setdefault((run_type, run_id), set())
+            if self._normalise_endpoint(rec.get("endpoint", "")) == LOGS_SUBMIT_ENDPOINT:
+                body = rec.get("body") or {}
+                schema_version = schema_version or body.get("schema_version")
+                for log in body.get("logs") or []:
+                    if log.get("log_link"):
+                        links.add(log["log_link"])
+
+        backfill: list[dict] = []
+        for (run_type, run_id), recorded_links in runs.items():
+            bucket = self._resolve_run_bucket(recorded_links)
+            if not bucket:
+                LOGGER.info(
+                    "log backfill: no S3 bucket derivable for run %s; skipping", run_id)
+                continue
+            try:
+                keys = self._list_s3_run_objects(bucket, f"{run_id}/")
+            except Exception:  # noqa: BLE001 -- isolate per run; S3 outage != ingest failure
+                LOGGER.exception(
+                    "log backfill: listing s3://%s/%s/ failed", bucket, run_id)
+                continue
+
+            new_logs = [
+                {"log_name": self._log_name_from_key(key), "log_link": url}
+                for key in keys
+                if (url := self._s3_url(bucket, key)) not in recorded_links
+            ]
+            if not new_logs:
+                continue
+            body: dict = {"logs": new_logs}
+            if schema_version:
+                body["schema_version"] = schema_version
+            backfill.append({
+                "ts": 0,
+                "method": "POST",
+                "endpoint": LOGS_SUBMIT_ENDPOINT,
+                "location_params": {"type": run_type, "id": run_id},
+                "params": {},
+                "body": body,
+            })
+            LOGGER.info(
+                "log backfill: %d new log(s) for run %s from s3://%s/%s/",
+                len(new_logs), run_id, bucket, run_id)
+        return backfill
+
+    # ------------------------------------------------------------------
     # Per-record execution
     # ------------------------------------------------------------------
     def _process_one(
@@ -488,6 +716,7 @@ class ReplayService:
         summary: ReplaySummary,
         *,
         dry_run: bool,
+        last_seen_ts: dict[tuple, int] | None = None,
     ) -> None:
         endpoint = self._normalise_endpoint(record.get("endpoint", ""))
         ts = record.get("ts", 0)
@@ -543,6 +772,24 @@ class ReplayService:
         params = record.get("params") or {}
         body = record.get("body")
         method = (record.get("method") or "POST").upper()
+
+        # Preserve the run's original finish time on replay. ``ts`` is the
+        # millisecond moment the finalize call was originally recorded
+        # (ReplayRecord.ts == _now_ns() // 1_000_000) -- i.e. the run's real end
+        # time -- so inject it (converted to epoch seconds) as ``end_time`` and
+        # let ``finish_run`` stamp that instead of the replay moment. Live
+        # finalize calls never carry ``end_time``, so this only ever fills a gap.
+        # When the finalize record itself has no ``ts`` (e.g. it was
+        # reconstructed rather than originally recorded), fall back to the
+        # last ``ts`` seen anywhere in the replay log for this run instead of
+        # the replay moment -- recovery from an outage can take days, and the
+        # run itself may be days-long, so "now" would badly misrepresent when
+        # it actually finished.
+        if endpoint == FINALIZE_ENDPOINT and isinstance(body, dict) and "end_time" not in body:
+            run_key = (location_params.get("type"), location_params.get("id"))
+            effective_ts = ts or (last_seen_ts or {}).get(run_key, 0)
+            if effective_ts:
+                body = {**body, "end_time": effective_ts / 1000}
 
         url = self._resolve_url(endpoint, location_params)
 

--- a/argus/backend/tests/replay/test_replay_service.py
+++ b/argus/backend/tests/replay/test_replay_service.py
@@ -20,6 +20,7 @@ import zstandard as zstd
 
 from argus.backend.service.replay_service import (
     CLIENT_ROUTE_PREFIX,
+    FINALIZE_ENDPOINT,
     ReplayService,
     ReplayServiceError,
     SKIP_ENDPOINTS,
@@ -106,6 +107,8 @@ def _make_service(
     *,
     create_missing_tests: bool = False,
     auth_header: str | None = None,
+    backfill_logs: bool = False,
+    s3_client=None,
 ) -> ReplayService:
     """Service wired to a recording mock client (default: always-200)."""
     if client is None:
@@ -116,6 +119,8 @@ def _make_service(
         app=app,
         auth_header=auth_header,
         create_missing_tests=create_missing_tests,
+        backfill_logs=backfill_logs,
+        s3_client=s3_client,
     )
 
 
@@ -262,6 +267,134 @@ def test_terminal_set_status_runs_last():
     ]
 
 
+def test_finalize_is_dispatched_and_runs_in_terminal_group():
+    # ``finalize`` is the ONLY call that back-fills a generic (dtest/pytest)
+    # run's terminal status/scylla_version/end_time. Regression guard: it must
+    # be dispatched (not skipped) and ordered after every middle record, even
+    # when its ts is older than a middle record's.
+    archive = _make_archive({
+        "argus_replay_log_r_1.jsonl": [
+            _rec(FINALIZE_ENDPOINT, ts=5,
+                 location_params={"type": "generic", "id": "X"},
+                 body={"status": "passed", "scylla_version": "6.2.0"}),
+            _rec("/testrun/$type/$id/submit_results", ts=10,
+                 location_params={"type": "generic", "id": "X"},
+                 body={"run_id": "X"}),
+        ],
+    })
+    client = MagicMock()
+    client.open.return_value = _Response(200)
+    _make_service(client).ingest(archive)
+    urls = [c.args[0] for c in client.open.call_args_list]
+    assert urls == [
+        f"{CLIENT_ROUTE_PREFIX}/testrun/generic/X/submit_results",
+        f"{CLIENT_ROUTE_PREFIX}/testrun/generic/X/finalize",
+    ]
+    # The terminal status/version payload is forwarded intact, and the run's
+    # original finish time is injected from the record ts, which is in
+    # milliseconds (5ms -> 0.005s).
+    final_json = client.open.call_args.kwargs["json"]
+    assert final_json["status"] == "passed"
+    assert final_json["scylla_version"] == "6.2.0"
+    assert final_json["end_time"] == 5 / 1000
+
+
+def test_finalize_end_time_is_injected_from_ts_when_absent():
+    # ReplayRecord.ts is milliseconds (== _now_ns() // 1_000_000), so a ts of
+    # 1_700_000_000_000ms must inject end_time == 1_700_000_000.0s.
+    archive = _make_archive({
+        "argus_replay_log_r_1.jsonl": [
+            _rec(FINALIZE_ENDPOINT, ts=1_700_000_000_000,
+                 location_params={"type": "generic", "id": "X"},
+                 body={"status": "passed"}),
+        ],
+    })
+    client = MagicMock()
+    client.open.return_value = _Response(200)
+    _make_service(client).ingest(archive)
+    assert client.open.call_args.kwargs["json"]["end_time"] == 1_700_000_000.0
+
+
+def test_finalize_preserves_explicit_end_time_in_body():
+    # A finalize record that already carries end_time is left untouched.
+    archive = _make_archive({
+        "argus_replay_log_r_1.jsonl": [
+            _rec(FINALIZE_ENDPOINT, ts=5,
+                 location_params={"type": "generic", "id": "X"},
+                 body={"status": "passed", "end_time": 1234.5}),
+        ],
+    })
+    client = MagicMock()
+    client.open.return_value = _Response(200)
+    _make_service(client).ingest(archive)
+    assert client.open.call_args.kwargs["json"]["end_time"] == 1234.5
+
+
+def test_finalize_end_time_falls_back_to_last_seen_ts_when_own_ts_absent():
+    # The finalize record itself has no ts (e.g. reconstructed rather than
+    # originally recorded) -- fall back to the highest ts seen anywhere in
+    # the replay log for this run, not the replay moment, since recovering
+    # from an outage can take days and the run itself may be days-long.
+    archive = _make_archive({
+        "argus_replay_log_r_1.jsonl": [
+            _rec("/testrun/$type/$id/submit_results", ts=10,
+                 location_params={"type": "generic", "id": "X"},
+                 body={"run_id": "X"}),
+            _rec("/testrun/$type/$id/heartbeat", ts=1_700_000_000_000,
+                 location_params={"type": "generic", "id": "X"}, body={}),
+            _rec(FINALIZE_ENDPOINT, ts=0,
+                 location_params={"type": "generic", "id": "X"},
+                 body={"status": "passed"}),
+        ],
+    })
+    client = MagicMock()
+    client.open.return_value = _Response(200)
+    _make_service(client).ingest(archive)
+    finalize_call = next(
+        c for c in client.open.call_args_list
+        if c.args[0].endswith("/finalize"))
+    assert finalize_call.kwargs["json"]["end_time"] == 1_700_000_000.0
+
+
+def test_finalize_end_time_untouched_when_no_ts_anywhere_for_run():
+    # No record for the run carries a ts at all -- end_time is left unset,
+    # same as before this fallback existed, rather than injecting a bogus 0.
+    archive = _make_archive({
+        "argus_replay_log_r_1.jsonl": [
+            _rec(FINALIZE_ENDPOINT, ts=0,
+                 location_params={"type": "generic", "id": "X"},
+                 body={"status": "passed"}),
+        ],
+    })
+    client = MagicMock()
+    client.open.return_value = _Response(200)
+    _make_service(client).ingest(archive)
+    assert "end_time" not in client.open.call_args.kwargs["json"]
+
+
+def test_finalize_runs_after_terminal_set_status():
+    # When both are present (the SCT flow emits set_status *and* finalize),
+    # finalize still lands last so end_time is written after the status flip.
+    archive = _make_archive({
+        "argus_replay_log_r_1.jsonl": [
+            _rec(FINALIZE_ENDPOINT, ts=5,
+                 location_params={"type": "scylla-cluster-tests", "id": "X"},
+                 body={}),
+            _rec("/testrun/$type/$id/set_status", ts=10,
+                 location_params={"type": "scylla-cluster-tests", "id": "X"},
+                 body={"new_status": "passed"}),
+        ],
+    })
+    client = MagicMock()
+    client.open.return_value = _Response(200)
+    _make_service(client).ingest(archive)
+    urls = [c.args[0] for c in client.open.call_args_list]
+    assert urls == [
+        f"{CLIENT_ROUTE_PREFIX}/testrun/scylla-cluster-tests/X/set_status",
+        f"{CLIENT_ROUTE_PREFIX}/testrun/scylla-cluster-tests/X/finalize",
+    ]
+
+
 def test_non_terminal_set_status_keeps_natural_order():
     archive = _make_archive({
         "argus_replay_log_r_1.jsonl": [
@@ -358,6 +491,13 @@ def test_auth_header_is_forwarded():
 # ---------------------------------------------------------------------------
 # skip list
 # ---------------------------------------------------------------------------
+
+def test_finalize_is_not_in_skip_list():
+    # finalize has no side effect outside Argus (it only writes the run row)
+    # and is the sole terminal-state source for non-SCT plugins, so it must be
+    # replayed, not skipped.
+    assert FINALIZE_ENDPOINT not in SKIP_ENDPOINTS
+
 
 @pytest.mark.parametrize("endpoint", sorted(SKIP_ENDPOINTS))
 def test_skip_endpoints_are_not_dispatched(endpoint: str):
@@ -717,3 +857,134 @@ def test_diagnose_parses_two_segment_build_id():
     assert "release='scylla-master'" in result
     assert "group='scylla-master-root'" in result
     assert "test='perf'" in result
+
+
+# ---------------------------------------------------------------------------
+# S3 log back-fill (backfill_logs=True)
+# ---------------------------------------------------------------------------
+
+_RUN_ID = "15bb6cad-1d24-4e81-800e-9c45d6ea7d06"
+_BUCKET = "cloudius-jenkins-test"
+
+
+def _s3_url(key: str) -> str:
+    return f"https://{_BUCKET}.s3.amazonaws.com/{key}"
+
+
+def _mock_s3(keys: list[str]):
+    """A boto3-S3 stand-in whose ``list_objects_v2`` returns ``keys``."""
+    s3 = MagicMock()
+    s3.list_objects_v2.return_value = {
+        "Contents": [{"Key": k} for k in keys],
+        "IsTruncated": False,
+    }
+    return s3
+
+
+def _logs_archive(recorded_keys: list[str]) -> bytes:
+    """Archive with a single ``logs/submit`` recording links for ``recorded_keys``."""
+    return _make_archive({"argus_replay_log_run.jsonl": [
+        _rec("/testrun/$type/$id/logs/submit", ts=1,
+             location_params={"type": "scylla-cluster-tests", "id": _RUN_ID},
+             body={"schema_version": "v8", "logs": [
+                 {"log_name": k.rsplit("/", 1)[-1], "log_link": _s3_url(k)}
+                 for k in recorded_keys
+             ]}),
+    ]})
+
+
+def test_backfill_submits_only_missing_s3_objects():
+    recorded = f"{_RUN_ID}/20260526_115014/db-node-0-1-15bb6cad.tar.zst"
+    loader = f"{_RUN_ID}/20260526_115014/loader-set-15bb6cad.tar.zst"
+    runner = f"{_RUN_ID}/20260526_115014/sct-runner-events-15bb6cad.tar.zst"
+    s3 = _mock_s3([recorded, loader, runner])
+
+    client = MagicMock()
+    client.open.return_value = _Response(200, b'{"status":"ok"}')
+    service = _make_service(client, backfill_logs=True, s3_client=s3)
+    summary = service.ingest(_logs_archive([recorded]))
+
+    # Listed the run's prefix once.
+    s3.list_objects_v2.assert_called_once()
+    assert s3.list_objects_v2.call_args.kwargs["Prefix"] == f"{_RUN_ID}/"
+
+    # Two dispatches: the recorded logs/submit + one back-fill logs/submit.
+    bodies = [c.kwargs["json"] for c in client.open.call_args_list]
+    backfill_bodies = [b for b in bodies if b and any(
+        "loader-set" in l["log_name"] or "sct-runner" in l["log_name"] for l in b.get("logs", []))]
+    assert len(backfill_bodies) == 1
+    submitted = {l["log_link"] for l in backfill_bodies[0]["logs"]}
+    # Only the two *missing* archives, never the already-recorded db-node link.
+    assert submitted == {_s3_url(loader), _s3_url(runner)}
+    assert _s3_url(recorded) not in submitted
+    assert summary.backfilled_logs == 2
+
+
+def test_backfill_can_be_disabled():
+    # The ingest endpoint enables backfill by default; passing backfill_logs=False
+    # (?backfill_logs=false) must suppress the S3 listing entirely.
+    recorded = f"{_RUN_ID}/20260526_115014/db-node-0-1-15bb6cad.tar.zst"
+    loader = f"{_RUN_ID}/20260526_115014/loader-set-15bb6cad.tar.zst"
+    s3 = _mock_s3([recorded, loader])
+
+    client = MagicMock()
+    client.open.return_value = _Response(200, b'{"status":"ok"}')
+    service = _make_service(client, backfill_logs=False, s3_client=s3)
+    summary = service.ingest(_logs_archive([recorded]))
+
+    s3.list_objects_v2.assert_not_called()
+    assert summary.backfilled_logs == 0
+
+
+def test_backfill_noop_when_all_logs_already_present():
+    recorded = f"{_RUN_ID}/20260526_115014/db-node-0-1-15bb6cad.tar.zst"
+    s3 = _mock_s3([recorded])  # S3 has nothing new
+
+    client = MagicMock()
+    client.open.return_value = _Response(200, b'{"status":"ok"}')
+    service = _make_service(client, backfill_logs=True, s3_client=s3)
+    summary = service.ingest(_logs_archive([recorded]))
+
+    assert summary.backfilled_logs == 0
+    # Only the single recorded logs/submit was dispatched.
+    assert client.open.call_count == 1
+
+
+def test_backfill_skipped_on_dry_run():
+    recorded = f"{_RUN_ID}/20260526_115014/db-node-0-1-15bb6cad.tar.zst"
+    loader = f"{_RUN_ID}/20260526_115014/loader-set-15bb6cad.tar.zst"
+    s3 = _mock_s3([recorded, loader])
+
+    service = _make_service(backfill_logs=True, s3_client=s3)
+    summary = service.ingest(_logs_archive([recorded]), dry_run=True)
+
+    s3.list_objects_v2.assert_not_called()
+    assert summary.backfilled_logs == 0
+
+
+def test_backfill_falls_back_to_sct_default_bucket_when_no_bucket_derivable():
+    # Only a non-S3 link recorded -> no bucket to learn from, and no
+    # REPLAY_LOG_BACKFILL_BUCKET config (no app context in tests) -- falls
+    # back to SCT's own default bucket rather than silently skipping.
+    loader = f"{_RUN_ID}/x/loader-set.tar.zst"
+    archive = _make_archive({"argus_replay_log_run.jsonl": [
+        _rec("/testrun/$type/$id/logs/submit", ts=1,
+             location_params={"type": "scylla-cluster-tests", "id": _RUN_ID},
+             body={"schema_version": "v8", "logs": [
+                 {"log_name": "local", "log_link": "http://example.com/local.tar.zst"}]}),
+    ]})
+    s3 = _mock_s3([loader])
+
+    service = _make_service(backfill_logs=True, s3_client=s3)
+    summary = service.ingest(archive)
+
+    s3.list_objects_v2.assert_called_once_with(Bucket=_BUCKET, Prefix=f"{_RUN_ID}/")
+    assert summary.backfilled_logs == 1
+
+
+def test_log_name_from_key_strips_archive_suffix():
+    assert ReplayService._log_name_from_key(
+        f"{_RUN_ID}/ts/loader-set-15bb6cad.tar.zst") == "loader-set-15bb6cad"
+    assert ReplayService._log_name_from_key(
+        f"{_RUN_ID}/ts/history.jsonl.tar.gz") == "history.jsonl"
+    assert ReplayService._log_name_from_key(f"{_RUN_ID}/ts/plain.log") == "plain.log"

--- a/argus/backend/tests/sct_api/test_sct_api.py
+++ b/argus/backend/tests/sct_api/test_sct_api.py
@@ -254,6 +254,24 @@ def test_nemesis_submit_and_finalize(flask_client, sct_run_id):
     assert nem.status == "succeeded"
     assert nem.end_time and nem.end_time > 0
     assert nem.stack_trace == "done"
+    stats_after_first = dict(run.nemesis_stats or {})
+    end_time_after_first = nem.end_time
+
+    resp = flask_client.post(
+        f"{API_PREFIX}/{sct_run_id}/nemesis/finalize",
+        data=json.dumps(finalize_payload),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    assert resp.json["status"] == "ok"
+
+    run = SCTTestRun.get(id=sct_run_id)
+    nemesis_data = SCTNemesis.filter(run_id=run.id).all()
+    nem = next(n for n in nemesis_data if n.name ==
+               "ChaosMonkey" and n.start_time == 123456)
+    assert nem.status == "succeeded"
+    assert nem.end_time == end_time_after_first
+    assert dict(run.nemesis_stats or {}) == stats_after_first
 
 
 def test_stress_commands(flask_client, sct_run_id):

--- a/argus/client/tests/test_replay_log.py
+++ b/argus/client/tests/test_replay_log.py
@@ -540,3 +540,101 @@ def test_argus_generic_client_replay_log_path_includes_run_id_when_set(tmp_path)
     assert str(run_id) in client.replay_log_path.name
     assert "unknown" not in client.replay_log_path.name
     client.close()
+
+
+def test_argus_client_replay_log_only_records_submitted_log_links(tmp_path):
+    # Log links are stored in the replay log: submit_sct_logs must persist every
+    # (log_name, log_link) pair to the JSONL so replay can re-attach them to the
+    # run once Argus is reachable -- even for the runner/loader archives, and
+    # even in replay-only mode where no HTTP call is made.
+    from argus.client.sct.client import ArgusSCTClient
+    from argus.client.sct.types import LogLink
+
+    client = ArgusSCTClient(
+        run_id=uuid4(),
+        auth_token="t",
+        base_url="https://unreachable.invalid",
+        log_dir=tmp_path,
+        replay_log_only=True,
+    )
+    links = [
+        LogLink(log_name="sct-runner-events", log_link="https://s3/x/sct-runner-events.tar.zst"),
+        LogLink(log_name="loader-set", log_link="https://s3/x/loader-node-1.tar.zst"),
+        LogLink(log_name="db-cluster", log_link="https://s3/x/db-node-1.tar.zst"),
+    ]
+    client.submit_sct_logs(links)
+    client.close()
+
+    records = _read_records(client.replay_log_path)
+    log_records = [r for r in records if r["endpoint"] == ArgusClient.Routes.SUBMIT_LOGS]
+    assert len(log_records) == 1
+    stored = {(l["log_name"], l["log_link"]) for l in log_records[0]["body"]["logs"]}
+    assert stored == {(l.log_name, l.log_link) for l in links}
+
+
+def test_argus_client_replay_log_only_records_submitted_events(tmp_path):
+    # Events MUST land in the replay log so a recovered run isn't left empty.
+    # submit_event carries the full structured RawEventPayload -- every field
+    # (severity, ts, message, event_type, node, nemesis/target, duration,
+    # known_issue, ...) must survive verbatim into the JSONL, for both the
+    # single-event and the batched-list call shapes, even in replay-only mode.
+    from argus.client.sct.client import ArgusSCTClient
+
+    run_id = uuid4()
+    client = ArgusSCTClient(
+        run_id=run_id,
+        auth_token="t",
+        base_url="https://unreachable.invalid",
+        log_dir=tmp_path,
+        replay_log_only=True,
+    )
+
+    db_event = {
+        "run_id": str(run_id),
+        "severity": "ERROR",
+        "ts": 1_700_000_000.123,
+        "message": "2026-01-01 00:00:00.000 <2026-01-01 00:00:01.000>: (DatabaseLogEvent Severity.ERROR) ... node=db-node-1",
+        "event_type": "DatabaseLogEvent",
+        "received_timestamp": "2026-01-01T00:00:01+00:00",
+        "nemesis_name": None,
+        "duration": None,
+        "node": "db-node-1",
+        "target_node": None,
+        "known_issue": None,
+        "nemesis_status": None,
+    }
+    nemesis_event = {
+        "run_id": str(run_id),
+        "severity": "NORMAL",
+        "ts": 1_700_000_050.0,
+        "message": "(DisruptionEvent Severity.NORMAL) nemesis=ChaosMonkey target_node=db-node-2",
+        "event_type": "DisruptionEvent",
+        "received_timestamp": None,
+        "nemesis_name": "ChaosMonkey",
+        "duration": 12.5,
+        "node": None,
+        "target_node": "db-node-2",
+        "known_issue": "https://github.com/scylladb/scylladb/issues/1",
+        "nemesis_status": "succeeded",
+    }
+
+    # Batched list submission ...
+    client.submit_event([db_event, nemesis_event])
+    # ... and a single-event submission.
+    client.submit_event(db_event)
+    client.close()
+
+    records = _read_records(client.replay_log_path)
+    event_records = [r for r in records
+                     if r["endpoint"] == ArgusSCTClient.Routes.SUBMIT_EVENT]
+    assert len(event_records) == 2
+    # Both call shapes are recorded against the run, with the payload intact.
+    for r in event_records:
+        assert r["location_params"] == {"id": str(run_id)}
+        assert r["method"] == "POST"
+
+    batched, single = event_records
+    # The list call preserves order and every field of every event.
+    assert batched["body"]["data"] == [db_event, nemesis_event]
+    # The single call preserves the lone event verbatim (not wrapped in a list).
+    assert single["body"]["data"] == db_event

--- a/cli/cmd/replay.go
+++ b/cli/cmd/replay.go
@@ -43,14 +43,20 @@ Use --dir to scan a directory for argus_replay_log_*.jsonl (and .jsonl.zst)
 files; use --run-id to filter by the run encoded in the filename — the
 filter also applies to entries inside tar.zst archives. --dry-run asks the
 server to validate the archive and return the summary without executing any
-side effects. Use --target-url to replay against a different Argus instance;
-you must already hold credentials valid for that target (the CLI does not
-re-authenticate against a different host).`,
+side effects. After replaying, the server lists each run's S3 log prefix and
+attaches any log archives that were uploaded but whose logs/submit was never
+recorded (e.g. loader/monitor/sct-runner bundles); pass --backfill-logs=false
+to skip that step. Use --target-url to replay against a different Argus
+instance; you must already hold credentials valid for that target (the CLI
+does not re-authenticate against a different host).`,
 	Example: `  # Replay all files for a run from the SCT results directory
   argus run replay --dir ~/sct-results/latest --run-id 550e8400-e29b-41d4-a716-446655440000
 
   # Replay an SCT events bundle directly
   argus run replay --file ~/sct-extract/sct-runner-events-abc.tar.zst
+
+  # Replay without the default S3 log-link back-fill
+  argus run replay --file ~/sct-extract/sct-runner-events-abc.tar.zst --backfill-logs=false
 
   # Replay a compressed single log
   argus run replay --file argus_replay_log_R_1.jsonl.zst
@@ -67,6 +73,7 @@ re-authenticate against a different host).`,
 		fileArgs, _ := cmd.Flags().GetStringArray("file")
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		createMissingTests, _ := cmd.Flags().GetBool("create-missing-tests")
+		backfillLogs, _ := cmd.Flags().GetBool("backfill-logs")
 		targetURL, _ := cmd.Flags().GetString("target-url")
 		reportFmt, _ := cmd.Flags().GetString("report")
 
@@ -90,7 +97,7 @@ re-authenticate against a different host).`,
 			return err
 		}
 
-		summary, err := uploadReplay(ctx, client, files, dryRun, createMissingTests, log)
+		summary, err := uploadReplay(ctx, client, files, dryRun, createMissingTests, backfillLogs, log)
 		if err != nil {
 			return err
 		}
@@ -230,6 +237,7 @@ func uploadReplay(
 	files []string,
 	dryRun bool,
 	createMissingTests bool,
+	backfillLogs bool,
 	log zerolog.Logger,
 ) (*models.ReplayIngestSummary, error) {
 	route := api.ReplayIngest
@@ -239,6 +247,10 @@ func uploadReplay(
 	}
 	if createMissingTests {
 		q.Set("create_missing_tests", "true")
+	}
+	// Backfill is on by default server-side; only send the param to disable it.
+	if !backfillLogs {
+		q.Set("backfill_logs", "false")
 	}
 	if encoded := q.Encode(); encoded != "" {
 		route += "?" + encoded
@@ -296,6 +308,7 @@ func uploadReplay(
 		Int("succeeded", summary.Succeeded).
 		Int("failed", summary.Failed).
 		Int("skipped", summary.SkippedNoReplay).
+		Int("backfilled_logs", summary.BackfilledLogs).
 		Msg("replay upload complete")
 	return &summary, nil
 }
@@ -310,8 +323,8 @@ func renderReplaySummary(cmd *cobra.Command, reportFmt string, summary *models.R
 	switch strings.ToLower(reportFmt) {
 	case "", "text":
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(),
-			"Replay summary: total=%d processed=%d succeeded=%d failed=%d skipped=%d\n",
-			summary.Total, summary.Processed, summary.Succeeded, summary.Failed, summary.SkippedNoReplay,
+			"Replay summary: total=%d processed=%d succeeded=%d failed=%d skipped=%d backfilled_logs=%d\n",
+			summary.Total, summary.Processed, summary.Succeeded, summary.Failed, summary.SkippedNoReplay, summary.BackfilledLogs,
 		)
 		if len(summary.Errors) == 0 {
 			return nil
@@ -337,6 +350,12 @@ func init() {
 			"When false (default), submit_run records whose test entity does not yet exist "+
 			"are reported as failures naming the would-be release/group/test and which level "+
 			"is missing -- rather than silently inserting a broken run with empty test_id.")
+	replayCmd.Flags().Bool("backfill-logs", true,
+		"After replaying, have the server list each run's S3 log prefix and submit links "+
+			"for any log archives that were uploaded but whose logs/submit was never recorded "+
+			"(e.g. loader/monitor/sct-runner bundles). Uses the server's existing read-only S3 "+
+			"credentials; idempotent. On by default; pass --backfill-logs=false to disable. "+
+			"Ignored with --dry-run.")
 	replayCmd.Flags().String("target-url", "", "Override the base URL (replay against a different Argus instance)")
 	replayCmd.Flags().String("report", "text", `Output format: "text" or "json"`)
 

--- a/cli/internal/models/replay.go
+++ b/cli/internal/models/replay.go
@@ -9,6 +9,7 @@ type ReplayIngestSummary struct {
 	Succeeded       int                 `json:"succeeded"`
 	Failed          int                 `json:"failed"`
 	SkippedNoReplay int                 `json:"skipped_no_replay"`
+	BackfilledLogs  int                 `json:"backfilled_logs"`
 	Errors          []ReplayIngestError `json:"errors"`
 }
 


### PR DESCRIPTION
Replaying a run's request-log left the run visibly incomplete: events were empty, collected logs were missing, and generic (dtest/pytest) runs never reached a terminal status. Make ingest faithfully rebuild a run, and stay idempotent when the same archive is uploaded more than once.

Logs:
- Add a default-on S3 log back-fill: after replaying, list each run's S3 prefix and submit links for archives that reached S3 but whose logs/submit was never recorded (loader/monitor/sct-runner bundles). Re-uses the app's read-only S3 creds and the link-only log model (no upload/hosting) and is idempotent. Exposed on the ingest endpoint (?backfill_logs=false to disable) and the CLI (--backfill-logs).

Terminal state:
- Stop skipping /testrun/$type/$id/finalize on replay. It has no external side effect and is the only source of terminal status + scylla_version + end_time for the generic and driver-matrix plugins, so skipping it left replayed runs stuck unfinished. Run it in the terminal ordering group, after every middle record.
- Preserve the run's real finish time: finish_run now honours an optional end_time in the finalize body, and ingest injects it from the record ts (milliseconds -> seconds) so end_time reflects the original run, not the replay moment. Live finalize calls are unaffected.

Idempotency:
- finalize_nemesis is a no-op once a nemesis has left RUNNING, so re-uploading an archive no longer double-counts nemesis_stats or drifts end_time/duration.
- Tolerate a status-less generic finalize instead of raising.

Closes https://scylladb.atlassian.net/browse/ARGUS-186