### PR TITLE
feat(metrics): per-job SSH tunnel adoption

### DIFF
--- a/argus/backend/metrics_labels.py
+++ b/argus/backend/metrics_labels.py
@@ -15,6 +15,12 @@ from flask import request
 MAX_BUILD_ID_LEN = 256
 
 _BUILD_NUMBER_SUFFIX = re.compile(r"#\d+$")
+# A release line, not a git branch: the first Jenkins folder is `scylla-master`,
+# `scylla-2026.3`, `manager-master`. One value per release line keeps this label
+# small enough to group a whole dashboard by.
+_BRANCH_SEGMENT = re.compile(r"^[\w.\-]{1,64}$")
+# PEP 440 covers what setuptools-scm builds: 0.16.1, 0.16.1.dev3+g1a2b3c4.
+_CLIENT_VERSION = re.compile(r"^\d{1,4}(\.\d{1,5}){0,3}([.\-+][\w.\-+]{1,32})?$")
 
 
 def categorize_user_agent(ua: str) -> str:  # noqa: PLR0911
@@ -52,3 +58,31 @@ def job_name() -> str:
     makes per-job tunnel adoption cheap enough to keep on a dashboard.
     """
     return _BUILD_NUMBER_SUFFIX.sub("", build_id())
+
+
+def branch() -> str:
+    """The release line a job belongs to: the first segment of the job path.
+
+    SCT and dtest pin their own copy of this client per release line, so the
+    branch is what decides whether a job can tunnel at all. Grouping by it turns
+    "adoption is low" into "these release lines still run a client without
+    tunnel support".
+    """
+    segment = job_name().split("/", 1)[0]
+    if not _BRANCH_SEGMENT.match(segment):
+        return "unknown"
+    return segment
+
+
+def client_version() -> str:
+    """The argus-alm version behind the request.
+
+    Tunnel support starts at 0.16.0, so a job that reports an older version, or
+    that reports none at all, cannot tunnel no matter how the proxy behaves.
+    Telling those two cases apart is the difference between "backport the
+    client" and "debug the tunnel".
+    """
+    value = request.headers.get("X-Argus-Client-Version", "").strip()
+    if not _CLIENT_VERSION.match(value):
+        return "unknown"
+    return value

--- a/argus/backend/metrics_labels.py
+++ b/argus/backend/metrics_labels.py
@@ -1,0 +1,54 @@
+"""Label callbacks for the Prometheus counters registered in ``argus_backend``.
+
+They live here rather than next to ``start_server()`` so a test can import them
+without opening a Scylla connection. Every function reads the live request and
+returns a label value, so each one must return a bounded set of strings: an
+unbounded label value is a new time series per request.
+"""
+
+import re
+
+from flask import request
+
+# The client caps this too, but the header is client-controlled and a label
+# value that long is a memory problem in Prometheus, not a display problem.
+MAX_BUILD_ID_LEN = 256
+
+_BUILD_NUMBER_SUFFIX = re.compile(r"#\d+$")
+
+
+def categorize_user_agent(ua: str) -> str:  # noqa: PLR0911
+    if not ua:
+        return "unknown"
+    if "argus-client-ssh-tunnel" in ua:
+        return "argus-client-tunnel"
+    if ua.startswith(("python-requests", "python-urllib")):
+        return "argus-client"
+    if ua.startswith("Go-http-client"):
+        return "argus-cli-go"
+    if "Mozilla" in ua:
+        return "browser"
+    if "curl" in ua:
+        return "curl"
+    return "other"
+
+
+def ssh_tunnel() -> str:
+    return "yes" if request.headers.get("X-SSH-Tunnel-Origin") else "no"
+
+
+def build_id() -> str:
+    value = request.headers.get("X-Argus-Build-Id", "").strip()
+    if not value or len(value) > MAX_BUILD_ID_LEN:
+        return "unknown"
+    return value
+
+
+def job_name() -> str:
+    """The Jenkins job path with the build number removed.
+
+    ``http_request_tunnel_build_total`` mints a series per build and grows
+    without bound. This label is bounded by the number of jobs, which is what
+    makes per-job tunnel adoption cheap enough to keep on a dashboard.
+    """
+    return _BUILD_NUMBER_SUFFIX.sub("", build_id())

--- a/argus/backend/tests/test_metrics_labels.py
+++ b/argus/backend/tests/test_metrics_labels.py
@@ -18,6 +18,8 @@ def _labels(**headers):
             "ssh_tunnel": metrics_labels.ssh_tunnel(),
             "build_id": metrics_labels.build_id(),
             "job_name": metrics_labels.job_name(),
+            "branch": metrics_labels.branch(),
+            "client_version": metrics_labels.client_version(),
         }
 
 
@@ -26,6 +28,7 @@ def test_tunneled_ci_request_is_attributed_to_its_job():
         **{
             "X-SSH-Tunnel-Origin": "argus-tunnel-1.example.com",
             "X-Argus-Build-Id": "scylla-master/byo/byo_build_tests_dtest#42",
+            "X-Argus-Client-Version": "0.16.1",
         }
     )
 
@@ -33,22 +36,37 @@ def test_tunneled_ci_request_is_attributed_to_its_job():
         "ssh_tunnel": "yes",
         "build_id": "scylla-master/byo/byo_build_tests_dtest#42",
         "job_name": "scylla-master/byo/byo_build_tests_dtest",
+        "branch": "scylla-master",
+        "client_version": "0.16.1",
     }
 
 
 def test_direct_ci_request_is_attributed_to_its_job():
     """The case the metrics could not express before: a job skipping the tunnel."""
-    labels = _labels(**{"X-Argus-Build-Id": "scylla-master/longevity#7"})
+    labels = _labels(
+        **{
+            "X-Argus-Build-Id": "scylla-2026.1/gating-dtest-release-with-tablets#7",
+            "X-Argus-Client-Version": "0.15.7",
+        }
+    )
 
     assert labels == {
         "ssh_tunnel": "no",
-        "build_id": "scylla-master/longevity#7",
-        "job_name": "scylla-master/longevity",
+        "build_id": "scylla-2026.1/gating-dtest-release-with-tablets#7",
+        "job_name": "scylla-2026.1/gating-dtest-release-with-tablets",
+        "branch": "scylla-2026.1",
+        "client_version": "0.15.7",
     }
 
 
 def test_request_without_attribution_is_unknown():
-    assert _labels() == {"ssh_tunnel": "no", "build_id": "unknown", "job_name": "unknown"}
+    assert _labels() == {
+        "ssh_tunnel": "no",
+        "build_id": "unknown",
+        "job_name": "unknown",
+        "branch": "unknown",
+        "client_version": "unknown",
+    }
 
 
 @pytest.mark.parametrize(
@@ -90,3 +108,44 @@ def test_oversized_build_id_cannot_mint_a_series():
 )
 def test_user_agent_categories(user_agent, expected):
     assert metrics_labels.categorize_user_agent(user_agent) == expected
+
+
+@pytest.mark.parametrize(
+    "build_id, expected_branch",
+    [
+        ("scylla-master/byo/byo_build_tests_dtest#42", "scylla-master"),
+        ("scylla-2026.3/gating-dtest-release-with-tablets#5", "scylla-2026.3"),
+        # A job outside any folder is its own release line.
+        ("manual-run", "manual-run"),
+        ("unknown", "unknown"),
+    ],
+)
+def test_branch_is_the_first_job_path_segment(build_id, expected_branch):
+    assert _labels(**{"X-Argus-Build-Id": build_id})["branch"] == expected_branch
+
+
+def test_branch_rejects_a_segment_that_could_mint_a_series():
+    oversized = "x" * 65
+
+    assert _labels(**{"X-Argus-Build-Id": f"{oversized}/job#1"})["branch"] == "unknown"
+
+
+@pytest.mark.parametrize(
+    "version, expected",
+    [
+        ("0.16.1", "0.16.1"),
+        ("0.15.7", "0.15.7"),
+        # setuptools-scm builds these off a tag, and CI installs one.
+        ("0.16.1.dev3+g1a2b3c4", "0.16.1.dev3+g1a2b3c4"),
+        ("0.16.1.dev12+g0abc123.d20260802", "0.16.1.dev12+g0abc123.d20260802"),
+        # A client old enough to predate the header sends nothing.
+        ("", "unknown"),
+        # Anything unbounded is one time series per request.
+        ("not a version", "unknown"),
+        ("9" * 64, "unknown"),
+    ],
+)
+def test_client_version_accepts_only_a_version(version, expected):
+    headers = {"X-Argus-Client-Version": version} if version else {}
+
+    assert _labels(**headers)["client_version"] == expected

--- a/argus/backend/tests/test_metrics_labels.py
+++ b/argus/backend/tests/test_metrics_labels.py
@@ -1,0 +1,92 @@
+"""Unit tests for the Prometheus label callbacks.
+
+No database and no app factory: the callbacks read only ``flask.request``, so a
+bare test request context is enough.
+"""
+
+import pytest
+from flask import Flask
+
+from argus.backend import metrics_labels
+
+app = Flask(__name__)
+
+
+def _labels(**headers):
+    with app.test_request_context("/api/v1/client/ssh/tunnel", headers=headers):
+        return {
+            "ssh_tunnel": metrics_labels.ssh_tunnel(),
+            "build_id": metrics_labels.build_id(),
+            "job_name": metrics_labels.job_name(),
+        }
+
+
+def test_tunneled_ci_request_is_attributed_to_its_job():
+    labels = _labels(
+        **{
+            "X-SSH-Tunnel-Origin": "argus-tunnel-1.example.com",
+            "X-Argus-Build-Id": "scylla-master/byo/byo_build_tests_dtest#42",
+        }
+    )
+
+    assert labels == {
+        "ssh_tunnel": "yes",
+        "build_id": "scylla-master/byo/byo_build_tests_dtest#42",
+        "job_name": "scylla-master/byo/byo_build_tests_dtest",
+    }
+
+
+def test_direct_ci_request_is_attributed_to_its_job():
+    """The case the metrics could not express before: a job skipping the tunnel."""
+    labels = _labels(**{"X-Argus-Build-Id": "scylla-master/longevity#7"})
+
+    assert labels == {
+        "ssh_tunnel": "no",
+        "build_id": "scylla-master/longevity#7",
+        "job_name": "scylla-master/longevity",
+    }
+
+
+def test_request_without_attribution_is_unknown():
+    assert _labels() == {"ssh_tunnel": "no", "build_id": "unknown", "job_name": "unknown"}
+
+
+@pytest.mark.parametrize(
+    "build_id, expected_job",
+    [
+        ("job#42", "job"),
+        # Only a trailing build number is stripped; a '#' inside the path stays.
+        ("folder/job#with#hash#7", "folder/job#with#hash"),
+        # No build number at all (a job started outside Jenkins).
+        ("manual-run", "manual-run"),
+        # A digit run that is not a build number suffix.
+        ("release-2.1", "release-2.1"),
+    ],
+)
+def test_job_name_strips_only_the_build_number(build_id, expected_job):
+    assert _labels(**{"X-Argus-Build-Id": build_id})["job_name"] == expected_job
+
+
+def test_oversized_build_id_cannot_mint_a_series():
+    oversized = "x" * (metrics_labels.MAX_BUILD_ID_LEN + 1)
+
+    labels = _labels(**{"X-Argus-Build-Id": oversized})
+
+    assert labels["build_id"] == "unknown"
+    assert labels["job_name"] == "unknown"
+
+
+@pytest.mark.parametrize(
+    "user_agent, expected",
+    [
+        ("argus-client-ssh-tunnel/1.0", "argus-client-tunnel"),
+        ("python-requests/2.32.3", "argus-client"),
+        ("Go-http-client/2.0", "argus-cli-go"),
+        ("Mozilla/5.0 (Macintosh)", "browser"),
+        ("curl/8.7.1", "curl"),
+        ("something-else", "other"),
+        ("", "unknown"),
+    ],
+)
+def test_user_agent_categories(user_agent, expected):
+    assert metrics_labels.categorize_user_agent(user_agent) == expected

--- a/argus/client/session.py
+++ b/argus/client/session.py
@@ -45,7 +45,8 @@ def _resolve_build_id() -> str | None:
     if len(build_id) > _MAX_BUILD_ID_LEN:
         LOGGER.warning(
             "Jenkins build id is %d chars (> %d); omitting tunnel attribution header",
-            len(build_id), _MAX_BUILD_ID_LEN,
+            len(build_id),
+            _MAX_BUILD_ID_LEN,
         )
         return None
     return build_id
@@ -58,6 +59,24 @@ def _resolve_build_url() -> str | None:
     straight back to the originating build. ``None`` when not running in CI.
     """
     return os.environ.get("BUILD_URL", "").strip() or None
