### PR TITLE
feature(cli/users): add users list and get subcommands

### DIFF
--- a/cli/cmd/users.go
+++ b/cli/cmd/users.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"github.com/scylladb/argus/cli/cmd/users"
+	"github.com/spf13/cobra"
+)
+
+// usersCmd is the parent command for user lookups.
+var usersCmd = &cobra.Command{
+	Use:   "users",
+	Short: "Look up Argus users",
+	Long: `List Argus users or fetch a single user by username, UUID or email.
+
+  argus users list
+  argus users get --username alice`,
+}
+
+func init() {
+	users.Register(usersCmd)
+	rootCmd.AddCommand(usersCmd)
+}

--- a/cli/cmd/users/get.go
+++ b/cli/cmd/users/get.go
@@ -1,0 +1,61 @@
+package users
+
+import (
+	"github.com/scylladb/argus/cli/internal/cmdctx"
+	"github.com/scylladb/argus/cli/internal/logging"
+	"github.com/scylladb/argus/cli/internal/models"
+	"github.com/scylladb/argus/cli/internal/services"
+	"github.com/spf13/cobra"
+)
+
+// registerGet adds the "get" sub-command to parent.
+func registerGet(parent *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Show a single user",
+		Long: `Show a single user addressed by exactly one of --username, --uuid
+or --email, e.g.:
+  argus users get --username alice
+  argus users get --uuid 7f3c1e90-...
+  argus users get --email alice@scylladb.com`,
+		RunE: runGet,
+	}
+
+	cmd.Flags().String("username", "", "Look up the user by username")
+	cmd.Flags().String("uuid", "", "Look up the user by UUID")
+	cmd.Flags().String("email", "", "Look up the user by email")
+	cmd.MarkFlagsMutuallyExclusive("username", "uuid", "email")
+	cmd.MarkFlagsOneRequired("username", "uuid", "email")
+
+	parent.AddCommand(cmd)
+}
+
+// runGet is the RunE handler for "users get".
+func runGet(cmd *cobra.Command, _ []string) error {
+	cmd.SilenceUsage = true
+	ctx := cmd.Context()
+	client := cmdctx.APIClientFrom(ctx)
+	out := cmdctx.OutputterFrom(ctx)
+	c := cmdctx.CacheFrom(ctx)
+	log := logging.For(cmdctx.LoggerFrom(ctx), "users-get")
+
+	var field, value string
+	for _, f := range []string{"username", "uuid", "email"} {
+		if v, _ := cmd.Flags().GetString(f); v != "" {
+			field, value = f, v
+			break
+		}
+	}
+	log.Debug().Str("field", field).Str("value", value).Msg("fetching user")
+
+	svc := services.NewUserService(client, c)
+
+	user, err := svc.GetUser(ctx, field, value)
+	if err != nil {
+		log.Error().Err(err).Str("field", field).Str("value", value).Msg("failed to fetch user")
+		return err
+	}
+
+	log.Info().Str("field", field).Str("value", value).Msg("user fetched successfully")
+	return out.Write(models.NewKVTabular(models.NewUserListEntry(user)))
+}

--- a/cli/cmd/users/list.go
+++ b/cli/cmd/users/list.go
@@ -1,0 +1,47 @@
+package users
+
+import (
+	"github.com/scylladb/argus/cli/internal/cmdctx"
+	"github.com/scylladb/argus/cli/internal/logging"
+	"github.com/scylladb/argus/cli/internal/models"
+	"github.com/scylladb/argus/cli/internal/services"
+	"github.com/spf13/cobra"
+)
+
+// registerList adds the "list" sub-command to parent.
+func registerList(parent *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all users",
+		Long: `List all Argus users, showing username, email and UUID:
+  argus users list`,
+		RunE: runList,
+	}
+	parent.AddCommand(cmd)
+}
+
+// runList is the RunE handler for "users list".
+func runList(cmd *cobra.Command, _ []string) error {
+	cmd.SilenceUsage = true
+	ctx := cmd.Context()
+	client := cmdctx.APIClientFrom(ctx)
+	out := cmdctx.OutputterFrom(ctx)
+	c := cmdctx.CacheFrom(ctx)
+	log := logging.For(cmdctx.LoggerFrom(ctx), "users-list")
+
+	svc := services.NewUserService(client, c)
+
+	usrs, err := svc.ListUsers(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to list users")
+		return err
+	}
+
+	entries := make([]models.UserListEntry, len(usrs))
+	for i, u := range usrs {
+		entries[i] = models.NewUserListEntry(u)
+	}
+
+	log.Info().Int("count", len(entries)).Msg("users listed successfully")
+	return out.Write(models.NewTabularSlice(entries))
+}

