### PR TITLE
cli/validate params for execute

### DIFF
--- a/argus/backend/controller/testrun_api.py
+++ b/argus/backend/controller/testrun_api.py
@@ -436,6 +436,17 @@ def build_jenkins_job():
     payload = get_payload(request)
     service = JenkinsService()
 
+    # scylla-cluster-tests jobs require exactly one Scylla version source to be
+    # set, otherwise the build fails to start. Validate before triggering so the
+    # caller (CLI/UI/API) gets a clear error instead of a broken run. Skipped
+    # when the test/plugin can't be resolved (e.g. a brand-new job).
+    try:
+        test = ArgusTest.get(build_system_id=payload["buildId"])
+    except ArgusTest.DoesNotExist:
+        test = None
+    if test and test.plugin_name == "scylla-cluster-tests":
+        JenkinsService.validate_sct_version_source(payload["parameters"])
+
     result = service.build_job(build_id=payload["buildId"], params=payload["parameters"])
 
     response = {

--- a/argus/backend/controller/testrun_api.py
+++ b/argus/backend/controller/testrun_api.py
@@ -419,7 +419,11 @@ def get_jenkins_job_params():
     payload = get_payload(request)
     service = JenkinsService()
 
-    result = service.retrieve_job_parameters(build_id=payload["buildId"], build_number=payload["buildNumber"])
+    result = service.retrieve_job_parameters(
+        build_id=payload["buildId"],
+        build_number=payload["buildNumber"],
+        from_defaults=payload.get("fromDefaults", False),
+    )
 
     return {
         "status": "ok",

--- a/argus/backend/service/jenkins_service.py
+++ b/argus/backend/service/jenkins_service.py
@@ -84,18 +84,25 @@ class JenkinsService:
             choices[name] = [s.text for s in define.findall("choices//string") if s.text is not None]
         return choices
 
-    def retrieve_job_parameters(self, build_id: str, build_number: int | None) -> list[Parameter]:
+    def _default_params_from_job_info(self, job_info: dict) -> list[Parameter]:
+        """Build the parameter list from the job's configured default values
+        (its "initial" parameters), independent of any past build. Optional
+        choice parameters default to empty rather than their first option."""
+        default_params = next((prop for prop in job_info["property"] if prop.get(
+            "_class", "") == "hudson.model.ParametersDefinitionProperty"), {}).get("parameterDefinitions", {})
+        return [{"name": param["name"],
+                 "value": "" if param["name"] in self.OPTIONAL_CHOICE_PARAMETERS
+                 else param.get("defaultParameterValue", {}).get("value", "")}
+                for param in default_params if param["name"] != self.RESERVED_PARAMETER_NAME]
+
+    def retrieve_job_parameters(self, build_id: str, build_number: int | None,
+                                from_defaults: bool = False) -> list[Parameter]:
+        """Return a job's parameters. By default (from_defaults=True, used by the
+        CLI) the job's configured default values are returned so a fresh trigger
+        starts from a clean slate. When from_defaults is False the values are
+        seeded from a past build instead: the given build_number, or the last
+        build when build_number is falsy (the rebuild/clone behaviour)."""
         job_info = self._jenkins.get_job_info(name=build_id)
-        if not build_number:
-            next_build_number = job_info.get("nextBuildNumber")
-            if not next_build_number:
-                raise JenkinsServiceError("#noBuildsAvailable")
-            try:
-                build_info = self._jenkins.get_build_info(name=build_id, number=next_build_number - 1)
-            except jenkins.JenkinsException:
-                raise JenkinsServiceError("#noBuildsAvailable")
-        else:
-            build_info = self._jenkins.get_build_info(name=build_id, number=build_number)
         raw_config = self._jenkins.get_job_config(name=build_id)
         config = ET.fromstring(raw_config)
         parameter_defs = config.find("*//parameterDefinitions")
@@ -107,17 +114,26 @@ class JenkinsService:
         else:
             descriptions = {}
         choices = self._extract_choice_parameters(config)
-        params = next((a for a in build_info["actions"] if a.get(
-            "_class", "#NONE") == "hudson.model.ParametersAction"), None)
-        if params:
-            params = [param for param in params["parameters"] if param["name"] != self.RESERVED_PARAMETER_NAME]
+
+        if from_defaults:
+            params = self._default_params_from_job_info(job_info)
         else:
-            default_params = next((prop for prop in job_info["property"] if prop.get(
-                "_class", "") == "hudson.model.ParametersDefinitionProperty"), {}).get("parameterDefinitions", {})
-            params = [{"name": param["name"],
-                       "value": "" if param["name"] in self.OPTIONAL_CHOICE_PARAMETERS
-                       else param.get("defaultParameterValue", {}).get("value", "")}
-                      for param in default_params if param["name"] != self.RESERVED_PARAMETER_NAME]
+            if not build_number:
+                next_build_number = job_info.get("nextBuildNumber")
+                if not next_build_number:
+                    raise JenkinsServiceError("#noBuildsAvailable")
+                try:
+                    build_info = self._jenkins.get_build_info(name=build_id, number=next_build_number - 1)
+                except jenkins.JenkinsException:
+                    raise JenkinsServiceError("#noBuildsAvailable")
+            else:
+                build_info = self._jenkins.get_build_info(name=build_id, number=build_number)
+            params = next((a for a in build_info["actions"] if a.get(
+                "_class", "#NONE") == "hudson.model.ParametersAction"), None)
+            if params:
+                params = [param for param in params["parameters"] if param["name"] != self.RESERVED_PARAMETER_NAME]
+            else:
+                params = self._default_params_from_job_info(job_info)
         self._apply_choice_defaults(params, choices, descriptions)
 
         return params

--- a/argus/backend/service/jenkins_service.py
+++ b/argus/backend/service/jenkins_service.py
@@ -8,10 +8,23 @@ import logging
 
 from flask import current_app, g
 
+from argus.backend.error_handlers import DataValidationError
 from argus.backend.models.web import ArgusGroup, ArgusRelease, ArgusTest, UserOauthToken
 
 LOGGER = logging.getLogger(__name__)
 GITHUB_REPO_RE = r"(?P<http>^https?:\/\/(www\.)?github\.com\/(?P<user>[\w\d\-]+)\/(?P<repo>[\w\d\-]+)(\.git)?$)|(?P<ssh>git@github\.com:(?P<ssh_user>[\w\d\-]+)\/(?P<ssh_repo>[\w\d\-]+)(\.git)?)"
+
+# The mutually-exclusive Scylla "version source" families for scylla-cluster-tests
+# jobs, mirroring the SCTParameterWizard front-end. Exactly one family must carry
+# a non-empty value for a build to start correctly. The image family groups the
+# per-backend image parameters (only one is ever relevant for a given backend).
+SCT_VERSION_SOURCE_FAMILIES: dict[str, list[str]] = {
+    "scylla_version": ["scylla_version"],
+    "scylla_repo": ["scylla_repo"],
+    "scylla_image": ["scylla_ami_id", "gce_image_db", "azure_image_db", "oci_image_db"],
+    "rolling_upgrade": ["new_scylla_repo"],
+    "scylla_byo": ["byo_scylla_repo"],
+}
 
 
 class Parameter(TypedDict):
@@ -156,6 +169,30 @@ class JenkinsService:
             return job_info.get("nextBuildNumber", -1)
         except jenkins.JenkinsException:
             return -1
+
+    @staticmethod
+    def validate_sct_version_source(params: dict) -> None:
+        """Ensure a scylla-cluster-tests build specifies exactly one Scylla
+        version source (see SCT_VERSION_SOURCE_FAMILIES). Raises
+        DataValidationError when none or more than one family carries a value, so
+        the trigger is aborted before Jenkins schedules a doomed build."""
+        set_families = [
+            family
+            for family, keys in SCT_VERSION_SOURCE_FAMILIES.items()
+            if any(str(params.get(key) or "").strip() for key in keys)
+        ]
+        if not set_families:
+            options = ", ".join(
+                key for keys in SCT_VERSION_SOURCE_FAMILIES.values() for key in keys
+            )
+            raise DataValidationError(
+                f"A Scylla version source must be set: one of {options}."
+            )
+        if len(set_families) > 1:
+            raise DataValidationError(
+                "Only one Scylla version source may be set, but multiple were "
+                f"provided: {', '.join(set_families)}."
+            )
 
     def get_releases_for_clone(self, test_id: str):
         test_id = UUID(test_id)

--- a/argus/backend/service/jenkins_service.py
+++ b/argus/backend/service/jenkins_service.py
@@ -97,11 +97,13 @@ class JenkinsService:
 
     def retrieve_job_parameters(self, build_id: str, build_number: int | None,
                                 from_defaults: bool = False) -> list[Parameter]:
-        """Return a job's parameters. By default (from_defaults=True, used by the
-        CLI) the job's configured default values are returned so a fresh trigger
-        starts from a clean slate. When from_defaults is False the values are
+        """Return a job's parameters. When from_defaults is False the values are
         seeded from a past build instead: the given build_number, or the last
-        build when build_number is falsy (the rebuild/clone behaviour)."""
+        build when build_number is falsy (the rebuild/clone behaviour).
+        Default values:
+        Cli: True
+        Frontend: False
+        """
         job_info = self._jenkins.get_job_info(name=build_id)
         raw_config = self._jenkins.get_job_config(name=build_id)
         config = ET.fromstring(raw_config)

--- a/argus/backend/tests/jenkins_service/test_jenkins_service.py
+++ b/argus/backend/tests/jenkins_service/test_jenkins_service.py
@@ -124,14 +124,22 @@ class _FakeJenkins:
     """Minimal stand-in for the python-jenkins client so next_build_number can
     be tested without a real Jenkins connection."""
 
-    def __init__(self, job_info=None, error=None):
+    def __init__(self, job_info=None, error=None, job_config=None, build_info=None):
         self._job_info = job_info or {}
         self._error = error
+        self._job_config = job_config
+        self._build_info = build_info or {}
 
     def get_job_info(self, name):  # noqa: ARG002 - signature parity
         if self._error is not None:
             raise self._error
         return self._job_info
+
+    def get_job_config(self, name):  # noqa: ARG002 - signature parity
+        return self._job_config
+
+    def get_build_info(self, name, number):  # noqa: ARG002 - signature parity
+        return self._build_info
 
 
 def _service_with(fake):
@@ -187,3 +195,84 @@ def test_validate_sct_version_source_rejects_multiple_families():
     # The message should name the conflicting families.
     assert "scylla_version" in str(exc.value)
     assert "scylla_image" in str(exc.value)
+
+
+# job_info whose configured defaults (scylla_version=master:latest) differ from
+# the last build's actual parameters, so the two fetch modes are distinguishable.
+_JOB_INFO_WITH_DEFAULTS = {
+    "nextBuildNumber": 6,
+    "property": [
+        {
+            "_class": "hudson.model.ParametersDefinitionProperty",
+            "parameterDefinitions": [
+                {"name": "scylla_version", "defaultParameterValue": {"value": "master:latest"}},
+                {"name": "billing_project", "defaultParameterValue": {"value": "sct"}},
+                {"name": "requested_by_user", "defaultParameterValue": {"value": "seed"}},
+            ],
+        }
+    ],
+}
+
+_BUILD_INFO_WITH_PARAMS = {
+    "actions": [
+        {
+            "_class": "hudson.model.ParametersAction",
+            "parameters": [
+                {"name": "scylla_version", "value": "5.4:latest"},
+                {"name": "billing_project", "value": "qa"},
+                {"name": "requested_by_user", "value": "someone"},
+            ],
+        }
+    ],
+}
+
+
+def _params_by_name(params):
+    return {p["name"]: p for p in params}
+
+
+def _params_service():
+    fake = _FakeJenkins(
+        job_info=_JOB_INFO_WITH_DEFAULTS,
+        job_config=CONFIG_WITH_CHOICES,
+        build_info=_BUILD_INFO_WITH_PARAMS,
+    )
+    return _service_with(fake)
+
+
+def test_retrieve_job_parameters_from_defaults_uses_job_config():
+    # from_defaults ignores the last build and returns the configured defaults.
+    params = _params_service().retrieve_job_parameters("job", None, from_defaults=True)
+    by_name = _params_by_name(params)
+    assert by_name["scylla_version"]["value"] == "master:latest"
+    # requested_by_user is always stripped from the returned set.
+    assert "requested_by_user" not in by_name
+    # billing_project is an optional choice: it defaults to empty with a blank
+    # option prepended, regardless of its configured default.
+    assert by_name["billing_project"]["value"] == ""
+    assert by_name["billing_project"]["choices"] == ["", "sct", "qa", "perf"]
+
+
+def test_retrieve_job_parameters_from_defaults_ignores_missing_builds():
+    # A fresh job with no builds still yields its defaults (no build lookup).
+    fake = _FakeJenkins(
+        job_info={"property": _JOB_INFO_WITH_DEFAULTS["property"]},
+        job_config=CONFIG_WITH_CHOICES,
+    )
+    params = _service_with(fake).retrieve_job_parameters("job", None, from_defaults=True)
+    assert _params_by_name(params)["scylla_version"]["value"] == "master:latest"
+
+
+def test_retrieve_job_parameters_rebuild_uses_last_build():
+    # Default mode (from_defaults=False) seeds from the last build's parameters.
+    params = _params_service().retrieve_job_parameters("job", None, from_defaults=False)
+    by_name = _params_by_name(params)
+    assert by_name["scylla_version"]["value"] == "5.4:latest"
+    assert by_name["billing_project"]["value"] == "qa"
+    assert "requested_by_user" not in by_name
+
+
+def test_retrieve_job_parameters_rebuild_specific_build():
+    # A specific build number also uses the build's parameters.
+    params = _params_service().retrieve_job_parameters("job", 3, from_defaults=False)
+    assert _params_by_name(params)["scylla_version"]["value"] == "5.4:latest"

--- a/argus/backend/tests/jenkins_service/test_jenkins_service.py
+++ b/argus/backend/tests/jenkins_service/test_jenkins_service.py
@@ -1,7 +1,9 @@
 import xml.etree.ElementTree as ET
 
 import jenkins
+import pytest
 
+from argus.backend.error_handlers import DataValidationError
 from argus.backend.service.jenkins_service import JenkinsService
 
 
@@ -154,3 +156,34 @@ def test_next_build_number_jenkins_error_is_non_fatal():
     # A Jenkins error must not propagate: the trigger already succeeded.
     service = _service_with(_FakeJenkins(error=jenkins.JenkinsException("boom")))
     assert service.next_build_number("scylla-2026.2/longevity/longevity-100gb") == -1
+
+
+def test_validate_sct_version_source_accepts_single_source():
+    # Exactly one family set (with other keys empty) is valid.
+    JenkinsService.validate_sct_version_source({"scylla_version": "master:latest", "scylla_repo": ""})
+
+
+def test_validate_sct_version_source_accepts_image_variant():
+    # Any single key of the image family counts as one source.
+    JenkinsService.validate_sct_version_source({"gce_image_db": "https://www.googleapis.com/compute/v1/x"})
+
+
+def test_validate_sct_version_source_rejects_none_set():
+    with pytest.raises(DataValidationError):
+        JenkinsService.validate_sct_version_source({"scylla_version": "", "scylla_repo": "  "})
+
+
+def test_validate_sct_version_source_rejects_missing_keys_entirely():
+    # No source keys present at all is also invalid.
+    with pytest.raises(DataValidationError):
+        JenkinsService.validate_sct_version_source({"backend": "aws"})
+
+
+def test_validate_sct_version_source_rejects_multiple_families():
+    with pytest.raises(DataValidationError) as exc:
+        JenkinsService.validate_sct_version_source(
+            {"scylla_version": "master:latest", "scylla_ami_id": "ami-1234"}
+        )
+    # The message should name the conflicting families.
+    assert "scylla_version" in str(exc.value)
+    assert "scylla_image" in str(exc.value)

--- a/argus/backend/tests/testrun_api/test_testrun_api.py
+++ b/argus/backend/tests/testrun_api/test_testrun_api.py
@@ -532,7 +532,7 @@ def test_jenkins_params_invokes_service(flask_client, mock_jenkins_service):
     assert resp.status_code == 200, resp.text
     assert resp.json["status"] == "ok"
     assert resp.json["response"]["parameters"] == [{"name": "BRANCH", "value": "main"}]
-    inst.retrieve_job_parameters.assert_called_once_with(build_id="job/foo", build_number=17)
+    inst.retrieve_job_parameters.assert_called_once_with(build_id="job/foo", build_number=17, from_defaults=False)
 
 
 def test_jenkins_build_returns_queue_item(flask_client, mock_jenkins_service):

--- a/cli/cmd/test/execute.go
+++ b/cli/cmd/test/execute.go
@@ -141,6 +141,7 @@ func runExecuteSingle(cmd *cobra.Command, _ []string) error {
 	}
 
 	merged := services.MergeParams(defaults, fileParams, flagParams)
+	normalizeSCTVersionSource(merged, explicitParamKeys(fileParams, flagParams))
 
 	if dryRun {
 		log.Info().Str("build_id", buildID).Int("count", len(merged)).Msg("dry run: not triggering build")
@@ -254,8 +255,17 @@ func runExecutePlan(cmd *cobra.Command) error {
 		}
 
 		merged := services.MergeParams(defaults, nil, flagParams)
+		normalizeSCTVersionSource(merged, explicitParamKeys(flagParams))
 		queueItem, err := svc.TriggerBuild(ctx, t.BuildSystemID, merged)
 		if err != nil {
+			// A validation failure is terminal (the request can never succeed
+			// as-is) and usually stems from --param overrides shared across the
+			// whole fan-out, so the remaining tests would fail identically.
+			// Abort immediately instead of triggering more doomed builds.
+			if services.IsValidationError(err) {
+				log.Error().Err(err).Str("build_id", t.BuildSystemID).Msg("build request failed validation; aborting remaining builds")
+				return fmt.Errorf("aborting plan execution: %s failed validation: %w", t.BuildSystemID, err)
+			}
 			log.Error().Err(err).Str("build_id", t.BuildSystemID).Msg("failed to trigger build")
 			results[i].Status = "error: " + err.Error()
 			continue
@@ -339,6 +349,92 @@ func argusRunURL(base, buildID string, number int) string {
 		return ""
 	}
 	return strings.TrimRight(base, "/") + "/test/" + buildID + "/" + strconv.Itoa(number)
+}
+
+// sctVersionSourceFamilies mirrors the backend SCT_VERSION_SOURCE_FAMILIES: each
+// family maps to the parameter keys that *select* it. A scylla-cluster-tests
+// build must set exactly one family, otherwise the backend rejects it. Keep this
+// in sync with argus/backend/service/jenkins_service.py.
+var sctVersionSourceFamilies = map[string][]string{
+	"scylla_version":  {"scylla_version"},
+	"scylla_repo":     {"scylla_repo"},
+	"scylla_image":    {"scylla_ami_id", "gce_image_db", "azure_image_db", "oci_image_db"},
+	"rolling_upgrade": {"new_scylla_repo"},
+	"scylla_byo":      {"byo_scylla_repo"},
+}
+
+// sctFamilyCompanionKeys lists non-selecting parameters that belong to a family
+// and must be cleared alongside it (e.g. the BYO branch that only makes sense
+// paired with a BYO repo).
+var sctFamilyCompanionKeys = map[string][]string{
+	"scylla_byo": {"byo_scylla_branch"},
+}
+
+// normalizeSCTVersionSource resolves Scylla version-source collisions before a
+// scylla-cluster-tests build is triggered. Job defaults frequently seed several
+// version-source keys at once (e.g. a default scylla_version alongside a
+// scylla_repo), which the backend rejects as ambiguous. When the caller
+// *explicitly* selects exactly one source family (via --file/--param, tracked in
+// explicit), the sibling families' keys present in merged are cleared to "" so
+// only the chosen source survives. Keys are emptied rather than deleted so
+// Jenkins cannot reintroduce its own default and recreate the collision.
+//
+// When zero or several families are explicitly selected, merged is left
+// untouched and the backend validator has the final say.
+func normalizeSCTVersionSource(merged map[string]any, explicit map[string]struct{}) {
+	var chosen string
+	families := 0
+	for family, keys := range sctVersionSourceFamilies {
+		if anyKeyExplicit(explicit, keys) {
+			families++
+			chosen = family
+		}
+	}
+	if families != 1 {
+		return
+	}
+	for family, keys := range sctVersionSourceFamilies {
+		if family == chosen {
+			continue
+		}
+		clearPresent(merged, keys)
+		clearPresent(merged, sctFamilyCompanionKeys[family])
+	}
+}
+
+// anyKeyExplicit reports whether any of keys was explicitly provided by the
+// caller.
+func anyKeyExplicit(explicit map[string]struct{}, keys []string) bool {
+	for _, key := range keys {
+		if _, ok := explicit[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// clearPresent empties (to "") the given keys that already exist in merged,
+// leaving absent keys absent so no spurious parameters are added to the build.
+func clearPresent(merged map[string]any, keys []string) {
+	for _, key := range keys {
+		if _, ok := merged[key]; ok {
+			merged[key] = ""
+		}
+	}
+}
+
+// explicitParamKeys returns the set of parameter names the caller explicitly
+// provided across the given maps (--file and --param). It distinguishes the
+// version source the user actually chose from values merely inherited from job
+// defaults.
+func explicitParamKeys(maps ...map[string]any) map[string]struct{} {
+	keys := make(map[string]struct{})
+	for _, m := range maps {
+		for k := range m {
+			keys[k] = struct{}{}
+		}
+	}
+	return keys
 }
 
 // readFileOrStdin returns the contents of the file at path, or of standard

--- a/cli/cmd/test/execute.go
+++ b/cli/cmd/test/execute.go
@@ -27,9 +27,12 @@ func registerExecute(parent *cobra.Command) {
 		Use:   "execute",
 		Short: "Trigger a Jenkins test build",
 		Long: `Trigger a build of a test. Parameters are resolved with the cascade
-defaults < --file < --param: the job's current default parameters are the base,
-a --file JSON map overrides them, and repeatable --param name=value flags
-override both.
+defaults < --file < --param: the job's default parameters are the base, a --file
+JSON map overrides them, and repeatable --param name=value flags override both.
+
+By default the base is the job's configured default parameters (a clean initial
+set). Use --rebuild to base it on the last build's parameters instead, or
+--build-number to base it on a specific build.
 
 The test is addressed either by its build_system_id directly, or by a release
 name plus a test reference resolved against that release's gridview:
@@ -69,7 +72,8 @@ parallel:
 	cmd.Flags().StringP("plan-id", "p", "", "Plan UUID or key to fan out across (with --label)")
 	cmd.Flags().StringArray("label", nil, "Select plan tests carrying this label (repeatable; requires --plan-id)")
 	cmd.Flags().Bool("match-all", false, "Require plan tests to carry all --label values instead of any")
-	cmd.Flags().Int("build-number", 0, "Seed default parameters from this build number (default: last build)")
+	cmd.Flags().Int("build-number", 0, "Seed default parameters from this build number (implies --rebuild)")
+	cmd.Flags().Bool("rebuild", false, "Seed from the last build's parameters instead of the job's defaults")
 	cmd.Flags().StringP("file", "f", "", "JSON file with a {name: value} parameter map (\"-\" for stdin)")
 	cmd.Flags().StringArray("param", nil, "Parameter override as name=value (repeatable)")
 	cmd.Flags().Bool("dry-run", false, "Print the merged parameters and exit without triggering a build")
@@ -129,7 +133,7 @@ func runExecuteSingle(cmd *cobra.Command, _ []string) error {
 
 	// Fetch defaults; a job with no builds/defaults is not fatal here — proceed
 	// with empty defaults so --file/--param can still launch it.
-	defaults, err := svc.FetchParams(ctx, buildID, buildNumber)
+	defaults, err := svc.FetchParams(ctx, buildID, buildNumber, seedFromDefaults(cmd))
 	if err != nil {
 		if errors.Is(err, services.ErrNoBuildsAvailable) {
 			log.Warn().Str("build_id", buildID).Msg("no builds available; sending empty defaults plus --file/--param values")
@@ -236,13 +240,17 @@ func runExecutePlan(cmd *cobra.Command) error {
 
 	svc := services.NewTestExecutionService(client, c)
 
+	// --build-number is rejected above, so this reflects only --rebuild: default
+	// seeds each test from its job defaults, --rebuild from its own last build.
+	fromDefaults := seedFromDefaults(cmd)
+
 	// Trigger sequentially so queue assignment is deterministic; a per-test
 	// failure is recorded and the batch continues.
 	results := make(models.TriggeredBuilds, len(targets))
 	for i, t := range targets {
 		results[i] = models.TriggeredBuild{Test: t.Ref, BuildSystemID: t.BuildSystemID}
 
-		defaults, err := svc.FetchParams(ctx, t.BuildSystemID, nil)
+		defaults, err := svc.FetchParams(ctx, t.BuildSystemID, nil, fromDefaults)
 		if err != nil {
 			if errors.Is(err, services.ErrNoBuildsAvailable) {
 				log.Warn().Str("build_id", t.BuildSystemID).Msg("no builds available; sending only --param values")

--- a/cli/cmd/test/params.go
+++ b/cli/cmd/test/params.go
@@ -15,8 +15,10 @@ func registerParams(parent *cobra.Command) {
 	cmd := &cobra.Command{
 		Use:   "params",
 		Short: "Show a Jenkins job's parameters",
-		Long: `Fetch the parameter set for a test. By default the last build's
-values are used, falling back to the job's default parameter definitions.
+		Long: `Fetch the parameter set for a test. By default the job's configured
+default parameters are returned. Use --rebuild to seed from the last build's
+values instead (falling back to the job defaults), or --build-number to seed
+from a specific build.
 
 The test is addressed either by its build_system_id directly, or by a release
 name plus a test reference resolved against that release's gridview:
@@ -27,14 +29,13 @@ By default only a {name: value} map is emitted, which can be redirected to a
 file and fed straight into 'test execute --file':
   argus test params --build-id scylla-2026.2/longevity/longevity-100gb > params.json
 
-Use --full to also see each parameter's description and allowed choices. If the
-job has no builds and no default definitions, this command fails; use
-'test execute' with --file/--param to launch it anyway.`,
+Use --full to also see each parameter's description and allowed choices.`,
 		RunE: runParams,
 	}
 
 	addAddressingFlags(cmd)
-	cmd.Flags().Int("build-number", 0, "Seed parameters from this build number (default: last build)")
+	cmd.Flags().Int("build-number", 0, "Seed parameters from this build number (implies --rebuild)")
+	cmd.Flags().Bool("rebuild", false, "Seed from the last build's parameters instead of the job's defaults")
 	cmd.Flags().Bool("full", false, "Show full parameter details (description, choices) instead of a values map")
 
 	parent.AddCommand(cmd)
@@ -59,7 +60,7 @@ func runParams(cmd *cobra.Command, _ []string) error {
 
 	svc := services.NewTestExecutionService(client, c)
 
-	params, err := svc.FetchParams(ctx, buildID, buildNumber)
+	params, err := svc.FetchParams(ctx, buildID, buildNumber, seedFromDefaults(cmd))
 	if err != nil {
 		if errors.Is(err, services.ErrNoBuildsAvailable) {
 			log.Error().Str("build_id", buildID).Msg("no builds available; job default parameters unavailable")
@@ -90,4 +91,13 @@ func buildNumberFlag(cmd *cobra.Command) *int {
 	}
 	n, _ := cmd.Flags().GetInt("build-number")
 	return &n
+}
+
+// seedFromDefaults reports whether parameters should be seeded from the job's
+// configured defaults (the initial set) rather than a past build. That is the
+// default; --rebuild opts into last-build seeding, and --build-number targets a
+// specific build (which also implies rebuild-style seeding).
+func seedFromDefaults(cmd *cobra.Command) bool {
+	rebuild, _ := cmd.Flags().GetBool("rebuild")
+	return !rebuild && !cmd.Flags().Changed("build-number")
 }

--- a/cli/cmd/test/test_test.go
+++ b/cli/cmd/test/test_test.go
@@ -43,6 +43,7 @@ func newExecuteCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "execute"}
 	cmd.Flags().String("file", "", "")
 	cmd.Flags().Int("build-number", 0, "")
+	cmd.Flags().Bool("rebuild", false, "")
 	return cmd
 }
 
@@ -86,6 +87,27 @@ func TestBuildNumberFlag(t *testing.T) {
 	n := buildNumberFlag(cmd)
 	require.NotNil(t, n)
 	assert.Equal(t, 42, *n)
+}
+
+func TestSeedFromDefaults(t *testing.T) {
+	// No flags → seed from the job's configured defaults.
+	assert.True(t, seedFromDefaults(newExecuteCmd()))
+
+	// --rebuild opts into last-build seeding.
+	rebuild := newExecuteCmd()
+	require.NoError(t, rebuild.Flags().Set("rebuild", "true"))
+	assert.False(t, seedFromDefaults(rebuild))
+
+	// --build-number targets a specific build (implies rebuild-style seeding).
+	byNumber := newExecuteCmd()
+	require.NoError(t, byNumber.Flags().Set("build-number", "7"))
+	assert.False(t, seedFromDefaults(byNumber))
+
+	// Both together are still not defaults.
+	both := newExecuteCmd()
+	require.NoError(t, both.Flags().Set("rebuild", "true"))
+	require.NoError(t, both.Flags().Set("build-number", "7"))
+	assert.False(t, seedFromDefaults(both))
 }
 
 // newAddressedCmd builds a command carrying the shared addressing flags so

--- a/cli/cmd/test/test_test.go
+++ b/cli/cmd/test/test_test.go
@@ -189,3 +189,76 @@ func TestArgusRunURL_NoBuildNumber(t *testing.T) {
 	// Build number not yet known → no link.
 	assert.Empty(t, argusRunURL("https://argus.scylladb.com", "scylla-2026.2/longevity/longevity-100gb", 0))
 }
+
+func TestNormalizeSCTVersionSource_ClearsSiblings(t *testing.T) {
+	// Defaults seed a scylla_version, but the caller explicitly picked
+	// scylla_repo — the inherited version (and any other sibling source present)
+	// must be emptied so only the chosen source survives.
+	merged := map[string]any{
+		"scylla_version": "master:latest",
+		"scylla_repo":    "http://repo/master.repo",
+		"scylla_ami_id":  "ami-123",
+		"backend":        "aws",
+	}
+	normalizeSCTVersionSource(merged, explicitParamKeys(map[string]any{"scylla_repo": "http://repo/master.repo"}))
+
+	assert.Equal(t, "", merged["scylla_version"])
+	assert.Equal(t, "", merged["scylla_ami_id"])
+	assert.Equal(t, "http://repo/master.repo", merged["scylla_repo"], "chosen source must be untouched")
+	assert.Equal(t, "aws", merged["backend"], "unrelated params must be untouched")
+}
+
+func TestNormalizeSCTVersionSource_ClearsByoCompanion(t *testing.T) {
+	// Choosing a repo clears the whole BYO family, including its companion
+	// byo_scylla_branch.
+	merged := map[string]any{
+		"scylla_repo":       "http://repo/master.repo",
+		"byo_scylla_repo":   "git@github.com:user/scylla",
+		"byo_scylla_branch": "next",
+	}
+	normalizeSCTVersionSource(merged, explicitParamKeys(map[string]any{"scylla_repo": "x"}))
+
+	assert.Equal(t, "", merged["byo_scylla_repo"])
+	assert.Equal(t, "", merged["byo_scylla_branch"])
+	assert.Equal(t, "http://repo/master.repo", merged["scylla_repo"])
+}
+
+func TestNormalizeSCTVersionSource_LeavesAbsentKeysAbsent(t *testing.T) {
+	// Sibling keys not present in merged must not be introduced.
+	merged := map[string]any{"scylla_repo": "http://repo/master.repo"}
+	normalizeSCTVersionSource(merged, explicitParamKeys(map[string]any{"scylla_repo": "x"}))
+
+	_, hasVersion := merged["scylla_version"]
+	assert.False(t, hasVersion, "absent sibling keys must stay absent")
+	assert.Len(t, merged, 1)
+}
+
+func TestNormalizeSCTVersionSource_NoExplicitSourceIsNoOp(t *testing.T) {
+	// No explicit source selected (only an unrelated override) → leave the
+	// collision for the backend to validate.
+	merged := map[string]any{
+		"scylla_version": "master:latest",
+		"scylla_repo":    "http://repo/master.repo",
+	}
+	normalizeSCTVersionSource(merged, explicitParamKeys(map[string]any{"backend": "aws"}))
+
+	assert.Equal(t, "master:latest", merged["scylla_version"])
+	assert.Equal(t, "http://repo/master.repo", merged["scylla_repo"])
+}
+
+func TestNormalizeSCTVersionSource_MultipleExplicitSourcesIsNoOp(t *testing.T) {
+	// The caller explicitly set two families; that is ambiguous, so we do not
+	// guess which to clear and defer to the backend validator.
+	merged := map[string]any{
+		"scylla_version": "master:latest",
+		"scylla_repo":    "http://repo/master.repo",
+	}
+	explicit := explicitParamKeys(map[string]any{
+		"scylla_version": "master:latest",
+		"scylla_repo":    "http://repo/master.repo",
+	})
+	normalizeSCTVersionSource(merged, explicit)
+
+	assert.Equal(t, "master:latest", merged["scylla_version"])
+	assert.Equal(t, "http://repo/master.repo", merged["scylla_repo"])
+}

--- a/cli/internal/models/testexec.go
+++ b/cli/internal/models/testexec.go
@@ -24,9 +24,13 @@ type JenkinsParameter struct {
 // JenkinsParamsRequest is the request body for POST /api/v1/jenkins/params.
 // BuildNumber is a pointer so that a nil value is encoded as JSON null, which
 // the backend interprets as "seed from the last build (or job defaults)".
+// FromDefaults asks the backend to return the job's configured default
+// parameters instead of seeding from a past build; it is omitted (false) for
+// rebuild/clone requests so the historical behaviour is preserved.
 type JenkinsParamsRequest struct {
-	BuildID     string `json:"buildId"`
-	BuildNumber *int   `json:"buildNumber"`
+	BuildID      string `json:"buildId"`
+	BuildNumber  *int   `json:"buildNumber"`
+	FromDefaults bool   `json:"fromDefaults,omitempty"`
 }
 
 // JenkinsParamsResponse is the response payload for POST /api/v1/jenkins/params.

--- a/cli/internal/services/testexec.go
+++ b/cli/internal/services/testexec.go
@@ -180,3 +180,16 @@ func isNoBuildsError(err error) bool {
 	}
 	return false
 }
+
+// validationErrorException is the backend exception class name raised when a
+// build request fails server-side validation (e.g. a scylla-cluster-tests job
+// without exactly one Scylla version source).
+const validationErrorException = "DataValidationError"
+
+// IsValidationError reports whether err is a backend validation failure. Such
+// errors are terminal: the request will never succeed as-is, so callers abort
+// immediately rather than retrying or continuing a batch.
+func IsValidationError(err error) bool {
+	var apiErr *api.APIError
+	return errors.As(err, &apiErr) && apiErr.Body.Exception == validationErrorException
+}

--- a/cli/internal/services/testexec.go
+++ b/cli/internal/services/testexec.go
@@ -44,14 +44,16 @@ func NewTestExecutionService(client *api.Client, c *cache.Cache) *TestExecutionS
 }
 
 // FetchParams returns the parameter set for the job identified by buildID
-// (a build_system_id). buildNumber selects which historical build's parameters
-// to seed from; nil means "the last build, falling back to job defaults".
+// (a build_system_id). When fromDefaults is true the backend returns the job's
+// configured default parameters (a clean starting point for a new trigger);
+// otherwise buildNumber selects which historical build's parameters to seed
+// from, nil meaning "the last build, falling back to job defaults".
 //
 // When the job has no builds and no default definitions, the backend signals
 // "#noBuildsAvailable"; FetchParams maps that to [ErrNoBuildsAvailable] so
 // callers can distinguish it from a genuine failure.
-func (s *TestExecutionService) FetchParams(ctx context.Context, buildID string, buildNumber *int) ([]models.JenkinsParameter, error) {
-	body := models.JenkinsParamsRequest{BuildID: buildID, BuildNumber: buildNumber}
+func (s *TestExecutionService) FetchParams(ctx context.Context, buildID string, buildNumber *int, fromDefaults bool) ([]models.JenkinsParameter, error) {
+	body := models.JenkinsParamsRequest{BuildID: buildID, BuildNumber: buildNumber, FromDefaults: fromDefaults}
 	req, err := s.client.NewRequest(ctx, "POST", api.JenkinsParams, body)
 	if err != nil {
 		return nil, err

--- a/cli/internal/services/testexec_test.go
+++ b/cli/internal/services/testexec_test.go
@@ -64,13 +64,14 @@ func TestFetchParams_Success(t *testing.T) {
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 		assert.Equal(t, "scylla/longevity", body.BuildID)
 		assert.Nil(t, body.BuildNumber)
+		assert.True(t, body.FromDefaults)
 		jsonOK(t, w, models.JenkinsParamsResponse{Parameters: []models.JenkinsParameter{
 			{Name: "backend", Value: "aws", Choices: []string{"aws", "gce"}},
 		}})
 	})
 	svc := newTestExecSvc(t, mux)
 
-	params, err := svc.FetchParams(context.Background(), "scylla/longevity", nil)
+	params, err := svc.FetchParams(context.Background(), "scylla/longevity", nil, true)
 	require.NoError(t, err)
 	require.Len(t, params, 1)
 	assert.Equal(t, "backend", params[0].Name)
@@ -84,12 +85,13 @@ func TestFetchParams_BuildNumberSent(t *testing.T) {
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 		require.NotNil(t, body.BuildNumber)
 		assert.Equal(t, 42, *body.BuildNumber)
+		assert.False(t, body.FromDefaults)
 		jsonOK(t, w, models.JenkinsParamsResponse{})
 	})
 	svc := newTestExecSvc(t, mux)
 
 	n := 42
-	_, err := svc.FetchParams(context.Background(), "scylla/longevity", &n)
+	_, err := svc.FetchParams(context.Background(), "scylla/longevity", &n, false)
 	require.NoError(t, err)
 }
 
@@ -100,7 +102,7 @@ func TestFetchParams_NoBuildsAvailable(t *testing.T) {
 	})
 	svc := newTestExecSvc(t, mux)
 
-	_, err := svc.FetchParams(context.Background(), "scylla/longevity", nil)
+	_, err := svc.FetchParams(context.Background(), "scylla/longevity", nil, false)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, services.ErrNoBuildsAvailable))
 }

--- a/cli/internal/services/testexec_test.go
+++ b/cli/internal/services/testexec_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -178,4 +179,17 @@ func TestWaitForBuild_Timeout(t *testing.T) {
 	_, err := svc.WaitForBuild(context.Background(), 777, 20*time.Millisecond, time.Millisecond)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "timed out")
+}
+
+func TestIsValidationError(t *testing.T) {
+	// A backend DataValidationError is recognised as a terminal validation
+	// failure, even when wrapped.
+	verr := &api.APIError{Body: models.ErrorBody{Exception: "DataValidationError", Message: "bad"}}
+	assert.True(t, services.IsValidationError(verr))
+	assert.True(t, services.IsValidationError(fmt.Errorf("wrapped: %w", verr)))
+
+	// Other API errors and plain errors are not validation failures.
+	assert.False(t, services.IsValidationError(&api.APIError{Body: models.ErrorBody{Exception: "SomeOtherError"}}))
+	assert.False(t, services.IsValidationError(errors.New("boom")))
+	assert.False(t, services.IsValidationError(nil))
 }