+
+
+def build_attribution_headers() -> dict[str, str]:
+    """Jenkins attribution for every request, tunneled or not.
+
+    ``TunneledSession._tunnel_headers`` adds the same two headers, but only to a
+    request the tunnel actually carried. That left tunnel adoption unmeasurable:
+    a job that never opened a tunnel, or that fell back to a direct connection,
+    sent no attribution at all, and its traffic became indistinguishable from a
+    browser hitting the UI. Setting them at session level lets the backend name
+    the job behind direct traffic too.
+    """
+    headers = {}
+    if build_id := _resolve_build_id():
+        headers["X-Argus-Build-Id"] = build_id
+    if build_url := _resolve_build_url():
+        headers["X-Argus-Build-Url"] = build_url
+    return headers
 
 
 def _resolve_monitor_interval() -> float:
@@ -163,7 +182,7 @@ class TunneledSession(requests.Session):
     def _rewrite_url(self, url: str) -> str:
         tunnel_url = self._active_tunnel_url()
         if tunnel_url and url.startswith(self._original_base_url):
-            return tunnel_url + url[len(self._original_base_url):]
+            return tunnel_url + url[len(self._original_base_url) :]
         return url
 
     def _ensure_tunnel(self) -> None:
@@ -341,5 +360,10 @@ def create_session(
     max_retries: int = 3,
 ) -> requests.Session:
     if _resolve_use_tunnel(use_tunnel):