--- a/cli/cmd/users/root.go
+++ b/cli/cmd/users/root.go
@@ -1,0 +1,9 @@
+package users
+
+import "github.com/spf13/cobra"
+
+// Register wires the users sub-commands onto parent.
+func Register(parent *cobra.Command) {
+	registerList(parent)
+	registerGet(parent)
+}

--- a/cli/cmd/users/root.go
+++ b/cli/cmd/users/root.go
@@ -6,4 +6,5 @@ import "github.com/spf13/cobra"
 func Register(parent *cobra.Command) {
 	registerList(parent)
 	registerGet(parent)
+	registerSearch(parent)
 }

--- a/cli/cmd/users/search.go
+++ b/cli/cmd/users/search.go
@@ -1,0 +1,53 @@
+package users
+
+import (
+	"github.com/scylladb/argus/cli/internal/cmdctx"
+	"github.com/scylladb/argus/cli/internal/logging"
+	"github.com/scylladb/argus/cli/internal/models"
+	"github.com/scylladb/argus/cli/internal/services"
+	"github.com/spf13/cobra"
+)
+
+// registerSearch adds the "search" sub-command to parent.
+func registerSearch(parent *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "search <term>",
+		Short: "Search users by username, full name or email",
+		Long: `Search users whose username, full name or email contains the given
+term (case-insensitive substring), e.g.:
+  argus users search alice
+  argus users search @scylladb.com`,
+		Args: cobra.ExactArgs(1),
+		RunE: runSearch,
+	}
+	parent.AddCommand(cmd)
+}
+
+// runSearch is the RunE handler for "users search".
+func runSearch(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+	ctx := cmd.Context()
+	client := cmdctx.APIClientFrom(ctx)
+	out := cmdctx.OutputterFrom(ctx)
+	c := cmdctx.CacheFrom(ctx)
+	log := logging.For(cmdctx.LoggerFrom(ctx), "users-search")
+
+	term := args[0]
+	log.Debug().Str("term", term).Msg("searching users")
+
+	svc := services.NewUserService(client, c)
+
+	usrs, err := svc.SearchUsers(ctx, term)
+	if err != nil {
+		log.Error().Err(err).Str("term", term).Msg("failed to search users")
+		return err
+	}
+
+	entries := make([]models.UserListEntry, len(usrs))
+	for i, u := range usrs {
+		entries[i] = models.NewUserListEntry(u)
+	}
+
+	log.Info().Str("term", term).Int("count", len(entries)).Msg("users searched successfully")
+	return out.Write(models.NewTabularSlice(entries))
+}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/zalando/go-keyring v0.2.7
 	golang.org/x/term v0.41.0