### PR DESCRIPTION
- **feature(service/jenkins): validate Scylla version source for SCT builds**
  scylla-cluster-tests jobs require exactly one Scylla version source
  (scylla_version, scylla_repo, an image, a rolling-upgrade repo, or a BYO
  repo) to start correctly; setting none or several silently produces a
  doomed build. Add JenkinsService.validate_sct_version_source, mirroring
  the SCTParameterWizard front-end, and call it in the /jenkins/build
  controller when the resolved test's plugin is scylla-cluster-tests so
  CLI/UI/API callers get a clear DataValidationError instead of a broken
  run. The check also closes the UI gap where the raw-param tabs bypass the
  client-side wizard validation.
  

- **feature(cli/test): clear conflicting Scylla version sources before execute**
  Job defaults frequently seed several Scylla version-source parameters at
  once (e.g. a default scylla_version alongside a scylla_repo), which the
  backend now rejects as ambiguous for scylla-cluster-tests jobs. When the
  caller explicitly picks exactly one source via --file/--param, clear the
  sibling families' keys (emptying rather than deleting, so Jenkins cannot
  re-apply its own default) so only the chosen source is sent; ambiguous or
  absent selections are left for the backend validator.
  
  Add IsValidationError so a backend DataValidationError is recognised as
  terminal: in plan fan-out, abort immediately instead of triggering the
  remaining doomed builds.
  

- **feature(service/jenkins): add fromDefaults mode to job parameter fetch**
  retrieve_job_parameters seeds a job's parameters from its last build by
  default, which carries over whatever the previous run mutated. Add a
  fromDefaults flag that instead returns the job's configured default
  parameters (the initial set), independent of any build history — this
  also lets a fresh job's parameters be fetched without a prior build.
  Wire it through the /jenkins/params controller (default false, so the
  front-end's rebuild/clone behaviour is unchanged). Factor the default
  extraction into _default_params_from_job_info, reused by both modes.
  

- **feature(cli/test): seed execute/params from job defaults, add --rebuild**
  test execute and test params now seed parameters from the job's
  configured defaults by default, giving each trigger a clean initial set
  rather than inheriting the last build's values — important for --plan-id
  fan-out, where every job would otherwise carry over whatever its previous
  run changed. Add --rebuild to restore last-build seeding; --build-number
  still targets a specific build (and implies rebuild-style seeding). The
  mode is sent to the backend via the new fromDefaults param.
  