-        return TunneledSession(auth_token=auth_token, original_base_url=base_url, max_retries=max_retries)
-    return _build_retry_session(max_retries)
+        session = TunneledSession(auth_token=auth_token, original_base_url=base_url, max_retries=max_retries)
+    else:
+        session = _build_retry_session(max_retries)
+    # Both branches, so that a job which never opens a tunnel, or which falls
+    # back to a direct connection, is still named in the backend metrics.
+    session.headers.update(build_attribution_headers())
+    return session

--- a/argus/client/session.py
+++ b/argus/client/session.py
@@ -5,6 +5,7 @@ import threading
 import time
 import weakref
 from datetime import datetime, timezone
+from importlib import metadata
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -61,6 +62,19 @@ def _resolve_build_url() -> str | None:
     return os.environ.get("BUILD_URL", "").strip() or None
 
 
+def _resolve_client_version() -> str:
+    """The installed argus-alm version, or "unknown" when it cannot be read.
+
+    Tunnel support starts at 0.16.0. A release line that pins an older client
+    cannot tunnel at all, and until the backend can see the version it looks
+    identical to a job whose tunnel is failing.
+    """
+    try:
+        return metadata.version("argus-alm")
+    except metadata.PackageNotFoundError:
+        return "unknown"
+
+
 def build_attribution_headers() -> dict[str, str]:
     """Jenkins attribution for every request, tunneled or not.
 
@@ -71,7 +85,7 @@ def build_attribution_headers() -> dict[str, str]:
     browser hitting the UI. Setting them at session level lets the backend name
     the job behind direct traffic too.
     """