+	golang.org/x/text v0.28.0
 )
 
 require (
@@ -41,6 +42,5 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/sys v0.42.0 // indirect
-	golang.org/x/text v0.28.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/cli/internal/models/planner.go
+++ b/cli/internal/models/planner.go
@@ -221,17 +221,18 @@ type User struct {
 // user's UUID string with the user object as the value.
 type UsersMap = map[string]User
 
-// UserListEntry is the compact row shown by `users list`: username, email and
-// the user's UUID (the backend's id, surfaced as "uuid").
+// UserListEntry is the compact row shown by `users list`: username, full name,
+// email and the user's UUID (the backend's id, surfaced as "uuid").
 type UserListEntry struct {
 	Username string `json:"username"`
+	FullName string `json:"full_name"`
 	Email    string `json:"email"`
 	ID       string `json:"uuid"`
 }
 
 // NewUserListEntry projects a [User] onto the compact list row.
 func NewUserListEntry(u User) UserListEntry {
-	return UserListEntry{Username: u.Username, Email: u.Email, ID: u.ID}
+	return UserListEntry{Username: u.Username, FullName: u.FullName, Email: u.Email, ID: u.ID}
 }
 
 // GridEntity is a single test or group in a release's gridview (and the shape

--- a/cli/internal/models/planner.go
+++ b/cli/internal/models/planner.go
@@ -221,6 +221,19 @@ type User struct {
 // user's UUID string with the user object as the value.
 type UsersMap = map[string]User
 
+// UserListEntry is the compact row shown by `users list`: username, email and
+// the user's UUID (the backend's id, surfaced as "uuid").
+type UserListEntry struct {
+	Username string `json:"username"`
+	Email    string `json:"email"`
+	ID       string `json:"uuid"`
+}
+
+// NewUserListEntry projects a [User] onto the compact list row.
+func NewUserListEntry(u User) UserListEntry {
+	return UserListEntry{Username: u.Username, Email: u.Email, ID: u.ID}
+}
+
 // GridEntity is a single test or group in a release's gridview (and the shape
 // of index-mapped entities in copy-check "missing" lists).
 //

--- a/cli/internal/services/normalize.go
+++ b/cli/internal/services/normalize.go
@@ -1,0 +1,43 @@
+package services
+
+import (
+	"strings"
+	"unicode"
+
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
+)
+
+// latinReplacer maps Latin letters that do NOT decompose under Unicode NFD
+// (i.e. they are single code points with no combining-mark form) to their
+// closest ASCII equivalent. Diacritics that DO decompose (á, ę, ř, ž, ...) are
+// handled by the NFD + combining-mark removal below and need no entry here.
+var latinReplacer = strings.NewReplacer(
+	"Ł", "L", "ł", "l",
+	"Ø", "O", "ø", "o",
+	"Đ", "D", "đ", "d",
+	"Ð", "D", "ð", "d",
+	"Þ", "Th", "þ", "th",
+	"ß", "ss",
+	"Æ", "Ae", "æ", "ae",
+	"Œ", "Oe", "œ", "oe",
+	"Ĳ", "Ij", "ĳ", "ij",
+	"İ", "I", "ı", "i",
+	"Ŀ", "L", "ŀ", "l",
+	"ĸ", "k",
+)
+
+// normalizeLatin folds a string to a diacritic-free, lower-cased ASCII-ish form
+// for accent-insensitive matching. For example "Łukasz Częstochowski" becomes
+// "lukasz czestochowski", so a search for "lukasz czestochowski" (or a partial
+// "czest") matches regardless of the diacritics in the stored name.
+func normalizeLatin(s string) string {
+	s = latinReplacer.Replace(s)
+	t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
+	folded, _, err := transform.String(t, s)
+	if err != nil {
+		folded = s
+	}
+	return strings.ToLower(folded)
+}

--- a/cli/internal/services/planner.go
+++ b/cli/internal/services/planner.go
@@ -47,8 +47,9 @@ type PlannerService struct {
 	client *api.Client
 	cache  *cache.Cache
 
+	userSvc *UserService
+
 	releases  models.ReleaseList
-	users     models.UsersMap
 	gridviews map[string]models.GridView
 }
 
@@ -57,6 +58,7 @@ func NewPlannerService(client *api.Client, c *cache.Cache) *PlannerService {
 	return &PlannerService{
 		client:    client,
 		cache:     c,
+		userSvc:   NewUserService(client, c),
 		gridviews: map[string]models.GridView{},
 	}
 }
@@ -227,52 +229,17 @@ func (s *PlannerService) ResolveReleaseID(ctx context.Context, ref string) (stri
 // User resolution
 // ---------------------------------------------------------------------------
 
-// getUsers returns the users map, memoised then disk-cached.
+// getUsers returns the users map. User fetching and caching is owned by
+// [UserService]; this shim delegates so a PlannerService and its UserService
+// share a single fetch.
 func (s *PlannerService) getUsers(ctx context.Context) (models.UsersMap, error) {
-	if s.users != nil {
-		return s.users, nil
-	}
-	if cached, _, err := cache.Get[models.UsersMap](s.cache, cache.UsersKey()); err == nil {
-		s.users = cached
-		return cached, nil
-	}
-
-	req, err := s.client.NewRequest(ctx, "GET", api.Users, nil)
-	if err != nil {
-		return nil, err
-	}
-	users, err := api.DoJSON[models.UsersMap](s.client, req)
-	if err != nil {
-		return nil, err
-	}
-	_ = cache.Set(s.cache, cache.UsersKey(), users, api.Users, cache.TTLUsers)
-	s.users = users
-	return users, nil
+	return s.userSvc.getUsers(ctx)
 }
 
 // ResolveUserID resolves a username (exact, case-insensitive) to its UUID.
-// Raw UUIDs are not accepted; 0 or >1 matches error with candidate usernames.
+// It delegates to [UserService.ResolveUserID].
 func (s *PlannerService) ResolveUserID(ctx context.Context, ref string) (string, error) {
-	users, err := s.getUsers(ctx)
-	if err != nil {
-		return "", err
-	}
-
-	var matches []string
-	for id, u := range users {
-		if strings.EqualFold(u.Username, ref) {
-			matches = append(matches, id)
-		}
-	}
-
-	switch len(matches) {
-	case 1:
-		return matches[0], nil
-	case 0:
-		return "", fmt.Errorf("no user named %q", ref)
-	default:
-		return "", fmt.Errorf("ambiguous username %q (%d matches)", ref, len(matches))
-	}
+	return s.userSvc.ResolveUserID(ctx, ref)
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/internal/services/users.go
+++ b/cli/internal/services/users.go
@@ -69,6 +69,32 @@ func (s *UserService) ListUsers(ctx context.Context) ([]models.User, error) {
 	return out, nil
 }
 
+// SearchUsers returns users whose username, email or full name contains term
+// (case-insensitive, accent-insensitive substring). Diacritics are folded to
+// their ASCII equivalents on both the term and the compared fields, so "lukasz"
+// matches a full name of "Łukasz". An empty term returns every user. Results
+// are sorted by username for stable output.
+func (s *UserService) SearchUsers(ctx context.Context, term string) ([]models.User, error) {
+	users, err := s.getUsers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	needle := normalizeLatin(term)
+
+	out := make([]models.User, 0, len(users))
+	for _, u := range users {
+		if strings.Contains(normalizeLatin(u.Username), needle) ||
+			strings.Contains(normalizeLatin(u.Email), needle) ||
+			strings.Contains(normalizeLatin(u.FullName), needle) {
+			out = append(out, u)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return strings.ToLower(out[i].Username) < strings.ToLower(out[j].Username)
+	})
+	return out, nil
+}
+
 // GetUser returns the single user whose field matches value (case-insensitive).
 // field must be one of "username", "uuid", or "email". It errors when no user
 // matches or when more than one does.

--- a/cli/internal/services/users.go
+++ b/cli/internal/services/users.go
@@ -1,0 +1,132 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/scylladb/argus/cli/internal/api"
+	"github.com/scylladb/argus/cli/internal/cache"
+	"github.com/scylladb/argus/cli/internal/models"
+)
+
+// UserService is the single owner of user fetching and caching. It backs the
+// `users` command and provides the username→UUID resolution that
+// [PlannerService] delegates to when turning human references into UUIDs.
+//
+// It memoises the users list for the lifetime of the service so that a single
+// command resolves many references with at most one network fetch.
+type UserService struct {
+	client *api.Client
+	cache  *cache.Cache
+
+	users models.UsersMap
+}
+
+// NewUserService constructs a [UserService].
+func NewUserService(client *api.Client, c *cache.Cache) *UserService {
+	return &UserService{client: client, cache: c}
+}
+
+// getUsers returns the users map, memoised then disk-cached.
+func (s *UserService) getUsers(ctx context.Context) (models.UsersMap, error) {
+	if s.users != nil {
+		return s.users, nil
+	}
+	if cached, _, err := cache.Get[models.UsersMap](s.cache, cache.UsersKey()); err == nil {
+		s.users = cached
+		return cached, nil
+	}
+
+	req, err := s.client.NewRequest(ctx, "GET", api.Users, nil)
+	if err != nil {
+		return nil, err
+	}
+	users, err := api.DoJSON[models.UsersMap](s.client, req)
+	if err != nil {
+		return nil, err
+	}
+	_ = cache.Set(s.cache, cache.UsersKey(), users, api.Users, cache.TTLUsers)
+	s.users = users
+	return users, nil
+}
+
+// ListUsers returns every user, sorted by username (case-insensitive) for
+// stable output.
+func (s *UserService) ListUsers(ctx context.Context) ([]models.User, error) {
+	users, err := s.getUsers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]models.User, 0, len(users))
+	for _, u := range users {
+		out = append(out, u)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return strings.ToLower(out[i].Username) < strings.ToLower(out[j].Username)
+	})
+	return out, nil
+}
+
+// GetUser returns the single user whose field matches value (case-insensitive).
+// field must be one of "username", "uuid", or "email". It errors when no user
+// matches or when more than one does.
+func (s *UserService) GetUser(ctx context.Context, field, value string) (models.User, error) {
+	users, err := s.getUsers(ctx)
+	if err != nil {
+		return models.User{}, err
+	}
+
+	match := func(u models.User) bool {
+		switch field {
+		case "uuid":
+			return strings.EqualFold(u.ID, value)
+		case "email":
+			return strings.EqualFold(u.Email, value)
+		default: // username
+			return strings.EqualFold(u.Username, value)
+		}
+	}
+
+	var matches []models.User
+	for _, u := range users {
+		if match(u) {
+			matches = append(matches, u)
+		}
+	}
+
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		return models.User{}, fmt.Errorf("no user with %s %q", field, value)
+	default:
+		return models.User{}, fmt.Errorf("ambiguous %s %q (%d matches)", field, value, len(matches))
+	}
+}
+
+// ResolveUserID resolves a username (exact, case-insensitive) to its UUID.
+// Raw UUIDs are not accepted; 0 or >1 matches error with candidate usernames.
+func (s *UserService) ResolveUserID(ctx context.Context, ref string) (string, error) {
+	users, err := s.getUsers(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	var matches []string
+	for id, u := range users {
+		if strings.EqualFold(u.Username, ref) {
+			matches = append(matches, id)
+		}
+	}
+
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		return "", fmt.Errorf("no user named %q", ref)
+	default:
+		return "", fmt.Errorf("ambiguous username %q (%d matches)", ref, len(matches))
+	}
+}

