### PR TITLE
fix(json-encoder): serialize bytes instead of raising TypeError

### DIFF
--- a/argus/backend/tests/test_encoders.py
+++ b/argus/backend/tests/test_encoders.py
@@ -1,0 +1,19 @@
+import json
+
+import pytest
+
+from argus.backend.util.encoders import ArgusJSONEncoder
+
+
+def test_encoder_decodes_bytes_to_str():
+    assert json.dumps({"value": b"hello"}, cls=ArgusJSONEncoder) == '{"value": "hello"}'
+
+
+def test_encoder_replaces_undecodable_bytes():
+    payload = json.dumps({"value": b"\xff\xfe"}, cls=ArgusJSONEncoder)
+    assert json.loads(payload)["value"] == b"\xff\xfe".decode("utf-8", errors="replace")
+
+
+def test_encoder_still_raises_for_unsupported_types():
+    with pytest.raises(TypeError):
+        json.dumps({"value": object()}, cls=ArgusJSONEncoder)

--- a/argus/backend/util/encoders.py
+++ b/argus/backend/util/encoders.py
@@ -23,6 +23,8 @@ class ArgusJSONEncoder(JSONEncoder):
                 return dict(o.items())
             case datetime():
                 return o.strftime("%Y-%m-%dT%H:%M:%S.%fZ")[:-4] + "Z"  # Include milliseconds, trim to 3 decimal places
+            case bytes():
+                return o.decode("utf-8", errors="replace")
             case _:
                 return super().default(o)
 
@@ -55,5 +57,7 @@ class ArgusJSONProvider(DefaultJSONProvider):
                 return {str(k): v for k, v in o.items()}
             case datetime():
                 return o.strftime("%Y-%m-%dT%H:%M:%S.%fZ")[:-4] + "Z"  # Include milliseconds, trim to 3 decimal places
+            case bytes():
+                return o.decode("utf-8", errors="replace")
             case _:
                 return super().default(o)


### PR DESCRIPTION
flask.json.dumps (used by jsonify and Jinja's tojson filter, e.g. in the unsupported-email-section debug view) has no case for bytes, raising "Object of type bytes is not JSON serializable" whenever a blob-typed value reaches it. Decode bytes to str in both encoders.

Fixes: ARGUS-188