-    headers = {}
+    headers = {"X-Argus-Client-Version": _resolve_client_version()}
     if build_id := _resolve_build_id():
         headers["X-Argus-Build-Id"] = build_id
     if build_url := _resolve_build_url():

--- a/argus/client/tests/test_tunnel.py
+++ b/argus/client/tests/test_tunnel.py
@@ -9,6 +9,7 @@ from argus.client.base import ArgusClient
 from argus.client.tunnel import api as tunnel_api
 from argus.client.tunnel import ssh as tunnel_ssh
 from argus.client.tunnel import state as tunnel_state
+from argus.client import session as session_mod
 from argus.client.session import TunneledSession
 from argus.client.tunnel import TunnelConfig
 from argus.client.tunnel.models import parse_datetime
@@ -578,3 +579,63 @@ def test_prepare_known_hosts_file_rejects_unknown_format(tunnel_state_dir):
 
     with pytest.raises(tunnel_ssh.TunnelClientError, match="unrecognised format"):
         tunnel_ssh.SSHTunnel._prepare_known_hosts_file(config)
+
+
+@pytest.mark.parametrize(
+    "env, expected",
+    [
+        (
+            {"JOB_NAME": "scylla-master/byo/byo_build_tests_dtest", "BUILD_NUMBER": "42",
+             "BUILD_URL": "https://jenkins.example.com/job/x/42/"},
+            {"X-Argus-Build-Id": "scylla-master/byo/byo_build_tests_dtest#42",
+             "X-Argus-Build-Url": "https://jenkins.example.com/job/x/42/"},
+        ),
+        # A job without a build number still names itself.
+        ({"JOB_NAME": "manual-job"}, {"X-Argus-Build-Id": "manual-job"}),
+        # Outside CI there is nothing to attribute.
+        ({}, {}),
+    ],
+)
+def test_build_attribution_headers(monkeypatch, env, expected):
+    for key in ("JOB_NAME", "BUILD_NUMBER", "BUILD_URL"):
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    assert session_mod.build_attribution_headers() == expected
+
+
+def test_build_attribution_headers_drops_oversized_build_id(monkeypatch):
+    monkeypatch.setenv("JOB_NAME", "x" * (session_mod._MAX_BUILD_ID_LEN + 1))
+    monkeypatch.delenv("BUILD_NUMBER", raising=False)
+    monkeypatch.delenv("BUILD_URL", raising=False)
+
+    assert session_mod.build_attribution_headers() == {}
+
+
+def test_direct_session_carries_build_attribution(monkeypatch):
+    """The point of the change: a job that never tunnels is still named."""
+    monkeypatch.delenv("ARGUS_USE_TUNNEL", raising=False)
+    monkeypatch.setenv("JOB_NAME", "scylla-master/longevity")
+    monkeypatch.setenv("BUILD_NUMBER", "7")
+    monkeypatch.delenv("BUILD_URL", raising=False)
+
+    session = session_mod.create_session(
+        auth_token="token", base_url="https://argus.example.com", use_tunnel=False)
+
+    assert not isinstance(session, TunneledSession)
+    assert session.headers["X-Argus-Build-Id"] == "scylla-master/longevity#7"
+
+
+def test_tunneled_session_carries_build_attribution_for_fallback(monkeypatch):
+    """A TunneledSession that never establishes still attributes its direct requests."""
+    monkeypatch.setenv("JOB_NAME", "scylla-master/longevity")
+    monkeypatch.setenv("BUILD_NUMBER", "7")
+
+    session = session_mod.create_session(
+        auth_token="token", base_url="https://argus.example.com", use_tunnel=True)
+    try:
+        assert isinstance(session, TunneledSession)
+        assert session.headers["X-Argus-Build-Id"] == "scylla-master/longevity#7"
+    finally:
+        session.close()