--- a/cli/internal/services/users_test.go
+++ b/cli/internal/services/users_test.go
@@ -94,3 +94,69 @@ func TestUserService_GetUser_Ambiguous(t *testing.T) {
 	_, err := svc.GetUser(context.Background(), "email", "shared@scylladb.com")
 	require.Error(t, err)
 }
+
+func TestUserService_SearchUsers(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		term          string
+		wantUsernames []string
+	}{
+		{"username substring", "ali", []string{"alice"}},
+		{"case-insensitive", "ALI", []string{"alice"}},
+		{"full name substring", "Bob B", []string{"bob"}},
+		{"email domain matches all", "@scylladb.com", []string{"alice", "bob", "carol"}},
+		{"empty term returns all", "", []string{"alice", "bob", "carol"}},
+		{"no match", "dave", []string{}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			svc := newUserSvc(t, userServiceMux(t))
+			got, err := svc.SearchUsers(context.Background(), tc.term)
+			require.NoError(t, err)
+
+			names := make([]string, len(got))
+			for i, u := range got {
+				names[i] = u.Username
+			}
+			assert.Equal(t, tc.wantUsernames, names)
+		})
+	}
+}
+
+func TestUserService_SearchUsers_DiacriticInsensitive(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/users", func(w http.ResponseWriter, _ *http.Request) {
+		jsonOK(t, w, models.UsersMap{
+			"u1": {ID: "u1", Username: "lkaczmarek", Email: "lk@scylladb.com", FullName: "Łukasz Częstochowski"},
+			"u2": {ID: "u2", Username: "jnovak", Email: "jn@scylladb.com", FullName: "Jiří Dvořák"},
+		})
+	})
+
+	cases := []struct {
+		name     string
+		term     string
+		wantUser string
+	}{
+		{"ascii term matches diacritic name", "lukasz", "lkaczmarek"},
+		{"partial folded surname", "czest", "lkaczmarek"},
+		{"czech name folded", "jiri dvorak", "jnovak"},
+		{"diacritic term matches too", "Łukasz", "lkaczmarek"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			svc := newUserSvc(t, mux)
+			got, err := svc.SearchUsers(context.Background(), tc.term)
+			require.NoError(t, err)
+			require.Len(t, got, 1)
+			assert.Equal(t, tc.wantUser, got[0].Username)
+		})
+	}
+}

