### PR TITLE
feature(dashboard): use proper node_exporter metrics to see ssh tunnel

### DIFF
--- a/scripts/grafana/argus-overview.json
+++ b/scripts/grafana/argus-overview.json
@@ -1228,7 +1228,7 @@
               }
             ]
           },
-          "unit": "reqps"
+          "unit": "rpm"
         },
         "overrides": []
       },
@@ -1260,7 +1260,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(http_request_ssh_tunnel_total{ssh_tunnel=\"yes\"}[$__rate_interval]))",
+          "expr": "sum(rate(http_request_ssh_tunnel_total{ssh_tunnel=\"yes\"}[$__rate_interval])) * 60",
           "legendFormat": "via SSH tunnel",
           "range": true,
           "refId": "A"
@@ -1271,7 +1271,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(http_request_ssh_tunnel_total{ssh_tunnel=\"no\"}[$__rate_interval]))",
+          "expr": "sum(rate(http_request_ssh_tunnel_total{ssh_tunnel=\"no\"}[$__rate_interval])) * 60",
           "legendFormat": "direct / cloudflare",
           "range": true,
           "refId": "B"
@@ -1279,7 +1279,7 @@
       ],
       "title": "Tunneled vs Direct Traffic (proof)",
       "type": "timeseries",
-      "description": "Requests arriving with X-SSH-Tunnel-Origin (set by the client ONLY when traffic actually traverses the established SSH tunnel). Non-zero 'via SSH tunnel' is proof the tunnel is up and carrying traffic."
+      "description": "Requests arriving with X-SSH-Tunnel-Origin (set by the client ONLY when traffic actually traverses the established SSH tunnel), shown as requests/min. Non-zero 'via SSH tunnel' is proof the tunnel is up and carrying traffic."
     },
     {
       "datasource": {
@@ -2050,7 +2050,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(node_network_receive_bytes_total{job=~\"$proxy_job\",device!~\"lo\"}[$__rate_interval])*8",
+          "expr": "rate(node_network_receive_bytes_total{app=~\"$tunnel_app\",device!~\"lo\"}[$__rate_interval])*8",
           "legendFormat": "Rx {{device}}",
           "range": true,
           "refId": "A"
@@ -2061,7 +2061,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "rate(node_network_transmit_bytes_total{job=~\"$proxy_job\",device!~\"lo\"}[$__rate_interval])*8",
+          "expr": "rate(node_network_transmit_bytes_total{app=~\"$tunnel_app\",device!~\"lo\"}[$__rate_interval])*8",
           "legendFormat": "Tx {{device}}",
           "range": true,
           "refId": "B"
@@ -2069,7 +2069,7 @@
       ],
       "title": "Proxy Bandwidth (NIC)",
       "type": "timeseries",
-      "description": "Per-interface bandwidth on the proxy host. REQUIRES node_exporter running on the proxy, scraped under job=$proxy_job."
+      "description": "Per-interface bandwidth on the proxy host. REQUIRES node_exporter running on the proxy, scraped under app=$tunnel_app."
     },
     {
       "datasource": {
@@ -2135,7 +2135,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "100 * (1 - avg(rate(node_cpu_seconds_total{job=~\"$proxy_job\",mode=\"idle\"}[$__rate_interval])))",
+          "expr": "100 * (1 - avg(rate(node_cpu_seconds_total{app=~\"$tunnel_app\",mode=\"idle\"}[$__rate_interval])))",
           "legendFormat": "cpu busy %",
           "range": true,
           "refId": "A"
@@ -2209,7 +2209,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "100 * (1 - node_memory_MemAvailable_bytes{job=~\"$proxy_job\"} / node_memory_MemTotal_bytes{job=~\"$proxy_job\"})",
+          "expr": "100 * (1 - node_memory_MemAvailable_bytes{app=~\"$tunnel_app\"} / node_memory_MemTotal_bytes{app=~\"$tunnel_app\"})",
           "legendFormat": "mem used %",
           "range": true,
           "refId": "A"
@@ -2305,7 +2305,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "node_netstat_Tcp_CurrEstab{job=~\"$proxy_job\"}",
+          "expr": "node_netstat_Tcp_CurrEstab{app=~\"$tunnel_app\"}",
           "legendFormat": "established TCP",
           "range": true,
           "refId": "A"
@@ -2401,7 +2401,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "100 * (1 - node_filesystem_avail_bytes{job=~\"$proxy_job\",fstype!~\"tmpfs|overlay|squashfs\"} / node_filesystem_size_bytes{job=~\"$proxy_job\",fstype!~\"tmpfs|overlay|squashfs\"})",
+          "expr": "100 * (1 - node_filesystem_avail_bytes{app=~\"$tunnel_app\",fstype!~\"tmpfs|overlay|squashfs\"} / node_filesystem_size_bytes{app=~\"$tunnel_app\",fstype!~\"tmpfs|overlay|squashfs\"})",
           "legendFormat": "{{mountpoint}}",
           "range": true,
           "refId": "A"
@@ -2410,6 +2410,406 @@
       "title": "Proxy Disk Space Used",
       "type": "timeseries",
       "description": "Filesystem usage on the proxy host. Requires node_exporter on the proxy."
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 87
+      },
+      "id": 200,
+      "panels": [],
+      "title": "SSH Tunnel Deep Dive",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Client IPs driving the most tunnel-registration / key-lookup / config-fetch traffic. Uses the existing http_request_by_ip_total counter, filtered to the ssh_api endpoints.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 88
+      },
+      "id": 201,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": false
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "topk(10, sum by(ip) (rate(http_request_by_ip_total{endpoint=~\".*(register_tunnel|get_tunnel_connection|get_authorized_keys)\"}[$__rate_interval])))",
+          "instant": true,
+          "legendFormat": "{{ip}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Top Client IPs (Tunnel Endpoints)",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Approximate tunnel session churn, derived from the delta of established TCP connections on the argus_tunnel node_exporter instance: positive deltas plotted as 'opens', negative deltas (negated) as 'closes'. This is a rough proxy, not a true per-session open/close event — sshd on the proxy host doesn't report individual session lifecycle to Argus.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 40,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "closes (approx)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 88
+      },
+      "id": 202,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(delta(node_netstat_Tcp_CurrEstab{app=~\"$tunnel_app\"}[$__rate_interval]), 0)",
+          "legendFormat": "opens (approx)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(-delta(node_netstat_Tcp_CurrEstab{app=~\"$tunnel_app\"}[$__rate_interval]), 0)",
+          "legendFormat": "closes (approx)",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Tunnel Session Churn (approx.)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "HTTP-layer failures (non-2xx) on tunnel registration, config-fetch and authorized-keys endpoints. This is the closest available failure signal — actual SSH public-key auth rejections happen inside sshd on the proxy host and are never reported back to Argus, so this will NOT catch a client whose key was rejected by sshd itself.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 0.01
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 96
+      },
+      "id": 203,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(endpoint, status) (rate(http_request_by_endpoint_total{endpoint=~\".*(register_tunnel|get_tunnel_connection|get_authorized_keys)\",status!~\"2..\"}[$__rate_interval]))",
+          "legendFormat": "{{endpoint}} {{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Tunnel Registration / Key-fetch Failures",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Tunneled request volume broken down by backend instance — shows whether the proxy/load balancer is spreading tunnel traffic evenly across backend replicas, or piling onto one. Relies on Prometheus's own 'instance' label, so a single-replica backend will show a single series.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 96
+      },
+      "id": 204,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(instance) (rate(http_request_ssh_tunnel_total{ssh_tunnel=\"yes\"}[$__rate_interval]))",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Tunneled Traffic by Backend Instance",
+      "type": "timeseries"
     }
   ],
   "preload": false,
@@ -2432,20 +2832,23 @@
         "type": "datasource"
       },
       {
-        "current": {},
+        "current": {
+          "text": "argus_tunnel",
+          "value": "argus_tunnel"
+        },
         "datasource": {
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(node_uname_info, job)",
+        "definition": "label_values(node_uname_info, app)",
         "includeAll": true,
-        "label": "Proxy node_exporter job",
+        "label": "Tunnel node_exporter app",
         "multi": true,
-        "name": "proxy_job",
+        "name": "tunnel_app",
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(node_uname_info, job)",
+          "query": "label_values(node_uname_info, app)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,


### PR DESCRIPTION
Dashboard already deployed on monitoring server.

Closes https://scylladb.atlassian.net/browse/ARGUS-187