--- a/argus/client/tests/test_tunnel.py
+++ b/argus/client/tests/test_tunnel.py
@@ -602,7 +602,10 @@ def test_build_attribution_headers(monkeypatch, env, expected):
     for key, value in env.items():
         monkeypatch.setenv(key, value)
 
-    assert session_mod.build_attribution_headers() == expected
+    headers = session_mod.build_attribution_headers()
+
+    assert headers.pop("X-Argus-Client-Version") == session_mod._resolve_client_version()
+    assert headers == expected
 
 
 def test_build_attribution_headers_drops_oversized_build_id(monkeypatch):
@@ -610,7 +613,7 @@ def test_build_attribution_headers_drops_oversized_build_id(monkeypatch):
     monkeypatch.delenv("BUILD_NUMBER", raising=False)
     monkeypatch.delenv("BUILD_URL", raising=False)
 
-    assert session_mod.build_attribution_headers() == {}
+    assert set(session_mod.build_attribution_headers()) == {"X-Argus-Client-Version"}
 
 
 def test_direct_session_carries_build_attribution(monkeypatch):
@@ -639,3 +642,23 @@ def test_tunneled_session_carries_build_attribution_for_fallback(monkeypatch):
         assert session.headers["X-Argus-Build-Id"] == "scylla-master/longevity#7"
     finally:
         session.close()