--- a/cli/internal/services/users_test.go
+++ b/cli/internal/services/users_test.go
@@ -1,0 +1,96 @@
+package services_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/scylladb/argus/cli/internal/api"
+	"github.com/scylladb/argus/cli/internal/cache"
+	"github.com/scylladb/argus/cli/internal/models"
+	"github.com/scylladb/argus/cli/internal/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newUserSvc(t *testing.T, mux *http.ServeMux) *services.UserService {
+	t.Helper()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	client, err := api.New(srv.URL, api.WithHTTPClient(srv.Client()))
+	require.NoError(t, err)
+	ca := cache.New(t.TempDir(), cache.WithDisabled(true))
+	return services.NewUserService(client, ca)
+}
+
+// userServiceMux serves three users for get/list tests.
+func userServiceMux(t *testing.T) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/users", func(w http.ResponseWriter, _ *http.Request) {
+		jsonOK(t, w, models.UsersMap{
+			"u1": {ID: "u1", Username: "alice", Email: "alice@scylladb.com", FullName: "Alice A"},
+			"u2": {ID: "u2", Username: "bob", Email: "bob@scylladb.com", FullName: "Bob B"},
+			"u3": {ID: "u3", Username: "carol", Email: "carol@scylladb.com", FullName: "Carol C"},
+		})
+	})
+	return mux
+}
+
+func TestUserService_ListUsers_SortedByUsername(t *testing.T) {
+	t.Parallel()
+	svc := newUserSvc(t, userServiceMux(t))
+
+	users, err := svc.ListUsers(context.Background())
+	require.NoError(t, err)
+	require.Len(t, users, 3)
+	assert.Equal(t, []string{"alice", "bob", "carol"},
+		[]string{users[0].Username, users[1].Username, users[2].Username})
+}
+
+func TestUserService_GetUser(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		field   string
+		value   string
+		wantID  string
+		wantErr bool
+	}{
+		{"by username", "username", "Alice", "u1", false},
+		{"by uuid", "uuid", "U2", "u2", false},
+		{"by email", "email", "carol@scylladb.com", "u3", false},
+		{"no match", "username", "dave", "", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			svc := newUserSvc(t, userServiceMux(t))
+			u, err := svc.GetUser(context.Background(), tc.field, tc.value)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantID, u.ID)
+		})
+	}
+}
+
+func TestUserService_GetUser_Ambiguous(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/users", func(w http.ResponseWriter, _ *http.Request) {
+		jsonOK(t, w, models.UsersMap{
+			"u1": {ID: "u1", Username: "alice", Email: "shared@scylladb.com"},
+			"u2": {ID: "u2", Username: "bob", Email: "shared@scylladb.com"},
+		})
+	})
+	svc := newUserSvc(t, mux)
+
+	_, err := svc.GetUser(context.Background(), "email", "shared@scylladb.com")
+	require.Error(t, err)
+}


### PR DESCRIPTION
Add an 'argus users' command with 'list' (all users: username, email, uuid)
and 'get' (single user by --username/--uuid/--email). Consolidate user
fetching and caching into a new UserService that owns getUsers, ListUsers,
GetUser and ResolveUserID; PlannerService now delegates to it via thin shims.