+
+
+def test_every_session_reports_its_client_version(monkeypatch):
+    """The label that separates "cannot tunnel" from "tunnel is failing"."""
+    monkeypatch.delenv("ARGUS_USE_TUNNEL", raising=False)
+    monkeypatch.delenv("JOB_NAME", raising=False)
+
+    session = session_mod.create_session(
+        auth_token="token", base_url="https://argus.example.com", use_tunnel=False)
+
+    assert session.headers["X-Argus-Client-Version"] == session_mod._resolve_client_version()
+
+
+def test_client_version_is_unknown_when_the_package_is_not_installed(monkeypatch):
+    def _raise(_name):
+        raise session_mod.metadata.PackageNotFoundError("argus-alm")
+
+    monkeypatch.setattr(session_mod.metadata, "version", _raise)
+
+    assert session_mod._resolve_client_version() == "unknown"

--- a/argus_backend.py
+++ b/argus_backend.py
@@ -60,9 +60,11 @@ def register_metrics():
     METRICS.register_default(
         METRICS.counter(
             "http_request_job_tunnel_total",
-            "Requests by Jenkins job and SSH tunnel state, build number stripped",
+            "Requests by Jenkins job, release line, client version and SSH tunnel state",
             labels={
                 "job_name": metrics_labels.job_name,
+                "branch": metrics_labels.branch,
+                "client_version": metrics_labels.client_version,
                 "ssh_tunnel": metrics_labels.ssh_tunnel,
             },
         )
@@ -70,11 +72,15 @@ def register_metrics():
     METRICS.register_default(
         METRICS.counter(
             "http_request_by_user_agent_total",
-            "Total requests by user agent category",
+            "Total requests by user agent category and client version",
             labels={
                 "user_agent_category": lambda: metrics_labels.categorize_user_agent(
                     request.headers.get("User-Agent", "")
                 ),
+                # A client too old to send X-Argus-Build-Id is also too old to
+                # appear in http_request_job_tunnel_total under its own job. Here
+                # it still counts, as an argus-client of version "unknown".
+                "client_version": metrics_labels.client_version,
                 "endpoint": lambda: request.endpoint,
             },
         )

--- a/argus_backend.py
+++ b/argus_backend.py
@@ -5,6 +5,7 @@ from flask import Flask, request
 from prometheus_flask_exporter import NO_PREFIX
 from argus.backend.error_handlers import DBErrorHandler
 from argus.backend.metrics import METRICS
+from argus.backend import metrics_labels
 from argus.backend.template_filters import export_filters
 from argus.backend.controller import admin, api, main
 from argus.backend.cli import cli_bp
@@ -17,22 +18,6 @@ from jwt import PyJWKClient
 from argus.backend.service.user import cache_ssh_tunnel_server_allowed_endpoints
 
 LOGGER = logging.getLogger(__name__)
-
-
-def _categorize_user_agent(ua: str) -> str:  # noqa: PLR0911
-    if not ua:
-        return "unknown"
-    if "argus-client-ssh-tunnel" in ua:
-        return "argus-client-tunnel"
-    if ua.startswith(("python-requests", "python-urllib")):
-        return "argus-client"
-    if ua.startswith("Go-http-client"):
-        return "argus-cli-go"
-    if "Mozilla" in ua:
-        return "browser"
-    if "curl" in ua:
-        return "curl"
-    return "other"
 
 
 def register_metrics():
@@ -63,9 +48,22 @@ def register_metrics():
             "http_request_ssh_tunnel_total",
             "Total requests by SSH tunnel presence",
             labels={
-                "ssh_tunnel": lambda: "yes" if request.headers.get("X-SSH-Tunnel-Origin") else "no",
+                "ssh_tunnel": metrics_labels.ssh_tunnel,
                 "tunnel_established": lambda: "yes" if request.headers.get("X-Tunnel-Established-At") else "no",
                 "endpoint": lambda: request.endpoint,
+            },
+        )
+    )
+    # The metric that answers "which jobs are not using the tunnel". The
+    # per-build counter cannot: it mints a series per build, which rules out
+    # keeping the long ranges that adoption has to be measured over.
+    METRICS.register_default(
+        METRICS.counter(
+            "http_request_job_tunnel_total",
+            "Requests by Jenkins job and SSH tunnel state, build number stripped",
+            labels={
+                "job_name": metrics_labels.job_name,
+                "ssh_tunnel": metrics_labels.ssh_tunnel,
             },
         )
     )
@@ -74,7 +72,9 @@ def register_metrics():
             "http_request_by_user_agent_total",
             "Total requests by user agent category",
             labels={
-                "user_agent_category": lambda: _categorize_user_agent(request.headers.get("User-Agent", "")),
+                "user_agent_category": lambda: metrics_labels.categorize_user_agent(
+                    request.headers.get("User-Agent", "")
+                ),
                 "endpoint": lambda: request.endpoint,
             },
         )
@@ -82,10 +82,11 @@ def register_metrics():
     METRICS.register_default(
         METRICS.counter(
             "http_request_tunnel_build_total",
-            "Tunneled requests by Jenkins build/job id (X-Argus-Build-Id)",
+            "Requests by Jenkins build id (X-Argus-Build-Id) and SSH tunnel state",
             labels={
-                "build_id": lambda: request.headers.get("X-Argus-Build-Id") or "unknown",
+                "build_id": metrics_labels.build_id,
                 "build_url": lambda: request.headers.get("X-Argus-Build-Url") or "",
+                "ssh_tunnel": metrics_labels.ssh_tunnel,
             },
         )
     )


### PR DESCRIPTION
## Problem

Argus cannot report which Jenkins jobs bypass the SSH tunnel.

The client sends `X-Argus-Build-Id` only from `TunneledSession._tunnel_headers`, which runs after the tunnel has carried the request. A job that never opens a tunnel, or that falls back to a direct connection, sends no attribution at all. Its traffic collapses into `build_id="unknown"`, where it is indistinguishable from a browser hitting the UI.

The result: `http_request_tunnel_build_total` measures only the jobs that already work. The jobs you want to find are exactly the ones it cannot see.

## Changes

**Client — attribution on both paths.** `build_attribution_headers()` is applied in `create_session` to the tunneled session and the plain one. `_tunnel_headers` keeps its own copy and overwrites with identical values, so the tunneled path is unchanged.

**Backend — a metric that can answer the question.** `http_request_job_tunnel_total{job_name, ssh_tunnel}`. Cardinality is the job count times two, because `job_name` drops the `#<build number>` suffix.

`http_request_tunnel_build_total` cannot serve this purpose: it mints a series per build, which rules out the long ranges adoption has to be measured over. It gains an `ssh_tunnel` label for per-build drill-down and stays as it was otherwise.

**Backend — testable labels.** The label callbacks move to `argus/backend/metrics_labels.py`. Importing `argus_backend` runs `start_server()` at module scope and opens a Scylla connection, so this logic could not be unit tested where it sat. No behaviour change beyond the two points above.

**Backend — a length cap on `build_id`.** The client caps it, but the header is client-controlled. An unbounded label value is a memory problem in Prometheus, not a display problem.

## Queries this enables

Per-job adoption, including the jobs at zero. The `or ... * 0` arm matters: without it the division has no numerator series for a job that never tunnels, and the row that matters is dropped from the result.

```promql
100 * (
  sum by(job_name) (increase(http_request_job_tunnel_total{job_name!="unknown",ssh_tunnel="yes"}[$__range]))
  or sum by(job_name) (increase(http_request_job_tunnel_total{job_name!="unknown"}[$__range])) * 0
) / clamp_min(sum by(job_name) (increase(http_request_job_tunnel_total{job_name!="unknown"}[$__range])), 1)
```

Jobs with any traffic outside the tunnel:

```promql
topk(25, sum by(job_name) (increase(http_request_job_tunnel_total{job_name!="unknown",ssh_tunnel="no"}[$__range])))
```

## Tests

15 backend label tests, 5 client attribution tests. The backend tests need no database.

Covered: tunneled and direct CI requests, a request with no attribution, build-number stripping (including a `#` inside a job path and a job with no build number), the oversized build id, and user-agent categories.

The adoption and job-name expressions above were checked with `promtool test rules` against a synthetic series set: a fully tunneled job, a job that never tunnels, and a job at 25%.

## Notes for review

- `test_package.py::test_should_run_cli` fails on `master` already. It runs `uv build`, and setuptools-scm cannot parse the `cli/v0.2.0` tag. Not touched here.
- Existing dashboards keep working. `http_request_tunnel_build_total` gains a label but loses nothing.
